### PR TITLE
Added JAVA generator from Arthur Benemann

### DIFF
--- a/pymavlink/generator/java/lib/Messages/MAVLinkMessage.java
+++ b/pymavlink/generator/java/lib/Messages/MAVLinkMessage.java
@@ -1,0 +1,21 @@
+
+package com.MAVLink.Messages;
+
+import java.io.Serializable;
+
+public abstract class MAVLinkMessage implements Serializable {
+	private static final long serialVersionUID = -7754622750478538539L;
+	// The MAVLink message classes have been changed to implement Serializable, 
+	// this way is possible to pass a mavlink message trought the Service-Acctivity interface
+	
+	/**
+	 *  Simply a common interface for all MAVLink Messages
+	 */
+	
+	public  int sysid;
+	public int compid;
+	public int msgid;
+	public abstract MAVLinkPacket pack();
+	public abstract void unpack(MAVLinkPayload payload);
+}
+	

--- a/pymavlink/generator/java/lib/Messages/MAVLinkPayload.java
+++ b/pymavlink/generator/java/lib/Messages/MAVLinkPayload.java
@@ -1,0 +1,121 @@
+package com.MAVLink.Messages;
+
+import java.nio.ByteBuffer;
+
+public class MAVLinkPayload {
+
+	public static final int MAX_PAYLOAD_SIZE = 512;
+	
+	public ByteBuffer payload;
+	public int index;
+
+	public MAVLinkPayload() {
+		payload = ByteBuffer.allocate(MAX_PAYLOAD_SIZE);
+	}
+
+	public ByteBuffer getData() {
+		return payload;
+	}
+
+	public int size() {
+		return payload.position();
+	}
+
+	public void add(byte c) {
+		payload.put(c);
+	}
+
+	public void resetIndex() {
+		index = 0;
+	}
+
+	public byte getByte() {
+		byte result = 0;
+		result |= (payload.get(index + 0) & 0xFF);
+		index += 1;
+		return (byte) result;
+	}
+
+	public short getShort() {
+		short result = 0;
+		result |= (payload.get(index + 1) & 0xFF) << 8;
+		result |= (payload.get(index + 0) & 0xFF);
+		index += 2;
+		return (short) result;
+	}
+
+	public int getInt() {
+		int result = 0;
+		result |= (payload.get(index + 3) & (int)0xFF) << 24;
+		result |= (payload.get(index + 2) & (int)0xFF) << 16;
+		result |= (payload.get(index + 1) & (int)0xFF) << 8;
+		result |= (payload.get(index + 0) & (int)0xFF);
+		index += 4;
+		return (int) result;
+	}
+
+	public long getLong() {
+		long result = 0;
+		result |= (payload.get(index + 7) & (long)0xFF) << 56;
+		result |= (payload.get(index + 6) & (long)0xFF) << 48;
+		result |= (payload.get(index + 5) & (long)0xFF) << 40;
+		result |= (payload.get(index + 4) & (long)0xFF) << 32;
+		result |= (payload.get(index + 3) & (long)0xFF) << 24;
+		result |= (payload.get(index + 2) & (long)0xFF) << 16;
+		result |= (payload.get(index + 1) & (long)0xFF) << 8;
+		result |= (payload.get(index + 0) & (long)0xFF);
+		index += 8;
+		return (long) result;
+	}
+	
+
+	public long getLongReverse() {
+                long result = 0;
+                result |= (payload.get(index + 0) & (long)0xFF) << 56;
+                result |= (payload.get(index + 1) & (long)0xFF) << 48;
+                result |= (payload.get(index + 2) & (long)0xFF) << 40;
+                result |= (payload.get(index + 3) & (long)0xFF) << 32;
+                result |= (payload.get(index + 4) & (long)0xFF) << 24;
+                result |= (payload.get(index + 5) & (long)0xFF) << 16;
+                result |= (payload.get(index + 6) & (long)0xFF) << 8;
+                result |= (payload.get(index + 7) & (long)0xFF);
+                index += 8;
+                return (long) result;
+        }
+
+	public float getFloat() {
+		return Float.intBitsToFloat(getInt());
+	}
+	
+	public void putByte(byte data) {
+		add(data);
+	}
+
+	public void putShort(short data) {
+		add((byte) (data >> 0));
+		add((byte) (data >> 8));
+	}
+
+	public void putInt(int data) {
+		add((byte) (data >> 0));
+		add((byte) (data >> 8));
+		add((byte) (data >> 16));
+		add((byte) (data >> 24));
+	}
+
+	public void putLong(long data) {
+		add((byte) (data >> 0));
+		add((byte) (data >> 8));
+		add((byte) (data >> 16));
+		add((byte) (data >> 24));
+		add((byte) (data >> 32));
+		add((byte) (data >> 40));
+		add((byte) (data >> 48));
+		add((byte) (data >> 56));
+	}
+
+	public void putFloat(float data) {
+		putInt(Float.floatToIntBits(data));
+	}
+
+}

