### PR TITLE
Fixed the imports for the python generator. 

### DIFF
--- a/pymavlink/generator/mavgen.py
+++ b/pymavlink/generator/mavgen.py
@@ -9,7 +9,7 @@ Released under GNU GPL version 3 or later
 '''
 import sys, textwrap, os
 try:
-    from . import mavparse
+    import mavparse
 except Exception:
     from pymavlink.generator import mavparse
 
@@ -83,7 +83,7 @@ def mavgen(opts, args) :
     # Convert language option to lowercase and validate
     opts.language = opts.language.lower()
     if opts.language == 'python':
-        from . import mavgen_python
+        import mavgen_python
         mavgen_python.generate(opts.output, xml)
     elif opts.language == 'c':
         try:

--- a/pymavlink/generator/mavgen_python.py
+++ b/pymavlink/generator/mavgen_python.py
@@ -7,7 +7,7 @@ Released under GNU GPL version 3 or later
 '''
 
 import sys, textwrap, os
-from . import mavparse, mavtemplate
+import mavparse, mavtemplate
 
 t = mavtemplate.MAVTemplate()
 

--- a/pymavlink/generator/mavparse.py
+++ b/pymavlink/generator/mavparse.py
@@ -295,7 +295,7 @@ class MAVXML(object):
 def message_checksum(msg):
     '''calculate a 8-bit checksum of the key fields of a message, so we
        can detect incompatible XML changes'''
-    from .mavcrc import x25crc
+    from mavcrc import x25crc
     crc = x25crc(msg.name + ' ')
     for f in msg.ordered_fields:
         crc.accumulate(f.type + ' ')

--- a/pymavlink/generator/mavtemplate.py
+++ b/pymavlink/generator/mavtemplate.py
@@ -6,7 +6,7 @@ Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
 
-from .mavparse import MAVParseError
+from mavparse import MAVParseError
 
 class MAVTemplate(object):
     '''simple templating system'''


### PR DESCRIPTION
As far as I know, you can just use the plain import command as long as your files are on the same directory. Message generation would not work for me with out this fix.

I tried running mavgenerate.py and mavgen.py on ubuntu 12.04. 
