### PR TITLE
RALLY_LANDING modifications as specified on drones-discuss.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -772,16 +772,16 @@
                     <param index="5">Empty</param>
                     <param index="6">Empty</param>
                     <param index="7">Empty</param>
-               </entry>
-                <entry value="190" name="MAV_CMD_DO_RALLY_LAND">
-                    <description>Mission command to perform a landing from a rally point.</description>
+                </entry>
+                <entry value="190" name="MAV_CMD_DO_RALLY_LAND_START">
+                    <description>Mission command to perform a landing (usually from a rally point).</description>
                     <param index="1">Break altitude (meters)</param>
                     <param index="2">Landing speed (m/s)</param>
                     <param index="3">Empty</param>
                     <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
+                    <param index="5">Lat</param>
+                    <param index="6">Lon</param>
+                    <param index="7">Alt</param>
                 </entry>
                 <entry value="191" name="MAV_CMD_DO_GO_AROUND">
                     <description>Mission command to safely abort an autonmous landing.</description>


### PR DESCRIPTION
See this thread for the reason for changing MAV_CMD_DO_RALLY_LAND to MAV_CMD_DO_RALLY_START:

https://groups.google.com/forum/#!topic/drones-discuss/XmVM9v4kIeo