--- a/pymavlink/generator/java/lib/Messages/MAVLinkStats.java
+++ b/pymavlink/generator/java/lib/Messages/MAVLinkStats.java
@@ -1,0 +1,69 @@
+package com.MAVLink.Messages;
+
+/**
+ * Storage for MAVLink Packet and Error statistics
+ * 
+ */
+public class MAVLinkStats /* implements Serializable */{
+
+	public int receivedPacketCount;
+
+	public int crcErrorCount;
+
+	public int lostPacketCount;
+
+	private int lastPacketSeq;
+
+	/**
+	 * Check the new received packet to see if has lost someone between this and
+	 * the last packet
+	 * 
+	 * @param packet
+	 *            Packet that should be checked
+	 */
+	public void newPacket(MAVLinkPacket packet) {
+		advanceLastPacketSequence();
+		if (hasLostPackets(packet)) {
+			updateLostPacketCount(packet);
+		}
+		lastPacketSeq = packet.seq;
+		receivedPacketCount++;
+	}
+
+	private void updateLostPacketCount(MAVLinkPacket packet) {
+		int lostPackets;
+		if (packet.seq - lastPacketSeq < 0) {
+			lostPackets = (packet.seq - lastPacketSeq) + 255;
+		} else {
+			lostPackets = (packet.seq - lastPacketSeq);
+		}
+		lostPacketCount += lostPackets;
+	}
+
+	private boolean hasLostPackets(MAVLinkPacket packet) {
+		return lastPacketSeq > 0 && packet.seq != lastPacketSeq;
+	}
+
+	private void advanceLastPacketSequence() {
+		// wrap from 255 to 0 if necessary
+		lastPacketSeq = (lastPacketSeq + 1) & 0xFF;
+	}
+
+	/**
+	 * Called when a CRC error happens on the parser
+	 */
+	public void crcError() {
+		crcErrorCount++;
+	}
+
+	/**
+	 * Resets statistics for this MAVLink.
+	 */
+	public void mavlinkResetStats() {
+		lastPacketSeq = -1;
+		lostPacketCount = 0;
+		crcErrorCount = 0;
+		receivedPacketCount = 0;
+	}
+
+}

