### PR TITLE
pymavlink:  a revised "try" part of the function (mavutil.py, line 76…

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -760,7 +760,10 @@ class mavserial(mavfile):
 
     def write(self, buf):
         try:
-            return self.port.write(buf)
+            if type(buf) == 'str':
+                return self.port.write(buf)
+            if type(buf) == 'bytearray':
+                return self.port.write(str(buf)) 
         except Exception:
             if not self.portdead:
                 print("Device %s is dead" % self.device)


### PR DESCRIPTION
…1) , where this handles bytearray data correctly, and it didn't before.  fixes issue 445