### PR TITLE
mavplayback: prevent crash on "" or non-digit speed value

### DIFF
--- a/pymavlink/tools/mavplayback.py
+++ b/pymavlink/tools/mavplayback.py
@@ -166,7 +166,10 @@ class App():
             self.root.after(100, self.next_message)
             return
 
-        speed = float(self.playback.get())
+        try:
+            speed = float(self.playback.get())
+        except:
+            speed = 0.0
         timestamp = getattr(msg, '_timestamp')
 
         now = time.strftime("%H:%M:%S", time.localtime(timestamp))


### PR DESCRIPTION
mavplayback would crash if speed were set to "" (delete/backspace removed last character) of a letter were enterd by accident when editing speed.
the fix prevents crash 