### PR TITLE
Mavnative - a native (distutils based) implementation of the mavlink rx code

### DIFF
--- a/pymavlink/generator/C/include_v0.9/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v0.9/mavlink_helpers.h
@@ -311,12 +311,7 @@ the headers.
 			status->parse_error++;
 			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
 			break;
-			if (c == MAVLINK_STX)
-			{
-				status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
-				mavlink_start_checksum(rxmsg);
-			}
-	        }
+	    }
 #endif
 		rxmsg->msgid = c;
 		mavlink_update_checksum(rxmsg, c);

--- a/pymavlink/generator/C/include_v0.9/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v0.9/mavlink_helpers.h
@@ -402,6 +402,9 @@ the headers.
 		status->packet_rx_success_count++;
 	}
 
+	r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
+	r_mavlink_status->parse_state = status->parse_state;
+	r_mavlink_status->packet_idx = status->packet_idx;
 	r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
 	r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
 	r_mavlink_status->packet_rx_drop_count = status->parse_error;

--- a/pymavlink/generator/C/include_v1.0/mavlink_conversions.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_conversions.h
@@ -157,7 +157,8 @@ MAVLINK_HELPER void mavlink_dcm_to_quaternion(const float dcm[3][3], float quate
         /* Find maximum diagonal element in dcm
          * store index in dcm_i */
         int dcm_i = 0;
-        for (int i = 1; i < 3; i++) {
+        int i;
+        for (i = 1; i < 3; i++) {
             if (dcm[i][i] > dcm[dcm_i][dcm_i]) {
                 dcm_i = i;
             }

--- a/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
@@ -338,12 +338,7 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 			status->parse_error++;
 			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
 			break;
-			if (c == MAVLINK_STX)
-			{
-				status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
-				mavlink_start_checksum(rxmsg);
-			}
-	        }
+	    }
 #endif
 		rxmsg->msgid = c;
 		mavlink_update_checksum(rxmsg, c);

--- a/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
@@ -429,6 +429,9 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 		status->packet_rx_success_count++;
 	}
 
+	r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
+	r_mavlink_status->parse_state = status->parse_state;
+	r_mavlink_status->packet_idx = status->packet_idx;
 	r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
 	r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
 	r_mavlink_status->packet_rx_drop_count = status->parse_error;

--- a/pymavlink/generator/mavgen_python.py
+++ b/pymavlink/generator/mavgen_python.py
@@ -29,7 +29,10 @@ from ...generator.mavcrc import x25crc
 WIRE_PROTOCOL_VERSION = "${WIRE_PROTOCOL_VERSION}"
 DIALECT = "${DIALECT}"
 
-native_supported = DIALECT == "ardupilotmega" # Not yet supported on other dialects
+native_supported = True # Not yet supported on other dialects
+native_force = 'MAVNATIVE_FORCE' in os.environ # Will force use of native code regardless of what client app wants
+native_testing = 'MAVNATIVE_TESTING' in os.environ # Will force both native and legacy code to be used and their results compared
+
 if native_supported:
     try:
         import mavnative
@@ -114,6 +117,26 @@ class MAVLink_message(object):
         ret = ret[0:-2] + '}'
         return ret
 
+    def __eq__(self, other):
+        if self.get_type() != other.get_type():
+            return False
+
+        if self.get_crc() != other.get_crc():
+            return False
+
+        if self.get_seq() != other.get_seq():
+            return False
+
+        if self.get_srcSystem() != other.get_srcSystem():
+            return False            
+
+        if self.get_srcComponent() != other.get_srcComponent():
+            return False        
+            
+        for a in self._fieldnames:
+            if getattr(self, a) != getattr(other, a):
+                return False
+
     def to_dict(self):
         d = dict({})
         d['mavpackettype'] = self._type
@@ -181,18 +204,42 @@ def generate_classes(outf, msgs):
     print("Generating class definitions")
     wrapper = textwrap.TextWrapper(initial_indent="        ", subsequent_indent="        ")
     for m in msgs:
