### PR TITLE
Added support for MAV_CMD_NAV_DELAY in common.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -772,6 +772,16 @@
                     <param index="6">Empty</param>
                     <param index="7">Empty</param>
                </entry>
+               <entry value="93" name="MAV_CMD_NAV_DELAY">
+                    <description>Delay the next navigation command a number of seconds or until a specified time</description>
+                    <param index="1">Delay in seconds (decimal, -1 to enable time-of-day fields)</param>
+                    <param index="2">hour (24h format, UTC, -1 to ignore)</param>
+                    <param index="3">minute (24h format, UTC, -1 to ignore)</param>
+                    <param index="4">second (24h format, UTC)</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
                <entry value="95" name="MAV_CMD_NAV_LAST">
                     <description>NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration</description>
                     <param index="1">Empty</param>


### PR DESCRIPTION
This is a new MAV_CMD designed to delay execution of the following navigation commands until a specified time has passed or until an absolute time of day has been reached.  It's useful for adding simple coordination of vehicles as shown in this video.

https://www.youtube.com/watch?v=9VK3yjIyCSo

Note that in the video above, I actually hacked the CONDITION_DELAY but really we need a navigation command to do this properly.