### PR TITLE
Adding optional enum attribute to fields that represent an enum

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -214,7 +214,7 @@
 	    <description>Message to configure a camera mount, directional antenna, etc.</description>
 	    <field name="target_system" type="uint8_t">System ID</field>
 	    <field name="target_component" type="uint8_t">Component ID</field>
-	    <field name="mount_mode" type="uint8_t">mount operating mode (see MAV_MOUNT_MODE enum)</field>
+	    <field name="mount_mode" type="uint8_t" enum="MAV_MOUNT_MODE">mount operating mode (see MAV_MOUNT_MODE enum)</field>
 	    <field name="stab_roll" type="uint8_t">(1 = yes, 0 = no)</field>
 	    <field name="stab_pitch" type="uint8_t">(1 = yes, 0 = no)</field>
 	    <field name="stab_yaw" type="uint8_t">(1 = yes, 0 = no)</field>
@@ -263,7 +263,7 @@
 	    status stream when fencing enabled</description>
 	    <field name="breach_status" type="uint8_t">0 if currently inside fence, 1 if outside</field>
 	    <field name="breach_count" type="uint16_t">number of fence breaches</field>
-	    <field name="breach_type" type="uint8_t">last breach type (see FENCE_BREACH_* enum)</field>
+	    <field name="breach_type" type="uint8_t" enum="FENCE_BREACH">last breach type (see FENCE_BREACH_* enum)</field>
 	    <field name="breach_time" type="uint32_t">time of last breach in milliseconds since boot</field>
 	  </message>
 
@@ -315,7 +315,7 @@
 	  <message name="LIMITS_STATUS" id="167">
 	    <description>Status of AP_Limits. Sent in extended
 	    status stream when AP_Limits is enabled</description>
-	    <field name="limits_state" type="uint8_t">state of AP_Limits, (see enum LimitState, LIMITS_STATE)</field>
+	    <field name="limits_state" type="uint8_t" enum="LIMITS_STATE">state of AP_Limits, (see enum LimitState, LIMITS_STATE)</field>
 	    <field name="last_trigger" type="uint32_t">time of last breach in milliseconds since boot</field>
 	    <field name="last_action" type="uint32_t">time of last recovery action in milliseconds since boot</field>
 	    <field name="last_recovery" type="uint32_t">time of last successful recovery in milliseconds since boot</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -913,7 +913,7 @@
                <description>The heartbeat message shows that a system is present and responding. The type of the MAV and Autopilot hardware allow the receiving system to treat further messages from this system appropriate (e.g. by laying out the user interface based on the autopilot).</description>
                <field type="uint8_t" name="type">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
                <field type="uint8_t" name="autopilot">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
-               <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAGS ENUM in mavlink/include/mavlink_types.h</field>
+               <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
                <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
                <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
                <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
@@ -967,7 +967,7 @@
           <message id="11" name="SET_MODE">
                <description>Set the system mode, as defined by enum MAV_MODE. There is no target component id as the mode is by definition for the overall aircraft, not only for one component.</description>
                <field type="uint8_t" name="target_system">The system setting the mode</field>
-               <field type="uint8_t" name="base_mode">The new base mode</field>
+               <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode</field>
                <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
           </message>
           <message id="20" name="PARAM_REQUEST_READ">
@@ -986,7 +986,7 @@
                <description>Emit the value of a onboard parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows him to re-request missing parameters after a loss or timeout.</description>
                <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
                <field type="float" name="param_value">Onboard parameter value</field>
-               <field type="uint8_t" name="param_type">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+               <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
                <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
                <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
           </message>
@@ -996,7 +996,7 @@
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
                <field type="float" name="param_value">Onboard parameter value</field>
-               <field type="uint8_t" name="param_type">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+               <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
           </message>
           <message id="24" name="GPS_RAW_INT">
                <description>The global position, as returned by the Global Positioning System (GPS). This is
@@ -1219,7 +1219,7 @@
                <description>Ack message during MISSION handling. The type field states if this message is a positive ack (type=0) or if an error happened (type=non-zero).</description>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint8_t" name="type">See MAV_MISSION_RESULT enum</field>
+               <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">See MAV_MISSION_RESULT enum</field>
           </message>
           <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
                <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
@@ -1272,7 +1272,7 @@
                <description>Set a safety zone (volume), which is defined by two corners of a cube. This message can be used to tell the MAV which setpoints/MISSIONs to accept and which to reject. Safety areas are often enforced by national or competition regulations.</description>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint8_t" name="frame">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
+               <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
                <field type="float" name="p1x">x position 1 / Latitude 1</field>
                <field type="float" name="p1y">y position 1 / Longitude 1</field>
                <field type="float" name="p1z">z position 1 / Altitude 1</field>
@@ -1282,7 +1282,7 @@
           </message>
           <message id="55" name="SAFETY_ALLOWED_AREA">
                <description>Read out the safety zone the MAV currently assumes.</description>
-               <field type="uint8_t" name="frame">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
+               <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
                <field type="float" name="p1x">x position 1 / Latitude 1</field>
                <field type="float" name="p1y">y position 1 / Longitude 1</field>
                <field type="float" name="p1z">z position 1 / Altitude 1</field>
