### PR TITLE
Add MAV_CMD_NAV_START_RX_PAIR to COMMAND_LONG enum

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -687,6 +687,11 @@
                     <description>Arms / Disarms a component</description>
                     <param index="1">1 to arm, 0 to disarm</param>
                </entry>
+               <entry value="500" name="MAV_CMD_START_RX_PAIR">
+                    <description>Starts receiver pairing</description>
+                    <param index="1">0:Spektrum</param>
+                    <param index="2">0:Spektrum DSM2, 1:Spektrum DSMX</param>
+               </entry>
           </enum>
           <enum name="MAV_DATA_STREAM">
                <description>Data stream IDs. A data stream is not a fixed set of messages, but rather a
@@ -1409,7 +1414,7 @@
                <field type="float" name="climb">Current climb rate in meters/second</field>
           </message>
           <message id="76" name="COMMAND_LONG">
-               <description>Send a command with up to four parameters to the MAV</description>
+               <description>Send a command with up to seven parameters to the MAV</description>
                <field type="uint8_t" name="target_system">System which should execute the command</field>
                <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
                <field type="uint16_t" name="command">Command ID, as defined by MAV_CMD enum.</field>

--- a/message_definitions/v1.0/pixhawk.xml
+++ b/message_definitions/v1.0/pixhawk.xml
@@ -22,11 +22,6 @@
                     <description>Starts a search</description>
                     <param index="1">1 to arm, 0 to disarm</param>
                </entry>
-               <entry value="10004" name="MAV_CMD_NAV_START_RX_PAIR">
-                    <description>Starts receiver pairing</description>
-                    <param index="1">0:Spektrum</param>
-                    <param index="2">0:Spektrum DSM2, 1:DSMX</param>
-               </entry>
           </enum>
      </enums>
      <messages>


### PR DESCRIPTION
- Provide for a better way to start receiver pairing
