### PR TITLE
Added more datatypes to param_union

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -33,6 +33,9 @@ typedef struct param_union {
 		float param_float;
 		int32_t param_int32;
 		uint32_t param_uint32;
+		int16_t param_int16;
+		uint16_t param_uint16;
+		int8_t param_int8;
 		uint8_t param_uint8;
 		uint8_t bytes[4];
 	};


### PR DESCRIPTION
This paves the way for supporting all possible `MAV_PARAM` datatypes in QGC. Though really this param_union should be changed to be 64 or 128 bits and support doubles and (u)int64 datatypes as well. From looking at QGC's codebase, I don't think that change would affect anything either.
