### PR TITLE
LANDING_TARGET: added timestamp and target size fields to msg

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2772,11 +2772,14 @@
         </message>
         <message id="149" name="LANDING_TARGET">
             <description>The location of a landing area captured from a downward facing camera</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
             <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
             <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
             <field type="float" name="angle_x">X-axis angular offset (in radians) of the target from the center of the image</field>
             <field type="float" name="angle_y">Y-axis angular offset (in radians) of the target from the center of the image</field>
             <field type="float" name="distance">Distance to the target from the vehicle in meters</field>
+            <field type="float" name="size_x">Size in radians of target along x-axis</field>
+            <field type="float" name="size_y">Size in radians of target along y-axis</field>
         </message>
         <!-- MESSAGE IDs 180 - 240: Space for custom messages in individual projectname_messages.xml files -->
         <message id="241" name="VIBRATION">


### PR DESCRIPTION
In many offboard applications, mainly in ROS, these fields may be required:
* Timestamp of the message, so to guarantee sync between offboard app and the FCU;
* Size of target, which can be used for visualization purposes.

I'm not aware if adding these fields can break a firmware application already using them nor if it goes against https://github.com/mavlink/mavlink/pull/394, but right now I'm not aware of this msg being used in any system yet. Right now, I think users will benefit from this adds, and as @rmackay9, serve mainly as a informational message, but to both user and FCU.

**EDIT:** it will also allow to get all info from IRLock driver currently implemented.

@LorenzMeier, @tridge, @rmackay9 your call! Thank you!