### PR TITLE
Fixed references to non-existent generator.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Header files can be generated either with mavgen, or within QGroundControl.
 
 mavgen is a header generation tool written in python, which is included with MAVLink. It can be used directly or via the *generator.py* GUI. To use the GUI, run:
 
-    python generator.py
+    python generate.py
 
 If you would rather use mavgen from the command line see *pymavlink\generator\mavgen.py*.
 

--- a/generate.py
+++ b/generate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """\
-generator.py is a GUI front-end for mavgen, a python based MAVLink
+generate.py is a GUI front-end for mavgen, a python based MAVLink
 header generation tool.
 
 Notes:


### PR DESCRIPTION
The README instructed users to run a non-existent script, generator.py.
