### PR TITLE
[python3] try to compute properly the crc for python3

### DIFF
--- a/pymavlink/generator/mavgen_python.py
+++ b/pymavlink/generator/mavgen_python.py
@@ -163,7 +163,7 @@ class MAVLink_message(object):
         self._msgbuf = self._header.pack() + payload
         crc = x25crc(self._msgbuf[1:])
         if ${crc_extra}: # using CRC extra
-            crc.accumulate_str(chr(crc_extra))
+            crc.accumulate_str(struct.pack('B', crc_extra))
         self._crc = crc.crc
         self._msgbuf += struct.pack('<H', self._crc)
         return self._msgbuf


### PR DESCRIPTION
As reported in #407, the crc computation is still not completely correct. The issue is that the behaviour of chr  diverges between python2 and python3 for crc_extra >= 128 ("extented-ascii").

For example, in python2, chr(240) returns 0xf0 while it returns ð in python3. Once transformed in array in accumulate_str, it gives respectively array('B', [240]) and array('B', [195, 176]). 

The use of struct.pack fix the issue.