### PR TITLE
Added EKF_STATE message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1483,6 +1483,23 @@
                <field type="uint8_t" name="target_system">The system setting the mode</field>
                <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode</field>
                <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
+          </message>          
+          <message id="19" name="EKF_STATE">
+               <description>State information derived from a EKF in NED reference frame.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="int32_t"  name="lat">Latitude, expressed as * 1E7</field>
+               <field type="int32_t"  name="lon">Longitude, expressed as * 1E7</field>
+               <field type="int32_t"  name="alt">Altitude in meters above home altitude, expressed as * 1000 (millimeters), </field>
+               <field type="int32_t"  name="relative_alt">Fused altitude, expressed as * 1000 (millimeters)</field>
+               <field type="int16_t"  name="vx">Fused North velocity, expressed as m/s * 100</field>
+               <field type="int16_t"  name="vy">Fused East velocity, expressed as m/s * 100</field>
+               <field type="int16_t"  name="vz">Fused Down velocity, expressed as m/s * 100</field>
+               <field type="float"    name="roll">Roll angle (rad, -pi..+pi)</field>
+               <field type="float"    name="pitch">Pitch angle (rad, -pi..+pi)</field>
+               <field type="float"    name="yaw">Yaw angle (rad, -pi..+pi)</field>
+               <field type="float"    name="gyro_x">Roll angular speed (rad/s)</field>
+               <field type="float"    name="gyro_y">Pitch angular speed (rad/s)</field>
+               <field type="float"    name="gyro_z">Yaw angular speed (rad/s)</field>
           </message>
           <!-- reserved for PARAM_VALUE_UNION -->
           <message id="20" name="PARAM_REQUEST_READ">


### PR DESCRIPTION
To facilitate plane-to-plane coordination we need to get a single state estimation for a single point in time, which we don't get from MAVLink today (as far as I can tell). Position and linear velocities for one time (well, maybe, since the sensors are read at different times) are available in one message.  Attitude and angular velocities are in another message (again, may or may not be from a single point in time).

Ideally, our autonomy algorithm folks want all of the above for a single point in time, or at least filtered so that the data represents a single point in time.

This new message is single message replacement for ATTITUDE and GLOBAL_POSITION_INT in which the state is taken from an extended Kalman filter -- it was nice of ardupilot to provide an EKF. :)
