### PR TITLE
update NAV_CONTROLLER_OUTPUT comment

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2465,7 +2465,7 @@
                <field type="float[9]" name="covariance">Attitude covariance</field>
           </message>
           <message id="62" name="NAV_CONTROLLER_OUTPUT">
-               <description>Outputs of the APM navigation controller. The primary use of this message is to check the response and signs of the controller before actual flight and to assist with tuning controller parameters.</description>
+               <description>The state of the fixed wing navigation and position controller.</description>
                <field type="float" name="nav_roll">Current desired roll in degrees</field>
                <field type="float" name="nav_pitch">Current desired pitch in degrees</field>
                <field type="int16_t" name="nav_bearing">Current desired heading in degrees</field>


### PR DESCRIPTION
PX4 NAV_CONTROLLER_OUTPUT implemented here - https://github.com/PX4/Firmware/pull/4363

I'd personally rather have altitude/altitude_sp and airspeed/airspeed_sp instead of altitude/airspeed error. Any objection to adding the actual setpoints to this message as well?