@@ -1423,7 +1423,7 @@
                <description>Send a command with up to seven parameters to the MAV</description>
                <field type="uint8_t" name="target_system">System which should execute the command</field>
                <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
-               <field type="uint16_t" name="command">Command ID, as defined by MAV_CMD enum.</field>
+               <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
                <field type="uint8_t" name="confirmation">0: First transmission of this command. 1-255: Confirmation transmissions (e.g. for kill command)</field>
                <field type="float" name="param1">Parameter 1, as defined by MAV_CMD enum.</field>
                <field type="float" name="param2">Parameter 2, as defined by MAV_CMD enum.</field>
@@ -1435,7 +1435,7 @@
           </message>
           <message id="77" name="COMMAND_ACK">
                <description>Report status of a command. Includes feedback wether the command was executed.</description>
-               <field type="uint16_t" name="command">Command ID, as defined by MAV_CMD enum.</field>
+               <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
                <field type="uint8_t" name="result">See MAV_RESULT enum</field>
           </message>
          <message id="80" name="ROLL_PITCH_YAW_RATES_THRUST_SETPOINT">
@@ -1773,7 +1773,7 @@
           </message>
           <message id="253" name="STATUSTEXT">
                <description>Status text message. These messages are printed in yellow in the COMM console of QGroundControl. WARNING: They consume quite some bandwidth, so use only for important status and error messages. If implemented wisely, these messages are buffered on the MCU and sent only at a limited rate (e.g. 10 Hz).</description>
-               <field type="uint8_t" name="severity">Severity of status. Relies on the definitions within RFC-5424. See enum MAV_SEVERITY.</field>
+               <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424. See enum MAV_SEVERITY.</field>
                <field type="char[50]" name="text">Status text message, without null termination character</field>
           </message>
           <message id="254" name="DEBUG">

--- a/pymavlink/generator/mavgen_c.py
+++ b/pymavlink/generator/mavgen_c.py
@@ -103,11 +103,11 @@ ${{enum:
 /** @brief ${description} */
 #ifndef HAVE_ENUM_${name}
 #define HAVE_ENUM_${name}
-enum ${name}
+typedef enum ${name}
 {
 ${{entry:	${name}=${value}, /* ${description} |${{param:${description}| }} */
 }}
-};
+} ${name};
 #endif
 }}
 

--- a/pymavlink/generator/mavparse.py
+++ b/pymavlink/generator/mavparse.py
@@ -20,11 +20,12 @@ class MAVParseError(Exception):
         return self.message
 
 class MAVField(object):
-    def __init__(self, name, type, print_format, xml, description=''):
+    def __init__(self, name, type, print_format, xml, description='', enum=''):
         self.name = name
         self.name_upper = name.upper()
         self.description = description
         self.array_length = 0
+        self.enum = enum
         self.omit_arg = False
         self.const_value = None
         self.print_format = print_format
@@ -187,8 +188,12 @@ class MAVXML(object):
                     print_format = attrs['print_format']
                 else:
                     print_format = None
+                if 'enum' in attrs:
+                    enum = attrs['enum']
+                else:
+                    enum = ''
                 self.message[-1].fields.append(MAVField(attrs['name'], attrs['type'],
-                                                        print_format, self))
+                                                        print_format, self, enum=enum))
             elif in_element == "mavlink.enums.enum":
                 check_attrs(attrs, ['name'], 'enum')
                 self.enum.append(MAVEnum(attrs['name'], p.CurrentLineNumber))

--- a/pymavlink/generator/mavschema.xsd
+++ b/pymavlink/generator/mavschema.xsd
@@ -12,6 +12,7 @@
 <xs:attribute name="index" type="xs:unsignedByte"/> <!-- param -->
 <xs:attribute name="id" type="xs:unsignedByte"/> <!-- message -->
 <xs:attribute name="print_format" type="xs:string"/> <!-- field -->
+<xs:attribute name="enum" type="xs:string"/>
 <xs:attribute name="value"> <!-- entry -->
   <xs:simpleType>
     <xs:restriction base="xs:string">
@@ -56,6 +57,7 @@
         <xs:attribute ref="type" use="required"/>
         <xs:attribute ref="name" use="required"/>
         <xs:attribute ref="print_format" />
+        <xs:attribute ref="enum" />
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
This change does two things:

**First** the change to `mavgen_c.py` allows users of the generated C code to use the enum as the type. For example, currently, a function to set the base mode might look like this:

```
void set_base_mode(uint8_t base_mode);
```

With this change, you can instead use the `MAV_MODE` enum directly as the type.

```
void set_base_mode(MAV_MODE base_mode);
```

This makes the values that you should pass in as a base mode more explicit. It also helps modern development environments autocomplete the values in the MAV_MODE enum.

**Second** the change to the xml schema and mavparse.py allows generators to use the enum in their generated code. For example, a template could contain code that generates functions similar to the above:

```
${{fields:void set_${name}(${enum} ${name})}}
```
