### PR TITLE
Messages' field description with a newline corruption correction

### DIFF
--- a/pymavlink/generator/mavgen_c.py
+++ b/pymavlink/generator/mavgen_c.py
@@ -152,7 +152,7 @@ def generate_message_h(directory, m):
 
 typedef struct __mavlink_${name_lower}_t
 {
-${{ordered_fields: ${type} ${name}${array_suffix}; ///< ${description}
+${{ordered_fields: ${type} ${name}${array_suffix}; /*< ${description}*/
 }}
 } mavlink_${name_lower}_t;
 


### PR DESCRIPTION
As is easily understood if the ${description} placeholder is a string with newlines, a corrupt header will be generated as the description text will be expanded as probably invalid C because it is not protected by the comment guards.