### PR TITLE
Update mavlink_to_html_table.xsl

### DIFF
--- a/doc/mavlink_to_html_table.xsl
+++ b/doc/mavlink_to_html_table.xsl
@@ -47,7 +47,7 @@
 </xsl:template>
 
 <xsl:template match="//field">
-   <tr class="mavlink_field" id="{@name}">
+   <tr class="mavlink_field">
    <td class="mavlink_name" valign="top"><xsl:value-of select="@name" /></td>
    <td class="mavlink_type" valign="top"><xsl:value-of select="@type" /></td>
    <td class="mavlink_comment"><xsl:value-of select="." /></td>
@@ -83,7 +83,7 @@
 </xsl:template>
 
 <xsl:template match="//entry">
-   <tr class="mavlink_field">
+   <tr class="mavlink_field" id="{@name}">
    <td class="mavlink_type" valign="top"><xsl:value-of select="@value" /></td>
    <td class="mavlink_name" valign="top"><xsl:value-of select="@name" /></td>
    <td class="mavlink_comment"><xsl:value-of select="description" /></td>

--- a/doc/mavlink_to_html_table.xsl
+++ b/doc/mavlink_to_html_table.xsl
@@ -47,7 +47,7 @@
 </xsl:template>
 
 <xsl:template match="//field">
-   <tr class="mavlink_field">
+   <tr class="mavlink_field" id="{@name}">
    <td class="mavlink_name" valign="top"><xsl:value-of select="@name" /></td>
    <td class="mavlink_type" valign="top"><xsl:value-of select="@type" /></td>
    <td class="mavlink_comment"><xsl:value-of select="." /></td>


### PR DESCRIPTION
This adds an id (based on the element name) to every field.

The change makes it much easier to link to enums and other messages from external sources (including the ardupilot wiki). Prior to this you can only link to a small subset of messages.