### PR TITLE
Add LANDING_TARGET Message

### DIFF
--- a/message_definitions/v0.9/common.xml
+++ b/message_definitions/v0.9/common.xml
@@ -910,6 +910,14 @@ of the controller before actual flight and to assist with tuning controller para
                <field type="float" name="distance">Ground distance in meters</field>
           </message>
           <!-- MESSAGE IDs 80 - 250: Space for custom messages in individual projectname_messages.xml files -->
+          <message id="230" name="LANDING_TARGET">
+            <description>The location of a landing area captured from a downward facing camera</description>
+            <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
+            <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
+            <field type="float" name="angle_x">Angular offset(radians) of the object from the center of the image: x-axis</field>
+            <field type="float" name="angle_y">Angular offset(radians) of the object from the center of the image: x-axis</field>
+            <field type="float" name="distance">Distance to the object from the vehicle in meters</field>
+          </message>
           <message id="251" name="DEBUG_VECT">
                <field type="char[10]" name="name">Name</field>
                <field type="uint64_t" name="usec">Timestamp</field>

--- a/message_definitions/v0.9/common.xml
+++ b/message_definitions/v0.9/common.xml
@@ -910,14 +910,6 @@ of the controller before actual flight and to assist with tuning controller para
                <field type="float" name="distance">Ground distance in meters</field>
           </message>
           <!-- MESSAGE IDs 80 - 250: Space for custom messages in individual projectname_messages.xml files -->
-          <message id="230" name="LANDING_TARGET">
-            <description>The location of a landing area captured from a downward facing camera</description>
-            <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
-            <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
-            <field type="float" name="angle_x">Angular offset(radians) of the object from the center of the image: x-axis</field>
-            <field type="float" name="angle_y">Angular offset(radians) of the object from the center of the image: x-axis</field>
-            <field type="float" name="distance">Distance to the object from the vehicle in meters</field>
-          </message>
           <message id="251" name="DEBUG_VECT">
                <field type="char[10]" name="name">Name</field>
                <field type="uint64_t" name="usec">Timestamp</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2768,7 +2768,7 @@
             <field type="uint64_t" name="uid">UID if provided by hardware</field>
         </message>
         <!-- MESSAGE IDs 180 - 240: Space for custom messages in individual projectname_messages.xml files -->
-		 <message id="230" name="LANDING_TARGET">
+        <message id="230" name="LANDING_TARGET">
             <description>The location of a landing area captured from a downward facing camera</description>
             <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
             <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -599,7 +599,7 @@
                     <param index="5">Latitude</param>
                     <param index="6">Longitude</param>
                     <param index="7">Altitude</param>
-                </entry>
+               </entry>
                <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT">
                    <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
                     <param index="1">Empty</param>
@@ -609,7 +609,7 @@
                     <param index="5">Empty</param>
                     <param index="6">Empty</param>
                     <param index="7">Desired altitude in meters</param>
-                </entry>
+               </entry>
                 <entry value="31" name="MAV_CMD_NAV_LOITER_TO_ALT">
                     <description>Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint. </description>
                     <param index="1">Heading Required (0 = False)</param>
@@ -1034,7 +1034,7 @@
                     <description>Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.</description>
                     <param index="1">Parameter storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM</param>
                     <param index="2">Mission storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM</param>
-                    <param index="3">Reserved</param>
+                    <param index="3">Onboard logging: 0: Ignore, 1: Start default rate logging, -1: Stop logging, > 1: start logging with rate of param 3 in Hz (e.g. set to 1000 for 1000 Hz logging)</param>
                     <param index="4">Reserved</param>
                     <param index="5">Empty</param>
                     <param index="6">Empty</param>
@@ -1090,6 +1090,13 @@
                   <description>Stop image capture sequence</description>
                   <param index="1">Reserved</param>
                   <param index="2">Reserved</param>
