### PR TITLE
Fixes in external rx buffer logic and adds possibility for external rx status

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
@@ -15,7 +15,12 @@
 #ifndef MAVLINK_GET_CHANNEL_STATUS
 MAVLINK_HELPER mavlink_status_t* mavlink_get_channel_status(uint8_t chan)
 {
+#if MAVLINK_EXTERNAL_RX_STATUS
+	// No m_mavlink_status array defined in function,
+	// has to be defined externally
+#else
 	static mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
+#endif
 	return &m_mavlink_status[chan];
 }
 #endif
@@ -28,11 +33,8 @@ MAVLINK_HELPER mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan)
 {
 	
 #if MAVLINK_EXTERNAL_RX_BUFFER
-	// No m_mavlink_message array defined in function,
+	// No m_mavlink_buffer array defined in function,
 	// has to be defined externally
-#ifndef m_mavlink_message
-#error ERROR: IF #define MAVLINK_EXTERNAL_RX_BUFFER IS SET, THE BUFFER HAS TO BE ALLOCATED OUTSIDE OF THIS FUNCTION (mavlink_message_t m_mavlink_buffer[MAVLINK_COMM_NUM_BUFFERS];)
-#endif
 #else
 	static mavlink_message_t m_mavlink_buffer[MAVLINK_COMM_NUM_BUFFERS];
 #endif

--- a/pymavlink/generator/C/include_v1.0/protocol.h
+++ b/pymavlink/generator/C/include_v1.0/protocol.h
@@ -162,7 +162,7 @@ static inline void byte_copy_8(char *dst, const char *src)
 /*
   like memcpy(), but if src is NULL, do a memset to zero
 */
-static void mav_array_memcpy(void *dest, const void *src, size_t n)
+static inline void mav_array_memcpy(void *dest, const void *src, size_t n)
 {
 	if (src == NULL) {
 		memset(dest, 0, n);


### PR DESCRIPTION
An external rx buffer, possible using the macro `MAVLINK_EXTERNAL_RX_BUFFER` is necessary in the case of multiple object files linked together, as each will have a different instance of the static `m_mavlink_buffer`. This is also necessary for the `m_mavlink_status` variable, however there was no macro for this functionality.

Also corrected some errors. The `#ifndef` directive only works for macros, not variables, and I believe that the inline identifier was forgotten in the definition of `mav_array_memcpy`.
