### PR TITLE
Add warnings for ignored message types to mavlogdump.

### DIFF
--- a/pymavlink/tools/mavlogdump.py
+++ b/pymavlink/tools/mavlogdump.py
@@ -81,6 +81,7 @@ last_timestamp = None
 
 # Keep track of data from the current timestep. If the following timestep has the same data, it's stored in here as well. Output should therefore have entirely unique timesteps.
 csv_out = ["" for x in fields]
+types_ignored = set() # Track which message types were ignored
 while True:
     m = mlog.recv_match(blocking=args.follow)
     if m is None:
@@ -101,6 +102,11 @@ while True:
         continue
 
     if types is not None and m.get_type() not in types and m.get_type() != 'BAD_DATA':
+        # If this message hasn't been seen before, and it's not being output, issue a warning.
+        # This makes it easy for a developer to confirm that they're extracting all relevant data.
+        if m.get_type() not in types_ignored:
+            sys.stderr.write("WARNING: Ignoring '{}' message types.\n".format(m.get_type()))
+            types_ignored.add(m.get_type())
         continue
 
     if m.get_type() == 'BAD_DATA' and m.reason == "Bad prefix":


### PR DESCRIPTION
Useful when trying to extract ALL data from a .csv file or to extract a specific chunk of data and confiming that you haven't missed anything.
