### PR TITLE
C++ mavlink library generator

### DIFF
--- a/pymavlink/generator/CPP/include_v1.0/bytebuffer.h
+++ b/pymavlink/generator/CPP/include_v1.0/bytebuffer.h
@@ -1,0 +1,182 @@
+#ifndef MAVLINK_CPP_BYTEBUFFER_H
+#define MAVLINK_CPP_BYTEBUFFER_H
+
+#include <iostream>
+#include <deque>
+
+#include "protocol.h"
+
+namespace mavlink
+{
+  class ByteBuffer
+  {
+    public:
+      ByteBuffer():
+        m_buffer()
+      {}
+
+      ByteBuffer(ByteBuffer const& buffer):
+        ByteBuffer()
+      {
+        _load(buffer);
+      }
+
+      ByteBuffer(const char * data, size_t length):
+        ByteBuffer()
+      {
+        for(unsigned int i = 0; i < length; ++i)
+          m_buffer.push_back(data[i]);
+      }
+
+      void operator = (ByteBuffer const& buffer)
+      {
+        m_buffer.clear();
+        _load(buffer);
+      }
+
+      template <typename T>
+      void push_back(T n);
+      void push_back(ByteBuffer const& n){_load(n);}
+
+
+      template <typename T>
+      void push_back_array(T const* n, int array_length);
+
+      template <typename T>
+      void operator << (T n);
+      void operator << (ByteBuffer const& n){push_back(n);}
+
+      template <typename T>
+      T get(unsigned int n) const;
+      template <typename T>
+      T* get_array(unsigned int n, unsigned int array_length) const;
+
+      uint8_t operator [] (unsigned int i) const{return m_buffer[i];}
+
+      void pop_front(unsigned int i = 1)
+      {
+        for(unsigned int j = 0; j < i && m_buffer.size() > 0; ++j)
+          m_buffer.pop_front();
+      }
+
+      size_t size() const{return m_buffer.size();}
+
+      operator char*() const
+      {
+        char * buf = new char[m_buffer.size()];
+
+        int i(0);
+        for(auto it = m_buffer.cbegin(); it != m_buffer.cend(); ++it)
+          buf[i++] = *it;
+
+        return buf;
+      }
+
+      class const_iterator
+      {
+        friend class ByteBuffer;
+
+        public:
+          const_iterator(std::deque<uint8_t>::const_iterator it):m_it(it){}
+          const_iterator(ByteBuffer::const_iterator const& it):m_it(it.m_it){}
+
+          ByteBuffer::const_iterator& operator ++ (){++m_it;return *this;}
+          ByteBuffer::const_iterator  operator ++ (int)
+          {
+            ByteBuffer::const_iterator tmp(*this);
+            operator ++();
+            return tmp;
+          }
+          ByteBuffer::const_iterator& operator -- (){--m_it;return *this;}
+          ByteBuffer::const_iterator  operator -- (int)
+          {
+            ByteBuffer::const_iterator tmp(*this);
+            operator --();
+            return tmp;
+          }
+
+          uint8_t operator * () const{return *m_it;}
+          bool operator == (ByteBuffer::const_iterator const& it) const
+            {return m_it == it.m_it;}
+          bool operator != (ByteBuffer::const_iterator const& it) const
+            {return !operator == (it);}
+
+        private:
+          std::deque<uint8_t>::const_iterator m_it;
+      };
+
+      ByteBuffer::const_iterator cbegin() const{return ByteBuffer::const_iterator(m_buffer.cbegin());}
+      ByteBuffer::const_iterator cend() const{return ByteBuffer::const_iterator(m_buffer.cend());}
+
+    private:
+      std::deque<uint8_t> m_buffer;
+
+      void _load(ByteBuffer const& buffer)
+      {
+        for(auto it = buffer.m_buffer.cbegin(); it != buffer.m_buffer.cend(); ++it)
+          m_buffer.push_back(*it);
+      }
+  };
+};
+
+//implemenation
+
+template <typename T>
+void mavlink::ByteBuffer::push_back(T n)
+{
+  const char * t = (const char *)&n;
+  size_t length = sizeof(n);
+
+  if(mavlink::NEED_BYTE_SWAP)
+    for(unsigned int i = length - 1; i >= 0; --i)
+      m_buffer.push_back(t[i]);
+  else
+    for(unsigned int i = 0; i < length; ++i)
+      m_buffer.push_back(t[i]);
+}
+
+template <typename T>
+void mavlink::ByteBuffer::push_back_array(T const* n, int array_length)
+{
+  for(int i = 0; i < array_length; ++i)
+    push_back<T>(n[i]);
+}
+
+template <typename T>
+void mavlink::ByteBuffer::operator << (T n)
+{
+  push_back<T>(n);
+}
+
+template <typename T>
+T mavlink::ByteBuffer::get(unsigned int n) const
+{
+  const size_t length(sizeof(T));
+
+  char * t = new char[length];
+  for(size_t i = 0; i < length; ++i)
+  {
+    #if MAVLINK_NEED_BYTE_SWAP
+      t[i] = m_buffer[n + length-1-i];
+    #else
+      t[i] = m_buffer[n + i];
+    #endif
+  }
+
+  T ret(*(reinterpret_cast<T*>(t)));
+  delete[] t;
+
+  return ret;
+}
+
+template <typename T>
+T* mavlink::ByteBuffer::get_array(unsigned int n, unsigned int array_length) const
+{
+  T* array = new T[array_length];
+  for(unsigned int i = 0; i < array_length; ++i)
+    array[i] = get<T>(n+i);
+
+  return array;
+}
+
+#endif /* MAVLINK_CPP_BYTEBUFFER_H */

