### PR TITLE
Match mavlink_system_t.nav_mode size to allowed size in heartbeat msg (32bits).

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -48,7 +48,7 @@ typedef struct __mavlink_system {
     uint8_t type;    ///< Unused, can be used by user to store the system's type
     uint8_t state;   ///< Unused, can be used by user to store the system's state
     uint8_t mode;    ///< Unused, can be used by user to store the system's mode
-    uint8_t nav_mode;    ///< Unused, can be used by user to store the system's navigation mode
+    uint32_t nav_mode;    ///< Unused, can be used by user to store the system's navigation mode
 } mavlink_system_t;
 
 typedef struct __mavlink_message {


### PR DESCRIPTION
Heartbeat message uses 32 bits for "custom_mode" which is aka "nav_mode."
<field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>

Thanks,
-Max
