### PR TITLE
Updated mav_type for vtol_hexarotor

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -123,21 +123,21 @@
                <entry value="20" name="MAV_TYPE_VTOL_QUADROTOR">
                     <description>Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter.</description>
                </entry>
+               <entry value="21" name="MAV_TYPE_VTOL_HEXAROTOR">
+                    <description>Hexa-rotor VTOL using a Y-Shaped config in vertical operation.</description>
+               </entry>
                <!-- Entries up to 25 reserved for other VTOL airframes -->
-               <entry value="21" name="MAV_TYPE_VTOL_RESERVED1">
+               <entry value="22" name="MAV_TYPE_VTOL_RESERVED1">
                     <description>VTOL reserved 1</description>
                </entry>
-               <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
+               <entry value="23" name="MAV_TYPE_VTOL_RESERVED2">
                     <description>VTOL reserved 2</description>
                </entry>
-               <entry value="23" name="MAV_TYPE_VTOL_RESERVED3">
+               <entry value="24" name="MAV_TYPE_VTOL_RESERVED3">
                     <description>VTOL reserved 3</description>
                </entry>
-               <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
+               <entry value="25" name="MAV_TYPE_VTOL_RESERVED4">
                     <description>VTOL reserved 4</description>
-               </entry>
-               <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
-                    <description>VTOL reserved 5</description>
                </entry>
                <entry value="26" name="MAV_TYPE_GIMBAL">
                     <description>Onboard gimbal</description>


### PR DESCRIPTION
Updated MAV_TYPE 21 to hexa-rotor Y config. For airframes like FireFLY6.