### PR TITLE
Loiter commands param4 to offer flexible exit xtrack option for fixed wing

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -591,7 +591,7 @@
                     <param index="1">Turns</param>
                     <param index="2">Empty</param>
                     <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-                    <param index="4">Desired yaw angle.</param>
+                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
                     <param index="5">Latitude</param>
                     <param index="6">Longitude</param>
                     <param index="7">Altitude</param>
@@ -601,7 +601,7 @@
                     <param index="1">Seconds (decimal)</param>
                     <param index="2">Empty</param>
                     <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-                    <param index="4">Desired yaw angle.</param>
+                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
                     <param index="5">Latitude</param>
                     <param index="6">Longitude</param>
                     <param index="7">Altitude</param>
@@ -681,7 +681,7 @@
                     <param index="1">Heading Required (0 = False)</param>
                     <param index="2">Radius in meters. If positive loiter clockwise, negative counter-clockwise, 0 means no change to standard loiter.</param>
                     <param index="3">Empty</param>
-                    <param index="4">Empty</param>
+                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location</param>
                     <param index="5">Latitude</param>
                     <param index="6">Longitude</param>
                     <param index="7">Altitude</param>


### PR DESCRIPTION
When exiting a loiter in fixed wing it is sometimes nice to have flexible exit options. This PR uses param4 field for fixed wing as flag to the mission item that allows either:

- follow the path from center of loiter waypoint to next waypoint (0)
- follow the path from tangent exit point to next waypoint (1)

![loiter_exit_xtrack](https://cloud.githubusercontent.com/assets/4782875/14109920/34c4a3e4-f579-11e5-84ce-d2f732d12ba8.png)

Current use of param4 is "Desired yaw angle" which does not make any sense for a fixed wing forward-flying type aircraft.

Pending PR in ArduPilot https://github.com/ArduPilot/ardupilot/pull/3750 to utilize this