### PR TITLE
Display all supported languages as part of command line options

### DIFF
--- a/pymavlink/generator/mavgen.py
+++ b/pymavlink/generator/mavgen.py
@@ -113,13 +113,14 @@ def mavgen_validate(fname, schema, errorLimitNumber) :
     domTree = domTreeWrapper.getTree()
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     from optparse import OptionParser
 
+    supportedLanguages = ["C", "CS", "JavaScript", "Python", "WLua"]
     parser = OptionParser("%prog [options] <XML files>")
     parser.add_option("-o", "--output", dest="output", default="mavlink", help="output directory.")
-    parser.add_option("--lang", dest="language", default="Python", help="language of generated code: 'Python' or 'C' [default: %default]")
-    parser.add_option("--wire-protocol", dest="wire_protocol", default=mavparse.PROTOCOL_1_0, help="MAVLink protocol version: '0.9' or '1.0'. [default: %default]")
+    parser.add_option("--lang", dest="language", choices=supportedLanguages, default="Python", help="language of generated code, one of: {0} [default: %default]".format(supportedLanguages))
+    parser.add_option("--wire-protocol", dest="wire_protocol", choices=[mavparse.PROTOCOL_0_9, mavparse.PROTOCOL_1_0], default=mavparse.PROTOCOL_1_0, help="MAVLink protocol version: '0.9' or '1.0'. [default: %default]")
     parser.add_option("--error-limit", dest="error_limit", default=200, help="maximum number of validation errors.")
     (opts, args) = parser.parse_args()
 


### PR DESCRIPTION
Additionally move both the `--lang` and `--wire-protocol` command-line options to using a Choices option. This allows for more sensible errors and checking of arguments at the start of the script.
