### PR TITLE
A couple small fixes

### DIFF
--- a/pymavlink/generator/C/include_v0.9/checksum.h
+++ b/pymavlink/generator/C/include_v0.9/checksum.h
@@ -5,6 +5,12 @@ extern "C" {
 #ifndef _CHECKSUM_H_
 #define _CHECKSUM_H_
 
+// Visual Studio versions before 2010 don't have stdint.h, so we just error out.
+#if (defined _MSC_VER) && (_MSC_VER < 1600)
+#error "The C-MAVLink implementation requires Visual Studio 2010 or greater"
+#endif
+
+#include <stdint.h>
 
 /**
  *

--- a/pymavlink/generator/C/include_v0.9/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v0.9/mavlink_helpers.h
@@ -62,7 +62,7 @@ MAVLINK_HELPER uint16_t mavlink_finalize_message_chan(mavlink_message_t* msg, ui
 	msg->len = length;
 	msg->sysid = system_id;
 	msg->compid = component_id;
-	// One sequence number per component
+	// One sequence number per channel
 	msg->seq = mavlink_get_channel_status(chan)->current_tx_seq;
 	mavlink_get_channel_status(chan)->current_tx_seq = mavlink_get_channel_status(chan)->current_tx_seq+1;
 	checksum = crc_calculate((uint8_t*)&msg->len, length + MAVLINK_CORE_HEADER_LEN);

--- a/pymavlink/generator/C/include_v1.0/checksum.h
+++ b/pymavlink/generator/C/include_v1.0/checksum.h
@@ -5,6 +5,12 @@ extern "C" {
 #ifndef _CHECKSUM_H_
 #define _CHECKSUM_H_
 
+// Visual Studio versions before 2010 don't have stdint.h, so we just error out.
+#if (defined _MSC_VER) && (_MSC_VER < 1600)
+#error "The C-MAVLink implementation requires Visual Studio 2010 or greater"
+#endif
+
+#include <stdint.h>
 
 /**
  *

--- a/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_helpers.h
@@ -77,7 +77,7 @@ MAVLINK_HELPER uint16_t mavlink_finalize_message_chan(mavlink_message_t* msg, ui
 	msg->len = length;
 	msg->sysid = system_id;
 	msg->compid = component_id;
-	// One sequence number per component
+	// One sequence number per channel
 	msg->seq = mavlink_get_channel_status(chan)->current_tx_seq;
 	mavlink_get_channel_status(chan)->current_tx_seq = mavlink_get_channel_status(chan)->current_tx_seq+1;
 	msg->checksum = crc_calculate(((const uint8_t*)(msg)) + 3, MAVLINK_CORE_HEADER_LEN);


### PR DESCRIPTION
Fixed an incorrect comment.
Fixed #includes for checksum.h, which requires stdint.h to compile but didn't include it already. Problematic when defining your own mavlink_helpers functions.