### PR TITLE
TBD: Proposal to expose landed state

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1738,6 +1738,18 @@
                   <description>VTOL is in fixed-wing state</description>
               </entry>
           </enum>
+          <enum name="MAV_LANDED_STATE">
+              <description>Enumeration of landed detector states</description>
+              <entry value="0" name="MAV_LANDED_STATE_UNDEFINED">
+                  <description>MAV landed state is unknown</description>
+              </entry>
+              <entry value="1" name="MAV_LANDED_STATE_ON_GROUND">
+                  <description>MAV is landed (on ground)</description>
+              </entry>
+              <entry value="2" name="MAV_LANDED_STATE_IN_AIR">
+                  <description>MAV is in air</description>
+              </entry>
+          </enum>
      </enums>
      <messages>
           <message id="0" name="HEARTBEAT">
@@ -2976,9 +2988,10 @@
             <field type="uint16_t" name="message_id">The ID of the requested MAVLink message. v1.0 is limited to 254 messages.</field>
             <field type="int32_t" name="interval_us">The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, > 0 indicates the interval at which it is sent.</field>
         </message>
-        <message id="245" name="VTOL_STATE">
-            <description>Provides state for VTOL configurations</description>
-            <field type="uint8_t" name="state" enum="MAV_VTOL_STATE">The VTOL state the MAV is in</field>
+        <message id="245" name="EXTENDED_SYS_STATE">
+            <description>Provides state for additional features</description>
+            <field type="uint8_t" name="vtol_state" enum="MAV_VTOL_STATE">The VTOL state if applicable. Is set to MAV_VTOL_STATE_UNDEFINED if UAV is not in VTOL configuration.</field>
+            <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
         </message>
         <message id="248" name="V2_EXTENSION">
             <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>


### PR DESCRIPTION
@LorenzMeier 
I'd like to get https://github.com/PX4/Firmware/issues/2797 resolved somehow. Instead of adding yet another message with just a single field I changed the VTOL state message, since it's probably not used anywhere yet, into something more general.

Opinions? Is there maybe another way to get the landed state? (I also thought about the reserved bits from custom_mode)

(The only other VTOL related information we talked about was the estimated airflow. That could be added here too.)