### PR TITLE
Increases UDP max packet size to max.

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -817,7 +817,7 @@ class mavudp(mavfile):
 
     def recv(self,n=None):
         try:
-            data, self.last_address = self.port.recvfrom(300)
+            data, self.last_address = self.port.recvfrom(65535)
         except socket.error as e:
             if e.errno in [ errno.EAGAIN, errno.EWOULDBLOCK, errno.ECONNREFUSED ]:
                 return ""


### PR DESCRIPTION
Solo is pushing an update shortly which bundles several messages in one UDP datagram. In current pymavlink, messages get capped at 300 bytes, which drops many messages.

I understood the hardcoded 300 bytes to be approximately larger than the size of a MAVLink message. I believe extending this to be the theoretical UDP max should not impact any existing usage.

The underlying mavutil code will parse several sequential messages in a packet already (great!) so no other modification is needed.