### PR TITLE
Add mavlink messages for remote logging

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2741,6 +2741,21 @@
             <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
             <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
         </message>
+
+        <!-- remote log messages -->
+        <message id="141" name="REMOTE_LOG_DATA_BLOCK">
+            <description>Send a block of log data to remote location</description>
+            <field type="uint8_t" name="block_size">size of log data block i.e. being sent</field>
+            <field type="uint32_t" name="block_cnt">log data block count</field>
+            <field type="uint8_t[200]" name="data">log data block</field>
+        </message>
+
+        <message id="142" name="REMOTE_LOG_BLOCK_STATUS">
+            <description>Send Status of each log block that autopilot board might have sent</description>
+            <field type="uint32_t" name="block_cnt">log data block count</field>
+            <field type="uint8_t" name="block_status">0:log data failed, 1:log received</field>
+        </message>
+
         <message id="147" name="BATTERY_STATUS">
             <description>Battery information</description>
             <field type="uint8_t" name="id">Battery ID</field>


### PR DESCRIPTION
Messages added:
REMOTE_LOG_DATA_BLOCK
block of log data being sent to remote location mostly a parent board connected over high speed serial port

REMOTE_LOG_BLOCK_STATUS
Send Status of each log block that autopilot board might have sent, this message is sent from GCS application running on parent board. Using this message autopilot will know if the packet sent was successfully transmitted or missed by GCS 

Remote logging is expected to be done on vehicle probably on a parent board, due to high amount of data being collected for data logging and considerably low amount of RAM on Pixhawk or any other board using micro-controller, it is expected that baud rate will be very high, currently tested to be working with baud rate no less than 92100 with Pixhawk2. For Ardupilot side of code please refer 3drobotics/ardupilot-solo#79