--- a/pymavlink/generator/CPP/include_v1.0/message.h
+++ b/pymavlink/generator/CPP/include_v1.0/message.h
@@ -1,0 +1,149 @@
+#ifndef MAVLINK_CPP_MESSAGE_H
+#define MAVLINK_CPP_MESSAGE_H
+
+#define X25_INIT_CRC 0xffff
+#define X25_VALIDATE_CRC 0xf0b8
+
+#include <iostream>
+#include "bytebuffer.h"
+#include "protocol.h"
+
+namespace mavlink
+{
+  class message
+  {
+    public:
+      message(ByteBuffer & buffer):
+        m_payload()
+      {
+        m_header = buffer.get<uint8_t>(0);
+        m_length = buffer.get<uint8_t>(1);
+        m_sequence_number = buffer.get<uint8_t>(2);
+        m_system_id = buffer.get<uint8_t>(3);
+        m_component_id = buffer.get<uint8_t>(4);
+        m_message_id = buffer.get<uint8_t>(5);
+        for(unsigned int i = 6; i < buffer.size() - 2; ++i)
+          m_payload << buffer.get<uint8_t>(i);
+      }
+
+      message(message const& msg):
+        m_header(msg.m_header),
+        m_length(msg.m_length),
+        m_sequence_number(msg.m_sequence_number),
+        m_system_id(msg.m_system_id),
+        m_component_id(msg.m_component_id),
+        m_message_id(msg.m_message_id),
+        m_payload(msg.m_payload)
+      {}
+
+      ByteBuffer toByteBuffer() const
+      {
+        mavlink::ByteBuffer buffer(_toByteBufferWithoutChecksum());
+
+        buffer << _calculateChecksum(buffer);
+
+        return buffer;
+      }
+
+      uint8_t get_header() const{return m_header;}
+      uint8_t get_length() const{return m_length;}
+      uint8_t get_sequence_number() const{return m_sequence_number;}
+      uint8_t get_system_id() const{return m_system_id;}
+      uint8_t get_component_id() const{return m_component_id;}
+      uint8_t get_message_id() const{return m_message_id;}
+      ByteBuffer get_payload() const{return m_payload;}
+
+      bool isValid() const
+      {
+        /*  if the checksum is empty, we cannot compare to see if the message is valid
+            but, as the checksum is empty, it means that this message was crafted by
+            this application. Therefore, it is valid
+        */
+        if(m_checksum.size() == 0)
+          return true;
+        else
+        {
+          mavlink::ByteBuffer buffer(_toByteBufferWithoutChecksum());
+
+          return m_checksum == _calculateChecksum(buffer);
+        }
+      }
+
+    protected:
+      message(uint8_t length, uint8_t system_id, uint8_t component_id, uint8_t message_id):
+        m_header(mavlink::PROTOCOL_MARKER),
+        m_length(length),
+        m_sequence_number(mavlink::sequenceNumber()),
+        m_system_id(system_id),
+        m_component_id(component_id),
+        m_message_id(message_id)
+      {}
+
+      ByteBuffer m_payload;       ///< payload
+
+    private:
+      ByteBuffer _toByteBufferWithoutChecksum() const
+      {
+        mavlink::ByteBuffer buffer;
+
+        buffer << m_header;
+        buffer << m_length;
+        buffer << m_sequence_number;
+        buffer << m_system_id;
+        buffer << m_component_id;
+        buffer << m_message_id;
+        buffer << m_payload;
+
+        return buffer;
+      }
+
+      ByteBuffer _calculateChecksum(ByteBuffer const& buffer) const
+      {
+        mavlink::message::checksum cs;
+
+        //we skip the protocol magic marker (0xFE)
+        for(int i = 1; i < buffer.size(); ++i)
+          cs.accumulate(buffer[i]);
+
+        if(mavlink::USE_CRC_EXTRA)
+          cs.accumulate(mavlink::msg::crcs[m_message_id]);
+
+        uint16_t checksum = (uint16_t) cs;
+
+        mavlink::ByteBuffer retBuffer;
+        retBuffer << (uint8_t)(checksum & 0xFF);
+        retBuffer << (uint8_t)(checksum >> 8);
+
+        return retBuffer;
+      }
+
+      uint8_t m_header;           ///< 0xFE (MAVLink header)
+      uint8_t m_length;           ///< payload length
+      uint8_t m_sequence_number;  ///< sequence number. Rolls between 0x00 and 0xFF
+      uint8_t m_system_id;        ///< id of the sender system
+      uint8_t m_component_id;     ///< id of the sender component
+      uint8_t m_message_id;       ///< id of the message
+
+      ByteBuffer m_checksum;
+
+      class checksum
+      {
+        public:
+          checksum(){m_crc = X25_INIT_CRC;}
+
+          void accumulate(uint8_t data)
+          {
+            uint8_t tmp;
+            tmp = data ^ (uint8_t)(m_crc &0xff);
+            tmp ^= (tmp<<4);
+            m_crc = (m_crc>>8) ^ (tmp<<8) ^ (tmp <<3) ^ (tmp>>4);
+          }
+
+          operator uint16_t() const{return m_crc;}
+
+        private:
+          uint16_t m_crc;
+      };
+  };
+};
+#endif /* MAVLINK_CPP_MESSAGE_H */

