### PR TITLE
inttypes.h is not necessary, only stdint.h is, so just include that.

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
@@ -214,7 +214,7 @@ MAVLINK_HELPER void mavlink_update_checksum(mavlink_message_t* msg, uint8_t c)
  * A typical use scenario of this function call is:
  *
  * @code
- * #include <inttypes.h> // For fixed-width uint8_t type
+ * #include <stdint.h> // For fixed-width uint8_t type
  *
  * mavlink_message_t msg;
  * int chan = 0;

--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -1,7 +1,7 @@
 #ifndef MAVLINK_TYPES_H_
 #define MAVLINK_TYPES_H_
 
-#include <inttypes.h>
+#include <stdint.h>
 
 #ifndef MAVLINK_MAX_PAYLOAD_LEN
 // it is possible to override this, but be careful!


### PR DESCRIPTION
This fixes support for some microcontrollers that don't have inttypes.h in their standard library.
Only issue is that Microsoft's Visual Studio/C++ < 2010 don't have stdint.h, but I don't think that's a supported platform at this point.

I purposefully left MAVLink version 0.9 out of this change, because it's deprecated and old and I don't want to break things for old users of the library.
