### PR TITLE
pymavlink: add -c option to mavparms.py to show changed params.

### DIFF
--- a/pymavlink/tools/mavparms.py
+++ b/pymavlink/tools/mavparms.py
@@ -8,6 +8,7 @@ import sys, time, os
 
 from optparse import OptionParser
 parser = OptionParser("mavparms.py [options]")
+parser.add_option("-c", "--changes", dest="changesOnly", default=False, action="store_true", help="Show only changes to parameters.")
 
 (opts, args) = parser.parse_args()
 
@@ -29,14 +30,18 @@ def mavparms(logfile):
             return
         pname = str(m.param_id).strip()
         if len(pname) > 0:
+            if opts.changesOnly is True and pname in parms and parms[pname] != m.param_value:
+                print("%s %-15s %.6f -> %.6f" % (time.asctime(time.localtime(m._timestamp)), pname, parms[pname], m.param_value))
+            
             parms[pname] = m.param_value
 
 total = 0.0
 for filename in args:
     mavparms(filename)
 
-keys = parms.keys()
-keys.sort()
-for p in keys:
-    print("%-15s %.6f" % (p, parms[p]))
+if (opts.changesOnly is False):
+    keys = parms.keys()
+    keys.sort()
+    for p in keys:
+        print("%-15s %.6f" % (p, parms[p]))
     


### PR DESCRIPTION
Added a -c option to mavparams.py tool.  This option has the effect of showing only the changes to parameters inside of a log file.
