### PR TITLE
Allow compiling on Visual Studio 2012 and earlier.

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -1,7 +1,12 @@
 #ifndef MAVLINK_TYPES_H_
 #define MAVLINK_TYPES_H_
 
+// Visual Studio versions before 2013 don't conform to C99.
+#if (defined _MSC_VER) & (_MSC_VER < 1800)
+#include <stdint.h>
+#else
 #include <inttypes.h>
+#endif
 
 #ifndef MAVLINK_MAX_PAYLOAD_LEN
 // it is possible to override this, but be careful!


### PR DESCRIPTION
Hi!

I have replaced the `#include <inttypes.h>` with `#include <stdint.h>` when compiling with Visual Studio 2012 and earlier. This is because Microsoft only added the inttypes.h header required for fully supporting C99 in Visual Studio 2013. This change is OK because mavlink doesn't seem to need inttypes.h but only stdint.h, which Visual Studio 2012 and 2010 do have.

Thanks
Ryan