+              </entry>
+              
+              <entry name="MAV_CMD_DO_TRIGGER_CONTROL" value="2003">
+                   <description>Enable or disable on-board camera triggering system.</description>
+                   <param index="1">Trigger enable/disable (0 for disable, 1 for start)</param>
+                   <param index="2">Shutter integration time (in ms)</param>
+                   <param index="3">Reserved</param>
               </entry>
 
               <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
@@ -1403,10 +1410,133 @@
           <enum name="MAV_DISTANCE_SENSOR">
               <description>Enumeration of distance sensor types</description>
               <entry value="0" name="MAV_DISTANCE_SENSOR_LASER">
-                  <description>Laser altimeter, e.g. LightWare SF02/F or PulsedLight units</description>
+                  <description>Laser rangefinder, e.g. LightWare SF02/F or PulsedLight units</description>
               </entry>
               <entry value="1" name="MAV_DISTANCE_SENSOR_ULTRASOUND">
-                  <description>Ultrasound altimeter, e.g. MaxBotix units</description>
+                  <description>Ultrasound rangefinder, e.g. MaxBotix units</description>
+              </entry>
+              <entry value="2" name="MAV_DISTANCE_SENSOR_INFRARED">
+                  <description>Infrared rangefinder, e.g. Sharp units</description>
+              </entry>
+          </enum>
+          <enum name="MAV_SENSOR_ORIENTATION">
+              <description>Enumeration of sensor orientation, according to its rotations</description>
+              <entry value="0" name="MAV_SENSOR_ROTATION_NONE">
+                  <description>Roll: 0, Pitch: 0, Yaw: 0</description>
+              </entry>
+              <entry value="1" name="MAV_SENSOR_ROTATION_YAW_45">
+                  <description>Roll: 0, Pitch: 0, Yaw: 45</description>
+              </entry>
+              <entry value="2" name="MAV_SENSOR_ROTATION_YAW_90">
+                  <description>Roll: 0, Pitch: 0, Yaw: 90</description>
+              </entry>
+              <entry value="3" name="MAV_SENSOR_ROTATION_YAW_135">
+                  <description>Roll: 0, Pitch: 0, Yaw: 135</description>
+              </entry>
+              <entry value="4" name="MAV_SENSOR_ROTATION_YAW_180">
+                  <description>Roll: 0, Pitch: 0, Yaw: 180</description>
+              </entry>
+              <entry value="5" name="MAV_SENSOR_ROTATION_YAW_225">
+                  <description>Roll: 0, Pitch: 0, Yaw: 225</description>
+              </entry>
+              <entry value="6" name="MAV_SENSOR_ROTATION_YAW_270">
+                  <description>Roll: 0, Pitch: 0, Yaw: 270</description>
+              </entry>
+              <entry value="7" name="MAV_SENSOR_ROTATION_YAW_315">
+                  <description>Roll: 0, Pitch: 0, Yaw: 315</description>
+              </entry>
+              <entry value="8" name="MAV_SENSOR_ROTATION_ROLL_180">
+                  <description>Roll: 180, Pitch: 0, Yaw: 0</description>
+              </entry>
+              <entry value="9" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_45">
+                  <description>Roll: 180, Pitch: 0, Yaw: 45</description>
+              </entry>
+              <entry value="10" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_90">
+                  <description>Roll: 180, Pitch: 0, Yaw: 90</description>
+              </entry>
+              <entry value="11" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_135">
+                  <description>Roll: 180, Pitch: 0, Yaw: 135</description>
+              </entry>
+              <entry value="12" name="MAV_SENSOR_ROTATION_PITCH_180">
+                  <description>Roll: 0, Pitch: 180, Yaw: 0</description>
+              </entry>
+              <entry value="13" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_225">
+                  <description>Roll: 180, Pitch: 0, Yaw: 225</description>
+              </entry>
+              <entry value="14" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_270">
+                  <description>Roll: 180, Pitch: 0, Yaw: 270</description>
+              </entry>
+              <entry value="15" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_315">
+                  <description>Roll: 180, Pitch: 0, Yaw: 315</description>
+              </entry>
+              <entry value="16" name="MAV_SENSOR_ROTATION_ROLL_90">
+                  <description>Roll: 90, Pitch: 0, Yaw: 0</description>
+              </entry>
+              <entry value="17" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_45">
+                  <description>Roll: 90, Pitch: 0, Yaw: 45</description>
+              </entry>
+              <entry value="18" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_90">
+                  <description>Roll: 90, Pitch: 0, Yaw: 90</description>
+              </entry>
+              <entry value="19" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_135">
+                  <description>Roll: 90, Pitch: 0, Yaw: 135</description>
+              </entry>
+              <entry value="20" name="MAV_SENSOR_ROTATION_ROLL_270">
+                  <description>Roll: 270, Pitch: 0, Yaw: 0</description>
+              </entry>
+              <entry value="21" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_45">
+                  <description>Roll: 270, Pitch: 0, Yaw: 45</description>
+              </entry>
+              <entry value="22" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_90">
+                  <description>Roll: 270, Pitch: 0, Yaw: 90</description>
+              </entry>
+              <entry value="23" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_135">
+                  <description>Roll: 270, Pitch: 0, Yaw: 135</description>
+              </entry>
+              <entry value="24" name="MAV_SENSOR_ROTATION_PITCH_90">
+                  <description>Roll: 0, Pitch: 90, Yaw: 0</description>
+              </entry>
+              <entry value="25" name="MAV_SENSOR_ROTATION_PITCH_270">
+                <description>Roll: 0, Pitch: 270, Yaw: 0</description>
+              </entry>   
+              <entry value="26" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_90">
+                <description>Roll: 0, Pitch: 180, Yaw: 90</description>
+              </entry>  
+              <entry value="27" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_270">
+                  <description>Roll: 0, Pitch: 180, Yaw: 270</description>
+              </entry>
+              <entry value="28" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_90">
+                  <description>Roll: 90, Pitch: 90, Yaw: 0</description>
+              </entry>
+              <entry value="29" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_90">
+                  <description>Roll: 180, Pitch: 90, Yaw: 0</description>
+              </entry>
+              <entry value="30" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_90">
+                  <description>Roll: 270, Pitch: 90, Yaw: 0</description>
+              </entry>
+              <entry value="31" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180">
+                  <description>Roll: 90, Pitch: 180, Yaw: 0</description>
+              </entry>
+              <entry value="32" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_180">
+                  <description>Roll: 270, Pitch: 180, Yaw: 0</description>
+              </entry>
+              <entry value="33" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_270">
+                  <description>Roll: 90, Pitch: 270, Yaw: 0</description>
+              </entry>
+              <entry value="34" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_270">
+                  <description>Roll: 180, Pitch: 270, Yaw: 0</description>
+              </entry>
+              <entry value="35" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_270">
+                  <description>Roll: 270, Pitch: 270, Yaw: 0</description>
+              </entry>
+              <entry value="36" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90">
+                  <description>Roll: 90, Pitch: 180, Yaw: 90</description>
+              </entry>
+              <entry value="37" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_270">
+                  <description>Roll: 90, Pitch: 0, Yaw: 270</description>
+              </entry>
+              <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_315_PITCH_315_YAW_315">
+                  <description>Roll: 315, Pitch: 315, Yaw: 315</description>
               </entry>
           </enum>
           <enum name="MAV_PROTOCOL_CAPABILITY">
