### PR TITLE
Swift 2.0 mavlink library generator

### DIFF
--- a/pymavlink/generator/mavgen.py
+++ b/pymavlink/generator/mavgen.py
@@ -20,7 +20,7 @@ DEFAULT_ERROR_LIMIT = 200
 DEFAULT_VALIDATE = True
 
 # List the supported languages. This is done globally because it's used by the GUI wrapper too
-supportedLanguages = ["C", "CS", "JavaScript", "Python", "WLua", "ObjC", "Java"]
+supportedLanguages = ["C", "CS", "JavaScript", "Python", "WLua", "ObjC", "Swift", "Java"]
 
 
 def mavgen(opts, args) :
@@ -114,6 +114,9 @@ def mavgen(opts, args) :
     elif opts.language == 'objc':
         from . import mavgen_objc
         mavgen_objc.generate(opts.output, xml)
+    elif opts.language == 'swift':
+        from . import mavgen_swift
+        mavgen_swift.generate(opts.output, xml)
     elif opts.language == 'java':
         from . import mavgen_java
         mavgen_java.generate(opts.output, xml)

--- a/pymavlink/generator/mavgen_swift.py
+++ b/pymavlink/generator/mavgen_swift.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python
+"""
+Parse a MAVLink protocol XML file and generate Swift implementation
+
+Copyright Max Odnovolyk 2015
+Released under GNU GPL version 3 or later
+"""
+
+import os
+from . import mavparse, mavtemplate
+
+abbreviations = ["MAV", "PX4", "UDB", "PPZ", "PIXHAWK", "SLUGS", "FP", "ASLUAV", "VTOL", "ROI", "UART", "UDP", "IMU", "IMU2", "3D", "RC", "GPS", "GPS1", "GPS2", "NED", "RTK"]
+swift_types = {'char' : ("String", '"\\0"', "mavString(offset: %u, length: %u)"),
+               'uint8_t' : ("UInt8", 0, "mavNumber(offset: %u)"),
+               'int8_t' : ("Int8", 0, "mavNumber(offset: %u)"),
+               'uint16_t' : ("UInt16", 0, "mavNumber(offset: %u)"),
+               'int16_t' : ("Int16", 0, "mavNumber(offset: %u)"),
+               'uint32_t' : ("UInt32", 0, "mavNumber(offset: %u)"),
+               'int32_t' : ("Int32", 0, "mavNumber(offset: %u)"),
+               'uint64_t' : ("UInt64", 0, "mavNumber(offset: %u)"),
+               'int64_t' : ("Int64", 0, "mavNumber(offset: %u)"),
+               'float' : ("Float", 0, "mavNumber(offset: %u)"),
+               'double' : ("Double", 0, "mavNumber(offset: %u)"),
+               'uint8_t_mavlink_version' : ("UInt8", 0, "mavNumber(offset: %u)")}
+
+t = mavtemplate.MAVTemplate()
+
+def generate_header(outf, filelist, xml):
+    """Generate Swift file header with source files list and creation date"""
+
+    print("Generating Swift file header")
+
+    t.write(outf, """
+//
+//  MAVLink.swift
+//  MAVLink Micro Air Vehicle Communication Protocol
+//
+//  Generated from ${FILELIST} on ${PARSE_TIME} by mavgen_swift.py 
+//  http://qgroundcontrol.org/mavlink/start
+//
+
+import Foundation
+
+
+/**
+    Common protocol for all MAVLink entities which describes type metadata properties
+*/
+public protocol MAVLinkEntity: CustomStringConvertible, CustomDebugStringConvertible {
+    
+    /// Original MAVLink enum name (from declarations xml)
+    static var typeName: String { get }
+
+    /// Compact type description
+    static var typeDescription: String { get }
+
+    /// Verbose type description
+    static var typeDebugDescription: String { get }
+}
+
+
+// MARK: MAVLink enums
+
+
+/**
+    Enum protocol description with common for all MAVLink enums property requirements
+*/
+public protocol Enum: RawRepresentable, Equatable, MAVLinkEntity {
+
+    /// Array with all members of current enum
+    static var allMembers: [Self] { get }
+
+    // Array with `Name` - `Description` tuples (values from declarations xml file)
+    static var membersInfo: [(String, String)] { get }
+
+    /// Original MAVLinks enum member name (as declared in definitions xml file)
+    var memberName: String { get }
+
+    /// Specific member description from definitions xml
+    var memberDescription: String { get }
+}
+
+
+/**
+    Enum protocol default implementations
+*/
+extension Enum {
+    public static var typeDebugDescription: String {
+        // It seems Xcode 7 beta does not support default protocol implementations for type methods.
+        // Calling this method without specific implementations inside enums will cause following error on Xcode 7.0 beta (7A120f):
+        // "Command failed due to signal: Illegal instruction: 4"
+        let cases = "\\n\\t".join(allMembers.map { $0.debugDescription })
+        return "Enum \(typeName): \(typeDescription)\\nMembers:\\n\\t\(cases)"
+    }
+    
+    public var description: String {
+        return memberName
+    }
+
+    public var debugDescription: String {
+        return "\(memberName): \(memberDescription)"
+    }
+    
+    public var memberName: String {
+        return Self.membersInfo[Self.allMembers.indexOf(self)!].0
+    }
+
+    public var memberDescription: String {
+        return Self.membersInfo[Self.allMembers.indexOf(self)!].1
+    }
+}
+
+""", {'FILELIST' : ", ".join(filelist),
+      'PARSE_TIME' : xml[0].parse_time})
+
+def generate_enums(outf, enums, msgs):
+    """Iterate through all enums and create Swift equivalents"""
+
+    print("Generating Enums")
+
+    for enum in enums:
+        t.write(outf, """
+${formatted_description}public enum ${swift_name}: ${raw_value_type}, Enum {
+${{entry:${formatted_description}\tcase ${swift_name} = ${value}\n}}
+}
+
+extension ${swift_name} {
+    public static var typeName = "${name}"
+    public static var typeDescription = "${entity_description}"
+    public static var typeDebugDescription: String {
+        let cases = "\\n\\t".join(allMembers.map { $0.debugDescription })
+        return "Enum \(typeName): \(typeDescription)\\nMembers:\\n\\t\(cases)"
+    }
+    public static var allMembers = [${all_entities}]
+    public static var membersInfo = [${entities_info}]
+}
+
+""", enum)
+
+def get_enum_raw_type(enum, msgs):
+    """Search appropirate raw type for enums in messages fields"""
+
+    for msg in msgs:
+        for field in msg.fields:
+            if  field.enum == enum.name:
+                return swift_types[field.type][0]
+    return "Int"
+
+def generate_messages(outf, msgs):
+    """Generate Swift structs to represent all MAVLink messages"""
+
+    print("Generating Messages")
+
+    t.write(outf, """
+
+// MARK: MAVLink messages
+
+
+/**
+    Message protocol describes common for all MAVLink messages properties and methods requirements
+*/
+public protocol Message: MAVLinkEntity {
+
+    /**
+        Initialize Message from received data
+
+        - Warning: Throws `ParserError` or `ParserEnumError` if any parsing error occurred
+    */
+    init(data: NSData) throws
+
+    /// Array of tuples with fields name, offset, type and description information
+    static var fieldsInfo: [(String, Int, String, String)] { get }
+
+    /// All fields names and values of current Message
+    var allFields: [(String, Any)] { get }
+}
+
+
+/**
+    Message protocol default implementations
+*/
+extension Message {
+    public static var typeDebugDescription: String {
+        // It seems Xcode 7 beta does not support default protocol implementations for type methods.
+        // Calling this method without specific implementations inside messages will cause following error in Xcode 7.0 beta (7A120f):
+        // "Command failed due to signal: Illegal instruction: 4"
+        let fields = "\\n\\t".join(fieldsInfo.map { "\($0.0): \($0.2): \($0.3)" })
+        return "Struct \(typeName): \(typeDescription)\\nFields:\\n\\t\(fields)"
+    }
+
+    public var description: String {
+        let describeField: ((String, Any)) -> String = { (let name, var value) in
+            value = value is String ? "\\"\(value)\\"" : value
+            return "\(name): \(value)"
+        }
+        let fieldsDescription = ", ".join(allFields.map(describeField))
+        return "\(self.dynamicType)(\(fieldsDescription))"
+    }
+
+    public var debugDescription: String {
+        let describeFieldVerbose: ((String, Any)) -> String = { (let name, var value) in
+            value = value is String ? "\\"\(value)\\"" : value
+            let (_, _, _, description) = Self.fieldsInfo.filter { $0.0 == name }.first!
+            return "\(name) = \(value) : \(description)"
+        }
+        let fieldsDescription = "\\n\\t".join(allFields.map(describeFieldVerbose))
+        return "\(Self.typeName): \(Self.typeDescription)\\nFields:\\n\\t\(fieldsDescription)"
+    }
+
+    public var allFields: [(String, Any)] {
+        var result: [(String, Any)] = []
+        let mirror = reflect(self)
+        for i in 0..<mirror.count {
+            result.append((mirror[i].0, mirror[i].1.value))
+        }
+        return result
+    }
+}
+
+""")
+
+    for msg in msgs:
+        t.write(outf, """
+${formatted_description}public struct ${swift_name}: Message {
+${{fields:${formatted_description}\tpublic let ${swift_name}: ${return_type}\n}}
+
+    public init(data: NSData) throws {
+${{ordered_fields:\t\tself.${swift_name} = ${initial_value}\n}}
+    }
+}
+
+extension ${swift_name} {
+    public static var typeName = "${name}"
+    public static var typeDescription = "${message_description}"
+    public static var typeDebugDescription: String {
+        let fields = "\\n\\t".join(fieldsInfo.map { "\($0.0): \($0.2): \($0.3)" })
+        return "Struct \(typeName): \(typeDescription)\\nFields:\\n\\t\(fields)"
+    }
+    public static var fieldsInfo = [${fields_info}]
+}
+
+""", msg)
+
+def append_static_code(filename, outf):
+    """Open and copy static code from specified file"""
+
+    basepath = os.path.dirname(os.path.realpath(__file__))
+    filepath = os.path.join(basepath, 'swift/%s' % filename)
+    
+    print("Appending content of %s" % filename)
+    
+    with open(filepath) as inf:
+        for line in inf:
+            outf.write(line) 
+
+def generate_message_mappings_array(outf, msgs):
+    """Create array for mapping message Ids to proper structs"""
+
+    classes = []
+    for msg in msgs:
+        classes.append("%u: %s.self" % (msg.id, msg.swift_name))
+    t.write(outf, """
+
+
+
+/**
+    Array for mapping message id to proper struct
+*/
+private let messageIdToClass: [UInt8: Message.Type] = [${ARRAY_CONTENT}]
+""", {'ARRAY_CONTENT' : ", ".join(classes)})
+
+def generate_message_lengths_array(outf, msgs):
+    """Create array with message lengths to validate known message lengths"""
+
+    # form message lengths array
+    lengths = []
+    for msg in msgs:
+        lengths.append("%u: %u" % (msg.id, msg.wire_length))
+
+    t.write(outf, """
+
+
+/**
+    Message lengths array for known messages length validation
+*/
+private let messageLengths: [UInt8: UInt8] = [${ARRAY_CONTENT}]
+""", {'ARRAY_CONTENT' : ", ".join(lengths)})
+
+def generate_message_crc_extra_array(outf, msgs):
+    """Add array with CRC extra values to detect incompatible XML changes"""
+
+    crcs = []
+    for msg in msgs:
+        crcs.append("%u: %u" % (msg.id, msg.crc_extra))
+
+    t.write(outf, """
+
+
+/**
+    Message CRSs extra for detection incompatible XML changes
+*/
+private let messageCrcsExtra: [UInt8: UInt8] = [${ARRAY_CONTENT}]
+""", {'ARRAY_CONTENT' : ", ".join(crcs)})
+
+def camel_case_from_underscores(string):
+    """Generate a CamelCase string from an underscore_string"""
+
+    components = string.split('_')
+    string = ''
+
+    for component in components:
+        if component in abbreviations:
+            string += component
+        else:
+            string += component[0].upper() + component[1:].lower()
+
+    return string
+
+def lower_camel_case_from_underscores(string):
+    """Generate a lower-cased camelCase string from an underscore_string"""
+
+    components = string.split('_')
+    string = components[0]
+    for component in components[1:]:
+        string += component[0].upper() + component[1:]
+
+    return string
+
+def generate_enums_info(enums, msgs):
+    """Add camel case swift names for enums an entries, descriptions and sort enums alphabetically"""
+
+    for enum in enums:
+        enum.swift_name = camel_case_from_underscores(enum.name)
+        enum.raw_value_type = get_enum_raw_type(enum, msgs)
+
+        enum.formatted_description = ""
+        if enum.description:
+            enum.description = " ".join(enum.description.split())
+            enum.formatted_description = "\n/**\n    %s\n*/\n" % enum.description
+
+        all_entities = []
+        entities_info = []
+
+        for entry in enum.entry:
+            name = entry.name.replace(enum.name + '_', '')
+            """Ensure that enums entry name does not start from digit"""
+            if name[0].isdigit():
+                name = "MAV_" + name
+            entry.swift_name = camel_case_from_underscores(name)
+            
+            entry.formatted_description = ""
+            if entry.description:
+                entry.description = " ".join(entry.description.split())
+                entry.formatted_description = "\n\t/// " + entry.description + "\n"
+
+            all_entities.append(entry.swift_name)
+            entities_info.append('("%s", "%s")' % (entry.name, entry.description.replace('"','\\"')))
+
+        enum.all_entities = ", ".join(all_entities)
+        enum.entities_info = ", ".join(entities_info)
+        enum.entity_description = enum.description.replace('"','\\"')
+
+    enums.sort(key = lambda enum : enum.swift_name)
+
+def generate_messages_info(msgs):
+    """Add proper formated variable names, initializers and type names to use in templates"""
+
+    for msg in msgs:
+        msg.swift_name = camel_case_from_underscores(msg.name)
+
+        msg.formatted_description = ""
+        if msg.description:
+            msg.description = " ".join(msg.description.split())
+            msg.formatted_description = "\n/**\n    %s\n*/\n" % " ".join(msg.description.split())
+        msg.message_description = msg.description.replace('"','\\"')
+
+        for field in msg.ordered_fields:
+            field.swift_name = lower_camel_case_from_underscores(field.name)
+            field.return_type = swift_types[field.type][0]
+            
+            # configure fields initializers
+            if field.enum:
+                # handle enums
+                field.return_type = camel_case_from_underscores(field.enum)
+                field.initial_value = "try data.mavEnumeration(offset: %u)" % field.wire_offset
+            elif field.array_length > 0:
+                if field.return_type == "String":
+                    # handle strings
+                    field.initial_value = "data." + swift_types[field.type][2] % (field.wire_offset, field.array_length)
+                else:
+                    # other array types
+                    field.return_type = "[%s]" % field.return_type
+                    field.initial_value = "try data.mavArray(offset: %u, count: %u)" % (field.wire_offset, field.array_length)
+            else:
+                # simple type field
+                field.initial_value = "try data." + swift_types[field.type][2] % field.wire_offset
+            
+            field.formatted_description = ""
+            if field.description:
+                field.description = " ".join(field.description.split())
+                field.formatted_description = "\n\t/// " + field.description + "\n"
+         
+        fields_info = map(lambda field: '("%s", %u, "%s", "%s")' % (field.swift_name, field.wire_offset, field.return_type, field.description.replace('"','\\"')), msg.fields)
+        msg.fields_info = ", ".join(fields_info)
+
+    msgs.sort(key = lambda msg : msg.id)
+
+def generate(basename, xml_list):
+    """Generate complete MAVLink Swift implemenation"""
+
+    if os.path.isdir(basename):
+        filename = os.path.join(basename, 'MAVLink.swift')
+    else:
+        filename = basename
+
+    msgs = []
+    enums = []
+    filelist = []
+    for xml in xml_list:
+        msgs.extend(xml.message)
+        enums.extend(xml.enum)
+        filelist.append(os.path.basename(xml.filename))
+    
+    outf = open(filename, "w")
+    generate_header(outf, filelist, xml_list)
+    generate_enums_info(enums, msgs)
+    generate_enums(outf, enums, msgs)
+    generate_messages_info(msgs)
+    generate_messages(outf, msgs)
+    append_static_code('Parser.swift', outf)
+    generate_message_mappings_array(outf, msgs)
+    generate_message_lengths_array(outf, msgs)
+    generate_message_crc_extra_array(outf, msgs)
+    outf.close()

