### PR TITLE
add optional field to DFReader constructor to hold raw string from log.

### DIFF
--- a/pymavlink/DFReader.py
+++ b/pymavlink/DFReader.py
@@ -76,11 +76,12 @@ def null_term(str):
     return str
 
 class DFMessage(object):
-    def __init__(self, fmt, elements, apply_multiplier):
+    def __init__(self, fmt, elements, apply_multiplier, binary=None):
         self.fmt = fmt
         self._elements = elements
         self._apply_multiplier = apply_multiplier
         self._fieldnames = fmt.columns
+        self.binary = binary
 
     def to_dict(self):
         d = {'mavpackettype': self.fmt.name}
@@ -136,6 +137,9 @@ class DFMessage(object):
 
     def get_fieldnames(self):
         return self._fieldnames
+    
+    def get_raw_msgbuf(self):
+        return self.binary
 
 class DFReaderClock():
     '''base class for all the different ways we count time in logs'''
@@ -583,7 +587,7 @@ class DFReader_binary(DFReader):
 
         self.offset += fmt.len-3
         self.remaining -= fmt.len-3
-        m = DFMessage(fmt, elements, True)
+        m = DFMessage(fmt, elements, True, hdr+body)
         self._add_msg(m)
 
         self.percent = 100.0 * (self.offset / float(self.data_len))
@@ -667,7 +671,7 @@ class DFReader_text(DFReader):
             self.formats[elements[2]] = DFFormat(int(elements[0]), elements[2], int(elements[1]), elements[3], elements[4])
 
         try:
-            m = DFMessage(fmt, elements, False)
+            m = DFMessage(fmt, elements, False, s)
         except ValueError:
             return self._parse_next()
 


### PR DESCRIPTION
The goal of this Pull request is to provide access to the raw binary message bytes from a Dataflash log via the DFMessage object. It may be useful especially in truncated messages or in the case that the header/parser information is incorrect to have access to the raw information outside of the library.  It also prevents wrapped binary information from being falsely truncate by python if a '\0' character shows up in a string. 

Specifically, we at Swift are having difficulty parsing the data from the Dataflash log completely. The ability to get the raw binary is the most expedient way to get our logged SBP data into our analysis tools. 