### PR TITLE
dict comprehension syntax not supported in python2.6 :(

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -418,7 +418,7 @@ class mavfile(object):
             map = mode_mapping_rover
         if map is None:
             return None
-        inv_map = {a:b for b, a in map.items()}
+        inv_map = dict((a, b) for (b, a) in map.items())
         return inv_map
 
     def set_mode(self, mode):


### PR DESCRIPTION
this is all I had to do to get pymavlink working under python 2.6 on my machine (debian stable).