@@ -1897,16 +2027,19 @@
           </message>
           <message id="64" name="LOCAL_POSITION_NED_COV">
               <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-              <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+              <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot). 0 for system without monotonic timestamp</field>
               <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.</field>
               <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
               <field type="float" name="x">X Position</field>
               <field type="float" name="y">Y Position</field>
               <field type="float" name="z">Z Position</field>
-              <field type="float" name="vx">X Speed</field>
-              <field type="float" name="vy">Y Speed</field>
-              <field type="float" name="vz">Z Speed</field>
-              <field type="float[36]" name="covariance">Covariance matrix (first six entries are the first ROW, next six entries are the second row, etc.)</field>
+              <field type="float" name="vx">X Speed (m/s)</field>
+              <field type="float" name="vy">Y Speed (m/s)</field>
+              <field type="float" name="vz">Z Speed (m/s)</field>
+              <field type="float" name="ax">X Acceleration (m/s^2)</field>
+              <field type="float" name="ay">Y Acceleration (m/s^2)</field>
+              <field type="float" name="az">Z Acceleration (m/s^2)</field>
+              <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first nine entries are the first ROW, next eight entries are the second row, etc.)</field>
           </message>
           <message id="65" name="RC_CHANNELS">
                <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
@@ -2335,6 +2468,11 @@
             <field type="int64_t" name="tc1">Time sync timestamp 1</field>
             <field type="int64_t" name="ts1">Time sync timestamp 2</field>
         </message>
