### PR TITLE
CMakeLists.txt: Remove NONE from project name, which invalidates cmake a...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (mavlink NONE)
+project (mavlink)
 
 # settings
 cmake_minimum_required (VERSION 2.8.2)
@@ -34,6 +34,12 @@ include(CheckLibraryExists)
 #include(CheckCXXSourceCompiles)
 #include(CheckCSourceCompiles)
 include(ExternalProjectWithFilename)
+
+if (UNIX)
+    include(GNUInstallDirs)
+    set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "Installation path for libraries")
+endif ()
+
 
 # spawn new cmake to build deps
 if (WITH_BUILD_DEPS AND ROOT_THREAD)
@@ -165,12 +171,16 @@ endif()
 install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include/${PROJECT_NAME} COMPONENT Dev FILES_MATCHING PATTERN "*.h*")
 install(DIRECTORY ${CMAKE_BINARY_DIR}/src/ DESTINATION share/${PROJECT_NAME} COMPONENT Dev FILES_MATCHING PATTERN "*.c*")
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/share/${PROJECT_NAME} DESTINATION share COMPONENT Dev FILES_MATCHING PATTERN "*.c*")
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/pymavlink DESTINATION "share/pyshared" COMPONENT Dev)
+if (UNIX)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/pymavlink DESTINATION ${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages COMPONENT Dev)
+else ()
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/pymavlink DESTINATION "share/pyshared" COMPONENT Dev)
+endif ()
 
 configure_file(pc.in ${PROJECT_NAME}.pc)
 install(FILES
     ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.pc
-    DESTINATION "lib/pkgconfig" COMPONENT Dev
+    DESTINATION lib${LIB_SUFFIX}/pkgconfig COMPONENT Dev
     )
 
 ### packaging

--- a/pc.in
+++ b/pc.in
@@ -2,6 +2,6 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
 
 Name: @PROJECT_NAME@
-Description: @CPACK_PACKAGE_DESCRIPTION_SUMMARY@
-Version: @APPLICATION_VERSION@
+Description: MAVLink micro air vehicle marshalling / communication library
+Version: @PROJECT_VERSION@
 Cflags: -I@CMAKE_INSTALL_PREFIX@/include/@PROJECT_NAME@


### PR DESCRIPTION
CMakeLists.txt: Remove NONE from project name, which invalidates cmake ability to check arch

CMakeLists.txt: Proper use LIB_SUFFIX and LIB_INSTALL_DIR enable some 64 bit Linux distros find pkgconfig file
CmakeLists.txt: Install python on default site_packages instead of pyshared. Most Linux distros already made the transition, for reference Debian statement https://wiki.debian.org/Python/TransitionToDHPython2?action=show&redirect=Python%2FPyCentral2DhPython2
pc.in: Use correct package version and add proper description.

Signed-off-by: Helio Chissini de Castro helio@kde.org
