### PR TITLE
ardupilotmega.xml: Fix possible UInt8 overflow in capture_mode field of GOPRO_HEARTBEAT message

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -554,7 +554,7 @@
                 <description>Playback mode, hero 4 only</description>
             </entry>
 
-            <entry name="GOPRO_CAPTURE_MODE_UNKNOWN" value="255">
+            <entry name="GOPRO_CAPTURE_MODE_UNKNOWN" value="254">
                 <description>Mode not yet known</description>
             </entry>
         </enum>


### PR DESCRIPTION
Definition of entry `GOPRO_CAPTURE_MODE_UNKNOWN`:
```
<entry name="GOPRO_CAPTURE_MODE_UNKNOWN" value="255">
```
contradicts type requirements for `capture_mode` field in `GOPRO_HEARTBEAT` message:
```
<field enum="GOPRO_CAPTURE_MODE" name="capture_mode" type="uint8_t">Current capture mode</field>
```
as default generator implementation will generate `ENUM_END` flag entry by increasing last case value.
In this case  `ENUM_END` will be `GOPRO_CAPTURE_MODE_UNKNOWN + 1` (255 + 1)  that does not fit into UInt8.

Also I think it will be safer to use 0 by default for unknown (undefined) cases.