### PR TITLE
Alternative LANDING_TARGET message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2767,17 +2767,15 @@
             <field type="uint16_t" name="product_id">ID of the product</field>
             <field type="uint64_t" name="uid">UID if provided by hardware</field>
         </message>
-        <!-- MESSAGE IDs 180 - 240: Space for custom messages in individual projectname_messages.xml files -->
-        <message id="230" name="LANDING_TARGET">
+        <message id="149" name="LANDING_TARGET">
             <description>The location of a landing area captured from a downward facing camera</description>
-            <field type="uint8_t" name="lnd_target_num">The ID of the target if multiple targets are present</field>
-            <field type="uint8_t" name="target_system">System ID</field>
-            <field type="uint8_t" name="target_component">Component ID</field>
+            <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
             <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
-            <field type="float" name="angle_x">Angular offset(radians) of the object from the center of the image: x-axis</field>
-            <field type="float" name="angle_y">Angular offset(radians) of the object from the center of the image: y-axis</field>
-            <field type="float" name="distance">Distance to the object from the vehicle in meters</field>
+            <field type="float" name="angle_x">X-axis angular offset (in radians) of the target from the center of the image</field>
+            <field type="float" name="angle_y">Y-axis angular offset (in radians) of the target from the center of the image</field>
+            <field type="float" name="distance">Distance to the target from the vehicle in meters</field>
         </message>
+        <!-- MESSAGE IDs 180 - 240: Space for custom messages in individual projectname_messages.xml files -->
         <message id="248" name="V2_EXTENSION">
             <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
             <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2768,6 +2768,16 @@
             <field type="uint64_t" name="uid">UID if provided by hardware</field>
         </message>
         <!-- MESSAGE IDs 180 - 240: Space for custom messages in individual projectname_messages.xml files -->
+        <message id="230" name="LANDING_TARGET">
+            <description>The location of a landing area captured from a downward facing camera</description>
+            <field type="uint8_t" name="lnd_target_num">The ID of the target if multiple targets are present</field>
+            <field type="uint8_t" name="target_system">System ID</field>
+            <field type="uint8_t" name="target_component">Component ID</field>
+            <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
+            <field type="float" name="angle_x">Angular offset(radians) of the object from the center of the image: x-axis</field>
+            <field type="float" name="angle_y">Angular offset(radians) of the object from the center of the image: y-axis</field>
+            <field type="float" name="distance">Distance to the object from the vehicle in meters</field>
+        </message>
         <message id="248" name="V2_EXTENSION">
             <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
             <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>


### PR DESCRIPTION
Based on Daniel's PR.  I've made a few modifications:
1. squashed most of the commits down into a single commit
2. removed the target-id and component-id fields because I think this message is more of an informational message to anyone who is interested (most likely just the flight controller) rather than a command that is meant to be sent to just a particular device.
3. minor wording changes.