### PR TITLE
Common: rename FIRMWARE_VERSION_TYPE and fully qualify items

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1169,6 +1169,11 @@
                   <param index="4">Speed of the vertical rotation (in degrees per second)</param>
               </entry>
 
+              <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION">
+                  <description>Request VTOL transition</description>
+                  <param index="1">The target VTOL state, as defined by ENUM MAV_VTOL_STATE. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
+              </entry>
+
               <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
 
               <!-- BEGIN of payload range (30000 to 30999) -->
@@ -1685,6 +1690,24 @@
               </entry>
               <entry value="4" name="MAV_BATTERY_TYPE_PAYLOAD">
                   <description>Payload battery</description>
+              </entry>
+          </enum>
+          <enum name="MAV_VTOL_STATE">
+              <description>Enumeration of VTOL states</description>
+              <entry value="0" name="MAV_VTOL_STATE_UNDEFINED">
+                  <description>MAV is not configured as VTOL</description>
+              </entry>
+              <entry value="1" name="MAV_VTOL_STATE_TRANSITION_TO_FW">
+                  <description>VTOL is in transition from multicopter to fixed-wing</description>
+              </entry>
+              <entry value="2" name="MAV_VTOL_STATE_TRANSITION_TO_MC">
+                  <description>VTOL is in transition from fixed-wing to multicopter</description>
+              </entry>
+              <entry value="3" name="MAV_VTOL_STATE_MC">
+                  <description>VTOL is in multicopter state</description>
+              </entry>
+              <entry value="4" name="MAV_VTOL_STATE_FW">
+                  <description>VTOL is in fixed-wing state</description>
               </entry>
           </enum>
      </enums>
@@ -2917,6 +2940,10 @@
             <description>This interface replaces DATA_STREAM</description>
             <field type="uint16_t" name="message_id">The ID of the requested MAVLink message. v1.0 is limited to 254 messages.</field>
             <field type="int32_t" name="interval_us">The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, > 0 indicates the interval at which it is sent.</field>
+        </message>
+        <message id="245" name="VTOL_STATE">
+            <description>Provides state for VTOL configurations</description>
+            <field type="uint8_t" name="state" enum="MAV_VTOL_STATE">The VTOL state the MAV is in</field>
         </message>
         <message id="248" name="V2_EXTENSION">
             <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -143,23 +143,23 @@
                     <description>Onboard gimbal</description>
                </entry>
           </enum>
-          <enum name="FIRMWARE_RELEASE_TYPE">
-                <description>These values define the type of firmware release.</description>
-                <entry value="0" name="DEV">
-                    <description>A development version of the software.  Basically, anything compiled from master branch.</description>
-                </entry>
-                <entry value="64" name="ALPHA1">
-                    <description>The first alpha release.</description>
-                </entry>
-                <entry value="128" name="BETA1">
-                    <description>The first beta release.</description>
-                </entry>
-                <entry value="192" name="RC1">
-                    <description>The first release candidate.</description>
-                </entry>
-                <entry value="255" name="RELEASE">
-                    <description>The official, stable release.</description>
-                </entry>
+          <enum name="FIRMWARE_VERSION_TYPE">
+              <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>
+              <entry value="0" name="FIRMWARE_VERSION_TYPE_DEV">
+                  <description>development release</description>
+              </entry>
+              <entry value="64" name="FIRMWARE_VERSION_TYPE_ALPHA">
+                  <description>alpha release</description>
+              </entry>
+              <entry value="128" name="FIRMWARE_VERSION_TYPE_BETA">
+                  <description>beta release</description>
+              </entry>
+              <entry value="192" name="FIRMWARE_VERSION_TYPE_RC">
+                  <description>release candidate</description>
+              </entry>
+              <entry value="255" name="FIRMWARE_VERSION_TYPE_OFFICIAL">
+                  <description>official stable release</description>
+              </entry>
           </enum>
           <!-- WARNING: MAV_ACTION Enum is no longer supported - has been removed. Please use MAV_CMD -->
           <enum name="MAV_MODE_FLAG">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -143,6 +143,24 @@
                     <description>Onboard gimbal</description>
                </entry>
           </enum>
+          <enum name="FIRMWARE_RELEASE_TYPE">
+                <description>These values define the type of firmware release.</description>
+                <entry value="0" name="DEV">
+                    <description>A development version of the software.  Basically, anything compiled from master branch.</description>
+                </entry>
+                <entry value="64" name="ALPHA1">
+                    <description>The first alpha release.</description>
+                </entry>
+                <entry value="128" name="BETA1">
+                    <description>The first beta release.</description>
+                </entry>
+                <entry value="192" name="RC1">
+                    <description>The first release candidate.</description>
+                </entry>
+                <entry value="255" name="RELEASE">
+                    <description>The official, stable release.</description>
+                </entry>
+          </enum>
           <!-- WARNING: MAV_ACTION Enum is no longer supported - has been removed. Please use MAV_CMD -->
           <enum name="MAV_MODE_FLAG">
                 <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
This renames the FIRMWARE_RELEASE_TYPE to FIRMWARE_VERSION_TYPE but also more importantly it fully qualifies the entries of the enum to reduce the chance that they could conflict with other definitions within the autopilots.