+        <message id="112" name="CAMERA_TRIGGER">
+            <description>Camera-IMU triggering and synchronisation message.</description>
+            <field type="uint64_t" name="time_usec">Timestamp for the image frame in microseconds</field>
+            <field type="uint32_t" name="seq">Image frame sequence</field>
+        </message>
          <message id="113" name="HIL_GPS">
              <description>The global position, as returned by the Global Positioning System (GPS). This is
                  NOT the global position estimate of the sytem, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
@@ -2541,7 +2679,7 @@
             <field type="uint16_t" name="current_distance">Current distance reading</field>
             <field type="uint8_t" name="type">Type from MAV_DISTANCE_SENSOR enum.</field>
             <field type="uint8_t" name="id">Onboard ID of the sensor</field>
-            <field type="uint8_t" name="orientation">Direction the sensor faces from FIXME enum.</field>
+            <field type="uint8_t" name="orientation">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
             <field type="uint8_t" name="covariance">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
          </message>
          <message id="133" name="TERRAIN_REQUEST">
@@ -2630,7 +2768,7 @@
             <field type="uint64_t" name="uid">UID if provided by hardware</field>
         </message>
         <!-- MESSAGE IDs 180 - 240: Space for custom messages in individual projectname_messages.xml files -->
-        <message id="230" name="LANDING_TARGET">
+		 <message id="230" name="LANDING_TARGET">
             <description>The location of a landing area captured from a downward facing camera</description>
             <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
             <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -599,7 +599,7 @@
                     <param index="5">Latitude</param>
                     <param index="6">Longitude</param>
                     <param index="7">Altitude</param>
-               </entry>
+                </entry>
                <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT">
                    <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
                     <param index="1">Empty</param>
@@ -609,7 +609,7 @@
                     <param index="5">Empty</param>
                     <param index="6">Empty</param>
                     <param index="7">Desired altitude in meters</param>
-               </entry>
+                </entry>
                 <entry value="31" name="MAV_CMD_NAV_LOITER_TO_ALT">
                     <description>Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint. </description>
                     <param index="1">Heading Required (0 = False)</param>
@@ -1034,7 +1034,7 @@
                     <description>Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.</description>
                     <param index="1">Parameter storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM</param>
                     <param index="2">Mission storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM</param>
-                    <param index="3">Onboard logging: 0: Ignore, 1: Start default rate logging, -1: Stop logging, > 1: start logging with rate of param 3 in Hz (e.g. set to 1000 for 1000 Hz logging)</param>
+                    <param index="3">Reserved</param>
                     <param index="4">Reserved</param>
                     <param index="5">Empty</param>
                     <param index="6">Empty</param>
@@ -1090,13 +1090,6 @@
                   <description>Stop image capture sequence</description>
                   <param index="1">Reserved</param>
                   <param index="2">Reserved</param>
