### PR TITLE
mavnative: Fixes for 32 bit arches and zero length strings

### DIFF
--- a/pymavlink/mavnative/mavnative.c
+++ b/pymavlink/mavnative/mavnative.c
@@ -585,12 +585,12 @@ static PyObject *pyextract_mavlink(const mavlink_message_t *msg, const py_field_
         if(arrayResult != NULL)  
             PyList_SetItem(arrayResult, index, val);
         else if(stringResult != NULL) {
-            if(!string_ended) {
+            if(!string_ended)
                 PyByteString_ConcatAndDel(&stringResult, val);
-                result = stringResult;
-            }
             else
                 Py_DECREF(val); // We didn't use this char
+
+            result = stringResult;
         }
         else // Not building an array
             result = val;

--- a/pymavlink/mavnative/mavnative.c
+++ b/pymavlink/mavnative/mavnative.c
@@ -563,10 +563,10 @@ static PyObject *pyextract_mavlink(const mavlink_message_t *msg, const py_field_
                 val = PyInt_FromLong(_MAV_RETURN_int32_t(msg, offset));   
                 break;
             case MAVLINK_TYPE_UINT64_T:
-                val = PyLong_FromLong(_MAV_RETURN_uint64_t(msg, offset));
+                val = PyLong_FromLongLong(_MAV_RETURN_uint64_t(msg, offset));
                 break;
             case MAVLINK_TYPE_INT64_T:
-                val = PyLong_FromLong(_MAV_RETURN_int64_t(msg, offset));
+                val = PyLong_FromLongLong(_MAV_RETURN_int64_t(msg, offset));
                 break;
             case MAVLINK_TYPE_FLOAT:
                 val = PyFloat_FromDouble(_MAV_RETURN_float(msg, offset));


### PR DESCRIPTION
Hi @tridge - This PR includes fixes for mavnative.  The first problem would only occur if you used 64 bit fields on a 32 bit arch (if running on a 64 bit OS the problem would not appear)