### PR TITLE
Add an option to ignore BAD_DATA messages to mavlogdump.py

### DIFF
--- a/pymavlink/tools/mavlogdump.py
+++ b/pymavlink/tools/mavlogdump.py
@@ -25,6 +25,7 @@ parser.add_argument("--csv_sep", dest="csv_sep", default=",", help="Select the d
 parser.add_argument("--types", default=None, help="types of messages (comma separated)")
 parser.add_argument("--dialect", default="ardupilotmega", help="MAVLink dialect")
 parser.add_argument("--zero-time-base", action='store_true', help="use Z time base for DF logs")
+parser.add_argument("--no-bad-data", action='store_true', help="Don't output corrupted messages")
 parser.add_argument("log", metavar="LOG")
 args = parser.parse_args()
 
@@ -103,7 +104,9 @@ while True:
     if types is not None and m.get_type() not in types and m.get_type() != 'BAD_DATA':
         continue
 
-    if m.get_type() == 'BAD_DATA' and m.reason == "Bad prefix":
+    # Ignore BAD_DATA messages is the user requested or if they're because of a bad prefix. The
+    # latter case is normally because of a mismatched MAVLink version.
+    if m.get_type() == 'BAD_DATA' and (args.no_bad_data is True or m.reason == "Bad prefix"):
         continue
 
     # Grab the timestamp.


### PR DESCRIPTION
Though I'm unsure why messages with a bad prefix are being ignored, but all the other BAD_DATA reasons are allowed (though I'm unsure how many there are). I attempted to document this, but would like some feedback as to why exactly that was being done. I can't see a reason to do it, especially now that BAD_DATA messages can be ignored, but I left it in anyways.