### PR TITLE
pymavlink: DFReader: handle zero-length columns field

### DIFF
--- a/pymavlink/DFReader.py
+++ b/pymavlink/DFReader.py
@@ -40,6 +40,9 @@ class DFFormat(object):
         self.format = format
         self.columns = columns.split(',')
 
+        if self.columns == ['']:
+            self.columns = []
+
         msg_struct = "<"
         msg_mults = []
         msg_types = []


### PR DESCRIPTION
Copter's STRT message has a zero-length columns field, which, when translated to a list using split, turns into [""]
