### PR TITLE
Update mavlink_types.h (mavlink_param_union_double_t)

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -86,12 +86,12 @@ typedef union {
         uint8_t mavlink_type:7;
         union {
             char c;
-            uint8_t uint8;
-            int8_t int8;
-            uint16_t uint16;
-            int16_t int16;
-            uint32_t uint32;
-            int32_t int32;
+            uint8_t u8;
+            int8_t i8;
+            uint16_t u16;
+            int16_t i16;
+            uint32_t u32;
+            int32_t i32;
             float f;
             uint8_t align[7];
         };


### PR DESCRIPTION
More convenient / less verbose fields' names.
