### PR TITLE
ADS-B: vertical velocity should have been signed

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3074,7 +3074,7 @@
           <field type="int32_t" name="altitude">Altitude(ASL) in millimeters</field>
           <field type="uint16_t" name="heading">Course over ground in centidegrees</field>
           <field type="uint16_t" name="hor_velocity">The horizontal velocity in centimeters/second</field>
-          <field type="uint16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
+          <field type="int16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
           <field type="char[9]" name="callsign">The callsign, 8+null</field>
           <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">Type from ADSB_EMITTER_TYPE enum</field>
           <field type="uint8_t" name="tslc">Time since last communication in seconds</field>


### PR DESCRIPTION
Vertical velocity was incorrectly using uint16 instead of int16. Needs to be signed to report climb/sink rates. This mistake was recently introduced when we changed format from float to integer.