### PR TITLE
Returned LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET to common.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1287,6 +1287,16 @@
                <field type="uint16_t" name="command">Command ID, as defined by MAV_CMD enum.</field>
                <field type="uint8_t" name="result">See MAV_RESULT enum</field>
           </message>
+          <message id="89" name="LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET">
+               <description>The offset in X, Y, Z and yaw between the LOCAL_POSITION_NED messages of MAV X and the global coordinate frame in NED coordinates. Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="x">X Position</field>
+               <field type="float" name="y">Y Position</field>
+               <field type="float" name="z">Z Position</field>
+               <field type="float" name="roll">Roll</field>
+               <field type="float" name="pitch">Pitch</field>
+               <field type="float" name="yaw">Yaw</field>
+          </message>
           <message id="90" name="HIL_STATE">
                <description>Sent from simulation to autopilot. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
                <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>


### PR DESCRIPTION
Currently you can't compile QGC with the standard version of MAVLink as this message was removed from common.xml and QGC relies on it. It should be returned promptly. This change should also be committed to the master branch.
