### PR TITLE
MAVUtil: Recognize Tri, Hexa, Octa and Tradheli as using the ACM Mode Map

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -442,7 +442,11 @@ class mavfile(object):
         if mav_type is None:
             return None
         map = None
-        if mav_type == mavlink.MAV_TYPE_QUADROTOR:
+        if mav_type in [mavlink.MAV_TYPE_QUADROTOR,
+                        mavlink.MAV_TYPE_HELICOPTER,
+                        mavlink.MAV_TYPE_HEXAROTOR,
+                        mavlink.MAV_TYPE_OCTOROTOR,
+                        mavlink.MAV_TYPE_TRICOPTER]:
             map = mode_mapping_acm
         if mav_type == mavlink.MAV_TYPE_FIXED_WING:
             map = mode_mapping_apm
@@ -1214,7 +1218,11 @@ mode_mapping_px4 = {
 def mode_mapping_byname(mav_type):
     '''return dictionary mapping mode names to numbers, or None if unknown'''
     map = None
-    if mav_type == mavlink.MAV_TYPE_QUADROTOR:
+    if mav_type in [mavlink.MAV_TYPE_QUADROTOR,
+                    mavlink.MAV_TYPE_HELICOPTER,
+                    mavlink.MAV_TYPE_HEXAROTOR,
+                    mavlink.MAV_TYPE_OCTOROTOR,
+                    mavlink.MAV_TYPE_TRICOPTER]:
         map = mode_mapping_acm
     if mav_type == mavlink.MAV_TYPE_FIXED_WING:
         map = mode_mapping_apm
@@ -1230,7 +1238,11 @@ def mode_mapping_byname(mav_type):
 def mode_mapping_bynumber(mav_type):
     '''return dictionary mapping mode numbers to name, or None if unknown'''
     map = None
-    if mav_type == mavlink.MAV_TYPE_QUADROTOR:
+    if mav_type in [mavlink.MAV_TYPE_QUADROTOR,
+                    mavlink.MAV_TYPE_HELICOPTER,
+                    mavlink.MAV_TYPE_HEXAROTOR,
+                    mavlink.MAV_TYPE_OCTOROTOR,
+                    mavlink.MAV_TYPE_TRICOPTER]:
         map = mode_mapping_acm
     if mav_type == mavlink.MAV_TYPE_FIXED_WING:
         map = mode_mapping_apm


### PR DESCRIPTION
Without this change, MAVProxy et al doesn't work for copter frame types
other than quad.  This manifests as an inability to change modes and an
exception whenever one types an unrecognized command (as MAVProxy tries
to map them to mode commands by default)

To have true coverage of the ACM codebase, MAV_TYPE_ROCKET would need to
be added to the list also as ACM uses this for FRAME_SINGLE (MAVLink not
providing an actual Single class). I don't want to be the one to extend
that hackery in to generic MAVLink code though!
