### PR TITLE
MAV_VAR fix

### DIFF
--- a/message_definitions/common.xml
+++ b/message_definitions/common.xml
@@ -753,30 +753,6 @@
                     <description>The Z or altitude value is out of range.</description>
                </entry>
           </enum>
-          <enum name="MAV_VAR">
-               <description>type of a mavlink parameter</description>
-               <entry value="0" name="MAV_VAR_FLOAT">
-                    <description>32 bit float</description>
-               </entry>
-               <entry value="1" name="MAV_VAR_UINT8">
-                    <description>8 bit unsigned integer</description>
-               </entry>
-               <entry value="2" name="MAV_VAR_INT8">
-                    <description>8 bit signed integer</description>
-               </entry>
-               <entry value="3" name="MAV_VAR_UINT16">
-                    <description>16 bit unsigned integer</description>
-               </entry>
-               <entry value="4" name="MAV_VAR_INT16">
-                    <description>16 bit signed integer</description>
-               </entry>
-               <entry value="5" name="MAV_VAR_UINT32">
-                    <description>32 bit unsigned integer</description>
-               </entry>
-               <entry value="6" name="MAV_VAR_INT32">
-                    <description>32 bit signed integer</description>
-               </entry>
-          </enum>
           <enum name="MAV_RESULT">
                <description>result from a mavlink command</description>
                <entry value="0" name="MAV_RESULT_ACCEPTED">
@@ -922,7 +898,7 @@
                <description>Emit the value of a onboard parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows him to re-request missing parameters after a loss or timeout.</description>
                <field type="char[16]" name="param_id">Onboard parameter id</field>
                <field type="float" name="param_value">Onboard parameter value</field>
-               <field type="uint8_t" name="param_type">Onboard parameter type: see MAV_VAR enum</field>
+               <field type="uint8_t" name="param_type">Onboard parameter type: see MAVLINK_TYPE_* in generated code</field>
                <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
                <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
           </message>
@@ -932,7 +908,7 @@
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="char[16]" name="param_id">Onboard parameter id</field>
                <field type="float" name="param_value">Onboard parameter value</field>
-               <field type="uint8_t" name="param_type">Onboard parameter type: see MAV_VAR enum</field>
+               <field type="uint8_t" name="param_type">Onboard parameter type: see MAVLINK_TYPE_* in generated code</field>
           </message>
           <message id="24" name="GPS_RAW_INT">
                <description>The global position, as returned by the Global Positioning System (GPS). This is


### PR DESCRIPTION
removed _wrong_ reference to MAV_VAR in the parameters section
removed MAV_VAR at all, since grep says it is unused in qgroundcontrol
