### PR TITLE
add reverse motor status to SYS_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -457,6 +457,9 @@
                <entry value="4194304" name="MAV_SYS_STATUS_TERRAIN">
                     <description>0x400000 Terrain subsystem health</description>
                </entry>
+               <entry value="8388608" name="MAV_SYS_STATUS_REVERSE_MOTOR">
+                    <description>0x800000 Motors are reversed</description>
+               </entry>
           </enum>
           <enum name="MAV_FRAME">
                <entry value="0" name="MAV_FRAME_GLOBAL">


### PR DESCRIPTION
status bit to signify that motors are in reverse. This allows VFR_HUD, an unsigned 01-00% value, to be interpreted as a negative value.