### PR TITLE
pymavlink/mavgen: Add option to allow duplicate enum values

### DIFF
--- a/pymavlink/generator/mavgen.py
+++ b/pymavlink/generator/mavgen.py
@@ -18,6 +18,7 @@ DEFAULT_WIRE_PROTOCOL = mavparse.PROTOCOL_1_0
 DEFAULT_LANGUAGE = 'Python'
 DEFAULT_ERROR_LIMIT = 200
 DEFAULT_VALIDATE = True
+DEFAULT_ERR_ON_DUPE_ENUMS = True
 
 # List the supported languages. This is done globally because it's used by the GUI wrapper too
 supportedLanguages = ["C", "CS", "JavaScript", "Python", "WLua", "ObjC", "Swift", "Java"]
@@ -88,7 +89,7 @@ def mavgen(opts, args) :
     for x in xml:
         x.largest_payload = largest_payload
 
-    if mavparse.check_duplicates(xml):
+    if mavparse.check_duplicates(xml, opts.error_dupe_enums):
         sys.exit(1)
 
     print("Found %u MAVLink message types in %u XML files" % (
@@ -126,12 +127,14 @@ def mavgen(opts, args) :
 
 # build all the dialects in the dialects subpackage
 class Opts:
-    def __init__(self, output, wire_protocol=DEFAULT_WIRE_PROTOCOL, language=DEFAULT_LANGUAGE, validate=DEFAULT_VALIDATE, error_limit=DEFAULT_ERROR_LIMIT):
+    def __init__(self, output, wire_protocol=DEFAULT_WIRE_PROTOCOL, language=DEFAULT_LANGUAGE, validate=DEFAULT_VALIDATE, 
+            error_limit=DEFAULT_ERROR_LIMIT, error_dupe_enums=DEFAULT_ERR_ON_DUPE_ENUMS):
         self.wire_protocol = wire_protocol
         self.error_limit = error_limit
         self.language = language
         self.output = output
         self.validate = validate
+        self.error_dupe_enums = error_dupe_enums
 
 def mavgen_python_dialect(dialect, wire_protocol):
     '''generate the python code on the fly for a MAVLink dialect'''

--- a/pymavlink/generator/mavparse.py
+++ b/pymavlink/generator/mavparse.py
@@ -328,7 +328,7 @@ def merge_enums(xml):
         emap[e].entry.append(MAVEnumEntry("%s_ENUM_END" % emap[e].name,
                                             emap[e].entry[-1].value+1, end_marker=True))
 
-def check_duplicates(xml):
+def check_duplicates(xml, error_dupe_enums=True):
     '''check for duplicate message IDs'''
 
     merge_enums(xml)
@@ -357,10 +357,12 @@ def check_duplicates(xml):
                 s1 = "%s.%s" % (enum.name, entry.name)
                 s2 = "%s.%s" % (enum.name, entry.value)
                 if s1 in enummap or s2 in enummap:
-                    print("ERROR: Duplicate enums %s/%s at %s:%u and %s" % (
+                    print("%s: Duplicate enums %s/%s at %s:%u and %s" % (
+                        "ERROR" if error_dupe_enums else "WARNING",
                         s1, entry.value, x.filename, enum.linenumber,
                         enummap.get(s1) or enummap.get(s2)))
-                    return True
+                    if (error_dupe_enums):
+                        return True
                 enummap[s1] = "%s:%u" % (x.filename, enum.linenumber)
                 enummap[s2] = "%s:%u" % (x.filename, enum.linenumber)
 

--- a/pymavlink/tools/mavgen.py
+++ b/pymavlink/tools/mavgen.py
@@ -24,6 +24,7 @@ parser.add_argument("--lang", dest="language", choices=mavgen.supportedLanguages
 parser.add_argument("--wire-protocol", choices=[mavparse.PROTOCOL_0_9, mavparse.PROTOCOL_1_0], default=mavgen.DEFAULT_WIRE_PROTOCOL, help="MAVLink protocol version. [default: %(default)s]")
 parser.add_argument("--no-validate", action="store_false", dest="validate", default=mavgen.DEFAULT_VALIDATE, help="Do not perform XML validation. Can speed up code generation if XML files are known to be correct.")
 parser.add_argument("--error-limit", default=mavgen.DEFAULT_ERROR_LIMIT, help="maximum number of validation errors to display")
+parser.add_argument("--no-err-dupe-enum", "--nee", action="store_false", dest="error_dupe_enums", default=mavgen.DEFAULT_ERR_ON_DUPE_ENUMS, help="Treat duplicate enum values as warning instead of error.")
 parser.add_argument("definitions", metavar="XML", nargs="+", help="MAVLink definitions")
 args = parser.parse_args()
 


### PR DESCRIPTION
Add option to treat duplicate enum values as warning instead of error (`--no-err-dupe-enum` or `--nee`). Current default behavior is unchanged.

Rationale is that multiple variables could have the same meaning, eg. for legacy purposes to rename an enum, or simply to provide the same value multiple times. After all, there is no technical reason multiple variables can't hold the same value.  Unless this is a protocol specification which I'm not aware of.

Thanks,
-Max