### PR TITLE
Removed invalid constant rate for ATT

### DIFF
--- a/pymavlink/DFReader.py
+++ b/pymavlink/DFReader.py
@@ -182,7 +182,6 @@ class DFReader(object):
             if rate > self.msg_rate.get(type, 0):
                 self.msg_rate[type] = rate
         self.msg_rate['IMU'] = 50.0
-        self.msg_rate['ATT'] = 50.0
         self.timebase = t
         self.counts_since_gps = {}        
 


### PR DESCRIPTION
ATT can be MED or FAST - 50hz results in improper behavior with ATTITUDE_MED logging.

Are these lines needed for use with ATTITUDE_FAST and IMU? If so, perhaps we should choose the valid value closest to the one we have detected.