### PR TITLE
Plot PX4 flight modes as background colors

### DIFF
--- a/pymavlink/DFReader.py
+++ b/pymavlink/DFReader.py
@@ -257,6 +257,11 @@ class DFReader(object):
                 self.flightmode = mavutil.mode_string_apm(m.ModeNum)
             else:
                 self.flightmode = mavutil.mode_string_acm(m.Mode)
+        if type == 'STAT':
+            if 'MainState' in m._fieldnames:
+                self.flightmode = mavutil.mode_string_px4(m.MainState)
+            else:
+                self.flightmode = "UNKNOWN"
         if type == 'PARM' and getattr(m, 'Name', None) is not None:
             self.params[m.Name] = m.Value
         self._set_time(m)

--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -1200,6 +1200,13 @@ mode_mapping_tracker = {
     16 : 'INITIALISING'
     }
 
+mode_mapping_px4 = {
+    0 : 'MANUAL',
+    1 : 'ATTITUDE',
+    2 : 'EASY',
+    3 : 'AUTO'
+    }
+
 def mode_string_v10(msg):
     '''mode string for 1.0 protocol, from heartbeat'''
     if not msg.base_mode & mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED:
@@ -1229,7 +1236,12 @@ def mode_string_acm(mode_number):
     if mode_number in mode_mapping_acm:
         return mode_mapping_acm[mode_number]
     return "Mode(%u)" % mode_number
-    
+
+def mode_string_px4(mode_number):
+    '''return mode string for PX4 flight stack'''
+    if mode_number in mode_mapping_px4:
+        return mode_mapping_px4[mode_number]
+    return "Mode(%u)" % mode_number
 
 class x25crc(object):
     '''x25 CRC - based on checksum.h from mavlink library'''

--- a/pymavlink/tools/mavgraph.py
+++ b/pymavlink/tools/mavgraph.py
@@ -31,6 +31,13 @@ colourmap = {
         'GUIDED'    : (0.5, 0.5, 1.0),
         'ACRO'      : (1.0, 1.0,   0),
         'CRUISE'    : (  0, 1.0, 1.0)
+        },
+    'px4' : {
+        'MANUAL'    : (1.0,   0,   0),
+        'SEATBELT'  : (  0.5, 0.5,   0),
+        'EASY'      : (  0, 1.0,   0),
+        'AUTO'    : (  0,   0, 1.0),
+        'UNKNOWN'    : (  1.0,   1.0, 1.0)
         }
     }
 
@@ -140,7 +147,7 @@ parser.add_option("--linestyle",  default=None, help="line style")
 parser.add_option("--xaxis",  default=None, help="X axis expression")
 parser.add_option("--zero-time-base",  action='store_true', help="use Z time base for DF logs")
 parser.add_option("--flightmode", default=None,
-                    help="Choose the plot background according to the active flight mode of the specified type, e.g. --flightmode=apm for ArduPilot logs.  Cannot be specified with --xaxis.")
+                    help="Choose the plot background according to the active flight mode of the specified type, e.g. --flightmode=apm for ArduPilot or --flightmode=px4 for PX4 stack logs.  Cannot be specified with --xaxis.")
 (opts, args) = parser.parse_args()
 
 from pymavlink import mavutil
@@ -256,4 +263,5 @@ for fi in range(0, len(filenames)):
         x[i] = []
         y[i] = []
 pylab.show()
+pylab.draw()
 raw_input('press enter to exit....')


### PR DESCRIPTION
This adds mode plotting to PX4 logs and fixes a long-standing issue on MacOS where the plot was only partially drawn - the additional pylab.draw() call fixed this. @tridge Please review.
