### PR TITLE
accel peak-hold values

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1563,5 +1563,14 @@
             <field name="rpm1" type="float">RPM Sensor1</field>
             <field name="rpm2" type="float">RPM Sensor2</field>
         </message>
+        <message id="227" name="ACCEL_PEAKS">
+            <description>Accelerometer peak hold values. Useful for slower systems (down to 4 Hz) to detect absolute unfiltered accel peaks. Peaks are held for 300ms.</description>
+            <field type="float" name="accel_peak_pos_x">Accel positive peak level X-axis in m/s/s</field>
+            <field type="float" name="accel_peak_pos_y">Accel positive peak level Y-axis in m/s/s</field>
+            <field type="float" name="accel_peak_pos_z">Accel positive peak level Z-axis in m/s/s</field>
+            <field type="float" name="accel_peak_neg_x">Accel negative peak level X-axis in m/s/s</field>
+            <field type="float" name="accel_peak_neg_y">Accel negative peak level Y-axis in m/s/s</field>
+            <field type="float" name="accel_peak_neg_z">Accel negative peak level Z-axis in m/s/s</field>
+        </message>
     </messages>
 </mavlink>


### PR DESCRIPTION
 Accelerometer peak hold values. Useful for slower systems (down to 4 Hz) to detect absolute unfiltered accel peaks such as companion computers. Peaks are held for 300ms. 
