### PR TITLE
Add a tool to remove one or more packet types from a mavlink log

### DIFF
--- a/pymavlink/tools/mav_filter
+++ b/pymavlink/tools/mav_filter
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+""" Remove 'ERR' packets which droneshare seems to choke on with 'Invalid location data was found in that log, ignoring' error """
+from pymavlink import mavlinkv10 as mavlink
+from pymavlink import mavutil, mavextra, mavparm
+from pymavlink.dialects.v10 import pixhawk
+
+import sys, struct, time, os, array, tempfile
+
+from argparse import ArgumentParser
+parser = ArgumentParser("log_processor infile outfile [options]")
+parser.add_argument("infile", help="file to cleanup")
+parser.add_argument("outfile", help="cleaned file")
+
+args = parser.parse_args()
+
+ilog = mavutil.mavlink_connection(args.infile)
+olog = open(args.outfile,"w")
+m = ilog.recv_msg()
+
+while m != None:
+    if m.get_type() != "ERR":
+        olog.write(m.get_msgbuf())
+    m = ilog.recv_msg()
+olog.close()

--- a/pymavlink/tools/mav_filter
+++ b/pymavlink/tools/mav_filter
@@ -10,6 +10,7 @@ from argparse import ArgumentParser
 parser = ArgumentParser("log_processor infile outfile [options]")
 parser.add_argument("infile", help="file to cleanup")
 parser.add_argument("outfile", help="cleaned file")
+parser.add_argument("--remove", default="ERR", help="What types of packets to remove default ERR, comma seperated for multiple")
 
 args = parser.parse_args()
 
@@ -17,8 +18,10 @@ ilog = mavutil.mavlink_connection(args.infile)
 olog = open(args.outfile,"w")
 m = ilog.recv_msg()
 
+unwanted = args.remove.split(",")
+
 while m != None:
-    if m.get_type() != "ERR":
+    if m.get_type() not in unwanted:
         olog.write(m.get_msgbuf())
     m = ilog.recv_msg()
 olog.close()


### PR DESCRIPTION
I wrote this tool because droneshare seems to choke on 'ERR' packets.  This tool by default cleans up logs with this issue but also lets you remove whatever you want (by packet type)

Oh, and thanks for these tools so I could do this so easily.