-              </entry>
-              
-              <entry name="MAV_CMD_DO_TRIGGER_CONTROL" value="2003">
-                   <description>Enable or disable on-board camera triggering system.</description>
-                   <param index="1">Trigger enable/disable (0 for disable, 1 for start)</param>
-                   <param index="2">Shutter integration time (in ms)</param>
-                   <param index="3">Reserved</param>
               </entry>
 
               <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
@@ -1410,133 +1403,10 @@
           <enum name="MAV_DISTANCE_SENSOR">
               <description>Enumeration of distance sensor types</description>
               <entry value="0" name="MAV_DISTANCE_SENSOR_LASER">
-                  <description>Laser rangefinder, e.g. LightWare SF02/F or PulsedLight units</description>
+                  <description>Laser altimeter, e.g. LightWare SF02/F or PulsedLight units</description>
               </entry>
               <entry value="1" name="MAV_DISTANCE_SENSOR_ULTRASOUND">
-                  <description>Ultrasound rangefinder, e.g. MaxBotix units</description>
-              </entry>
-              <entry value="2" name="MAV_DISTANCE_SENSOR_INFRARED">
-                  <description>Infrared rangefinder, e.g. Sharp units</description>
-              </entry>
-          </enum>
-          <enum name="MAV_SENSOR_ORIENTATION">
-              <description>Enumeration of sensor orientation, according to its rotations</description>
-              <entry value="0" name="MAV_SENSOR_ROTATION_NONE">
-                  <description>Roll: 0, Pitch: 0, Yaw: 0</description>
-              </entry>
-              <entry value="1" name="MAV_SENSOR_ROTATION_YAW_45">
-                  <description>Roll: 0, Pitch: 0, Yaw: 45</description>
-              </entry>
-              <entry value="2" name="MAV_SENSOR_ROTATION_YAW_90">
-                  <description>Roll: 0, Pitch: 0, Yaw: 90</description>
-              </entry>
-              <entry value="3" name="MAV_SENSOR_ROTATION_YAW_135">
-                  <description>Roll: 0, Pitch: 0, Yaw: 135</description>
-              </entry>
-              <entry value="4" name="MAV_SENSOR_ROTATION_YAW_180">
-                  <description>Roll: 0, Pitch: 0, Yaw: 180</description>
-              </entry>
-              <entry value="5" name="MAV_SENSOR_ROTATION_YAW_225">
-                  <description>Roll: 0, Pitch: 0, Yaw: 225</description>
-              </entry>
-              <entry value="6" name="MAV_SENSOR_ROTATION_YAW_270">
-                  <description>Roll: 0, Pitch: 0, Yaw: 270</description>
-              </entry>
-              <entry value="7" name="MAV_SENSOR_ROTATION_YAW_315">
-                  <description>Roll: 0, Pitch: 0, Yaw: 315</description>
-              </entry>
-              <entry value="8" name="MAV_SENSOR_ROTATION_ROLL_180">
-                  <description>Roll: 180, Pitch: 0, Yaw: 0</description>
-              </entry>
-              <entry value="9" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_45">
-                  <description>Roll: 180, Pitch: 0, Yaw: 45</description>
-              </entry>
-              <entry value="10" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_90">
-                  <description>Roll: 180, Pitch: 0, Yaw: 90</description>
-              </entry>
-              <entry value="11" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_135">
-                  <description>Roll: 180, Pitch: 0, Yaw: 135</description>
-              </entry>
-              <entry value="12" name="MAV_SENSOR_ROTATION_PITCH_180">
-                  <description>Roll: 0, Pitch: 180, Yaw: 0</description>
-              </entry>
-              <entry value="13" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_225">
-                  <description>Roll: 180, Pitch: 0, Yaw: 225</description>
-              </entry>
-              <entry value="14" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_270">
-                  <description>Roll: 180, Pitch: 0, Yaw: 270</description>
-              </entry>
-              <entry value="15" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_315">
-                  <description>Roll: 180, Pitch: 0, Yaw: 315</description>
-              </entry>
-              <entry value="16" name="MAV_SENSOR_ROTATION_ROLL_90">
-                  <description>Roll: 90, Pitch: 0, Yaw: 0</description>
-              </entry>
-              <entry value="17" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_45">
-                  <description>Roll: 90, Pitch: 0, Yaw: 45</description>
-              </entry>
-              <entry value="18" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_90">
-                  <description>Roll: 90, Pitch: 0, Yaw: 90</description>
-              </entry>
-              <entry value="19" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_135">
-                  <description>Roll: 90, Pitch: 0, Yaw: 135</description>
-              </entry>
-              <entry value="20" name="MAV_SENSOR_ROTATION_ROLL_270">
-                  <description>Roll: 270, Pitch: 0, Yaw: 0</description>
-              </entry>
-              <entry value="21" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_45">
-                  <description>Roll: 270, Pitch: 0, Yaw: 45</description>
-              </entry>
-              <entry value="22" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_90">
-                  <description>Roll: 270, Pitch: 0, Yaw: 90</description>
-              </entry>
-              <entry value="23" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_135">
-                  <description>Roll: 270, Pitch: 0, Yaw: 135</description>
-              </entry>
-              <entry value="24" name="MAV_SENSOR_ROTATION_PITCH_90">
-                  <description>Roll: 0, Pitch: 90, Yaw: 0</description>
-              </entry>
-              <entry value="25" name="MAV_SENSOR_ROTATION_PITCH_270">
-                <description>Roll: 0, Pitch: 270, Yaw: 0</description>
-              </entry>   
-              <entry value="26" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_90">
-                <description>Roll: 0, Pitch: 180, Yaw: 90</description>
-              </entry>  
-              <entry value="27" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_270">
-                  <description>Roll: 0, Pitch: 180, Yaw: 270</description>
-              </entry>
-              <entry value="28" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_90">
-                  <description>Roll: 90, Pitch: 90, Yaw: 0</description>
-              </entry>
-              <entry value="29" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_90">
-                  <description>Roll: 180, Pitch: 90, Yaw: 0</description>
-              </entry>
-              <entry value="30" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_90">
-                  <description>Roll: 270, Pitch: 90, Yaw: 0</description>
-              </entry>
-              <entry value="31" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180">
-                  <description>Roll: 90, Pitch: 180, Yaw: 0</description>
-              </entry>
-              <entry value="32" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_180">
-                  <description>Roll: 270, Pitch: 180, Yaw: 0</description>
-              </entry>
-              <entry value="33" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_270">
-                  <description>Roll: 90, Pitch: 270, Yaw: 0</description>
-              </entry>
-              <entry value="34" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_270">
-                  <description>Roll: 180, Pitch: 270, Yaw: 0</description>
-              </entry>
-              <entry value="35" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_270">
-                  <description>Roll: 270, Pitch: 270, Yaw: 0</description>
-              </entry>
-              <entry value="36" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90">
-                  <description>Roll: 90, Pitch: 180, Yaw: 90</description>
-              </entry>
-              <entry value="37" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_270">
-                  <description>Roll: 90, Pitch: 0, Yaw: 270</description>
-              </entry>
-              <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_315_PITCH_315_YAW_315">
-                  <description>Roll: 315, Pitch: 315, Yaw: 315</description>
+                  <description>Ultrasound altimeter, e.g. MaxBotix units</description>
               </entry>
           </enum>
           <enum name="MAV_PROTOCOL_CAPABILITY">
