### PR TITLE
Add acceleration to LOCAL_POSITION_NED_COV

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1867,16 +1867,19 @@
           </message>
           <message id="64" name="LOCAL_POSITION_NED_COV">
               <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-              <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+              <field type="uint32_t" name="time_usec">Timestamp (milliseconds since system boot). 0 for system without monotonic timestam</field>
               <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.</field>
               <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
               <field type="float" name="x">X Position</field>
               <field type="float" name="y">Y Position</field>
               <field type="float" name="z">Z Position</field>
-              <field type="float" name="vx">X Speed</field>
-              <field type="float" name="vy">Y Speed</field>
-              <field type="float" name="vz">Z Speed</field>
-              <field type="float[36]" name="covariance">Covariance matrix (first six entries are the first ROW, next six entries are the second row, etc.)</field>
+              <field type="float" name="vx">X Speed (m/s)</field>
+              <field type="float" name="vy">Y Speed (m/s)</field>
+              <field type="float" name="vz">Z Speed (m/s)</field>
+              <field type="float" name="ax">X Acceleration (m/s^2)</field>
+              <field type="float" name="ay">Y Acceleration (m/s^2)</field>
+              <field type="float" name="az">Z Acceleration (m/s^2)</field>
+              <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first six entries are the first ROW, next six entries are the second row, etc.)</field>
           </message>
           <message id="65" name="RC_CHANNELS">
                <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1879,7 +1879,7 @@
               <field type="float" name="ax">X Acceleration (m/s^2)</field>
               <field type="float" name="ay">Y Acceleration (m/s^2)</field>
               <field type="float" name="az">Z Acceleration (m/s^2)</field>
-              <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first six entries are the first ROW, next six entries are the second row, etc.)</field>
+              <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first nine entries are the first ROW, next eight entries are the second row, etc.)</field>
           </message>
           <message id="65" name="RC_CHANNELS">
                <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1867,7 +1867,7 @@
           </message>
           <message id="64" name="LOCAL_POSITION_NED_COV">
               <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-              <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot). 0 for system without monotonic timestam</field>
+              <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot). 0 for system without monotonic timestamp</field>
               <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.</field>
               <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
               <field type="float" name="x">X Position</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1867,7 +1867,7 @@
           </message>
           <message id="64" name="LOCAL_POSITION_NED_COV">
               <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-              <field type="uint32_t" name="time_usec">Timestamp (milliseconds since system boot). 0 for system without monotonic timestam</field>
+              <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot). 0 for system without monotonic timestam</field>
               <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.</field>
               <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
               <field type="float" name="x">X Position</field>


### PR DESCRIPTION
So two messages should now give us full back-to-back ROS-PX4 interoperability :
1. LOCAL_POSITION_NED_COV (this PR)
2. ATTITUDE_QUATERNION_COV

Originating system is expected to send these with same timestamps and receiver publishes them simultaneously, if required, after receiving the last message.