### PR TITLE
Named an unnamed struct

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -81,7 +81,7 @@ typedef struct param_union {
 */
 MAVPACKED(
 typedef union {
-    struct {
+    struct __data{
         uint8_t is_double:1;
         uint8_t mavlink_type:7;
         union {


### PR DESCRIPTION
Unnamed struct led to compiler warnings.