### PR TITLE
bug fix - mavutil forgot to write its timestamped log.

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -251,6 +251,9 @@ class mavfile(object):
                 self.auto_mavlink_version(s)
             msg = self.mav.parse_char(s)
             if msg:
+                if self.logfile and  msg.get_type() != 'BAD_DATA' :
+                    usec = int(time.time() * 1.0e6) & ~3
+                    self.logfile.write(str(struct.pack('>Q', usec) + msg.get_msgbuf()))
                 self.post_message(msg)
                 return msg
                 


### PR DESCRIPTION
mavutil can create the timestamped logfile but forgot
to write anything to it. This fix is to get the log file
written.

Signed-off-by: Quy Tonthat qtonthat@gmail.com
