### PR TITLE
pymavlink: Just moved the check for end of file up a couple of lines

### DIFF
--- a/pymavlink/DFReader.py
+++ b/pymavlink/DFReader.py
@@ -447,15 +447,15 @@ class DFReader_text(DFReader):
             if len(elements) >= 2:
                 break
 
+        if self.line >= len(self.lines):
+            return None
+
         # cope with empty structures
         if len(elements) == 5 and elements[-1] == ',':
             elements[-1] = ''
             elements.append('')
 
         self.percent = 100.0 * (self.line / float(len(self.lines)))
-
-        if self.line >= len(self.lines):
-            return None
 
         msg_type = elements[0]
 


### PR DESCRIPTION
I have a log file which this was failing on as we were accessing the
elements variable even though it hadn't been initialised.  I just
moved the check up a couple of lines before accessing elements so it
will return if we are past the end of all the lines.