### PR TITLE
JS MAVLink: removed jspack submodule since it's not necessary anymore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pymavlink/generator/javascript/lib/jspack"]
-	path = pymavlink/generator/javascript/lib/jspack
-	url = https://github.com/AndreasAntener/node-jspack

--- a/pymavlink/generator/javascript/README.md
+++ b/pymavlink/generator/javascript/README.md
@@ -46,7 +46,8 @@ Then, you can use the MAVLink module, as sketched below.
 In your ```server.js``` script, you need to include the generated parser and instantiate it; you also need some kind of binary stream library that can read/write binary data and emit an event when new data is ready to be parsed (TCP, UDP, serial port all have appropriate libraries in the npm-o-sphere).  The connection's "data is ready" event is bound to invoke the MAVLink parser to try and extract a valid message.
 
 ```javascript
-// requires Underscore.js, can use Winston for logging ,
+// requires Underscore.js and jspack
+// can use Winston for logging
 // see package.json for dependencies for the implementation
 var mavlink = require('mavlink_ardupilotmega_v1.0'), 
 	net = require('net');

--- a/pymavlink/generator/javascript/package.json
+++ b/pymavlink/generator/javascript/package.json
@@ -5,7 +5,8 @@
     "repository": "private",
     "dependencies" : {
       "underscore" : "",
-      "winston": ""
+      "winston": "",
+      "jspack": "0.0.4"
     },
     "devDependencies" : {
       "should" : "",

--- a/pymavlink/generator/mavgen_javascript.py
+++ b/pymavlink/generator/mavgen_javascript.py
@@ -23,7 +23,7 @@ Generated from: ${FILELIST}
 Note: this file has been auto-generated. DO NOT EDIT
 */
 
-jspack = require("./jspack.js").jspack,
+jspack = require("jspack").jspack,
     _ = require("underscore"),
     events = require("events"),
     util = require("util");
@@ -538,11 +538,6 @@ module.exports = mavlink;
 def generate(basename, xml):
     '''generate complete javascript implementation'''
 
-    if basename.rfind(os.sep) >= 0:
-        jspackFilename = basename[0:basename.rfind(os.sep)] + '/jspack.js'
-    else:
-        jspackFilename = 'jspack.js'
-    
     if basename.endswith('.js'):
         filename = basename
     else:
@@ -577,5 +572,3 @@ def generate(basename, xml):
     generate_footer(outf)
     outf.close()
     print("Generated %s OK" % filename)
-    copyfile('./javascript/lib/jspack/jspack.js', jspackFilename)
-    print("Copied jspack %s" % jspackFilename)


### PR DESCRIPTION
The fixed version of jspack is now available through NPM repositories