### PR TITLE
add MAV_CMD_DO_CHANGE_ALTITUDE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -932,6 +932,16 @@
                     <param index="6">Empty</param>
                     <param index="7">Empty</param>
                 </entry>
+                <entry value="186" name="MAV_CMD_DO_CHANGE_ALTITUDE">
+                    <description>Change altitude set point.</description>
+                    <param index="1">Altitude type (0=amsl, 1=local, 2=relative, 3=terrain)</param>
+                    <param index="2">Altitude in meters</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+                </entry>
                 <entry value="189" name="MAV_CMD_DO_LAND_START">
                     <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0/0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>
                     <param index="1">Empty</param>


### PR DESCRIPTION
The goal is to assign gamepad buttons for changing altitude +- 100m for altitude control, loiter, etc. 