### PR TITLE
Fix template bug that occurs when variable is used at the end of a repetition

### DIFF
--- a/pymavlink/generator/mavtemplate.py
+++ b/pymavlink/generator/mavtemplate.py
@@ -24,7 +24,7 @@ class MAVTemplate(object):
         self.trim_leading_lf = trim_leading_lf
         self.checkmissing = checkmissing
 
-    def find_end(self, text, start_token, end_token):
+    def find_end(self, text, start_token, end_token, ignore_end_token=None):
         '''find the of a token.
         Returns the offset in the string immediately after the matching end_token'''
         if not text.startswith(start_token):
@@ -34,6 +34,12 @@ class MAVTemplate(object):
         while nesting > 0:
             idx1 = text[offset:].find(start_token)
             idx2 = text[offset:].find(end_token)
+            # Check for false positives due to another similar token
+            # For example, make sure idx2 points to the second '}' in ${{field: ${name}}}
+            if ignore_end_token:
+                combined_token = ignore_end_token + end_token
+                if text[offset+idx2:offset+idx2+len(combined_token)] == combined_token:
+                    idx2 += len(ignore_end_token)
             if idx1 == -1 and idx2 == -1:
                 raise MAVParseError("token nesting error")
             if idx1 == -1 or idx1 > idx2:
@@ -50,7 +56,7 @@ class MAVTemplate(object):
 
     def find_rep_end(self, text):
         '''find the of a repitition'''
-        return self.find_end(text, self.start_rep_token, self.end_rep_token)
+        return self.find_end(text, self.start_rep_token, self.end_rep_token, ignore_end_token=self.end_var_token)
 
     def substitute(self, text, subvars={},
                    trim_leading_lf=None, checkmissing=None):


### PR DESCRIPTION
Currently, when a template contains a repetition that ends with a variable, template generation fails with `mavparse.MAVParseError: missing end of variable`. This occurs because the default end_var_token `}` is the same character as the default end_rep_token `}}`.

For example, when generating a list of parameters to pass a function 

```
my_function(self, ${{parameters:, ${value}}});
```

The end_var_token is then mistaken for the first `}` of end_rep_token causing mavtemplate to later try to parse `, ${value`

This commit fixes the issue by incrementing the index of the matching end_rep_token (`idx2`) by `len(end_var_token)` if the match is the same as the concatenation of end_var_token and end_rep_token.