--- a/pymavlink/generator/CPP/include_v1.0/protocol.cpp
+++ b/pymavlink/generator/CPP/include_v1.0/protocol.cpp
@@ -1,0 +1,9 @@
+#include <cstdint>
+
+namespace mavlink {
+  /* the sequence number of the system.
+     do NOT use _sequenceNumber directly to craft a message.
+     use sequenceNumber() instead, which guarantee you that the variable is incremented at each call
+   */
+  volatile uint8_t _sequenceNumber = 0;
+}

--- a/pymavlink/generator/CPP/include_v1.0/protocol.h
+++ b/pymavlink/generator/CPP/include_v1.0/protocol.h
@@ -1,0 +1,26 @@
+#ifndef  MAVLINK_CPP_PROTOCOL_H
+#define  MAVLINK_CPP_PROTOCOL_H
+
+#include <cstdint>
+
+/*
+   If you want MAVLink on a system that is native big-endian,
+   you need to define NATIVE_BIG_ENDIAN
+*/
+namespace mavlink
+{
+  #ifdef NATIVE_BIG_ENDIAN
+    const bool NEED_BYTE_SWAP = mavlink::PROTOCOL_USE_LITTLE_ENDIAN;
+  #else
+    const bool NEED_BYTE_SWAP = !mavlink::PROTOCOL_USE_LITTLE_ENDIAN;
+  #endif
+
+  /* the sequence number of the system.
+     do NOT use _sequenceNumber directly to craft a message.
+     use sequenceNumber() instead, which guarantee you that the variable is incremented at each call
+   */
+  extern volatile uint8_t _sequenceNumber;
+  inline uint8_t sequenceNumber(){return _sequenceNumber++;}
+}
+
+#endif // _MAVLINK_PROTOCOL_H_

--- a/pymavlink/generator/mavgen.py
+++ b/pymavlink/generator/mavgen.py
@@ -20,7 +20,7 @@ DEFAULT_ERROR_LIMIT = 200
 DEFAULT_VALIDATE = True
 
 # List the supported languages. This is done globally because it's used by the GUI wrapper too
