### PR TITLE
Update mavkml to match new ardupilot log messages

### DIFF
--- a/pymavlink/tools/mavkml.py
+++ b/pymavlink/tools/mavkml.py
@@ -13,7 +13,7 @@ import time
 import re
 
 mainstate_field = 'STAT.MainState'
-position_field_types = ['Lon', 'Lat', 'Alt']  # kml order is lon, lat
+position_field_types = ['Lng', 'Lat', 'Alt']  # kml order is lon, lat
 
 colors = [simplekml.Color.red, simplekml.Color.green, simplekml.Color.blue,
           simplekml.Color.violet, simplekml.Color.yellow,


### PR DESCRIPTION
The new ardupilot logs appear to use the abbreviations Lng, Lat, Alt instead of Lon, Lat, Alt.
However, if this breaks compatibility with PX4 etc, I'm happy to do a more extensive patch sniffing for known variants.
