### PR TITLE
Python decoder. Added array support.

### DIFF
--- a/message_definitions/v1.0/python_array_test.xml
+++ b/message_definitions/v1.0/python_array_test.xml
@@ -1,0 +1,67 @@
+<?xml version='1.0'?>
+<!-- MESSAGE IDs 150 - 240: Space for custom messages in individual projectname_messages.xml files -->
+<mavlink>
+<include>common.xml</include>
+	<messages>
+		<message id="150" name="ARRAY_TEST_0">
+			<description>Array test #0.</description>
+			<field type="uint8_t" name="v1">Stub field</field>
+			<field type="int8_t[4]" name="ar_i8">Value array</field>
+			<field type="uint8_t[4]" name="ar_u8">Value array</field>
+			<field type="uint16_t[4]" name="ar_u16">Value array</field>
+			<field type="uint32_t[4]" name="ar_u32">Value array</field>
+		</message>
+		<message id="151" name="ARRAY_TEST_1">
+			<description>Array test #1.</description>
+			<field type="uint32_t[4]" name="ar_u32">Value array</field>
+		</message>
+		<message id="153" name="ARRAY_TEST_3">
+			<description>Array test #3.</description>
+			<field type="uint8_t" name="v">Stub field</field>
+			<field type="uint32_t[4]" name="ar_u32">Value array</field>
+		</message>
+		<message id="154" name="ARRAY_TEST_4">
+			<description>Array test #4.</description>
+			<field type="uint32_t[4]" name="ar_u32">Value array</field>
+			<field type="uint8_t" name="v">Stub field</field>
+		</message>
+		<message id="155" name="ARRAY_TEST_5">
+			<description>Array test #5.</description>
+			<field type="char[5]" name="c1">Value array</field>
+			<field type="char[5]" name="c2">Value array</field>
+		</message>
+		<message id="156" name="ARRAY_TEST_6">
+			<description>Array test #6.</description>
+			<field type="uint8_t"		name="v1">Stub field</field>
+			<field type="uint16_t"		name="v2">Stub field</field>
+			<field type="uint32_t"		name="v3">Stub field</field>
+			<field type="uint32_t[2]"	name="ar_u32">Value array</field>
+			<field type="int32_t[2]"	name="ar_i32">Value array</field>
+			<field type="uint16_t[2]"	name="ar_u16">Value array</field>
+			<field type="int16_t[2]"	name="ar_i16">Value array</field>
+			<field type="uint8_t[2]"	name="ar_u8">Value array</field>
+			<field type="int8_t[2]"		name="ar_i8">Value array</field>
+			<field type="char[32]"		name="ar_c">Value array</field>
+			<field type="double[2]"		name="ar_d">Value array</field>
+			<field type="float[2]"		name="ar_f">Value array</field>
+		</message>
+		<message id="157" name="ARRAY_TEST_7">
+			<description>Array test #7.</description>
+			<field type="double[2]"		name="ar_d">Value array</field>
+			<field type="float[2]"		name="ar_f">Value array</field>
+			<field type="uint32_t[2]"	name="ar_u32">Value array</field>
+			<field type="int32_t[2]"	name="ar_i32">Value array</field>
+			<field type="uint16_t[2]"	name="ar_u16">Value array</field>
+			<field type="int16_t[2]"	name="ar_i16">Value array</field>
+			<field type="uint8_t[2]"	name="ar_u8">Value array</field>
+			<field type="int8_t[2]"		name="ar_i8">Value array</field>
+			<field type="char[32]"		name="ar_c">Value array</field>
+		</message>
+		<message id="158" name="ARRAY_TEST_8">
+			<description>Array test #8.</description>
+			<field type="uint32_t"		name="v3">Stub field</field>
+			<field type="double[2]"		name="ar_d">Value array</field>
+			<field type="uint16_t[2]"	name="ar_u16">Value array</field>
+		</message>
+	</messages>
+</mavlink>

--- a/pymavlink/generator/mavparse.py
+++ b/pymavlink/generator/mavparse.py
@@ -246,6 +246,7 @@ class MAVXML(object):
         for m in self.message:
             m.wire_length = 0
             m.fieldnames = []
+            m.fieldlengths = []
             m.ordered_fieldnames = []
             if self.sort_fields:
                 m.ordered_fields = sorted(m.fields,
@@ -255,6 +256,13 @@ class MAVXML(object):
                 m.ordered_fields = m.fields
             for f in m.fields:
                 m.fieldnames.append(f.name)
+                L = f.array_length
+                if L == 0:
+                    m.fieldlengths.append(1)
+                elif L > 1 and f.type == 'char':
+                    m.fieldlengths.append(1)
+                else:
+                    m.fieldlengths.append(L)
             for f in m.ordered_fields:
                 f.wire_offset = m.wire_length
                 m.wire_length += f.wire_length
@@ -277,7 +285,7 @@ class MAVXML(object):
     def __str__(self):
         return "MAVXML for %s from %s (%u message, %u enums)" % (
             self.basename, self.filename, len(self.message), len(self.enum))
-    
+
 
 def message_checksum(msg):
     '''calculate a 8-bit checksum of the key fields of a message, so we
@@ -347,7 +355,7 @@ def check_duplicates(xml):
                     return True
                 enummap[s1] = "%s:%u" % (x.filename, enum.linenumber)
                 enummap[s2] = "%s:%u" % (x.filename, enum.linenumber)
-                    
+
     return False
 
 

--- a/pymavlink/tools/python_array_test_recv.py
+++ b/pymavlink/tools/python_array_test_recv.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pymavlink import mavutil
+
+master = mavutil.mavlink_connection("udp::14555", dialect="array_test")
+
+while True:
+    m = master.recv_msg()
+    if m is not None:
+        print m

--- a/pymavlink/tools/python_array_test_send.py
+++ b/pymavlink/tools/python_array_test_send.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import time
+from pymavlink import mavutil
+
+master = mavutil.mavlink_connection("udp::14555", input=False, dialect="array_test")
+while True:
+    master.mav.system_time_send(1,2)
+    master.mav.array_test_0_send(1, [-3, -2, -1, 0], [1,2,3,4], [5,6,7,8], [9,10,11,12])
+    master.mav.array_test_1_send([1,2,3,4])
+    master.mav.array_test_3_send(1, [2,3,4,5])
+    master.mav.array_test_4_send([1,2,3,4], 5)
+    master.mav.array_test_5_send("test1", "test2")
+    master.mav.array_test_6_send(1,2,3, [4,5], [6,7], [8,9], [10,11], [12,13], [14,15], "long value", [1.1, 2.2], [3.3, 4.4])
+    master.mav.array_test_7_send([1.1, 2.2], [3.3, 4.4],
+            [4,5], [6,7], [8,9], [10,11], [12,13], [14,15], "long value")
+    master.mav.array_test_8_send(1, [2.2, 3.3], [14,15])
+    time.sleep(1)
+
+master.close()
+


### PR DESCRIPTION
Now generated python code can successfully decode message containing
array(s) of standard C type. One drawback - only char[] fields decode as
python string, but uint8_t[] decode as python list. As I know there are no
mixing of uint8_t/char in common.xml so it is not a problem. Pull
request also contain tests for array handling. I can not find where
to place pythonic tests so I have placed them in pymavlink/tools dir.
