### PR TITLE
Add commands to takeoff and land in local position

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -585,7 +585,7 @@
                     <param index="1">Empty</param>
                     <param index="2">Empty</param>
                     <param index="3">Empty</param>
-                    <param index="4">Desired yaw angle.</param>
+                    <param index="4">Desired yaw angle</param>
                     <param index="5">Latitude</param>
                     <param index="6">Longitude</param>
                     <param index="7">Altitude</param>
@@ -599,6 +599,26 @@
                     <param index="5">Latitude</param>
                     <param index="6">Longitude</param>
                     <param index="7">Altitude</param>
+               </entry>
+               <entry value="23" name="MAV_CMD_NAV_LAND_LOCAL">
+                    <description>Land at local position (local frame only)</description>
+                    <param index="1">Landing target number (if available)</param>
+                    <param index="2">Maximum accepted offset from desired landing position [m] - computed magnitude from spherical coordinates: d = sqrt(x^2 + y^2 + z^2), which gives the maximum accepted distance between the desired landing position and the position where the vehicle is about to land</param>
+                    <param index="3">Landing descend rate [ms^-1]</param>
+                    <param index="4">Desired yaw angle [rad]</param>
+                    <param index="5">Y-axis position [m]</param>
+                    <param index="6">X-axis position [m]</param>
+                    <param index="7">Z-axis / ground level position [m]</param>
+               </entry>
+               <entry value="24" name="MAV_CMD_NAV_TAKEOFF_LOCAL">
+                    <description>Takeoff from local position (local frame only)</description>
+                    <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor [rad]</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Takeoff ascend rate [ms^-1]</param>
+                    <param index="4">Yaw angle [rad] (if magnetometer or another yaw estimation source present), ignored without one of these</param>
+                    <param index="5">Y-axis position [m]</param>
+                    <param index="6">X-axis position [m]</param>
+                    <param index="7">Z-axis position [m]</param>
                </entry>
                <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT">
                    <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>


### PR DESCRIPTION
Main reason for this PR is to allow offboard control of takeoff and landing routines in local frame. This is pretty useful so to implement takeoff and landing when no global coordinates are known and also to apply landing target locations to the same routine.
Apllications: no GPS systems; indoor flight; external navigation controllers; others