### PR TITLE
Fix #includes referencing inttypes.h

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
@@ -226,7 +226,7 @@ MAVLINK_HELPER void mavlink_update_checksum(mavlink_message_t* msg, uint8_t c)
  * A typical use scenario of this function call is:
  *
  * @code
- * #include <inttypes.h> // For fixed-width uint8_t type
+ * #include <mavlink.h>
  *
  * mavlink_message_t msg;
  * int chan = 0;

--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -1,12 +1,12 @@
 #ifndef MAVLINK_TYPES_H_
 #define MAVLINK_TYPES_H_
 
-// Visual Studio versions before 2013 don't conform to C99.
-#if (defined _MSC_VER) && (_MSC_VER < 1800)
-#include <stdint.h>
-#else
-#include <inttypes.h>
+// Visual Studio versions before 2010 don't have stdint.h, so we just error out.
+#if (defined _MSC_VER) && (_MSC_VER < 1600)
+#error "The C-MAVLink implementation requires Visual Studio 2010 or greater"
 #endif
+
+#include <stdint.h>
 
 // Macro to define packed structures
 #ifdef __GNUC__


### PR DESCRIPTION
@LorenzMeier here's your PR for #170!

This change has been limited to the 1.0 version of MAVLink, as this code change makes a firm cutoff on supported compilers at VS2010. I don't know if anyone was actually using those compilers with this library, because the old code actually did the opposite of what it should have done. And neither `<inttypes.h>` **nor** `<stdint.h>` are available in these older versions. So this really doesn't break the status quo, it just cleans it up and makes the errors more sane for users trying to compile with older MSVC compilers.

This has been tested with VS2013 as well as Microchip's XC16 compiler.