### PR TITLE
mavgen_c.py: prefix header guards with ‘MAVLINK_’ to namespace them from...

### DIFF
--- a/pymavlink/generator/mavgen_c.py
+++ b/pymavlink/generator/mavgen_c.py
@@ -72,11 +72,11 @@ def generate_main_h(directory, xml):
  *	@brief MAVLink comm protocol generated from ${basename}.xml
  *	@see http://qgroundcontrol.org/mavlink/
  */
-#ifndef ${basename_upper}_H
-#define ${basename_upper}_H
+#ifndef MAVLINK_${basename_upper}_H
+#define MAVLINK_${basename_upper}_H
 
 #ifndef MAVLINK_H
-    #error Wrong include order: ${basename_upper}.H MUST NOT BE DIRECTLY USED. Include mavlink.h from the same directory instead or set ALL AND EVERY defines from MAVLINK.H manually accordingly, including the #define MAVLINK_H call.
+    #error Wrong include order: MAVLINK_${basename_upper}.H MUST NOT BE DIRECTLY USED. Include mavlink.h from the same directory instead or set ALL AND EVERY defines from MAVLINK.H manually accordingly, including the #define MAVLINK_H call.
 #endif
 
 #ifdef __cplusplus
@@ -136,7 +136,7 @@ ${{message:#include "./mavlink_msg_${name_lower}.h"
 #ifdef __cplusplus
 }
 #endif // __cplusplus
-#endif // ${basename_upper}_H
+#endif // MAVLINK_${basename_upper}_H
 ''', xml)
 
     f.close()


### PR DESCRIPTION
... other application code

i already have a common.h in my project that uses COMMON_H as a header guard, so the mavlink common.h was not being included properly

Side note - I'm not actually sure how the permissions on that file got changed. Must have been the default behavior of one of my editors or something? If you'd like to introduce these edits as part of another commit that doesn't include the permissions changes, that would be totally fine by me!
