### PR TITLE
mavparse: transfer enums description to child definition while merging enums 

### DIFF
--- a/pymavlink/generator/mavparse.py
+++ b/pymavlink/generator/mavparse.py
@@ -310,6 +310,8 @@ def merge_enums(xml):
         for enum in x.enum:
             if enum.name in emap:
                 emap[enum.name].entry.extend(enum.entry)
+                if not emap[enum.name].description:
+                    emap[enum.name].description = enum.description
                 print("Merged enum %s" % enum.name)
             else:
                 newenums.append(enum)


### PR DESCRIPTION
Hi,

Current implementation of `merge_enums(xml)` function in mavparse.py does not merge description of enum from parent (included) file which can be confusing if child definition does not provide updated description.

As a result if you generate protocol from `pixhawk.xml` (could be any definition which extends common enums) enum description for `MAV_CMD` (any extended enum without provided description) will be lost.

Not sure whether it is expected behaviour or bug.

Max