### PR TITLE
Add ATTITUDE_ESTIMATE message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1831,6 +1831,17 @@
                <field type="float" name="p2y">y position 2 / Longitude 2</field>
                <field type="float" name="p2z">z position 2 / Altitude 2</field>
           </message>
+          <message id="60" name="ATTITUDE_ESTIMATE">
+               <description>The attitude estimate in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
+               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+               <field type="float" name="ax">X acceleration (m/s^2)</field>
+               <field type="float" name="ay">Y acceleration (m/s^2)</field>
+               <field type="float" name="az">Z acceleration (m/s^2)</field>
+          </message>
           <message id="61" name="ATTITUDE_QUATERNION_COV">
                <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
                <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>


### PR DESCRIPTION
This message transports orientation, angular velocity and linear acceleration as computed from the on-board IMU(s) by a estimator.

This is to maintain congruence with ROS : http://docs.ros.org/api/sensor_msgs/html/msg/Imu.html

The output from ```attitude_estimator_ekf``` is sent to ROS with this, in order to use filters like ```robot_localisation``` with no IMU measurement model. (They assume the IMU runs an EKF internally e.g CH Robotics IMUs)