--- a/pymavlink/generator/java/lib/Parser.java
+++ b/pymavlink/generator/java/lib/Parser.java
@@ -1,0 +1,127 @@
+package com.MAVLink;
+
+import com.MAVLink.Messages.MAVLinkPacket;
+import com.MAVLink.Messages.MAVLinkStats;
+
+public class Parser {
+
+	/**
+	 * States from the parsing state machine
+	 */
+	enum MAV_states {
+		MAVLINK_PARSE_STATE_UNINIT, MAVLINK_PARSE_STATE_IDLE, MAVLINK_PARSE_STATE_GOT_STX, MAVLINK_PARSE_STATE_GOT_LENGTH, MAVLINK_PARSE_STATE_GOT_SEQ, MAVLINK_PARSE_STATE_GOT_SYSID, MAVLINK_PARSE_STATE_GOT_COMPID, MAVLINK_PARSE_STATE_GOT_MSGID, MAVLINK_PARSE_STATE_GOT_CRC1, MAVLINK_PARSE_STATE_GOT_PAYLOAD
+	}
+
+	MAV_states state = MAV_states.MAVLINK_PARSE_STATE_UNINIT;
+
+	static boolean msg_received;
+
+	public MAVLinkStats stats = new MAVLinkStats();
+	private MAVLinkPacket m;
+
+	/**
+	 * This is a convenience function which handles the complete MAVLink
+	 * parsing. the function will parse one byte at a time and return the
+	 * complete packet once it could be successfully decoded. Checksum and other
+	 * failures will be silently ignored.
+	 * 
+	 * @param c
+	 *            The char to parse
+	 */
+	public MAVLinkPacket mavlink_parse_char(int c) {
+		msg_received = false;
+
+		switch (state) {
+		case MAVLINK_PARSE_STATE_UNINIT:
+		case MAVLINK_PARSE_STATE_IDLE:
+
+			if (c == MAVLinkPacket.MAVLINK_STX) {
+				state = MAV_states.MAVLINK_PARSE_STATE_GOT_STX;
+				m = new MAVLinkPacket();
+			}
+			break;
+
+		case MAVLINK_PARSE_STATE_GOT_STX:
+			if (msg_received) {
+				msg_received = false;
+				state = MAV_states.MAVLINK_PARSE_STATE_IDLE;
+			} else {
+				m.len = c;
+				state = MAV_states.MAVLINK_PARSE_STATE_GOT_LENGTH;
+			}
+			break;
+
+		case MAVLINK_PARSE_STATE_GOT_LENGTH:
+			m.seq = c;
+			state = MAV_states.MAVLINK_PARSE_STATE_GOT_SEQ;
+			break;
+
+		case MAVLINK_PARSE_STATE_GOT_SEQ:
+			m.sysid = c;
+			state = MAV_states.MAVLINK_PARSE_STATE_GOT_SYSID;
+			break;
+
+		case MAVLINK_PARSE_STATE_GOT_SYSID:
+			m.compid = c;
+			state = MAV_states.MAVLINK_PARSE_STATE_GOT_COMPID;
+			break;
+
+		case MAVLINK_PARSE_STATE_GOT_COMPID:
+			m.msgid = c;
+			if (m.len == 0) {
+				state = MAV_states.MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+			} else {
+				state = MAV_states.MAVLINK_PARSE_STATE_GOT_MSGID;
+			}
+			break;
+
+		case MAVLINK_PARSE_STATE_GOT_MSGID:
+			m.payload.add((byte) c);
+			if (m.payloadIsFilled()) {
+				state = MAV_states.MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+			}
+			break;
+
+		case MAVLINK_PARSE_STATE_GOT_PAYLOAD:
+			m.generateCRC();
+			// Check first checksum byte
+			if (c != m.crc.getLSB()) {
+				msg_received = false;
+				state = MAV_states.MAVLINK_PARSE_STATE_IDLE;
+				if (c == MAVLinkPacket.MAVLINK_STX) {
+					state = MAV_states.MAVLINK_PARSE_STATE_GOT_STX;
+					m.crc.start_checksum();
+				}
+				stats.crcError();
+			} else {
+				state = MAV_states.MAVLINK_PARSE_STATE_GOT_CRC1;
+			}
+			break;
+
+		case MAVLINK_PARSE_STATE_GOT_CRC1:
+			// Check second checksum byte
+			if (c != m.crc.getMSB()) {
+				msg_received = false;
+				state = MAV_states.MAVLINK_PARSE_STATE_IDLE;
+				if (c == MAVLinkPacket.MAVLINK_STX) {
+					state = MAV_states.MAVLINK_PARSE_STATE_GOT_STX;
+					m.crc.start_checksum();
+				}
+				stats.crcError();
+			} else { // Successfully received the message
+				stats.newPacket(m);
+				msg_received = true;
+				state = MAV_states.MAVLINK_PARSE_STATE_IDLE;
+			}
+
+			break;
+
+		}
+		if (msg_received) {
+			return m;
+		} else {
+			return null;
+		}
+	}
+
+}

--- a/pymavlink/generator/mavgen.py
+++ b/pymavlink/generator/mavgen.py
@@ -23,7 +23,7 @@ DEFAULT_ERROR_LIMIT = 200
 DEFAULT_VALIDATE = True
 
 # List the supported languages. This is done globally because it's used by the GUI wrapper too
