### PR TITLE
Improve battery consumption reporting

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1594,9 +1594,9 @@
                <field type="uint16_t" name="voltage_cell_4">Battery voltage of cell 4, in millivolts (1 = 1 millivolt), -1: no cell</field>
                <field type="uint16_t" name="voltage_cell_5">Battery voltage of cell 5, in millivolts (1 = 1 millivolt), -1: no cell</field>
                <field type="uint16_t" name="voltage_cell_6">Battery voltage of cell 6, in millivolts (1 = 1 millivolt), -1: no cell</field>
-               <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current d>
-               <field type="int16_t" name="current_consumed">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
-               <field type="int16_t" name="energy_consumed">Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
+               <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+               <field type="int32_t" name="current_consumed">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
+               <field type="int32_t" name="energy_consumed">Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
                <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
           </message>
           <message id="148" name="SETPOINT_8DOF">


### PR DESCRIPTION
Proposal to add direct battery charge and energy consumption reporting in addition or instead of the existing battery percentage value.  

The problem with the battery percentage is that the on-board system in most cases does not natively know the size of the energy storage and relies on the (possibly) configured battery capacity value.  In case of changing the battery on the field there may be different battery size or there may even be a different type of power source on board. In any case, the percentage value is secondary information and dependent on a pre-configured capacity value, which may or may not be correct or relevant.  

If the on-board system has capability to report any consumption numbers, it almost certainly is measuring current and voltage samples.  These are primary information available to be reported and should be reported.

Possibly it could make sense to split message 147 to two separate messages: 1) multi-cell battery individual cell voltage reporting 2) total voltage & current readings and derivatives. That possibility in not included in this pull request, but is rather food for thought for further evolution.
