### PR TITLE
Loiter to altitude mission item added

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -599,7 +599,7 @@
                     <param index="5">Latitude</param>
                     <param index="6">Longitude</param>
                     <param index="7">Altitude</param>
-               </entry>
+                </entry>
                <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT">
                    <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
                     <param index="1">Empty</param>
@@ -609,6 +609,16 @@
                     <param index="5">Empty</param>
                     <param index="6">Empty</param>
                     <param index="7">Desired altitude in meters</param>
+                </entry>
+                <entry value="31" name="MAV_CMD_NAV_LOITER_TO_ALT">
+                    <description>Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint. </description>
+                    <param index="1">Heading Required (0 = False)</param>
+                    <param index="2">Radius in meters. If positive loiter clockwise, negative counter-clockwise, 0 means no change to standard loiter.</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
                </entry>
                <entry value="80" name="MAV_CMD_NAV_ROI">
                     <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>

--- a/pymavlink/mavwp.py
+++ b/pymavlink/mavwp.py
@@ -40,7 +40,8 @@ class MAVWPLoader(object):
         '''return true if waypoint is a loiter waypoint'''
         loiter_cmds = [mavutil.mavlink.MAV_CMD_NAV_LOITER_UNLIM,
                 mavutil.mavlink.MAV_CMD_NAV_LOITER_TURNS,
-                mavutil.mavlink.MAV_CMD_NAV_LOITER_TIME]
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_TIME,
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_TO_ALT]
 
         if (self.wpoints[i].command in loiter_cmds):
             return True    


### PR DESCRIPTION
Now that https://github.com/diydrones/ardupilot/pull/1981 is merged into master, mavlink needs to know about the corresponding MAV_CMD_NAV_LOITER_TO_ALT.