### PR TITLE
Fix broken compilation with Microchip's XC16 compiler

### DIFF
--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -95,8 +95,8 @@ typedef union {
             float f;
             uint8_t align[7];
         };
-    };
-    uint8_t data[8];
+    } data;
+    uint8_t bytes[8];
 }) mavlink_param_union_double_t;
 
 /**

--- a/pymavlink/generator/C/include_v1.0/mavlink_types.h
+++ b/pymavlink/generator/C/include_v1.0/mavlink_types.h
@@ -10,9 +10,9 @@
 
 // Macro to define packed structures
 #ifdef __GNUC__
-  #define MAVPACKED( __Declaration__ ) __Declaration__ __attribute__((packed))
+  #define MAVPACKED( decl ) decl __attribute__((packed))
 #else
-  #define MAVPACKED( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
+  #define MAVPACKED( decl ) __pragma( pack(push, 1) ) decl  __pragma( pack(pop) )
 #endif
 
 #ifndef MAVLINK_MAX_PAYLOAD_LEN


### PR DESCRIPTION
The C standard (and I believe the C++ standard) reserves all variables that start with a _
or __ followed by a capital letter for the compiler. Therefore they shouldn't be used in
user code.

This fixed compilation warnings and errors with Microchip's XC16 compiler.