-supportedLanguages = ["C", "CS", "JavaScript", "Python", "WLua", "ObjC", "Java"]
+supportedLanguages = ["C", "C++", "CS", "JavaScript", "Python", "WLua", "ObjC", "Java"]
 
 
 def mavgen(opts, args) :
@@ -102,6 +102,9 @@ def mavgen(opts, args) :
     elif opts.language == 'c':
         from . import mavgen_c
         mavgen_c.generate(opts.output, xml)
+    elif opts.language == 'c++':
+        from . import mavgen_cpp
+        mavgen_cpp.generate(opts.output, xml)
     elif opts.language == 'wlua':
         from . import mavgen_wlua
         mavgen_wlua.generate(opts.output, xml)

--- a/pymavlink/generator/mavgen_cpp.py
+++ b/pymavlink/generator/mavgen_cpp.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python
+'''
+parse a MAVLink protocol XML file and generate a C++ implementation
+
+Copyright Amaury Louarn 2015
+
+Released under GNU GPL version 3 or later
+
+----
+Based on the C generator :
+Copyright Andrew Tridgell 2011
+'''
+
+import sys, textwrap, os, time
+from . import mavparse, mavtemplate
+
+t = mavtemplate.MAVTemplate()
+
+def generate_version_h(directory, xml):
+    '''generate version.h'''
+    f = open(os.path.join(directory, "version.h"), mode='w')
+    t.write(f,'''
+/** @file
+ *	@brief MAVLink comm protocol built from ${basename}.xml
+ *	@see http://mavlink.org
+ */
+#ifndef MAVLINK_CPP_VERSION_H
+#define MAVLINK_CPP_VERSION_H
+
+namespace mavlink
+{
+  namespace version
+  {
+    const char * const build_date = "${parse_time}";
+    const char * const wire_protocol = "${wire_protocol_version}";
+    const uint8_t max_dialect_payload_size = ${largest_payload};
+  };
+};
+
+#endif // MAVLINK_CPP_VERSION_H
+''', xml)
+    f.close()
+
+def generate_mavlink_h(directory, xml):
+    '''generate mavlink.h'''
+    f = open(os.path.join(directory, "mavlink.h"), mode='w')
+    t.write(f,'''
+/** @file
+ *	@brief MAVLink comm protocol built from ${basename}.xml
+ *	@see http://mavlink.org
+ */
+#ifndef MAVLINK_CPP_H
+#define MAVLINK_CPP_H
+
+#include <cstdint>
+
+namespace mavlink
+{
+  const uint8_t PROTOCOL_MARKER = ${protocol_marker};
+  const bool PROTOCOL_USE_LITTLE_ENDIAN = ${mavlink_endian};
+  const bool ALIGNED_FIELDS = ${aligned_fields_define};
+  const bool USE_CRC_EXTRA = ${crc_extra_define};
+};
+
+#include "version.h"
+#include "${basename}.h"
+
+#endif // MAVLINK_CPP_H
+''', xml)
+    f.close()
+
+def generate_main_h(directory, xml):
+    '''generate main header per XML file'''
+    f = open(os.path.join(directory, xml.basename + ".h"), mode='w')
+    t.write(f, '''
+/** @file
+ *	@brief MAVLink comm protocol generated from ${basename}.xml
+ *	@see http://mavlink.org
+ */
+#ifndef MAVLINK_CPP_${basename_upper}_H
+#define MAVLINK_CPP_${basename_upper}_H
+
+#ifndef MAVLINK_CPP_H
+    #error Wrong include order: MAVLINK_${basename_upper}.H MUST NOT BE DIRECTLY USED. Include mavlink.h from the same directory instead or set ALL AND EVERY defines from MAVLINK.H manually accordingly, including the #define MAVLINK_CPP_H call.
+#endif
+
+// MESSAGE LENGTHS AND CRCS
+
+namespace mavlink
+{
+  namespace msg
+  {
+      const uint8_t lengths[] = {${message_lengths_array}};
+      const uint8_t crcs[] = {${message_crcs_array}};
+  };
+};
+
+#include "../protocol.h"
+
+#define MAVLINK_ENABLED_${basename_upper}
+
+// ENUM DEFINITIONS
+
+namespace mavlink
+{
+  ${{enum:
+  /** @brief ${description} */
+  #ifndef HAVE_ENUM_${name}
+  #define HAVE_ENUM_${name}
+  typedef enum ${name}
+  {
+  ${{entry:	${name}=${value}, /* ${description} |${{param:${description}| }} */
+  }}
+  } ${name};
+  #endif
+  }}
+};
+
+
+
+${{include_list:#include "../${base}/${base}.h"
+}}
+
+// MAVLINK VERSION
+
+#ifndef MAVLINK_VERSION
+#define MAVLINK_VERSION ${version}
+#endif
+
+#if (MAVLINK_VERSION == 0)
+#undef MAVLINK_VERSION
+#define MAVLINK_VERSION ${version}
+#endif
+
+// MESSAGE DEFINITIONS
+${{message:#include "./mavlink_msg_${name_lower}.h"
+}}
+
+#endif // MAVLINK_CPP_${basename_upper}_H
+''', xml)
+
+    f.close()
+
+
+def generate_message_h(directory, m):
+    '''generate per-message header for a XML file'''
+    f = open(os.path.join(directory, 'mavlink_msg_%s.h' % m.name_lower), mode='w')
+    t.write(f, '''
+#ifndef MAVLINK_CPP_MSG_${name}_H
+#define MAVLINK_CPP_MSG_${name}_H
+
+#include "../message.h"
+
+namespace mavlink
+{
+  namespace msg
+  {
+    const uint8_t ${name_lower}_id = ${id};
+    const uint8_t ${name_lower}_length = ${wire_length};
+    const uint8_t ${name_lower}_crc = ${crc_extra};
+
+    class ${name_lower} : public mavlink::message
+    {
+      public:
+        ${name_lower}(uint8_t system_id, uint8_t component_id, ${{arg_fields: ${array_const}${type} ${array_prefix} ${name},}}):
+          mavlink::message( mavlink::msg::${name_lower}_length,
+                            system_id,
+                            component_id,
+                            mavlink::msg::${name_lower}_id)
+        {
+          ${{scalar_fields: m_payload.push_back<${type}>(${putname}); ///< ${description}
+          }}
+          ${{array_fields:	m_payload.push_back_array<${type}>(${name}, ${array_length}); ///< ${description}
+          }}
+        }
+
+      ${{scalar_fields:	${type} get_${putname}() const
+          {return m_payload.get<${type}>(${wire_offset});}
+      }}
+      ${{array_fields: ${type} * get_${name}() const
+          {return m_payload.get_array<${type}>(${wire_offset}, ${array_length});}
+      }}
+    };
+  };
+};
+
+#endif //MAVLINK_CPP_MSG_${name}_H
+    ''', m)
+    f.close()
+
+def copy_fixed_headers(directory, xml):
+    '''copy the fixed protocol headers to the target directory'''
+    import shutil
+    hlist = [ 'message.h', 'bytebuffer.h', 'protocol.h', 'protocol.cpp' ]
+    basepath = os.path.dirname(os.path.realpath(__file__))
+    srcpath = os.path.join(basepath, 'CPP/include_v%s' % xml.wire_protocol_version)
+    print("Copying fixed headers")
+    for h in hlist:
+        src = os.path.realpath(os.path.join(srcpath, h))
+        dest = os.path.realpath(os.path.join(directory, h))
+        if src == dest:
+           continue
+        shutil.copy(src, dest)
+
+class mav_include(object):
+    def __init__(self, base):
+        self.base = base
+
+def generate_one(basename, xml):
+    '''generate headers for one XML file'''
+
+    directory = os.path.join(basename, xml.basename)
+
+    print("Generating C++ implementation in directory %s" % directory)
+    mavparse.mkdir_p(directory)
+
+    if xml.little_endian:
+        xml.mavlink_endian = "true"
+    else:
+        xml.mavlink_endian = "false"
+
+    if xml.crc_extra:
+        xml.crc_extra_define = "true"
+    else:
+        xml.crc_extra_define = "false"
+
+    if xml.sort_fields:
+        xml.aligned_fields_define = "true"
+    else:
+        xml.aligned_fields_define = "false"
+
+    # work out the included headers
+    xml.include_list = []
+    for i in xml.include:
+        base = i[:-4]
+        xml.include_list.append(mav_include(base))
+
+    # form message lengths array
+    xml.message_lengths_array = ''
+    for mlen in xml.message_lengths:
+        xml.message_lengths_array += '%u, ' % mlen
+    xml.message_lengths_array = xml.message_lengths_array[:-2]
+
+    # and message CRCs array
+    xml.message_crcs_array = ''
+    for crc in xml.message_crcs:
+        xml.message_crcs_array += '%u, ' % crc
+    xml.message_crcs_array = xml.message_crcs_array[:-2]
+
+    # form message info array
+    xml.message_info_array = ''
+    for name in xml.message_names:
+        if name is not None:
+            xml.message_info_array += 'MAVLINK_MESSAGE_INFO_%s, ' % name
+        else:
+            # Several C compilers don't accept {NULL} for
+            # multi-dimensional arrays and structs
+            # feed the compiler a "filled" empty message
+            xml.message_info_array += '{"EMPTY",0,{{"","",MAVLINK_TYPE_CHAR,0,0,0}}}, '
+    xml.message_info_array = xml.message_info_array[:-2]
+
+    # add some extra field attributes for convenience with arrays
+    for m in xml.message:
+        m.msg_name = m.name
+        if xml.crc_extra:
+            m.crc_extra_arg = ", %s" % m.crc_extra
+        else:
+            m.crc_extra_arg = ""
+        for f in m.fields:
+            if f.print_format is None:
+                f.c_print_format = 'NULL'
+            else:
+                f.c_print_format = '"%s"' % f.print_format
+            if f.array_length != 0:
+                f.array_suffix = '[%u]' % f.array_length
+                f.array_prefix = '*'
+                f.array_tag = '_array'
+                f.array_arg = ', %u' % f.array_length
+                f.array_return_arg = '%s, %u, ' % (f.name, f.array_length)
+                f.array_const = 'const '
+                f.decode_left = ''
+                f.decode_right = ', %s->%s' % (m.name_lower, f.name)
+                f.return_type = 'uint16_t'
+                f.get_arg = ', %s *%s' % (f.type, f.name)
+                if f.type == 'char':
+                    f.c_test_value = '"%s"' % f.test_value
+                else:
+                    test_strings = []
+                    for v in f.test_value:
+                        test_strings.append(str(v))
+                    f.c_test_value = '{ %s }' % ', '.join(test_strings)
+            else:
+                f.array_suffix = ''
+                f.array_prefix = ''
+                f.array_tag = ''
+                f.array_arg = ''
+                f.array_return_arg = ''
+                f.array_const = ''
+                f.decode_left = "%s->%s = " % (m.name_lower, f.name)
+                f.decode_right = ''
+                f.get_arg = ''
+                f.return_type = f.type
+                if f.type == 'char':
+                    f.c_test_value = "'%s'" % f.test_value
+                elif f.type == 'uint64_t':
+                    f.c_test_value = "%sULL" % f.test_value
+                elif f.type == 'int64_t':
+                    f.c_test_value = "%sLL" % f.test_value
+                else:
+                    f.c_test_value = f.test_value
+
+    # cope with uint8_t_mavlink_version
+    for m in xml.message:
+        m.arg_fields = []
+        m.array_fields = []
+        m.scalar_fields = []
+        for f in m.ordered_fields:
+            if f.array_length != 0:
+                m.array_fields.append(f)
+            else:
+                m.scalar_fields.append(f)
+        for f in m.fields:
+            if not f.omit_arg:
+                m.arg_fields.append(f)
+                f.putname = f.name
+            else:
+                f.putname = f.const_value
+
+    generate_mavlink_h(directory, xml)
+    generate_version_h(directory, xml)
+    generate_main_h(directory, xml)
+    for m in xml.message:
+        generate_message_h(directory, m)
+
+
+def generate(basename, xml_list):
+    '''generate complete MAVLink C++ implemenation'''
+
+    for xml in xml_list:
+        generate_one(basename, xml)
+    copy_fixed_headers(basename, xml_list[0])


### PR DESCRIPTION
Hi.
This is a simple C++ implementation of the mavlink protocol. It is based on the C implementation, and adds some "C++ flavoring" to it (such as objects and namespaces).

Features:
- simple message creation (no more mavlink_msg_pack, just a constructor instead)
- all mavlink messages inherits from one single class (mavlink::message), which regroups all the redundant code
- the storage of the bytes is sugar-coated by a convenience class (mavlink::ByteBuffer), which deals with byte swap
- the code is enclosed in its own namespace, to avoid conflicts
- most of the C-style preprocessor defines are replaced by namespace constant globals.
- almost header-only
