### PR TITLE
common: add firmware_release_type enum

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -143,6 +143,24 @@
                     <description>Onboard gimbal</description>
                </entry>
           </enum>
+          <enum name="FIRMWARE_RELEASE_TYPE">
+                <description>These values define the type of firmware release.</description>
+                <entry value="0" name="DEV">
+                    <description>A development version of the software.  Basically, anything compiled from master branch.</description>
+                </entry>
+                <entry value="64" name="ALPHA1">
+                    <description>The first alpha release.</description>
+                </entry>
+                <entry value="128" name="BETA1">
+                    <description>The first beta release.</description>
+                </entry>
+                <entry value="192" name="RC1">
+                    <description>The first release candidate.</description>
+                </entry>
+                <entry value="255" name="RELEASE">
+                    <description>The official, stable release.</description>
+                </entry>
+          </enum>
           <!-- WARNING: MAV_ACTION Enum is no longer supported - has been removed. Please use MAV_CMD -->
           <enum name="MAV_MODE_FLAG">
                 <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
@LorenzMeier 

Hi Lorenz

at the dev call we decided that we want to populate `AUTOPILOT_VERSION.firmware_type`.  But right now our versions look like:
`3.2.1-stable`
`3.3.0-rc9`
`3.4.0-dev`

So in order to put them into the 32 bit field, we decided that we want to chop the field up into 4 bytes and then use it like so:
(major)    (minor)    (patch)    (FIRMWARE_RELEASE_TYPE)

So with this system, the above versions would be written as:
`3.2.1.STABLE`
`3.3.0.(RC1+8)`
`3.4.0.DEV`

What do you think?