### PR TITLE
mavlink_types.h: fix typo introduced in d41fe510d8cd

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -23,7 +23,7 @@
 #define MAVLINK_MSG_ID_EXTENDED_MESSAGE 255
 #define MAVLINK_EXTENDED_HEADER_LEN 14
 
-#if (defined _MSC_VER) | ((defined __APPLE__) & (defined __MACH__)) | (defined __linux__)
+#if (defined _MSC_VER) || ((defined __APPLE__) && (defined __MACH__)) || (defined __linux__)
   /* full fledged 32bit++ OS */
   #define MAVLINK_MAX_EXTENDED_PACKET_LEN 65507
 #else


### PR DESCRIPTION
because this condition doesn't short circuit as expected when _MSC_VER is not defined, I get

```
src/mavlink/c_library/mavlink_types.h:5:27: error: "_MSC_VER" is not defined [-Werror=undef]
 #if (defined _MSC_VER) & (_MSC_VER < 1800)
                       ^
```

I am not familiar with the generator, so maybe this is not the right place to fix this, but I looked briefly and saw this was the file that was edited previously, so seemed like a reasonable guess :)
