### PR TITLE
pymavlink: Add wp_is_loiter method to mavwp to identify loiter WPs

### DIFF
--- a/pymavlink/mavwp.py
+++ b/pymavlink/mavwp.py
@@ -36,6 +36,17 @@ class MAVWPLoader(object):
         '''return a waypoint'''
         return self.wpoints[i]
 
+    def wp_is_loiter(self, i):
+        '''return true if waypoint is a loiter waypoint'''
+        loiter_cmds = [mavutil.mavlink.MAV_CMD_NAV_LOITER_UNLIM,
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_TURNS,
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_TIME]
+
+        if (self.wpoints[i].command in loiter_cmds):
+            return True    
+
+        return False
+
     def add(self, w, comment=''):
         '''add a waypoint'''
         w = copy.copy(w)


### PR DESCRIPTION
Needed a way to quickly identify a waypoint that results in a loiter.