### PR TITLE
ADSB Lat/Lon to use int*1E7 instead of float

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3044,14 +3044,14 @@
         <message id="246" name="ADSB_VEHICLE">
           <description>The location and information of an ADSB vehicle</description>
           <field type="uint32_t" name="ICAO_address">ICAO address</field>
-          <field type="float" name="lat">The reported latitude in degrees</field>
-          <field type="float" name="lon">The reported longitude in degrees</field>
-          <field type="uint8_t" name="altitude_type" enum="ADSB_ALTITUDE_TYPE">Type from ADSB_ALTITUDE_TYPE enum.</field>
+          <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
+          <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
+          <field type="uint8_t" name="altitude_type" enum="ADSB_ALTITUDE_TYPE">Type from ADSB_ALTITUDE_TYPE enum</field>
           <field type="float" name="altitude">Altitude(ASL) in meters</field>
-          <field type="uint16_t" name="heading">Course over ground in degrees * 10^2</field>
+          <field type="uint16_t" name="heading">Course over ground in centidegrees</field>
           <field type="float" name="hor_velocity">The horizontal velocity in meters/second</field>
           <field type="float" name="ver_velocity">The vertical velocity in meters/second, positive is up</field>
-          <field type="char[9]" name="callsign">The callsign(squawk)</field>
+          <field type="char[9]" name="callsign">The callsign, 8+null</field>
           <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">Type from ADSB_EMITTER_TYPE enum</field>
           <field type="uint8_t" name="tslc">Time since last communication in seconds</field>
           <field type="uint16_t" name="flags" enum="ADSB_FLAGS">Flags to indicate various statuses including valid data fields</field>


### PR DESCRIPTION
ADSB Lat/Lon to use int*1E7 instead of float