--- a/pymavlink/generator/swift/Parser.swift
+++ b/pymavlink/generator/swift/Parser.swift
@@ -1,0 +1,551 @@
+
+// MARK: MAVLink Message parser implementation
+
+
+/**
+    Convenient types aliases
+*/
+public typealias Channel = UInt8
+
+
+/**
+    Parsing errors
+*/
+public enum ParserError: ErrorType {
+    
+    /**
+        Size of expected number is larger than received data size
+        - offset: Expected number offset in received data
+        - size: Expected number size in bytes
+    */
+    case NumberSizeOutOfBounds(offset: Int, size: Int)
+    
+    /**
+        Length check of payload for known `messageId` failed
+        - messageId: Message id of expected Message
+        - receivedLength: Received payload length
+        - properLength: Expected payload length for `messageId`
+    */
+    case InvalidPayloadLength(messageId: UInt8, receivedLength: UInt8, properLength: UInt8)
+    
+    /**
+        Received `messageId` was not recognized so we can't create appropirate Message
+        - messageId: Id of message that was not found in known message list (`messageIdToClass` array)
+    */
+    case UnknownMessageId(messageId: UInt8)
+    
+    /// Checksum check failed. Message id is known but calculated CRC bytes does not match received CRC value
+    case BadCRC
+}
+
+
+/**
+    Special error type for returning Enum parsing errors with details in associated values (types of this values are not compatible with ParserError enum)
+*/
+public enum ParserEnumError<T: RawRepresentable>: ErrorType {
+    /**
+        Enumeration member with `rawValue` at `valueOffset` was not fouund in `enumType`
+        - enumType: Type of requested enumeration
+        - rawValue: Raw value that was not found in `enumType`
+        - valueOffset: Value offset in received payload data
+    */
+    case UnknownValue(enumType: T.Type, rawValue: T.RawValue, valueOffset: Int)
+}
+
+
+/**
+    Alternative way to receive parsed Messages and all errors is to implement this protocol and set Parsers delegate
+*/
+public protocol ParserDelegate {
+    
+    /**
+        Called when MAVLink Packet is successfully received, payload length and CRC checks are passed
+    
+        - Parameter parser: `Parser` object that handled `packet`
+        - Parameter packet: Completely received `Packet`
+        - Parameter channel: Channel on which `packet` was received
+    
+        - Returns: `Void`
+    */
+    func parser(parser: Parser, didReceivePacket packet: Packet, channel: Channel)
+    
+    /**
+        Packet receiving failed because `InvalidPayloadLength` or `BadCRC` error
+    
+        - Parameter parser: `Parser` object that received `data`
+        - Parameter error: Error that  occurred while receiving `data` (`InvalidPayloadLength` or `BadCRC` error)
+        - Parameter data: Partially received `Packet`
+        - Parameter channel: Channel on which `data` was received
+        
+        - Returns: `Void`
+    */
+    func parser(parser: Parser, didFailToReceivePacketWithError error: ErrorType, data: Packet?, channel: Channel)
+    
+    /**
+        Called when received data was successfully parsed into appropriate `message` structure
+        
+        - Parameter parser: `Parser` object that handled `packet`
+        - Parameter message: Successfully parsed `Message`
+        - Parameter packet: Completely received `Packet`
+        - Parameter channel: Channel on which `message` was received
+        
+        - Returns: `Void`
+    */
+    func parser(parser: Parser, didParseMessage message: Message, fromPacket packet: Packet, channel: Channel)
+    
+    /**
+        Called when `packet` completely received but `Parser` was not able to finish `Message` processing due unknown `messageId` or type validation errors
+    
+        - Parameter parser: `Parser` object that handled `packet`
+        - Parameter packet: Completely received `Packet`
+        - Parameter error: Error that  occurred while parsing `packet`s payload into `Message`
+        - Parameter channel: Channel on which `message` was received
+        
+        - Returns: `Void`
+    */
+    func parser(parser: Parser, didFailToParseMessageFromPacket packet: Packet, withError error: ErrorType, channel: Channel)
+}
+
+
+/**
+    Main parser class, performs `Packet` receiving, recognition, validation and `Message` structure creation. Also returns errors through delegation if any errors occurred.
+*/
+public class Parser {
+    
+    /// MAVlink constants used for packet parsing
+    struct Constants {
+        
+        /// Packet start sign. Indicates the start of a new packet. v1.0
+        static let PacketStx: UInt8 = 0xFE
+    }
+    
+    /// States for the parsing state machine
+    enum ParseState {
+        case Uninit
+        case Idle
+        case GotStx
+        case GotSequence
+        case GotLength
+        case GotSystemId
+        case GotComponentId
+        case GotMessageId
+        case GotPayload
+        case GotCRC1
+        case GotBadCRC1
+    }
+    
+    enum Framing: UInt8 {
+        case Incomplete = 0
+        case Ok = 1
+        case BadCRC = 2
+    }
+    
+    /// Storage for MAVLink parsed packets, states and errors statistics
+    class Status {
+        
+        /// Number of received packets
+        var packetReceived: Framing = .Incomplete
+        
+        /// Number of parse errors
+        var parseError: UInt8 = 0
+        
+        /// Parsing state machine
+        var parseState: ParseState = .Uninit
+        
+        /// Sequence number of last packet received
+        var currentRxSeq: UInt8 = 0
+        
+        /// Sequence number of last packet sent
+        var currentTxSeq: UInt8 = 0
+        
+        /// Received packets
+        var packetRxSuccessCount: UInt16 = 0
+        
+        /// Number of packet drops
+        var packetRxDropCount: UInt16 = 0
+    }
+    
+    /// Parser Packets and States buffers
+    let channelBuffers = [Packet](count: Int(Channel.max), repeatedValue: Packet())
+    let channelStatuses = [Status](count: Int(Channel.max), repeatedValue: Status())
+    
+    /// Object to pass received packets, messages, errors to
+    public var delegate: ParserDelegate?
+    
+    /// Enable this option to check the length of each message. This allows invalid messages to be caught much sooner. Use if the transmission medium is prone to missing (or extra) characters (e.g. a radio that fades in and out). Only use if the channel will only contain messages types listed in the headers.
+    public var checkMessageLength = true
+    
+    /// Use one extra CRC that is added to the message CRC to detect mismatches in message specifications. This is to prevent that two devices using different message versions incorrectly decode a message with the same length.
+    public var crcExtra = true
+    
+    /**
+        This is a convenience function which handles the complete MAVLink parsing. The function will parse one byte at a time and return the complete packet once it could be successfully decoded. Checksum and other failures will be delegated to `delegate`.
+        
+        - Parameter char: The char to barse
+        - Parameter chan: ID of the current channel. This allows to parse different channels with this function. A channel is not a physical message channel like a serial port, but a logic partition of the communication streams in this case.
+        
+        - Returns: `nil` if no packet could be decoded, the `Packet` structure else
+    */
+    public func parseChar(char: UInt8, channel: Channel) -> Packet? {
+        
+        /// Function to check if current char is Stx byte. If current char is STX, modifies current rxpack and status.
+        func handleStxChar(char: UInt8, rxpack: Packet, status: Status) {
+            if char == Constants.PacketStx {
+                rxpack.length = 0
+                rxpack.channel = channel
+                rxpack.magic = char
+                rxpack.checksum.start()
+                status.parseState = .GotStx
+            }
+        }
+        
+        let rxpack = channelBuffers[Int(channel)]
+        let status = channelStatuses[Int(channel)]
+        
+        status.packetReceived = .Incomplete
+        
+        switch status.parseState {
+        case .Uninit, .Idle:
+            handleStxChar(char, rxpack: rxpack, status: status)
+            
+        case .GotStx:
+            rxpack.length = char
+            rxpack.payload.length = 0
+            rxpack.checksum.accumulateChar(char)
+            status.parseState = .GotLength
+            
+        case .GotLength:
+            rxpack.sequence = char
+            rxpack.checksum.accumulateChar(char)
+            status.parseState = .GotSequence
+            
+        case .GotSequence:
+            rxpack.systemId = char
+            rxpack.checksum.accumulateChar(char)
+            status.parseState = .GotSystemId
+            
+        case .GotSystemId:
+            rxpack.componentId = char
+            rxpack.checksum.accumulateChar(char)
+            status.parseState = .GotComponentId
+            
+        case .GotComponentId:
+            // Check Message length is `checkMessageLength` enabled and `messageLengths` contains proper id.
+            // If `messageLengths` does not contain info for current messageId, parsing will fail later on CRC check.
+            if checkMessageLength && (messageLengths[char] != nil) {
+                if let messageLength = messageLengths[char] where rxpack.length != messageLength {
+                    status.parseError++
+                    status.parseState = .Idle
+                    let error = ParserError.InvalidPayloadLength(messageId: char, receivedLength: rxpack.length, properLength: messageLength)
+                    delegate?.parser(self, didFailToReceivePacketWithError: error, data: nil, channel: channel)
+                    break
+                }
+            }
+            rxpack.messageId = char
+            rxpack.checksum.accumulateChar(char)
+            if rxpack.length == 0 {
+                status.parseState = .GotPayload
+            } else {
+                status.parseState = .GotMessageId
+            }
+            
+        case .GotMessageId:
+            var char = char
+            rxpack.payload.appendBytes(&char, length: strideofValue(char))
+            rxpack.checksum.accumulateChar(char)
+            if rxpack.payload.length == Int(rxpack.length) {
+                status.parseState = .GotPayload
+            }
+            
+        case .GotPayload:
+            if crcExtra && (messageCrcsExtra[rxpack.messageId] != nil) { // `if let where` usage will force array lookup even if `crcExtra` is false
+                rxpack.checksum.accumulateChar(messageCrcsExtra[rxpack.messageId]!)
+            }
+            if char != rxpack.checksum.lowByte {
+                status.parseState = .GotBadCRC1
+            } else {
+                status.parseState = .GotCRC1
+            }
+            var char = char
+            rxpack.payload.appendBytes(&char, length: strideofValue(char))
+            
+        case .GotCRC1, .GotBadCRC1:
+            if (status.parseState == .GotBadCRC1) || (char != rxpack.checksum.highByte) {
+                status.parseError++
+                status.packetReceived = .BadCRC
+                let error = messageIdToClass[rxpack.messageId] == nil ? ParserError.UnknownMessageId(messageId: rxpack.messageId) : ParserError.BadCRC
+                delegate?.parser(self, didFailToReceivePacketWithError: error, data: Packet(packet: rxpack), channel: channel)
+            } else {
+                // Successfully got message
+                var char = char
+                rxpack.payload.appendBytes(&char, length: strideofValue(char))
+                status.packetReceived = .Ok
+            }
+            status.parseState = .Idle
+        }
+        
+        defer {
+            // Сollect stat here
+            
+            status.parseError = 0
+        }
+        
+        // If a packet has been sucessfully received
+        guard status.packetReceived == .Ok else {
+            return nil
+        }
+        
+        // Copy and delegate received packet
+        let packet = Packet(packet: rxpack)
+        delegate?.parser(self, didReceivePacket: packet, channel: channel)
+        
+        status.currentRxSeq = rxpack.sequence
+        // Initial condition: If no packet has been received so far, drop count is undefined
+        if status.packetRxSuccessCount == 0 {
+            status.packetRxDropCount = 0;
+        }
+        // Count this packet as received
+        status.packetRxSuccessCount = status.packetRxSuccessCount &+ 1
+        
+        // Try to create appropriate Message structure, delegate results
+        guard let messageClass = messageIdToClass[packet.messageId] else {
+            let error = ParserError.UnknownMessageId(messageId: rxpack.messageId)
+            delegate?.parser(self, didFailToParseMessageFromPacket: packet, withError: error, channel: channel)
+            return packet
+        }
+        
+        do {
+            packet.message = try messageClass(data: rxpack.payload)
+            delegate?.parser(self, didParseMessage: packet.message!, fromPacket: packet, channel: channel)
+        } catch {
+            delegate?.parser(self, didFailToParseMessageFromPacket: packet, withError: error, channel: channel)
+            return packet
+        }
+        
+        return packet
+    }
+    
+    /**
+        Append new portion of data to existing buffer, then call `messageHandler` if new message is available.
+        
+        - Parameter data: The data to be parsed.
+        - Parameter channel: ID of the current channel. This allows to parse different channels with this function. A channel is not a physical message channel like a serial port, but a logic partition of the communication streams in this case.
+        - Parameter messageHandler: The message handler to call when the provided data is enought to complete message parsing. Unless you have provided a custom delegate, this parameter must not be `nil`, because there is no other way to retrieve the parsed message and packet.
+        
+        - Returns: `Void`
+    */
+    public func appendData(data: NSData, channel: Channel, messageHandler:((message: Message, packet: Packet) -> Void)? = nil) {
+        let stream = NSInputStream(data: data)
+        var totalBytesRead: Int = 0
+        
+        stream.open()
+        
+        while (totalBytesRead < data.length) {
+            var char: UInt8 = 0
+            let numberOfBytesRead = stream.read(&char, maxLength: strideofValue(char))
+            if let packet = parseChar(char, channel: channel), message = packet.message, messageHandler = messageHandler {
+                messageHandler(message: message, packet: packet)
+            }
+            totalBytesRead += numberOfBytesRead
+        }
+    }
+}
+
+
+/**
+    MAVLink Packet structure to store received data that is not full message yet. Contains additional to Message info as channel, system id, component id and raw payload data, etc. Also used to store and transfer received data of unknown or corrupted Messages. [More details](http://qgroundcontrol.org/mavlink/start)
+*/
+public class Packet {
+    
+    /// MAVlink Packet constants
+    struct Constants {
+        
+        /// Maximum packets payload length
+        static let MaxPayloadLength = 255
+        static let NumberOfChecksumBytes = 2
+    }
+    
+    /// Channel on which packet was received
+    public internal(set) var channel: UInt8 = 0
+    
+    /// Sent at end of packet
+    public internal(set) var checksum: Checksum = Checksum()
+    
+    /// Protocol magic marker (PacketStx value)
+    public internal(set) var magic: UInt8 = 0
+    
+    /// Length of payload
+    public internal(set) var length: UInt8 = 0
+    
+    /// Sequence of packet
+    public internal(set) var sequence: UInt8 = 0
+    
+    /// ID of message sender system/aircraft
+    public internal(set) var systemId: UInt8 = 0
+    
+    /// ID of the message sender component
+    public internal(set) var componentId: UInt8 = 0
+    
+    /// ID of message in payload
+    public internal(set) var messageId: UInt8 = 0
+    
+    /// Message bytes
+    public internal(set) var payload: NSMutableData = NSMutableData(capacity: Constants.MaxPayloadLength + Constants.NumberOfChecksumBytes)!
+    
+    /// Received Message structure if available
+    public internal(set) var message: Message?
+    
+    /**
+        Initialize copy of provided Packet
+    
+        - Parameter packet: Packet to copy
+    */
+    init(packet: Packet) {
+        channel = packet.channel
+        checksum = packet.checksum
+        magic = packet.magic
+        length = packet.length
+        sequence = packet.sequence
+        systemId = packet.systemId
+        componentId = packet.componentId
+        messageId = packet.messageId
+        payload = NSMutableData(data: packet.payload)
+        message = packet.message
+    }
+    
+    init() { }
+}
+
+
+/**
+    Struct for storing and calculating checksum
+*/
+public struct Checksum {
+    
+    struct Constants {
+        static let X25InitCRCValue: UInt16 = 0xFFFF
+    }
+    
+    public private(set) var value: UInt16 = 0
+    public var lowByte: UInt8 {
+        return UInt8(truncatingBitPattern: value)
+    }
+    public var highByte: UInt8 {
+        return UInt8(truncatingBitPattern: value >> 8)
+    }
+    
+    init() {
+        start()
+    }
+    
+    /**
+        Initiliaze the buffer for the X.25 CRC
+    
+        - Returns: `Void`
+    */
+    mutating func start() {
+        value = Constants.X25InitCRCValue
+    }
+    
+    /**
+        Accumulate the X.25 CRC by adding one char at a time. The checksum function adds the hash of one char at a time to the 16 bit checksum `value` (`UInt16`).
+    
+        - Parameter char: New char to hash
+    
+        - Returns: `Void`
+    */
+    mutating func accumulateChar(char: UInt8) {
+        var tmp: UInt8 = char ^ UInt8(truncatingBitPattern: value)
+        tmp ^= (tmp << 4)
+        value = (UInt16(value) >> 8) ^ (UInt16(tmp) << 8) ^ (UInt16(tmp) << 3) ^ (UInt16(tmp) >> 4)
+    }
+}
+
+
+// MARK: Helper extentions
+
+
+/**
+    NSData extension with methods for getting proper typed values from received data
+*/
+extension NSData {
+    
+    /**
+        Returns Number value (integer and floating point) from data
+    
+        - Parameter offset: Offset in data bytes
+    
+        - Warning: Throws `ParserError`
+    
+        - Returns: `T`
+    */
+    func mavNumber<T>(offset offset: Int) throws -> T {
+        let size = strideof(T)
+        guard offset + size <= length else {
+            throw ParserError.NumberSizeOutOfBounds(offset: offset, size: size)
+        }
+        
+        var bytes = [UInt8](count: size, repeatedValue: 0)
+        getBytes(&bytes, range: NSRange(location: offset, length: size))
+        
+        if CFByteOrderGetCurrent() != Int(CFByteOrderLittleEndian.rawValue) {
+            bytes = bytes.reverse()
+        }
+        
+        return bytes.withUnsafeBufferPointer {
+            return UnsafePointer<T>($0.baseAddress).memory
+        }
+    }
+    
+    /**
+        Returns typed array from data
+        
+        - Parameter offset: Offset in data bytes
+        - Parameter count: Number of elements in array
+    
+        - Warning: Throws `ParserError`
+    
+        - Returns: `Array<T>`
+    */
+    func mavArray<T>(var offset offset: Int, count: Int) throws -> Array<T> {
+        var array: [T] = [T]()
+        for _ in 0..<count {
+            array.append(try mavNumber(offset: offset))
+            offset += strideof(T)
+        }
+        return array
+    }
+    
+    /**
+        Returns ASCII String from data
+        
+        - Parameter offset: Offset in data bytes
+        - Parameter length: Length of string to read
+    
+        - Returns: `String`
+    */
+    func mavString(offset offset: Int, length: Int) -> String {
+        let string = NSString(data: subdataWithRange(NSRange(location: offset, length: length)), encoding: NSASCIIStringEncoding) ?? ""
+        return string as String
+    }
+    
+    /**
+        Returns proper Enum from data or throws UnknownEnumValue error
+    
+        - Parameter offset: Offset in data bytes
+    
+        - Warning: Throws `ParserEnumError`
+    
+        - Returns: `T: RawRepresentable`
+    */
+    func mavEnumeration<T: RawRepresentable>(offset offset: Int) throws -> T {
+        let int: T.RawValue = try mavNumber(offset: offset)
+        if let enumeration = T(rawValue: int) {
+            return enumeration
+        }
+        throw ParserEnumError.UnknownValue(enumType: T.self, rawValue: int, valueOffset: offset)
+    }
+}
+
+
+// MARK: Additional MAVLink service info


### PR DESCRIPTION
This adds `mavgen_swift.py` script to generate MAVLink library for Swift 2.0 programming language which will allow to create native apps for iOS to work with MAVLink data. Compared to Objective C implementation this library uses Swift features to make it more safe and allows users to interact through MAVLink in native swifty manner. It does not depend on C MAVLink library implementation.

Features:
* complete Swift implementation, uses value types and protocols to work with data
* precise parsing error reporting
* comprehensive debug information
* payload length and CRC extra checks
* Xcode 7 header documentation

Current limitations:
* can only receive and unpack messages, does not support message packaging and sending yet
* does not contain any tests
* requires Xcode 7 beta or newer to build, not possible to submit to AppStore until Xcode 7 release