### PR TITLE
Message Definitions: add MAV_AUTOPILOT_SMACCMPILOT to MAV_AUTOPILOT enum 

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -44,7 +44,7 @@
                    <description>PX4 Autopilot - http://pixhawk.ethz.ch/px4/</description>
                </entry>
                <entry value="13" name="MAV_AUTOPILOT_SMACCMPILOT">
-                   <description>SMACCMPilot - A free autpilot from Galois, Inc.</description>
+                   <description>SMACCMPilot - http://smaccmpilot.org</description>
                </entry>
           </enum>
           <enum name="MAV_TYPE">


### PR DESCRIPTION
We (Galois, Inc) are developing a free autopilot, called the SMACCMPilot, which uses the MAVLink protocol. I've added an entry to the MAV_AUTOPILOT enum at the next available value to identify our autopilot software.
