### PR TITLE
PX4 now has more mainstate modes than colours available in mavkml.

### DIFF
--- a/pymavlink/tools/mavkml.py
+++ b/pymavlink/tools/mavkml.py
@@ -19,8 +19,9 @@ position_field_types = [  # Order must be lon, lat, alt to match KML
 ]
 
 colors = [simplekml.Color.red, simplekml.Color.green, simplekml.Color.blue,
-          simplekml.Color.violet, simplekml.Color.yellow,
-          simplekml.Color.orange]
+          simplekml.Color.violet, simplekml.Color.yellow, simplekml.Color.orange,
+          simplekml.Color.burlywood, simplekml.Color.azure, simplekml.Color.lightblue,
+          simplekml.Color.lawngreen, simplekml.Color.indianred, simplekml.Color.hotpink]
 
 kml = simplekml.Kml()
 kml_linestrings = []


### PR DESCRIPTION
Added more colours for now to prevent an out of index error. Not the most robust solution but should keep things alive for a while.