### PR TITLE
Add comment to aborted landing alt in CMD_NAV_LAND

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -600,7 +600,7 @@
                </entry>
                <entry value="21" name="MAV_CMD_NAV_LAND">
                     <description>Land at location</description>
-                    <param index="1">Empty</param>
+                    <param index="1">Altitude to climb to when landing is aborted</param>
                     <param index="2">Empty</param>
                     <param index="3">Empty</param>
                     <param index="4">Desired yaw angle</param>


### PR DESCRIPTION
This is part of ArduPilot PR https://github.com/diydrones/ardupilot/pull/2781 where an RC throttle-up during auto-land causes a take-off type mode where it holds heading and climbs. In ArduPilot we have the ability to restart the landing sequence automatically via roll-back to DO_LAND_START or decrement mission index