### PR TITLE
Python gen: allow for hex and binary notation in enum value attributes

### DIFF
--- a/pymavlink/generator/mavparse.py
+++ b/pymavlink/generator/mavparse.py
@@ -195,7 +195,7 @@ class MAVXML(object):
             elif in_element == "mavlink.enums.enum.entry":
                 check_attrs(attrs, ['name'], 'enum entry')
                 if 'value' in attrs:
-                    value = int(attrs['value'])
+                    value = eval(attrs['value'])
                 else:
                     value = self.enum[-1].highest_value + 1
                 if (value > self.enum[-1].highest_value):

--- a/pymavlink/generator/mavschema.xsd
+++ b/pymavlink/generator/mavschema.xsd
@@ -10,9 +10,17 @@
 <!-- definition of attributes -->
 <xs:attribute name="name" type="xs:string"/> <!-- enum,entry,message,field -->
 <xs:attribute name="index" type="xs:unsignedByte"/> <!-- param -->
-<xs:attribute name="value" type="xs:unsignedShort"/> <!-- entry -->
 <xs:attribute name="id" type="xs:unsignedByte"/> <!-- message -->
 <xs:attribute name="print_format" type="xs:string"/> <!-- field -->
+<xs:attribute name="value"> <!-- entry -->
+  <xs:simpleType>
+    <xs:restriction base="xs:string">
+        <xs:pattern value="^\d{1,10}$"/> <!-- base 10 int -->
+        <xs:pattern value="^0[xX][0-9a-fA-F]{1,8}$"/> <!-- base 16 -->
+        <xs:pattern value="^0[bB][0-1]{1,32}$"/> <!-- base 1 -->
+    </xs:restriction>
+  </xs:simpleType>
+</xs:attribute>
 <xs:attribute name="type">
   <xs:simpleType>
     <xs:restriction base="xs:string">


### PR DESCRIPTION
Problem: specifying long ints in base 10 format can get verbose/confusing, for example when setting up a 32-bit bitmask (eg. for heartbeat->custom_mode).  And unfortunately using shift operator (eg. 1<<31) is not practical due to XML syntax.  Using hex or binary can be much more readable in some cases.  Also, the previous constraint of unsignedShort was too short :)

Here is a quick solution. 

Thanks,
-Max
