### PR TITLE
Java: only allocate the payload space required for a message

### DIFF
--- a/pymavlink/generator/java/lib/Messages/MAVLinkPayload.java
+++ b/pymavlink/generator/java/lib/Messages/MAVLinkPayload.java
@@ -21,13 +21,17 @@ public class MAVLinkPayload {
 
     private static final long UNSIGNED_LONG_MIN_VALUE = 0;
 
-    public static final int MAX_PAYLOAD_SIZE = 512;
+    public static final int MAX_PAYLOAD_SIZE = 255;
     
     public final ByteBuffer payload;
     public int index;
 
-    public MAVLinkPayload() {
-        payload = ByteBuffer.allocate(MAX_PAYLOAD_SIZE);
+    public MAVLinkPayload(int payloadSize) {
+       if(payloadSize > MAX_PAYLOAD_SIZE) {
+            payload = ByteBuffer.allocate(MAX_PAYLOAD_SIZE);
+        } else {
+            payload = ByteBuffer.allocate(payloadSize);
+        }
     }
 
     public ByteBuffer getData() {

--- a/pymavlink/generator/java/lib/Parser.java
+++ b/pymavlink/generator/java/lib/Parser.java
@@ -43,7 +43,6 @@ public class Parser {
 
             if (c == MAVLinkPacket.MAVLINK_STX) {
                 state = MAV_states.MAVLINK_PARSE_STATE_GOT_STX;
-                m = new MAVLinkPacket();
             }
             break;
 
@@ -52,7 +51,7 @@ public class Parser {
                 msg_received = false;
                 state = MAV_states.MAVLINK_PARSE_STATE_IDLE;
             } else {
-                m.len = c;
+                m = new MAVLinkPacket(c);
                 state = MAV_states.MAVLINK_PARSE_STATE_GOT_LENGTH;
             }
             break;

--- a/pymavlink/generator/mavgen_java.py
+++ b/pymavlink/generator/mavgen_java.py
@@ -159,8 +159,7 @@ public class msg_${name_lower} extends MAVLinkMessage{
     * @return
     */
     public MAVLinkPacket pack(){
-        MAVLinkPacket packet = new MAVLinkPacket();
-        packet.len = MAVLINK_MSG_LENGTH;
+        MAVLinkPacket packet = new MAVLinkPacket(MAVLINK_MSG_LENGTH);
         packet.sysid = 255;
         packet.compid = 190;
         packet.msgid = MAVLINK_MSG_ID_${name};
@@ -259,7 +258,7 @@ public class MAVLinkPacket implements Serializable {
     /**
     * Message length. NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
     */
-    public int len;
+    public final int len;
 
     /**
     * Message sequence
@@ -297,18 +296,16 @@ public class MAVLinkPacket implements Serializable {
     */
     public CRC crc;
 
-    public MAVLinkPacket(){
-        payload = new MAVLinkPayload();
+    public MAVLinkPacket(int payloadLength){
+        len = payloadLength;
+        payload = new MAVLinkPayload(payloadLength);
     }
 
     /**
     * Check if the size of the Payload is equal to the "len" byte
     */
     public boolean payloadIsFilled() {
-        if (payload.size() >= MAVLinkPayload.MAX_PAYLOAD_SIZE-1) {
-            return true;
-        }
-        return (payload.size() == len);
+        return payload.size() >= len;
     }
 
     /**
@@ -329,8 +326,9 @@ public class MAVLinkPacket implements Serializable {
         crc.update_checksum(msgid);
 
         payload.resetIndex();
-        
-        for (int i = 0; i < payload.size(); i++) {
+
+        final int payloadSize = payload.size();
+        for (int i = 0; i < payloadSize; i++) {
             crc.update_checksum(payload.getByte());
         }
         crc.finish_checksum(msgid);
@@ -351,8 +349,9 @@ public class MAVLinkPacket implements Serializable {
         buffer[i++] = (byte) sysid;
         buffer[i++] = (byte) compid;
         buffer[i++] = (byte) msgid;
-        
-        for (int j = 0; j < payload.size(); j++) {
+
+        final int payloadSize = payload.size();
+        for (int j = 0; j < payloadSize; j++) {
             buffer[i++] = payload.payload.get(j);
         }
 


### PR DESCRIPTION
Also fixes a byte buffer overflow related to reseting to a new mavlink packet. Tested against my Java usage thus far and it has been stable, and noticeably reduced the GC intervals.

This is recreating the work that can be seen in https://github.com/dronekit/dronekit-android/commit/27b16751ffad6dccda2fb45717e61377fce28f78 from @ne0fhyk 