@@ -2027,19 +1897,16 @@
           </message>
           <message id="64" name="LOCAL_POSITION_NED_COV">
               <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-              <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot). 0 for system without monotonic timestamp</field>
+              <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
               <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.</field>
               <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
               <field type="float" name="x">X Position</field>
               <field type="float" name="y">Y Position</field>
               <field type="float" name="z">Z Position</field>
-              <field type="float" name="vx">X Speed (m/s)</field>
-              <field type="float" name="vy">Y Speed (m/s)</field>
-              <field type="float" name="vz">Z Speed (m/s)</field>
-              <field type="float" name="ax">X Acceleration (m/s^2)</field>
-              <field type="float" name="ay">Y Acceleration (m/s^2)</field>
-              <field type="float" name="az">Z Acceleration (m/s^2)</field>
-              <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first nine entries are the first ROW, next eight entries are the second row, etc.)</field>
+              <field type="float" name="vx">X Speed</field>
+              <field type="float" name="vy">Y Speed</field>
+              <field type="float" name="vz">Z Speed</field>
+              <field type="float[36]" name="covariance">Covariance matrix (first six entries are the first ROW, next six entries are the second row, etc.)</field>
           </message>
           <message id="65" name="RC_CHANNELS">
                <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
@@ -2468,11 +2335,6 @@
             <field type="int64_t" name="tc1">Time sync timestamp 1</field>
             <field type="int64_t" name="ts1">Time sync timestamp 2</field>
         </message>
