### PR TITLE
adsb_vehicle: add squawk valid flag

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1796,6 +1796,7 @@
               <entry value="8" name="ADSB_FLAGS_VALID_VELOCITY"></entry>
               <entry value="16" name="ADSB_FLAGS_VALID_CALLSIGN"></entry>
               <entry value="32" name="ADSB_FLAGS_SIMULATED"></entry>
+              <entry value="64" name="ADSB_FLAGS_VALID_SQUAWK"></entry>
           </enum>
      </enums>
      <messages>


### PR DESCRIPTION
It is not entirely clear if a squawk value of 0 is invalid per https://en.wikipedia.org/wiki/Transponder_(aeronautics) so use a new validity flag.