### PR TITLE
Added M_PI_2 to mavlink_conversions.h if not defined.

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_conversions.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_conversions.h
@@ -9,6 +9,10 @@
 #endif
 #include <math.h>
 
+#ifndef M_PI_2
+    #define M_PI_2 ((float)asin(1))
+#endif
+
 /**
  * @file mavlink_conversions.h
  *


### PR DESCRIPTION
fixes #131 

Added M_PI_2 definition to mavlink_conversions.h if not defined due to older math.h libraries not defining M_PI_2. I ran into this issue when compiling with the xc16 compiler/libraries for the pic16 microcontroller, which does not define M_PI or M_PI_2 anywhere.

asin(1) should be calculated at compile time, but if not it can be replaced with the actual value given enough precision.
