### PR TITLE
Revert "Parachute capability bit"

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1694,9 +1694,6 @@
               <entry value="4096" name="MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION">
                   <description>Autopilot supports onboard compass calibration.</description>
               </entry>
-              <entry value="8192" name="MAV_PROTOCOL_CAPABILITY_PARACHUTE">
-                  <description>Autopilot supports parachute deployment.</description>
-              </entry>
           </enum>
           <enum name="MAV_ESTIMATOR_TYPE">
               <description>Enumeration of estimator types</description>


### PR DESCRIPTION
Reverts mavlink/mavlink#491

@LorenzMeier There was disagreement with this once I got to diydrones/ardupilot.  Best to just undo it, unless you see a good reason for it.  Sorry to bother you with this.