-        <message id="112" name="CAMERA_TRIGGER">
-            <description>Camera-IMU triggering and synchronisation message.</description>
-            <field type="uint64_t" name="time_usec">Timestamp for the image frame in microseconds</field>
-            <field type="uint32_t" name="seq">Image frame sequence</field>
-        </message>
          <message id="113" name="HIL_GPS">
              <description>The global position, as returned by the Global Positioning System (GPS). This is
                  NOT the global position estimate of the sytem, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
@@ -2679,7 +2541,7 @@
             <field type="uint16_t" name="current_distance">Current distance reading</field>
             <field type="uint8_t" name="type">Type from MAV_DISTANCE_SENSOR enum.</field>
             <field type="uint8_t" name="id">Onboard ID of the sensor</field>
-            <field type="uint8_t" name="orientation">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
+            <field type="uint8_t" name="orientation">Direction the sensor faces from FIXME enum.</field>
             <field type="uint8_t" name="covariance">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
          </message>
          <message id="133" name="TERRAIN_REQUEST">
@@ -2768,6 +2630,14 @@
             <field type="uint64_t" name="uid">UID if provided by hardware</field>
         </message>
         <!-- MESSAGE IDs 180 - 240: Space for custom messages in individual projectname_messages.xml files -->
+        <message id="230" name="LANDING_TARGET">
+            <description>The location of a landing area captured from a downward facing camera</description>
+            <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
+            <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
+            <field type="float" name="angle_x">Angular offset(radians) of the object from the center of the image: x-axis</field>
+            <field type="float" name="angle_y">Angular offset(radians) of the object from the center of the image: x-axis</field>
+            <field type="float" name="distance">Distance to the object from the vehicle in meters</field>
+        </message>
         <message id="248" name="V2_EXTENSION">
             <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
             <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2770,10 +2770,12 @@
         <!-- MESSAGE IDs 180 - 240: Space for custom messages in individual projectname_messages.xml files -->
         <message id="230" name="LANDING_TARGET">
             <description>The location of a landing area captured from a downward facing camera</description>
-            <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
+            <field type="uint8_t" name="lnd_target_num">The ID of the target if multiple targets are present</field>
+            <field type="uint8_t" name="target_system">System ID</field>
+            <field type="uint8_t" name="target_component">Component ID</field>
             <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
             <field type="float" name="angle_x">Angular offset(radians) of the object from the center of the image: x-axis</field>
-            <field type="float" name="angle_y">Angular offset(radians) of the object from the center of the image: x-axis</field>
+            <field type="float" name="angle_y">Angular offset(radians) of the object from the center of the image: y-axis</field>
             <field type="float" name="distance">Distance to the object from the vehicle in meters</field>
         </message>
         <message id="248" name="V2_EXTENSION">


### PR DESCRIPTION
The message assists in communication from a companion computer to ardupilot for arducopter precision land. 

Currently is not sending with pymavlink but I do not believe that is an issue with the message definition

https://groups.google.com/forum/?nomobile=true#!topic/drones-discuss/SDaJjxB86Vw