### PR TITLE
add interactive .html output to mavgraph (using mpld3)

### DIFF
--- a/pymavlink/tools/mavgraph.py
+++ b/pymavlink/tools/mavgraph.py
@@ -8,6 +8,7 @@ import sys, struct, time, os, datetime
 import math, re
 import matplotlib
 from math import *
+import mpld3
 
 from pymavlink.mavextra import *
 
@@ -140,6 +141,7 @@ def plotit(x, y, fields, colors=[]):
     if empty:
         print("No data to graph")
         return
+    return fig
 
 
 from argparse import ArgumentParser
@@ -277,7 +279,7 @@ for fi in range(0, len(filenames)):
         col = colors[:]
     else:
         col = colors[fi*len(fields):]
-    plotit(x, y, lab, colors=col)
+    fig = plotit(x, y, lab, colors=col)
     for i in range(0, len(x)):
         x[i] = []
         y[i] = []
@@ -286,5 +288,12 @@ if args.output is None:
     pylab.draw()
     input('press enter to exit....')
 else:
-    pylab.legend(loc=2,prop={'size':8})
-    pylab.savefig(args.output, bbox_inches='tight', dpi=200)
+    fname, fext = os.path.splitext(args.output)
+    if fext == '.html':
+        html = mpld3.fig_to_html(fig)
+        f_out = open(args.output, 'w')
+        f_out.write(html)
+        f_out.close()
+    else:
+        pylab.legend(loc=2,prop={'size':8})
+        pylab.savefig(args.output, bbox_inches='tight', dpi=200)

--- a/pymavlink/tools/mavgraph.py
+++ b/pymavlink/tools/mavgraph.py
@@ -8,7 +8,6 @@ import sys, struct, time, os, datetime
 import math, re
 import matplotlib
 from math import *
-import mpld3
 
 from pymavlink.mavextra import *
 
@@ -290,6 +289,7 @@ if args.output is None:
 else:
     fname, fext = os.path.splitext(args.output)
     if fext == '.html':
+        import mpld3
         html = mpld3.fig_to_html(fig)
         f_out = open(args.output, 'w')
         f_out.write(html)


### PR DESCRIPTION
Generate interactive html plots using mpld3 when the output filename ends with `.html`.

In order to get this to run I just needed 

```
pip2 install --user mpld3 jinja2
```

Result:
png as usual:
![test](https://cloud.githubusercontent.com/assets/1419479/7428519/3b82df1c-eff2-11e4-8736-fc7a5f67625a.png)

html:
https://e049658cf92759a36117fcae85ac5edda5123a9b.googledrive.com/host/0B-rJ0xZBEd7feTdWa0VQV0t3ZXc

mpld3 seems to have some issues with the colored background ( it also issues a warning). However the result looks usable. 

@sjwilks this could be interesting for logmuncher. Note that the html files get quite large, so maybe they should only get loaded after a click on the image.
