### PR TITLE
Added target fields to SET_GLOBAL_POSITION_SETPOINT_INT message.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1531,6 +1531,8 @@
           </message>
           <message id="53" name="SET_GLOBAL_POSITION_SETPOINT_INT">
                <description>Set the current global position setpoint.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint8_t" name="coordinate_frame">Coordinate frame - valid values are only MAV_FRAME_GLOBAL or MAV_FRAME_GLOBAL_RELATIVE_ALT</field>
                <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
                <field type="int32_t" name="longitude">Longitude (WGS84), in degrees * 1E7</field>


### PR DESCRIPTION
The SET_GLOBAL_POSITION_SETPOINT_INT message does not contain fields to specify the target system, in contrast to other command messages, e.g., the SET_LOCAL_POSITION_SETPOINT message.
