### PR TITLE
Fix script for non-gcc compilers

### DIFF
--- a/pymavlink/generator/mavgen_c.py
+++ b/pymavlink/generator/mavgen_c.py
@@ -62,7 +62,11 @@ def generate_mavlink_h(directory, xml):
 #endif
 
 #ifndef MAVLINK_PACKED
+#ifdef __GNUC__
 #define MAVLINK_PACKED __attribute__((__packed__))
+#else
+#define MAVLINK_PACKED
+#endif
 #endif
 
 #include "version.h"


### PR DESCRIPTION
Generated header files won't compile using non-gcc compilers because of the __attribute__.  This fix will make them compile, but they won't be packed.  I'm not sure if you want something like MAVPACKED from mavlink_types.h to be used?