+        classname = "MAVLink_%s_message" % m.name.lower()
+        fieldname_str = ", ".join(map(lambda s: "'%s'" % s, m.fieldnames))
+        ordered_fieldname_str = ", ".join(map(lambda s: "'%s'" % s, m.ordered_fieldnames))
+
         outf.write("""
-class MAVLink_%s_message(MAVLink_message):
+class %s(MAVLink_message):
         '''
 %s
         '''
-        def __init__(self""" % (m.name.lower(), wrapper.fill(m.description.strip())))
+        id = MAVLINK_MSG_ID_%s
+        name = '%s'
+        fieldnames = [%s]
+        ordered_fieldnames = [ %s ]
+        format = '%s'
+        native_format = '%s'
+        orders = %s
+        lengths = %s
+        array_lengths = %s
+        crc_extra = %s
+
+        def __init__(self""" % (classname, wrapper.fill(m.description.strip()), 
+            m.name.upper(), 
+            m.name.upper(),
+            fieldname_str,
+            ordered_fieldname_str,
+            m.fmtstr,
+            m.native_fmtstr,
+            m.order_map,
+            m.len_map,
+            m.array_len_map,
+            m.crc_extra))
         if len(m.fields) != 0:
                 outf.write(", " + ", ".join(m.fieldnames))
         outf.write("):\n")
-        outf.write("                MAVLink_message.__init__(self, MAVLINK_MSG_ID_%s, '%s')\n" % (m.name.upper(), m.name.upper()))
-        if len(m.fieldnames) != 0:
-                outf.write("                self._fieldnames = ['%s']\n" % "', '".join(m.fieldnames))
+        outf.write("                MAVLink_message.__init__(self, %s.id, %s.name)\n" % (classname, classname))
+        outf.write("                self._fieldnames = %s.fieldnames\n" % (classname))
         for f in m.fields:
                 outf.write("                self.%s = %s\n" % (f.name, f.name))
         outf.write("""
@@ -206,6 +253,24 @@ class MAVLink_%s_message(MAVLink_message):
                         outf.write(", self.{0:s}".format(field.name))
         outf.write("))\n")
 
+
+def native_mavfmt(field):
+    '''work out the struct format for a type (in a form expected by mavnative)'''
+    map = {
+        'float'    : 'f',
+        'double'   : 'd',
+        'char'     : 'c',
+        'int8_t'   : 'b',
+        'uint8_t'  : 'B',
+        'uint8_t_mavlink_version'  : 'v',
+        'int16_t'  : 'h',
+        'uint16_t' : 'H',
+        'int32_t'  : 'i',
+        'uint32_t' : 'I',
+        'int64_t'  : 'q',
+        'uint64_t' : 'Q',
+        }
+    return map[field.type]
 
 def mavfmt(field):
     '''work out the struct format for a type'''
@@ -235,8 +300,7 @@ def generate_mavlink_class(outf, msgs, xml):
 
     outf.write("\n\nmavlink_map = {\n");
     for m in msgs:
-        outf.write("        MAVLINK_MSG_ID_%s : ( '%s', MAVLink_%s_message, %s, %s, %u ),\n" % (
-            m.name.upper(), m.fmtstr, m.name.lower(), m.order_map, m.len_map, m.crc_extra))
+        outf.write("        MAVLINK_MSG_ID_%s : MAVLink_%s_message,\n" % (m.name.upper(), m.name.lower()))
     outf.write("}\n\n")
 
     t.write(outf, """
@@ -298,9 +362,9 @@ class MAVLink(object):
                 self.total_bytes_received = 0
                 self.total_receive_errors = 0
                 self.startup_time = time.time()
-                if native_supported and use_native:
+                if native_supported and (use_native or native_testing or native_force):
                     print "NOTE: mavnative is currently beta-test code"
-                    self.native = mavnative.NativeConnection(MAVLink_message)
+                    self.native = mavnative.NativeConnection(MAVLink_message, mavlink_map)
                 else:
                     self.native = None
 
@@ -354,6 +418,12 @@ class MAVLink(object):
 
             if self.native:
                 m = self.__parse_char_native(c)
+
+                if native_testing:
+                    m2 = self.__parse_char_legacy(c)
+                    if m2 != m:
+                        print "Native: %s\\nLegacy: %s\\n" % (m, m2)
+                        raise Exception('Native vs. Legacy mismatch')                
             else:
                 m = self.__parse_char_legacy(c)
 
@@ -429,7 +499,11 @@ class MAVLink(object):
                     raise MAVError('unknown MAVLink message ID %u' % msgId)
 
                 # decode the payload
-                (fmt, type, order_map, len_map, crc_extra) = mavlink_map[msgId]
+                type = mavlink_map[msgId]
+                fmt = type.format
+                order_map = type.orders
+                len_map = type.lengths
+                crc_extra = type.crc_extra
 
                 # decode the checksum
                 try:
@@ -555,12 +629,16 @@ def generate(basename, xml):
             m.fmtstr = '<'
         else:
             m.fmtstr = '>'
+        m.native_fmtstr = m.fmtstr
         for f in m.ordered_fields:
             m.fmtstr += mavfmt(f)
+            m.native_fmtstr += native_mavfmt(f)
         m.order_map = [ 0 ] * len(m.fieldnames)
         m.len_map = [ 0 ] * len(m.fieldnames)
+        m.array_len_map = [ 0 ] * len(m.fieldnames)
         for i in range(0, len(m.fieldnames)):
             m.order_map[i] = m.ordered_fieldnames.index(m.fieldnames[i])
+            m.array_len_map[i] = m.ordered_fields[i].array_length
         for i in range(0, len(m.fieldnames)):
             n = m.order_map[i]
             m.len_map[n] = m.fieldlengths[i]

--- a/pymavlink/generator/mavgen_python.py
+++ b/pymavlink/generator/mavgen_python.py
@@ -433,14 +433,14 @@ class MAVLink(object):
                 if native_testing:
                     self.test_buf.extend(c)
                     m = self.__parse_char_native(self.test_buf)
-                    m2 = self.__parse_char_legacy(self.buf)
+                    m2 = self.__parse_char_legacy()
                     if m2 != m:
                         print "Native: %s\\nLegacy: %s\\n" % (m, m2)
                         raise Exception('Native vs. Legacy mismatch')
                 else:
                     m = self.__parse_char_native(self.buf)
             else:
-                m = self.__parse_char_legacy(self.buf)
+                m = self.__parse_char_legacy()
 
             if m != None:
                 self.total_packets_received += 1
@@ -448,15 +448,13 @@ class MAVLink(object):
 
             return m
 
-        def __parse_char_legacy(self, c):
+        def __parse_char_legacy(self):
             '''input some data bytes, possibly returning a new message (uses no native code)'''
             if len(self.buf) >= 1 and self.buf[0] != ${protocol_marker}:
                 magic = self.buf[0]
                 self.buf = self.buf[1:]
                 if self.robust_parsing:
                     m = MAVLink_bad_data(chr(magic), "Bad prefix")
-                    if self.callback:
-                        self.callback(m, *self.callback_args, **self.callback_kwargs)
                     self.expected_length = 8
                     self.total_receive_errors += 1
                     return m

--- a/pymavlink/generator/mavgen_python.py
+++ b/pymavlink/generator/mavgen_python.py
@@ -605,9 +605,7 @@ def generate_methods(outf, msgs):
                 '''
                 ${COMMENT}
                 '''
-                msg = MAVLink_${NAMELOWER}_message(${FIELDNAMES})
-                msg.pack(self)
-                return msg
+                return MAVLink_${NAMELOWER}_message(${FIELDNAMES})
 
 """, sub)
 

--- a/pymavlink/generator/mavgen_python.py
+++ b/pymavlink/generator/mavgen_python.py
@@ -465,10 +465,10 @@ class MAVLink(object):
                 raise MAVError("invalid MAVLink prefix '%s'" % magic)
             self.have_prefix_error = False
             if len(self.buf) >= 2:
-                (magic, self.expected_length) = struct.unpack('BB', self.buf[0:2])
+                (magic, self.expected_length) = struct.unpack('BB', str(self.buf[0:2])) # bytearrays are not supported in py 2.7.3
                 self.expected_length += 8
             if self.expected_length >= 8 and len(self.buf) >= self.expected_length:
-                mbuf = self.buf[0:self.expected_length]
+                mbuf = array.array('B', self.buf[0:self.expected_length])
                 self.buf = self.buf[self.expected_length:]
                 self.expected_length = 8
                 if self.robust_parsing:

--- a/pymavlink/mavnative/mavlink_defaults.h
+++ b/pymavlink/mavnative/mavlink_defaults.h
@@ -1,0 +1,22 @@
+#ifndef _MAVLINK_DEFAULTS_H
+#define _MAVLINK_DEFAULTS_H
+
+// This is normally dynamically generated as mavlink.h, but we just use the same settings for all native stacks
+
+#ifndef MAVLINK_STX
+#define MAVLINK_STX 254
+#endif
+
+#ifndef MAVLINK_ENDIAN
+#define MAVLINK_ENDIAN MAVLINK_LITTLE_ENDIAN
+#endif
+
+#ifndef MAVLINK_ALIGNED_FIELDS
+#define MAVLINK_ALIGNED_FIELDS 1
+#endif
+
+#ifndef MAVLINK_CRC_EXTRA
+#define MAVLINK_CRC_EXTRA 1
+#endif
+
+#endif

--- a/pymavlink/mavnative/mavnative.c
+++ b/pymavlink/mavnative/mavnative.c
@@ -1,0 +1,809 @@
+/*
+    Native mavlink glue for python.
+    Author: kevinh@geeksville.com
+*/
+
+#undef NDEBUG
+
+#include <Python.h>
+#include <structmember.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#define MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+// this trick allows us to make mavlink_message_t as small as possible
+// for this dialect, which saves some memory
+#include <version.h>
+#define MAVLINK_MAX_PAYLOAD_LEN MAVLINK_MAX_DIALECT_PAYLOAD_SIZE
+
+#include <mavlink_types.h>
+
+// Mavlink send support
+// Not currently used, but keeps mavlink_helpers send code happy
+static mavlink_system_t mavlink_system = {42,11,};
+static void comm_send_ch(mavlink_channel_t chan, uint8_t c) {
+    // Sending not supported yet in native code
+    assert(0);
+}
+
+#define MAVLINK_ASSERT(x) assert(x)
+
+// static mavlink_message_t last_msg;
+
+#include <mavlink.h>
+#include <protocol.h>
+
+static const unsigned message_lengths[] = MAVLINK_MESSAGE_LENGTHS;
+// static unsigned error_count;
+
+
+/**
+ * Contains a structure mavlink_message but also the raw bytes that make up that message
+ */
+typedef struct {
+    mavlink_message_t   msg;
+    int                 numBytes;
+    uint8_t             bytes[MAVLINK_MAX_PACKET_LEN];
+} py_message_t;
+
+/** (originally from mavlink_helpers.h - but now customized to not be channel based)
+ * This is a convenience function which handles the complete MAVLink parsing.
+ * the function will parse one byte at a time and return the complete packet once
+ * it could be successfully decoded. Checksum and other failures will be silently
+ * ignored.
+ *
+ * Messages are parsed into an internal buffer (one for each channel). When a complete
+ * message is received it is copies into *returnMsg and the channel's status is
+ * copied into *returnStats.
+ *
+ * @param c        The char to parse
+ *
+ * @param returnMsg NULL if no message could be decoded, the message data else
+ * @param returnStats if a message was decoded, this is filled with the channel's stats
+ * @return 0 if no message could be decoded, 1 else
+ *
+ */
+MAVLINK_HELPER uint8_t py_mavlink_parse_char(uint8_t c, py_message_t* pymsg, mavlink_status_t* status)
+{
+    mavlink_message_t *rxmsg = &pymsg->msg;
+
+    /*
+      default message crc function. You can override this per-system to
+      put this data in a different memory segment
+    */
+#if MAVLINK_CRC_EXTRA
+#undef MAVLINK_MESSAGE_CRC
+    static const uint8_t mavlink_message_crcs[256] = MAVLINK_MESSAGE_CRCS;
+#define MAVLINK_MESSAGE_CRC(msgid) mavlink_message_crcs[msgid]
+#endif
+
+/* Enable this option to check the length of each message.
+ This allows invalid messages to be caught much sooner. Use if the transmission
+ medium is prone to missing (or extra) characters (e.g. a radio that fades in
+ and out). Only use if the channel will only contain messages types listed in
+ the headers.
+*/
+#ifdef MAVLINK_CHECK_MESSAGE_LENGTH
+#undef MAVLINK_MESSAGE_LENGTH
+    static const uint8_t mavlink_message_lengths[256] = MAVLINK_MESSAGE_LENGTHS;
+#define MAVLINK_MESSAGE_LENGTH(msgid) mavlink_message_lengths[msgid]
+#endif
+
+    int bufferIndex = 0;
+
+    status->msg_received = 0;
+
+    switch (status->parse_state)
+    {
+    case MAVLINK_PARSE_STATE_UNINIT:
+    case MAVLINK_PARSE_STATE_IDLE:
+        if (c == MAVLINK_STX)
+        {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+            rxmsg->len = 0;
+            pymsg->numBytes = 0;
+            rxmsg->magic = c;
+            mavlink_start_checksum(rxmsg);
+            pymsg->bytes[pymsg->numBytes++] = c;
+        }
+        break;
+
+    case MAVLINK_PARSE_STATE_GOT_STX:
+            if (status->msg_received 
+/* Support shorter buffers than the
+   default maximum packet size */
+#if (MAVLINK_MAX_PAYLOAD_LEN < 255)
+                || c > MAVLINK_MAX_PAYLOAD_LEN
+#endif
+                )
+        {
+            status->buffer_overrun++;
+            status->parse_error++;
+            status->msg_received = 0;
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+        }
+        else
+        {
+            // NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
+            rxmsg->len = c;
+            status->packet_idx = 0;
+            mavlink_update_checksum(rxmsg, c);
+            pymsg->bytes[pymsg->numBytes++] = c;
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_LENGTH;
+        }
+        break;
+
+    case MAVLINK_PARSE_STATE_GOT_LENGTH:
+        rxmsg->seq = c;
+        mavlink_update_checksum(rxmsg, c);
+        pymsg->bytes[pymsg->numBytes++] = c;
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_SEQ;
+        break;
+
+    case MAVLINK_PARSE_STATE_GOT_SEQ:
+        rxmsg->sysid = c;
+        mavlink_update_checksum(rxmsg, c);
+        pymsg->bytes[pymsg->numBytes++] = c;
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_SYSID;
+        break;
+
+    case MAVLINK_PARSE_STATE_GOT_SYSID:
+        rxmsg->compid = c;
+        mavlink_update_checksum(rxmsg, c);
+        pymsg->bytes[pymsg->numBytes++] = c;
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPID;
+        break;
+
+    case MAVLINK_PARSE_STATE_GOT_COMPID:
+#ifdef MAVLINK_CHECK_MESSAGE_LENGTH
+            if (rxmsg->len != MAVLINK_MESSAGE_LENGTH(c))
+        {
+            status->parse_error++;
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+            break;
+        }
+#endif
+        rxmsg->msgid = c;
+        mavlink_update_checksum(rxmsg, c);
+        pymsg->bytes[pymsg->numBytes++] = c;
+        if (rxmsg->len == 0)
+        {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+        }
+        else
+        {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID;
+        }
+        break;
+
+    case MAVLINK_PARSE_STATE_GOT_MSGID:
+        _MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx++] = (char)c;
+        mavlink_update_checksum(rxmsg, c);
+        pymsg->bytes[pymsg->numBytes++] = c;
+        if (status->packet_idx == rxmsg->len)
+        {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+        }
+        break;
+
+    case MAVLINK_PARSE_STATE_GOT_PAYLOAD:
+#if MAVLINK_CRC_EXTRA
+        mavlink_update_checksum(rxmsg, MAVLINK_MESSAGE_CRC(rxmsg->msgid));
+#endif
+        pymsg->bytes[pymsg->numBytes++] = c;
+        if (c != (rxmsg->checksum & 0xFF)) {
+            // Check first checksum byte
+            status->parse_error++;
+            status->msg_received = 0;
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+            if (c == MAVLINK_STX)
+            {
+                status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+                rxmsg->len = 0;
+                mavlink_start_checksum(rxmsg);
+            }
+        }
+        else
+        {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_CRC1;
+            _MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx] = (char)c;
+        }
+        break;
+
+    case MAVLINK_PARSE_STATE_GOT_CRC1:
+        pymsg->bytes[pymsg->numBytes++] = c;
+        if (c != (rxmsg->checksum >> 8)) {
+            // Check second checksum byte
+            status->parse_error++;
+            status->msg_received = 0;
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+            if (c == MAVLINK_STX)
+            {
+                status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+                rxmsg->len = 0;
+                mavlink_start_checksum(rxmsg);
+            }
+        }
+        else
+        {
+            // Successfully got message
+            status->msg_received = 1;
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+            _MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx+1] = (char)c;
+        }
+        break;
+    }
+
+    bufferIndex++;
+    // If a message has been sucessfully decoded, check index
+    if (status->msg_received == 1)
+    {
+        //while(status->current_seq != rxmsg->seq)
+        //{
+        //  status->packet_rx_drop_count++;
+        //               status->current_seq++;
+        //}
+        status->current_rx_seq = rxmsg->seq;
+        // Initial condition: If no packet has been received so far, drop count is undefined
+        if (status->packet_rx_success_count == 0) status->packet_rx_drop_count = 0;
+        // Count this packet as received
+        status->packet_rx_success_count++;
+    }
+
+    return status->msg_received;
+}
+
+
+typedef struct {
+    PyObject_HEAD
+
+    PyObject            *MAVLinkMessage;
+    mavlink_status_t    mav_status;
+    py_message_t        msg;
+} NativeConnection;
+
+
+typedef struct {
+        PyObject                *name;                 // name of this field
+        // const char *print_format;         // printing format hint, or NULL
+        mavlink_message_type_t  type;      // type of this field
+        unsigned int            array_length;        // if non-zero, field is an array
+        unsigned int            wire_offset;         // offset of each field in the payload
+        // unsigned int structure_offset;    // offset in a C structure
+} py_field_info_t;
+
+// note that in this structure the order of fields is the order
+// in the XML file, not necessary the wire order
+typedef struct {
+    PyObject            *id;                                          // The int id for this msg
+    PyObject            *name;                                        // name of the message
+    unsigned            num_fields;                                   // how many fields in this message
+    py_field_info_t     fields[MAVLINK_MAX_FIELDS];            // field information
+} py_message_info_t;
+
+static py_message_info_t py_message_info[256];
+
+
+#define TRUE 1
+#define FALSE 0
+
+// #define MAVNATIVE_DEBUG
+#ifdef MAVNATIVE_DEBUG
+#  define mavdebug    printf
+#else
+#  define mavdebug(x...)
+#endif
+
+
+// My exception type
+static PyObject *MAVNativeError;
+
+static jmp_buf python_entry;
+
+#define PYTHON_ENTRY if(!setjmp(python_entry)) {
+#define PYTHON_EXIT  } else { return NULL; }
+
+
+// Raise a python exception
+static void set_pyerror(const char *msg) {
+    PyErr_SetString(MAVNativeError,  msg);
+}
+
+// Pass assertion failures back to python (if we can)
+extern void __assert_fail(const char *__assertion, const char *__file, unsigned int __line, const char *__function)
+{
+    char msg[256];
+
+    sprintf(msg, "Assertion failed: %s, %s:%d", __assertion, __file, __line);
+
+    set_pyerror(msg);
+    longjmp(python_entry, 1);
+}
+
+
+
+/**
+    We preconvert message info from the C style representation to python objects (to minimize # of object allocs).
+    FIXME - it would be better to generate this from the python datastructures, so we'd automatically work with any
+    dialect.
+
+    FIXME - we really should free these PyObjects if our module gets unloaded.
+*/
+static void init_message_info(void) {
+    static const mavlink_message_info_t src[256] = MAVLINK_MESSAGE_INFO;
+    int i;
+
+    for(i = 0; i < 256; i++) {
+        const mavlink_message_info_t *s = &src[i];
+        py_message_info_t *d = &py_message_info[i];
+
+        d->id = PyInt_FromLong(i);
+        d->name = PyString_FromString(s->name);
+        d->num_fields = s->num_fields;
+        int fnum;
+        for(fnum = 0; fnum < d->num_fields; fnum++) {
+            d->fields[fnum].name = PyString_FromString(s->fields[fnum].name);
+            d->fields[fnum].type = s->fields[fnum].type;
+            d->fields[fnum].array_length = s->fields[fnum].array_length;
+            d->fields[fnum].wire_offset = s->fields[fnum].wire_offset;
+        }
+    }
+}
+
+static PyObject *createPyNone(void)
+{
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+
+
+/**
+    Set an attribute, but handing over ownership on the value
+*/
+static void set_attribute(PyObject *obj, const char *attrName, PyObject *val) {
+    assert(val);
+    PyObject_SetAttrString(obj, attrName, val);
+    Py_DECREF(val);
+}
+
+/**
+    Extract a field value from a mavlink msg
+
+    @return possibly null if mavlink stream is corrupted (FIXME, caller should check)
+*/
+static PyObject *pyextract_mavlink(const mavlink_message_t *msg, const py_field_info_t *field) {
+    unsigned offset = field->wire_offset;
+    int index;
+
+    // For arrays of chars we build the result in a string instead of an array
+    PyObject *arrayResult =  (field->array_length != 0 && field->type != MAVLINK_TYPE_CHAR) ? PyList_New(field->array_length) : NULL;
+    PyObject *stringResult = (field->array_length != 0 && field->type == MAVLINK_TYPE_CHAR) ? PyString_FromString("") : NULL;
+    PyObject *result = NULL;
+
+    int numValues = (field->array_length == 0) ? 1 : field->array_length;
+
+    // Either build a full array of results, or return a single value 
+    for(index = 0; index < numValues; index++) {
+        PyObject *val = NULL;
+        unsigned fieldSize;
+
+        switch(field->type) {
+            case MAVLINK_TYPE_CHAR: {
+                char c = _MAV_RETURN_char(msg, offset);
+                val = PyString_FromStringAndSize(&c, 1);
+                fieldSize = 1;
+                break;
+                }
+            case MAVLINK_TYPE_UINT8_T:
+                val = PyInt_FromLong(_MAV_RETURN_uint8_t(msg, offset));
+                fieldSize = 1;
+                break;
+            case MAVLINK_TYPE_INT8_T:
+                val = PyInt_FromLong(_MAV_RETURN_int8_t(msg, offset));
+                fieldSize = 1;
+                break;
+            case MAVLINK_TYPE_UINT16_T:
+                val = PyInt_FromLong(_MAV_RETURN_uint16_t(msg, offset));
+                fieldSize = 2;
+                break;
+            case MAVLINK_TYPE_INT16_T:
+                val = PyInt_FromLong(_MAV_RETURN_int16_t(msg, offset));
+                fieldSize = 2;
+                break;
+            case MAVLINK_TYPE_UINT32_T:
+                val = PyInt_FromLong(_MAV_RETURN_uint32_t(msg, offset));
+                fieldSize = 4;
+                break;
+            case MAVLINK_TYPE_INT32_T:
+                val = PyInt_FromLong(_MAV_RETURN_int32_t(msg, offset));   
+                fieldSize = 4;
+                break;
+            case MAVLINK_TYPE_UINT64_T:
+                val = PyInt_FromLong(_MAV_RETURN_uint64_t(msg, offset));
+                fieldSize = 8;
+                break;
+            case MAVLINK_TYPE_INT64_T:
+                val = PyInt_FromLong(_MAV_RETURN_int64_t(msg, offset));                     
+                fieldSize = 8;
+                break;
+            case MAVLINK_TYPE_FLOAT:
+                val = PyFloat_FromDouble(_MAV_RETURN_float(msg, offset));                     
+                fieldSize = 4;
+                break;
+            case MAVLINK_TYPE_DOUBLE:
+                val = PyFloat_FromDouble(_MAV_RETURN_double(msg, offset));                     
+                fieldSize = 8;
+                break;            
+            default:
+                mavdebug("BAD MAV TYPE %d\n", field->type);
+                set_pyerror("Unexpected mavlink type");
+                return NULL;
+        }
+        offset += fieldSize;
+
+        if(arrayResult != NULL)  {
+            PyList_SetItem(arrayResult, index, val);
+            result = arrayResult;
+        }
+        else if(stringResult != NULL) {
+            PyString_ConcatAndDel(&stringResult, val);
+            result = stringResult;
+        }
+        else // Not building an array
+            result = val;
+    }
+
+    assert(result);
+    return result;
+}
+
+
+/**
+    Convert a message to a valid python representation.
+
+    @return new message, or null if a valid encoding could not be made
+
+    FIXME - move msgclass, the mavstatus and channel context into an instance, created once with the mavfile object
+    */
+static PyObject *msg_to_py(PyObject* msgclass, const py_message_t *pymsg) {
+    const mavlink_message_t *msg = &pymsg->msg;
+    const py_message_info_t *info = &py_message_info[msg->msgid];
+
+    mavdebug("Found a msg: %s\n", PyString_AS_STRING(info->name));
+
+    /* Call the class object to create our instance */
+    // PyObject *obj = PyObject_CallObject((PyObject *) &NativeConnectionType, null);
+    PyObject *argList = PyTuple_Pack(2, info->id, info->name);
+    PyObject *obj = PyObject_CallObject(msgclass, argList);
+    uint8_t objValid = TRUE;
+    assert(obj);
+    Py_DECREF(argList);
+
+    // Find the header subobject
+    PyObject *header = PyObject_GetAttrString(obj, "_header");
+    assert(header);
+
+    // msgid already set in the constructor call
+    set_attribute(header, "mlen", PyInt_FromLong(msg->len));
+    set_attribute(header, "seq", PyInt_FromLong(msg->seq));
+    set_attribute(header, "srcSystem", PyInt_FromLong(msg->sysid));
+    set_attribute(header, "srcComponent", PyInt_FromLong(msg->compid));
+    Py_DECREF(header);
+    header = NULL;
+
+    // FIXME - we should generate this expensive field only as needed (via a getattr override)
+    set_attribute(obj, "_msgbuf", PyByteArray_FromStringAndSize((const char *) pymsg->bytes, pymsg->numBytes));
+
+    // Now add all the fields - FIXME - do this lazily using getattr overrides
+    PyObject *fieldNameList = PyList_New(info->num_fields);
+    set_attribute(obj, "_fieldnames", fieldNameList); // Transfers ownership of the namelist to the object
+
+    int fnum;
+    for(fnum = 0; fnum < info->num_fields && objValid; fnum++) {
+        const py_field_info_t *f = &info->fields[fnum];
+        PyObject *val = pyextract_mavlink(msg, f);
+
+        if(val != NULL) {
+            PyObject_SetAttr(obj, f->name, val);
+            Py_DECREF(val); // We no longer need val, the attribute will keep a ref
+
+            // SetItem is a rare special case - it will steal our reference
+            Py_INCREF(f->name);
+            PyList_SetItem(fieldNameList, fnum, f->name);
+        }
+        else 
+            objValid = FALSE;
+    }
+
+    if(objValid)
+        return obj;
+    else {
+        Py_DECREF(obj);
+        return NULL;
+    }
+}
+
+
+/**
+  * How many bytes would we like to read to complete current packet
+  */
+static int get_expectedlength(NativeConnection *self)
+{
+    int desired;
+
+    mavlink_message_t *msg = &self->msg.msg;
+
+    switch(self->mav_status.parse_state) {
+        case MAVLINK_PARSE_STATE_UNINIT: 
+        case MAVLINK_PARSE_STATE_IDLE: 
+            desired = 8;
+            break;
+        case MAVLINK_PARSE_STATE_GOT_STX: 
+            desired = 7;
+            break;
+        case MAVLINK_PARSE_STATE_GOT_LENGTH:
+            desired = msg->len + 6;
+            break;
+        case MAVLINK_PARSE_STATE_GOT_SEQ: 
+            desired = msg->len + 5;
+            break;
+        case MAVLINK_PARSE_STATE_GOT_SYSID: 
+            desired = msg->len + 4;
+            break;        
+        case MAVLINK_PARSE_STATE_GOT_COMPID:
+            desired = msg->len + 3;
+            break;         
+        case MAVLINK_PARSE_STATE_GOT_MSGID: 
+            desired = msg->len - self->mav_status.packet_idx + 2;
+            break;          
+        case MAVLINK_PARSE_STATE_GOT_PAYLOAD:
+            desired = 2;
+            break;          
+        case MAVLINK_PARSE_STATE_GOT_CRC1: 
+            desired = 1;
+            break;  
+        default:
+            // Huh?  Just claim 1
+            desired = 1;
+            break;
+    } 
+    
+    // mavdebug("in state %d, expected_length=%d\n", (int) self->mav_status.parse_state, desired);
+    return desired;
+}
+
+
+static PyObject *NativeConnection_getexpectedlength(NativeConnection *self, void *closure)
+{
+    return PyInt_FromLong(get_expectedlength(self));
+}
+
+/**
+  Given a byte array of bytes
+  @return a list of MAVProxy_message objects
+*/
+static PyObject *
+py_parse_chars(NativeConnection *self, PyObject *args)
+{
+    PYTHON_ENTRY
+
+    PyObject* byteObj;
+    if (!PyArg_ParseTuple(args, "O", &byteObj)) {
+        set_pyerror("Invalid arguments");
+        return NULL;
+    }
+    
+    assert(PyByteArray_Check(byteObj));
+    Py_ssize_t numBytes = PyByteArray_Size(byteObj);    
+    mavdebug("numbytes %u\n", (unsigned) numBytes);
+
+    char *start = PyByteArray_AsString(byteObj);
+    assert(start);
+    char *bytes = start;
+    PyObject *result = NULL;
+
+    // Generate a list of messages found 
+    while(numBytes) {
+        char c = *bytes++;
+        numBytes--;
+        // get_expectedlength(self); mavdebug("parse 0x%x\n", (unsigned char) c);
+
+        if (py_mavlink_parse_char(c, &self->msg, &self->mav_status)) {
+            mavdebug("got packet\n");
+            result = msg_to_py(self->MAVLinkMessage, &self->msg);
+            if(result != NULL)
+                break;
+        }
+    }
+
+    // We didn't process all bytes provided by the caller, so fixup their array
+    memmove(start, bytes, numBytes);
+    PyByteArray_Resize(byteObj, numBytes);
+
+    if(result != NULL) 
+        return result;
+    else
+        return createPyNone();
+
+    PYTHON_EXIT
+}
+
+/**
+  Given an string of bytes.
+
+  This routine is more efficient than parse_chars, because it doesn't need to buffer characters.
+
+  @return a list of MAVProxy_message objects
+*/
+static PyObject *
+py_parse_buffer(NativeConnection *self, PyObject *args)
+{
+    PYTHON_ENTRY
+
+    const char *bytes;
+    Py_ssize_t numBytes = 0;
+
+    if (!PyArg_ParseTuple(args, "s#", &bytes, &numBytes)) {
+        set_pyerror("Invalid arguments");
+        return NULL;
+    }
+    
+    // mavdebug("numbytes %u\n", (unsigned) numBytes);
+
+    PyObject* list = PyList_New(0);
+
+    // Generate a list of messages found 
+    while(numBytes--) {
+        char c = *bytes++;
+        // mavdebug("parse %c\n", c);
+
+        if (py_mavlink_parse_char(c, &self->msg, &self->mav_status)) {
+            PyObject *obj = msg_to_py(self->MAVLinkMessage, &self->msg);
+            if(obj != NULL) {
+                PyList_Append(list, obj);
+            
+                // Append will have bummped up the ref count on obj, so we need to release our count
+                Py_DECREF(obj);
+            }
+        }
+    }
+
+    return list;
+
+    PYTHON_EXIT
+}
+
+static PyObject *
+NativeConnection_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    NativeConnection *self = (NativeConnection *)type->tp_alloc(type, 0);
+
+    mavdebug("new connection\n");
+    return (PyObject *)self;
+}
+
+
+static int
+NativeConnection_init(NativeConnection *self, PyObject *args, PyObject *kwds)
+{
+    memset(&self->mav_status, 0, sizeof(self->mav_status));
+
+    PyObject* msgclass;
+    if (!PyArg_ParseTuple(args, "O", &msgclass)) {
+        set_pyerror("Invalid arguments");
+        return -1;
+    }
+
+    // keep a ref to our mavlink instance constructor
+    if(msgclass) {
+        self->MAVLinkMessage = msgclass;
+        Py_INCREF(msgclass);
+    }
+
+    mavdebug("inited connection\n");
+    return 0;
+}
+
+static void NativeConnection_dealloc(NativeConnection* self)
+{
+    Py_XDECREF(self->MAVLinkMessage);
+    self->ob_type->tp_free((PyObject*)self);
+}
+
+static PyMemberDef NativeConnection_members[] = {
+    {NULL}  /* Sentinel */
+};
+
+static PyGetSetDef NativeConnection_getseters[] = {
+    {"expected_length", 
+     (getter)NativeConnection_getexpectedlength, NULL,
+     "How many characters would the state-machine like to read now",
+     NULL},
+    {NULL}  /* Sentinel */
+};
+
+static PyMethodDef NativeConnection_methods[] = {
+    {"parse_chars",  (PyCFunction) py_parse_chars, METH_VARARGS,
+     "Given a msg class and an array of bytes, Parse chars, returning a message or None"},    
+    {"parse_buffer",  (PyCFunction) py_parse_buffer, METH_VARARGS,
+     "Given a msg class and a string like object, Parse chars, returning a (possibly empty) list of messages"},
+    {NULL,  NULL},
+};
+
+// FIXME - delete this?
+static PyTypeObject NativeConnectionType = {
+    PyObject_HEAD_INIT(NULL)
+    0,                       /* ob_size */
+    "mavnative.NativeConnection",      /* tp_name */
+    sizeof(NativeConnection),          /* tp_basicsize */
+    0,                       /* tp_itemsize */
+    (destructor)NativeConnection_dealloc,  /* tp_dealloc */
+    0,                       /* tp_print */
+    0,                       /* tp_getattr */
+    0,                       /* tp_setattr */
+    0,                       /* tp_compare */
+    0,                       /* tp_repr */
+    0,                       /* tp_as_number */
+    0,                       /* tp_as_sequence */
+    0,                       /* tp_as_mapping */
+    0,                       /* tp_hash */
+    0,                       /* tp_call */
+    0,                       /* tp_str */
+    0,                       /* tp_getattro */
+    0,                       /* tp_setattro */
+    0,                       /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT |
+      Py_TPFLAGS_BASETYPE,   /* tp_flags */
+    "NativeConnection objects",  /* tp_doc */
+    0,                       /* tp_traverse */
+    0,                       /* tp_clear */
+    0,                       /* tp_richcompare */
+    0,                       /* tp_weaklistoffset */
+    0,                       /* tp_iter */
+    0,                       /* tp_iternext */
+    NativeConnection_methods,  /* tp_methods */
+    NativeConnection_members,  /* tp_members */
+    NativeConnection_getseters,  /* tp_getset */
+    0,                       /* tp_base */
+    0,                       /* tp_dict */
+    0,                       /* tp_descr_get */
+    0,                       /* tp_descr_set */
+    0,                       /* tp_dictoffset */
+    (initproc)NativeConnection_init,   /* tp_init */
+    0,                       /* tp_alloc */
+    NativeConnection_new,    /* tp_new */
+};
+
+
+
+static PyMethodDef ModuleMethods[] = {
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+
+PyMODINIT_FUNC
+initmavnative(void)
+{
+    if (PyType_Ready(&NativeConnectionType) < 0)
+        return;
+
+    PyObject *m = Py_InitModule3("mavnative", ModuleMethods, "Mavnative module");
+    if (m == NULL)
+        return;
+
+    init_message_info();
+
+    MAVNativeError = PyErr_NewException("mavnative.error", NULL, NULL);
+    Py_INCREF(MAVNativeError);
+    PyModule_AddObject(m, "error", MAVNativeError);
+
+    Py_INCREF(&NativeConnectionType);
+    PyModule_AddObject(m, "NativeConnection", (PyObject *) &NativeConnectionType);
+}

--- a/pymavlink/mavnative/mavnative.c
+++ b/pymavlink/mavnative/mavnative.c
@@ -17,11 +17,6 @@
 
 #define MAVLINK_USE_CONVENIENCE_FUNCTIONS
 
-// this trick allows us to make mavlink_message_t as small as possible
-// for this dialect, which saves some memory
-#include <version.h>
-#define MAVLINK_MAX_PAYLOAD_LEN MAVLINK_MAX_DIALECT_PAYLOAD_SIZE
-
 #include <mavlink_types.h>
 
 // Mavlink send support

--- a/pymavlink/mavnative/mavnative.c
+++ b/pymavlink/mavnative/mavnative.c
@@ -453,6 +453,7 @@ static void init_message_info(PyObject *mavlink_map) {
         for(fnum = 0; fnum < num_fields; fnum++) {
             PyObject *field_name_obj = PyList_GetItem(fieldname_list, fnum); // returns a _borrowed_ reference
             assert(field_name_obj);
+            Py_INCREF(field_name_obj);
 
             PyObject *len_obj = PyList_GetItem(arrlen_list, fnum); // returns a _borrowed_ reference
             assert(len_obj);                        
@@ -469,8 +470,6 @@ static void init_message_info(PyObject *mavlink_map) {
         Py_DECREF(arrlen_list);
         Py_DECREF(type_format);
         //Py_DECREF(order_list);
-        Py_DECREF(arrlen_list);
-        Py_DECREF(type_format);
     }
 
     Py_DECREF(items_list);
@@ -755,6 +754,8 @@ py_parse_buffer(NativeConnection *self, PyObject *args)
 {
     PYTHON_ENTRY
 
+    mavdebug("Enter py_parse_buffer\n");
+
     const char *bytes;
     Py_ssize_t numBytes = 0;
 
@@ -802,6 +803,8 @@ static int
 NativeConnection_init(NativeConnection *self, PyObject *args, PyObject *kwds)
 {
     PYTHON_ENTRY
+
+    mavdebug("Enter init\n");
 
     memset(&self->mav_status, 0, sizeof(self->mav_status));
 

--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -309,6 +309,9 @@ class mavfile(object):
         start_time = time.time()
         while True:
             if timeout is not None:
+                now = time.time()
+                if now < start_time:
+                    start_time = now # If an external process rolls back system time, we should not spin forever.
                 if start_time + timeout < time.time():
                     return None
             m = self.recv_msg()

--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -40,6 +40,9 @@ mavlink = None
 # (set by mavlink_connection())
 mavfile_global = None
 
+# If the caller hasn't specified a particular native/legacy version, use this
+default_native = False
+
 # Use a globally-set MAVLink dialect if one has been specified as an environment variable.
 if not 'MAVLINK_DIALECT' in os.environ:
     os.environ['MAVLINK_DIALECT'] = 'ardupilotmega'
@@ -109,7 +112,7 @@ set_dialect(os.environ['MAVLINK_DIALECT'])
 
 class mavfile(object):
     '''a generic mavlink port'''
-    def __init__(self, fd, address, source_system=255, notimestamps=False, input=True):
+    def __init__(self, fd, address, source_system=255, notimestamps=False, input=True, use_native=default_native):
         global mavfile_global
         if input:
             mavfile_global = self
@@ -127,7 +130,7 @@ class mavfile(object):
         self.source_system = source_system
         self.first_byte = True
         self.robust_parsing = True
-        self.mav = mavlink.MAVLink(self, srcSystem=self.source_system)
+        self.mav = mavlink.MAVLink(self, srcSystem=self.source_system, use_native=use_native)
         self.mav.robust_parsing = self.robust_parsing
         self.logfile = None
         self.logfile_raw = None
@@ -687,7 +690,7 @@ def set_close_on_exec(fd):
 
 class mavserial(mavfile):
     '''a serial mavlink port'''
-    def __init__(self, device, baud=115200, autoreconnect=False, source_system=255):
+    def __init__(self, device, baud=115200, autoreconnect=False, source_system=255, use_native=default_native):
         import serial
         if ',' in device and not os.path.exists(device):
             device, baud = device.split(',')
@@ -705,7 +708,7 @@ class mavserial(mavfile):
         except Exception:
             fd = None
         self.set_baudrate(self.baud)
-        mavfile.__init__(self, fd, device, source_system=source_system)
+        mavfile.__init__(self, fd, device, source_system=source_system, use_native=use_native)
         self.rtscts = False
 
     def set_rtscts(self, enable):
@@ -763,7 +766,7 @@ class mavserial(mavfile):
 
 class mavudp(mavfile):
     '''a UDP mavlink socket'''
-    def __init__(self, device, input=True, broadcast=False, source_system=255):
+    def __init__(self, device, input=True, broadcast=False, source_system=255, use_native=default_native):
         a = device.split(':')
         if len(a) != 2:
             print("UDP ports must be specified as host:port")
@@ -780,7 +783,7 @@ class mavudp(mavfile):
         set_close_on_exec(self.port.fileno())
         self.port.setblocking(0)
         self.last_address = None
-        mavfile.__init__(self, self.port.fileno(), device, source_system=source_system, input=input)
+        mavfile.__init__(self, self.port.fileno(), device, source_system=source_system, input=input, use_native=use_native)
 
     def close(self):
         self.port.close()
@@ -822,7 +825,7 @@ class mavudp(mavfile):
 
 class mavtcp(mavfile):
     '''a TCP mavlink socket'''
-    def __init__(self, device, source_system=255, retries=3):
+    def __init__(self, device, source_system=255, retries=3, use_native=default_native):
         a = device.split(':')
         if len(a) != 2:
             print("TCP ports must be specified as host:port")
@@ -845,7 +848,7 @@ class mavtcp(mavfile):
         self.port.setblocking(0)
         set_close_on_exec(self.port.fileno())
         self.port.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
-        mavfile.__init__(self, self.port.fileno(), "tcp:" + device, source_system=source_system)
+        mavfile.__init__(self, self.port.fileno(), "tcp:" + device, source_system=source_system, use_native=use_native)
 
     def close(self):
         self.port.close()
@@ -872,7 +875,7 @@ class mavlogfile(mavfile):
     '''a MAVLink logfile reader/writer'''
     def __init__(self, filename, planner_format=None,
                  write=False, append=False,
-                 robust_parsing=True, notimestamps=False, source_system=255):
+                 robust_parsing=True, notimestamps=False, source_system=255, use_native=default_native):
         self.filename = filename
         self.writeable = write
         self.robust_parsing = robust_parsing
@@ -887,7 +890,7 @@ class mavlogfile(mavfile):
         self.f = open(filename, mode)
         self.filesize = os.path.getsize(filename)
         self.percent = 0
-        mavfile.__init__(self, None, filename, source_system=source_system, notimestamps=notimestamps)
+        mavfile.__init__(self, None, filename, source_system=source_system, notimestamps=notimestamps, use_native=use_native)
         if self.notimestamps:
             self._timestamp = 0
         else:
@@ -992,7 +995,7 @@ class mavmemlog(mavfile):
 
 class mavchildexec(mavfile):
     '''a MAVLink child processes reader/writer'''
-    def __init__(self, filename, source_system=255):
+    def __init__(self, filename, source_system=255, use_native=default_native):
         from subprocess import Popen, PIPE
         import fcntl
         
@@ -1006,7 +1009,7 @@ class mavchildexec(mavfile):
         fl = fcntl.fcntl(self.child.stdout.fileno(), fcntl.F_GETFL)
         fcntl.fcntl(self.child.stdout.fileno(), fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
-        mavfile.__init__(self, self.fd, filename, source_system=source_system)
+        mavfile.__init__(self, self.fd, filename, source_system=source_system, use_native=use_native)
 
     def close(self):
         self.child.close()
@@ -1026,21 +1029,21 @@ def mavlink_connection(device, baud=115200, source_system=255,
                        planner_format=None, write=False, append=False,
                        robust_parsing=True, notimestamps=False, input=True,
                        dialect=None, autoreconnect=False, zero_time_base=False,
-                       retries=3):
+                       retries=3, use_native=default_native):
     '''open a serial, UDP, TCP or file mavlink connection'''
     global mavfile_global
 
     if dialect is not None:
         set_dialect(dialect)
     if device.startswith('tcp:'):
-        return mavtcp(device[4:], source_system=source_system, retries=retries)
+        return mavtcp(device[4:], source_system=source_system, retries=retries, use_native=use_native)
     if device.startswith('udpin:'):
-        return mavudp(device[6:], input=True, source_system=source_system)
+        return mavudp(device[6:], input=True, source_system=source_system, use_native=use_native)
     if device.startswith('udpout:'):
-        return mavudp(device[7:], input=False, source_system=source_system)
+        return mavudp(device[7:], input=False, source_system=source_system, use_native=use_native)
     # For legacy purposes we accept the following syntax and let the caller to specify direction
     if device.startswith('udp:'):
-        return mavudp(device[4:], input=input, source_system=source_system)
+        return mavudp(device[4:], input=input, source_system=source_system, use_native=use_native)
 
     if device.lower().endswith('.bin') or device.lower().endswith('.px4log'):
         # support dataflash logs
@@ -1061,16 +1064,16 @@ def mavlink_connection(device, baud=115200, source_system=255,
     logsuffixes = ['mavlink', 'log', 'raw', 'tlog' ]
     suffix = device.split('.')[-1].lower()
     if device.find(':') != -1 and not suffix in logsuffixes:
-        return mavudp(device, source_system=source_system, input=input)
+        return mavudp(device, source_system=source_system, input=input, use_native=use_native)
     if os.path.isfile(device):
         if device.endswith(".elf") or device.find("/bin/") != -1:
             print("executing '%s'" % device)
-            return mavchildexec(device, source_system=source_system)
+            return mavchildexec(device, source_system=source_system, use_native=use_native)
         else:
             return mavlogfile(device, planner_format=planner_format, write=write,
                               append=append, robust_parsing=robust_parsing, notimestamps=notimestamps,
-                              source_system=source_system)
-    return mavserial(device, baud=baud, source_system=source_system, autoreconnect=autoreconnect)
+                              source_system=source_system, use_native=use_native)
+    return mavserial(device, baud=baud, source_system=source_system, autoreconnect=autoreconnect, use_native=use_native)
 
 class periodic_event(object):
     '''a class for fixed frequency events'''

--- a/pymavlink/setup.py
+++ b/pymavlink/setup.py
@@ -49,7 +49,6 @@ if not "NOGEN" in os.environ:
 mavnative_module = Extension('mavnative',
                     sources = ['mavnative/mavnative.c'],
                     include_dirs = [
-                        'generator/C/include_v1.0/ardupilotmega',
                         'generator/C/include_v1.0'
                         ]
                     )

--- a/pymavlink/setup.py
+++ b/pymavlink/setup.py
@@ -9,7 +9,7 @@ except LookupError:
     codecs.register(func)
 
 from distutils.core import setup, Extension
-import glob, os, shutil, fnmatch
+import glob, os, shutil, fnmatch, platform
 
 version = '1.1.43'
 
@@ -46,12 +46,16 @@ if not "NOGEN" in os.environ:
         print("Building %s" % xml)
         mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_1_0)
 
-mavnative_module = Extension('mavnative',
+extensions = [] # Assume we might be unable to build native code
+if platform.system() != 'Windows':
+    extensions = [ Extension('mavnative',
                     sources = ['mavnative/mavnative.c'],
                     include_dirs = [
                         'generator/C/include_v1.0'
                         ]
-                    )
+                    ) ]
+else:
+    print("Skipping mavnative due to Windows possibly missing a compiler...")
 
 setup (name = 'pymavlink',
        version = version,
@@ -101,5 +105,5 @@ setup (name = 'pymavlink',
                    'tools/mavkml.py',
                    'tools/mavsummarize.py',
                    'tools/MPU6KSearch.py'],
-       ext_modules = [mavnative_module]        
+       ext_modules = extensions
        )

--- a/pymavlink/setup.py
+++ b/pymavlink/setup.py
@@ -46,6 +46,14 @@ if not "NOGEN" in os.environ:
         print("Building %s" % xml)
         mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_1_0)
 
+mavnative_module = Extension('mavnative',
+                    sources = ['mavnative/mavnative.c'],
+                    include_dirs = [
+                        'generator/C/include_v1.0/ardupilotmega',
+                        'generator/C/include_v1.0'
+                        ]
+                    )
+
 setup (name = 'pymavlink',
        version = version,
        description = 'Python MAVLink code',
@@ -93,5 +101,6 @@ setup (name = 'pymavlink',
                    'tools/mavgen.py',
                    'tools/mavkml.py',
                    'tools/mavsummarize.py',
-                   'tools/MPU6KSearch.py']
+                   'tools/MPU6KSearch.py'],
+       ext_modules = [mavnative_module]        
        )


### PR DESCRIPTION
This patch set results in a 6x speedup in mavlink RX speed.  @tridge - ready to review.  See associated MAVProxy "--native" command line option. (Native defaults off otherwise)

If native dll can not be found at startup, we fall back to legacy and print a warning message.

Also two env vars can be used for testing:

You can now "export MAVNATIVE_TESTING=true" to force both the legacy
and native decoders to be used.  An exception will be thrown if there is
ever a mismatch.

You can also use "export MAVNATIVE_FORCE=true" to force use of native code
even if the client app has not requested it (normally native defaults
to false)