-supportedLanguages = ["C", "CS", "JavaScript", "Python", "WLua"]
+supportedLanguages = ["C", "CS", "JavaScript", "Python", "WLua", "ObjC", "Java"]
 
 def mavgen(opts, args) :
     """Generate mavlink message formatters and parsers (C and Python ) using options
@@ -131,6 +131,12 @@ def mavgen(opts, args) :
         except Exception:
             from pymavlink.generator import mavgen_objc
         mavgen_objc.generate(opts.output, xml)
+    elif opts.language == 'java':
+        try:
+            import mavgen_java
+        except Exception:
+            from pymavlink.generator import mavgen_java
+        mavgen_java.generate(opts.output, xml)
     else:
         print("Unsupported language %s" % opts.language)
 

--- a/pymavlink/generator/mavgen_c.py
+++ b/pymavlink/generator/mavgen_c.py
@@ -17,7 +17,7 @@ def generate_version_h(directory, xml):
     t.write(f,'''
 /** @file
  *	@brief MAVLink comm protocol built from ${basename}.xml
- *	@see http://pixhawk.ethz.ch/software/mavlink
+ *	@see http://mavlink.org
  */
 #ifndef MAVLINK_VERSION_H
 #define MAVLINK_VERSION_H
@@ -36,7 +36,7 @@ def generate_mavlink_h(directory, xml):
     t.write(f,'''
 /** @file
  *	@brief MAVLink comm protocol built from ${basename}.xml
- *	@see http://pixhawk.ethz.ch/software/mavlink
+ *	@see http://mavlink.org
  */
 #ifndef MAVLINK_H
 #define MAVLINK_H
@@ -70,7 +70,7 @@ def generate_main_h(directory, xml):
     t.write(f, '''
 /** @file
  *	@brief MAVLink comm protocol generated from ${basename}.xml
- *	@see http://qgroundcontrol.org/mavlink/
+ *	@see http://mavlink.org
  */
 #ifndef ${basename_upper}_H
 #define ${basename_upper}_H

--- a/pymavlink/generator/mavgen_java.py
+++ b/pymavlink/generator/mavgen_java.py
@@ -1,0 +1,620 @@
+#!/usr/bin/env python
+'''
+    parse a MAVLink protocol XML file and generate a Java implementation
+    
+    Copyright Andrew Tridgell 2011
+    Released under GNU GPL version 3 or later
+    '''
+
+import sys, textwrap, os, time
+import mavparse, mavtemplate
+
+t = mavtemplate.MAVTemplate()
+
+def generate_version_h(directory, xml):
+    '''generate version.h'''
+    f = open(os.path.join(directory, "version.h"), mode='w')
+    t.write(f,'''
+        /** @file
+        *	@brief MAVLink comm protocol built from ${basename}.xml
+        *	@see http://mavlink.org
+        */
+        #ifndef MAVLINK_VERSION_H
+        #define MAVLINK_VERSION_H
+        
+        #define MAVLINK_BUILD_DATE "${parse_time}"
+        #define MAVLINK_WIRE_PROTOCOL_VERSION "${wire_protocol_version}"
+        #define MAVLINK_MAX_DIALECT_PAYLOAD_SIZE ${largest_payload}
+        
+        #endif // MAVLINK_VERSION_H
+        ''', xml)
+    f.close()
+
+def generate_mavlink_h(directory, xml):
+    '''generate mavlink.h'''
+    f = open(os.path.join(directory, "mavlink.h"), mode='w')
+    t.write(f,'''
+        /** @file
+        *	@brief MAVLink comm protocol built from ${basename}.xml
+        *	@see http://mavlink.org
+        */
+        #ifndef MAVLINK_H
+        #define MAVLINK_H
+        
+        #ifndef MAVLINK_STX
+        #define MAVLINK_STX ${protocol_marker}
+        #endif
+        
+        #ifndef MAVLINK_ENDIAN
+        #define MAVLINK_ENDIAN ${mavlink_endian}
+        #endif
+        
+        #ifndef MAVLINK_ALIGNED_FIELDS
+        #define MAVLINK_ALIGNED_FIELDS ${aligned_fields_define}
+        #endif
+        
+        #ifndef MAVLINK_CRC_EXTRA
+        #define MAVLINK_CRC_EXTRA ${crc_extra_define}
+        #endif
+        
+        #include "version.h"
+        #include "${basename}.h"
+        
+        #endif // MAVLINK_H
+        ''', xml)
+    f.close()
+
+
+def generate_enums(basename, xml):
+    '''generate main header per XML file'''
+    directory = os.path.join(basename, '''enums''')
+    mavparse.mkdir_p(directory)
+    for en in xml.enum:
+        f = open(os.path.join(directory, en.name+".java"), mode='w')
+        t.write(f, '''
+            /** ${description}
+            */
+            package com.MAVLink.Messages.enums;
+            
+            public class ${name} {
+            ${{entry:	public static final int ${name} = ${value}; /* ${description} |${{param:${description}| }} */
+            }}
+            }
+            ''', en)
+        f.close()
+
+
+
+def generate_CRC(directory, xml):
+    # and message CRCs array
+    xml.message_crcs_array = ''
+    for crc in xml.message_crcs:
+        xml.message_crcs_array += '%u, ' % crc
+    xml.message_crcs_array = xml.message_crcs_array[:-2]
+    
+    f = open(os.path.join(directory, xml.basename + "CRC.java"), mode='w')
+    t.write(f,'''
+        package com.MAVLink.Messages;
+        
+        /**
+        * X.25 CRC calculation for MAVlink messages. The checksum must be initialized,
+        * updated with witch field of the message, and then finished with the message
+        * id.
+        *
+        */
+        public class CRC {
+        private final int[] MAVLINK_MESSAGE_CRCS = {${message_crcs_array}};
+        private static final int CRC_INIT_VALUE = 0xffff;
+        private int CRCvalue;
+        
+        /**
+        * Accumulate the X.25 CRC by adding one char at a time.
+        *
+        * The checksum function adds the hash of one char at a time to the 16 bit
+        * checksum (uint16_t).
+        *
+        * @param data
+        *            new char to hash
+        * @param crcAccum
+        *            the already accumulated checksum
+        **/
+        public  void update_checksum(int data) {
+		int tmp;
+		data= data & 0xff;	//cast because we want an unsigned type
+		tmp = data ^ (CRCvalue & 0xff);
+		tmp ^= (tmp << 4) & 0xff;
+		CRCvalue = ((CRCvalue >> 8) & 0xff) ^ (tmp << 8) ^ (tmp << 3)
+        ^ ((tmp >> 4) & 0xf);
+        }
+        
+        /**
+        * Finish the CRC calculation of a message, by running the CRC with the
+        * Magic Byte. This Magic byte has been defined in MAVlink v1.0.
+        *
+        * @param msgid
+        *            The message id number
+        */
+        public  void finish_checksum(int msgid) {
+		update_checksum(MAVLINK_MESSAGE_CRCS[msgid]);
+        }
+        
+        /**
+        * Initialize the buffer for the X.25 CRC
+        *
+        */
+        public void start_checksum() {
+		CRCvalue = CRC_INIT_VALUE;
+        }
+        
+        public int getMSB() {
+		return ((CRCvalue >> 8) & 0xff);
+        }
+        
+        public int getLSB() {
+		return (CRCvalue & 0xff);
+        }
+        
+        public CRC() {
+		start_checksum();
+        }
+        
+        }
+        ''',xml)
+    
+    f.close()
+
+
+def generate_message_h(directory, m):
+    '''generate per-message header for a XML file'''
+    f = open(os.path.join(directory, 'msg_%s.java' % m.name_lower), mode='w')
+    t.write(f, '''
+        // MESSAGE ${name} PACKING
+        package com.MAVLink.Messages.ardupilotmega;
+        
+        import com.MAVLink.Messages.MAVLinkMessage;
+        import com.MAVLink.Messages.MAVLinkPacket;
+        import com.MAVLink.Messages.MAVLinkPayload;
+        //import android.util.Log;
+        
+        /**
+        * ${description}
+        */
+        public class msg_${name_lower} extends MAVLinkMessage{
+        
+        public static final int MAVLINK_MSG_ID_${name} = ${id};
+        public static final int MAVLINK_MSG_LENGTH = ${wire_length};
+        private static final long serialVersionUID = MAVLINK_MSG_ID_${name};
+        
+        
+        ${{ordered_fields: 	/**
+        * ${description}
+        */
+        public ${type} ${name}${array_suffix};
+        }}
+        
+        /**
+        * Generates the payload for a mavlink message for a message of this type
+        * @return
+        */
+        public MAVLinkPacket pack(){
+		MAVLinkPacket packet = new MAVLinkPacket();
+		packet.len = MAVLINK_MSG_LENGTH;
+		packet.sysid = 255;
+		packet.compid = 190;
+		packet.msgid = MAVLINK_MSG_ID_${name};
+        ${{ordered_fields:		${packField}
+        }}
+		return packet;
+        }
+        
+        /**
+        * Decode a ${name_lower} message into this class fields
+        *
+        * @param payload The message to decode
+        */
+        public void unpack(MAVLinkPayload payload) {
+        payload.resetIndex();
+        ${{ordered_fields:	    ${unpackField}
+        }}
+        }
+        
+        /**
+        * Constructor for a new message, just initializes the msgid
+        */
+        public msg_${name_lower}(){
+    	msgid = MAVLINK_MSG_ID_${name};
+        }
+        
+        /**
+        * Constructor for a new message, initializes the message with the payload
+        * from a mavlink packet
+        *
+        */
+        public msg_${name_lower}(MAVLinkPacket mavLinkPacket){
+        this.sysid = mavLinkPacket.sysid;
+        this.compid = mavLinkPacket.compid;
+        this.msgid = MAVLINK_MSG_ID_${name};
+        unpack(mavLinkPacket.payload);
+        //Log.d("MAVLink", "${name}");
+        //Log.d("MAVLINK_MSG_ID_${name}", toString());
+        }
+        
+        ${{ordered_fields: ${getText} }}
+        /**
+        * Returns a string with the MSG name and data
+        */
+        public String toString(){
+    	return "MAVLINK_MSG_ID_${name} -"+${{ordered_fields:" ${name}:"+${name}+}}"";
+        }
+        }
+        ''', m)
+    f.close()
+
+
+def generate_MAVLinkMessage(directory, xml_list):
+    f = open(os.path.join(directory, "MAVLinkPacket.java"), mode='w')
+    f.write('''package com.MAVLink.Messages;
+        
+        import java.io.Serializable;
+        import android.util.Log;
+        import com.MAVLink.Messages.ardupilotmega.*;
+        
+        /**
+        * Common interface for all MAVLink Messages
+        * Packet Anatomy
+        * This is the anatomy of one packet. It is inspired by the CAN and SAE AS-4 standards.
+        
+        * Byte Index  Content              Value       Explanation
+        * 0            Packet start sign  v1.0: 0xFE   Indicates the start of a new packet.  (v0.9: 0x55)
+        * 1            Payload length      0 - 255     Indicates length of the following payload.
+        * 2            Packet sequence     0 - 255     Each component counts up his send sequence. Allows to detect packet loss
+        * 3            System ID           1 - 255     ID of the SENDING system. Allows to differentiate different MAVs on the same network.
+        * 4            Component ID        0 - 255     ID of the SENDING component. Allows to differentiate different components of the same system, e.g. the IMU and the autopilot.
+        * 5            Message ID          0 - 255     ID of the message - the id defines what the payload means and how it should be correctly decoded.
+        * 6 to (n+6)   Payload             0 - 255     Data of the message, depends on the message id.
+        * (n+7)to(n+8) Checksum (low byte, high byte)  ITU X.25/SAE AS-4 hash, excluding packet start sign, so bytes 1..(n+6) Note: The checksum also includes MAVLINK_CRC_EXTRA (Number computed from message fields. Protects the packet from decoding a different version of the same packet but with different variables).
+        
+        * The checksum is the same as used in ITU X.25 and SAE AS-4 standards (CRC-16-CCITT), documented in SAE AS5669A. Please see the MAVLink source code for a documented C-implementation of it. LINK TO CHECKSUM
+        * The minimum packet length is 8 bytes for acknowledgement packets without payload
+        * The maximum packet length is 263 bytes for full payload
+        *
+        */
+        public class MAVLinkPacket implements Serializable {
+        private static final long serialVersionUID = 2095947771227815314L;
+        
+        public static final int MAVLINK_STX = 254;
+        
+        /**
+        * Message length. NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
+        */
+        public int len;
+        /**
+        * Message sequence
+        */
+        public int seq;
+        /**
+        * ID of the SENDING system. Allows to differentiate different MAVs on the
+        * same network.
+        */
+        public int sysid;
+        /**
+        * ID of the SENDING component. Allows to differentiate different components
+        * of the same system, e.g. the IMU and the autopilot.
+        */
+        public int compid;
+        /**
+        * ID of the message - the id defines what the payload means and how it
+        * should be correctly decoded.
+        */
+        public int msgid;
+        /**
+        * Data of the message, depends on the message id.
+        */
+        public MAVLinkPayload payload;
+        /**
+        * ITU X.25/SAE AS-4 hash, excluding packet start sign, so bytes 1..(n+6)
+        * Note: The checksum also includes MAVLINK_CRC_EXTRA (Number computed from
+        * message fields. Protects the packet from decoding a different version of
+        * the same packet but with different variables).
+        */
+        public CRC crc;
+        
+        public MAVLinkPacket(){
+		payload = new MAVLinkPayload();
+        }
+        
+        /**
+        * Check if the size of the Payload is equal to the "len" byte
+        */
+        public boolean payloadIsFilled() {
+		if (payload.size() >= MAVLinkPayload.MAX_PAYLOAD_SIZE-1) {
+        Log.d("MAV","Buffer overflow");
+        return true;
+		}
+		return (payload.size() == len);
+        }
+        
+        /**
+        * Update CRC for this packet.
+        */
+        public void generateCRC(){
+		crc = new CRC();
+		crc.update_checksum(len);
+		crc.update_checksum(seq);
+		crc.update_checksum(sysid);
+		crc.update_checksum(compid);
+		crc.update_checksum(msgid);
+		payload.resetIndex();
+		for (int i = 0; i < payload.size(); i++) {
+        crc.update_checksum(payload.getByte());
+		}
+		crc.finish_checksum(msgid);
+        }
+        
+        /**
+        * Encode this packet for transmission.
+        *
+        * @return Array with bytes to be transmitted
+        */
+        public byte[] encodePacket() {
+		byte[] buffer = new byte[6 + len + 2];
+		int i = 0;
+		buffer[i++] = (byte) MAVLINK_STX;
+		buffer[i++] = (byte) len;
+		buffer[i++] = (byte) seq;
+		buffer[i++] = (byte) sysid;
+		buffer[i++] = (byte) compid;
+		buffer[i++] = (byte) msgid;
+		for (int j = 0; j < payload.size(); j++) {
+        buffer[i++] = payload.payload.get(j);
+		}
+		generateCRC();
+		buffer[i++] = (byte) (crc.getLSB());
+		buffer[i++] = (byte) (crc.getMSB());
+		return buffer;
+        }
+        
+        /**
+        * Unpack the data in this packet and return a MAVLink message
+        *
+        * @return MAVLink message decoded from this packet
+        */
+        public MAVLinkMessage unpack() {
+		switch (msgid) {
+        ''')
+    for xml in xml_list:
+        t.write(f, '''
+            ${{message:		case msg_${name_lower}.MAVLINK_MSG_ID_${name}:
+			return  new msg_${name_lower}(this);
+            }}
+            ''',xml)
+    f.write('''		default:
+        Log.d("MAVLink", "UNKNOW MESSAGE - " + msgid);
+        return null;
+		}
+        }
+        
+        }
+        
+        ''')
+    
+    f.close()
+
+def copy_fixed_headers(directory, xml):
+    '''copy the fixed protocol headers to the target directory'''
+    import shutil
+    hlist = [ 'Parser.java', 'Messages/MAVLinkMessage.java', 'Messages/MAVLinkPayload.java', 'Messages/MAVLinkStats.java' ]
+    basepath = os.path.dirname(os.path.realpath(__file__))
+    srcpath = os.path.join(basepath, 'java/lib')
+    print("Copying fixed headers")
+    for h in hlist:
+        src = os.path.realpath(os.path.join(srcpath, h))
+        dest = os.path.realpath(os.path.join(directory, h))
+        if src == dest:
+            continue
+        destdir = os.path.realpath(os.path.join(directory, 'Messages'))
+        try:
+            os.makedirs(destdir)
+        except:
+            print("Not re-creating Messages directory")
+        shutil.copy(src, dest)
+
+class mav_include(object):
+    def __init__(self, base):
+        self.base = base
+
+
+def mavfmt(field):
+    '''work out the struct format for a type'''
+    map = {
+        'float'    : 'float',
+        'double'   : 'double',
+        'char'     : 'byte',
+        'int8_t'   : 'byte',
+        'uint8_t'  : 'byte',
+        'uint8_t_mavlink_version'  : 'byte',
+        'int16_t'  : 'short',
+        'uint16_t' : 'short',
+        'int32_t'  : 'int',
+        'uint32_t' : 'int',
+        'int64_t'  : 'long',
+        'uint64_t' : 'long',
+    }
+    
+    return map[field.type]
+
+def generate_one(basename, xml):
+    '''generate headers for one XML file'''
+    
+    directory = os.path.join(basename, xml.basename)
+    
+    print("Generating Java implementation in directory %s" % directory)
+    mavparse.mkdir_p(directory)
+    
+    if xml.little_endian:
+        xml.mavlink_endian = "MAVLINK_LITTLE_ENDIAN"
+    else:
+        xml.mavlink_endian = "MAVLINK_BIG_ENDIAN"
+    
+    if xml.crc_extra:
+        xml.crc_extra_define = "1"
+    else:
+        xml.crc_extra_define = "0"
+    
+    if xml.sort_fields:
+        xml.aligned_fields_define = "1"
+    else:
+        xml.aligned_fields_define = "0"
+    
+    # work out the included headers
+    xml.include_list = []
+    for i in xml.include:
+        base = i[:-4]
+        xml.include_list.append(mav_include(base))
+    
+    # form message lengths array
+    xml.message_lengths_array = ''
+    for mlen in xml.message_lengths:
+        xml.message_lengths_array += '%u, ' % mlen
+    xml.message_lengths_array = xml.message_lengths_array[:-2]
+    
+    
+    
+    # form message info array
+    xml.message_info_array = ''
+    for name in xml.message_names:
+        if name is not None:
+            xml.message_info_array += 'MAVLINK_MESSAGE_INFO_%s, ' % name
+        else:
+            # Several C compilers don't accept {NULL} for
+            # multi-dimensional arrays and structs
+            # feed the compiler a "filled" empty message
+            xml.message_info_array += '{"EMPTY",0,{{"","",MAVLINK_TYPE_CHAR,0,0,0}}}, '
+    xml.message_info_array = xml.message_info_array[:-2]
+    
+    # add some extra field attributes for convenience with arrays
+    for m in xml.message:
+        m.msg_name = m.name
+        if xml.crc_extra:
+            m.crc_extra_arg = ", %s" % m.crc_extra
+        else:
+            m.crc_extra_arg = ""
+        for f in m.fields:
+            if f.print_format is None:
+                f.c_print_format = 'NULL'
+            else:
+                f.c_print_format = '"%s"' % f.print_format
+            f.getText = ''
+            if f.array_length != 0:
+                f.array_suffix = '[] = new %s[%u]' % (mavfmt(f),f.array_length)
+                f.array_prefix = '*'
+                f.array_tag = '_array'
+                f.array_arg = ', %u' % f.array_length
+                f.array_return_arg = '%s, %u, ' % (f.name, f.array_length)
+                f.array_const = 'const '
+                f.decode_left = ''
+                f.decode_right = 'm.%s' % (f.name)
+                
+                f.unpackField = ''' for (int i = 0; i < %s.length; i++) {
+                    %s[i] = payload.get%s();
+                    }''' % (f.name, f.name, mavfmt(f).title() )
+                f.packField = ''' for (int i = 0; i < %s.length; i++) {
+                    packet.payload.put%s(%s[i]);
+                    }''' % (f.name, mavfmt(f).title(),f.name)
+                f.return_type = 'uint16_t'
+                f.get_arg = ', %s *%s' % (f.type, f.name)
+                if f.type == 'char':
+                    f.c_test_value = '"%s"' % f.test_value
+                    f.getText = '''/**
+                        * Sets the buffer of this message with a string, adds the necessary padding
+                        */
+                        public void set%s(String str) {
+                        int len = Math.min(str.length(), %d);
+                        for (int i=0; i<len; i++) {
+                        %s[i] = (byte) str.charAt(i);
+                        }
+                        for (int i=len; i<%d; i++) {			// padding for the rest of the buffer
+                        %s[i] = 0;
+                        }
+                        }
+                        
+                        /**
+                        * Gets the message, formated as a string
+                        */
+                        public String get%s() {
+                        String result = "";
+                        for (int i = 0; i < %d; i++) {
+                        if (%s[i] != 0)
+                        result = result + (char) %s[i];
+                        else
+                        break;
+                        }
+                        return result;
+                        
+                        }''' % (f.name.title(),f.array_length,f.name,f.array_length,f.name,f.name.title(),f.array_length,f.name,f.name)
+                else:
+                    test_strings = []
+                    for v in f.test_value:
+                        test_strings.append(str(v))
+                    f.c_test_value = '{ %s }' % ', '.join(test_strings)
+            else:
+                f.array_suffix = ''
+                f.array_prefix = ''
+                f.array_tag = ''
+                f.array_arg = ''
+                f.array_return_arg = ''
+                f.array_const = ''
+                f.decode_left =  '%s' % (f.name)
+                f.decode_right = ''
+                f.unpackField = '%s = payload.get%s();' % (f.name, mavfmt(f).title())
+                f.packField = 'packet.payload.put%s(%s);' % (mavfmt(f).title(),f.name)                   
+                
+                
+                f.get_arg = ''
+                f.return_type = f.type
+                if f.type == 'char':
+                    f.c_test_value = "'%s'" % f.test_value
+                elif f.type == 'uint64_t':
+                    f.c_test_value = "%sULL" % f.test_value                    
+                elif f.type == 'int64_t':
+                    f.c_test_value = "%sLL" % f.test_value                    
+                else:
+                    f.c_test_value = f.test_value
+    
+    # cope with uint8_t_mavlink_version
+    for m in xml.message:
+        m.arg_fields = []
+        m.array_fields = []
+        m.scalar_fields = []
+        for f in m.ordered_fields:
+            if f.array_length != 0:
+                m.array_fields.append(f)
+            else:
+                m.scalar_fields.append(f)
+        for f in m.fields:
+            if not f.omit_arg:
+                m.arg_fields.append(f)
+                f.putname = f.name
+            else:
+                f.putname = f.const_value
+    
+    # fix types to java
+    for m in xml.message:
+        for f in m.ordered_fields:
+            f.type = mavfmt(f)
+    
+    #generate_mavlink_h(directory, xml)
+    #generate_version_h(directory, xml)
+    generate_CRC(directory, xml)
+    
+    for m in xml.message:
+        generate_message_h(directory, m)
+
+
+def generate(basename, xml_list):
+    '''generate complete MAVLink Java implemenation'''
+    for xml in xml_list:
+        generate_one(basename, xml)
+        generate_enums(basename, xml)
+        generate_MAVLinkMessage(basename, xml_list)
+    copy_fixed_headers(basename, xml_list[0])


### PR DESCRIPTION
This PR adds the JAVA MAVLink generator from Arthur Benemann.

@arthurbenemann There are a couple of items I would like to check with you:
1. Tridge and I want to re-license MAVLink as BSD (or similar), because LGPL is a bit confusing with a header only library and our intent is to be open and permissive. Are you ok to re-license all code in this PR as BSD (2 or 3 clause), MIT or Apache? Did you write all of the code or are there other authors we have to ask?
2. I had to change your folder structure slightly, because MAVLink supports more than one dialect. It now would look like this:

![2014-08-07 07 19 16 pm](https://cloud.githubusercontent.com/assets/1208119/3845904/789dc01e-1e57-11e4-8a5f-9d42aa59f04c.png)
1. Would you be willing to continue to work on this generator rather than maintaining your own? It would help the community to have one common standard and not three (there are three) incompatible Java generators.
