### PR TITLE
Update flags for DO_REPOSITION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -966,9 +966,9 @@
                <entry value="192" name="MAV_CMD_DO_REPOSITION">
                     <description>Reposition the vehicle to a specific WGS84 global position.</description>
                     <param index="1">Ground speed, less than 0 (-1) for default</param>
-                    <param index="2">Reserved</param>
+                    <param index="2">Bitmask of option flags, see the MAV_DO_REPOSITION_FLAGS enum.</param>
                     <param index="3">Reserved</param>
-                    <param index="4">Yaw heading, NaN for unchanged</param>
+                    <param index="4">Yaw heading, NaN for unchanged. For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
                     <param index="5">Latitude (deg * 1E7)</param>
                     <param index="6">Longitude (deg * 1E7)</param>
                     <param index="7">Altitude (meters)</param>
@@ -2023,6 +2023,12 @@
               <entry value="16" name="ADSB_FLAGS_VALID_CALLSIGN"></entry>
               <entry value="32" name="ADSB_FLAGS_VALID_SQUAWK"></entry>
               <entry value="64" name="ADSB_FLAGS_SIMULATED"></entry>
+          </enum>
+          <enum name="MAV_DO_REPOSITION_FLAGS">
+              <description>Bitmask of options for the MAV_CMD_DO_REPOSITION</description>
+              <entry value="1" name="MAV_DO_REPOSITION_FLAGS_CHANGE_MODE">
+                  <description>The aircraft should immediately transition into guided. This should not be set for follow me applications</description>
+              </entry>
           </enum>
      </enums>
      <messages>


### PR DESCRIPTION
Adds a flags field for DO_REPOSITION to enable mode changes, and adds a comment to allow plane to do a CCW loiter rather then yaw (since planes can't maintain a fixed heading)