### PR TITLE
pymavlink: Cope with the system time moving backwards

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -1054,6 +1054,11 @@ class periodic_event(object):
     def trigger(self):
         '''return True if we should trigger now'''
         tnow = time.time()
+
+        if tnow < self.last_time:
+            print "Warning, time moved backwards. Restarting timer."
+            self.last_time = tnow
+
         if self.last_time + (1.0/self.frequency) <= tnow:
             self.last_time = tnow
             return True


### PR DESCRIPTION
A user noticed that if they move time back on their PC (due to ntp in this
case).  Then that can cause mavproxy/droneapi to drop the link.
The problem was that mavproxy stopped sending heartbeats because the timer
is now quite a bit back in time.  This change fixes the periodic_event
class to restart timers (and warn user) if this unusual case occurs.