### PR TITLE
Java: track the stats per system, and allow ignoring the radio status

### DIFF
--- a/pymavlink/generator/java/lib/Messages/MAVLinkStats.java
+++ b/pymavlink/generator/java/lib/Messages/MAVLinkStats.java
@@ -7,6 +7,7 @@
 package com.MAVLink.Messages;
 
 import com.MAVLink.MAVLinkPacket;
+import com.MAVLink.common.msg_radio_status;
 
 /**
  * Storage for MAVLink Packet and Error statistics
@@ -14,13 +15,25 @@ import com.MAVLink.MAVLinkPacket;
  */
 public class MAVLinkStats /* implements Serializable */{
 
-    public int receivedPacketCount;
+    public int receivedPacketCount; // total recieved packet count for all sources
 
     public int crcErrorCount;
 
-    public int lostPacketCount;
+    public int lostPacketCount; // total lost packet count for all sources
 
-    private int lastPacketSeq;
+    public boolean ignoreRadioPackets;
+
+    // stats are nil for a system id until a packet has been received from a system
+    public SystemStat[] systemStats; // stats for each system that is known
+
+    public MAVLinkStats() {
+        this(false);
+    }
+
+    public MAVLinkStats(boolean ignoreRadioPackets) {
+        this.ignoreRadioPackets = ignoreRadioPackets;
+        resetStats();
+    }
 
     /**
      * Check the new received packet to see if has lost someone between this and
@@ -30,31 +43,16 @@ public class MAVLinkStats /* implements Serializable */{
      *            Packet that should be checked
      */
     public void newPacket(MAVLinkPacket packet) {
-        advanceLastPacketSequence();
-        if (hasLostPackets(packet)) {
-            updateLostPacketCount(packet);
+        if (ignoreRadioPackets && packet.msgid == msg_radio_status.MAVLINK_MSG_ID_RADIO_STATUS) {
+            return;
         }
-        lastPacketSeq = packet.seq;
+
+        if (systemStats[packet.sysid] == null) {
+            // only allocate stats for systems that exsist on the network
+            systemStats[packet.sysid] = new SystemStat();
+        }
+        lostPacketCount += systemStats[packet.sysid].newPacket(packet);
         receivedPacketCount++;
-    }
-
-    private void updateLostPacketCount(MAVLinkPacket packet) {
-        int lostPackets;
-        if (packet.seq - lastPacketSeq < 0) {
-            lostPackets = (packet.seq - lastPacketSeq) + 255;
-        } else {
-            lostPackets = (packet.seq - lastPacketSeq);
-        }
-        lostPacketCount += lostPackets;
-    }
-
-    private boolean hasLostPackets(MAVLinkPacket packet) {
-        return lastPacketSeq > 0 && packet.seq != lastPacketSeq;
-    }
-
-    private void advanceLastPacketSequence() {
-        // wrap from 255 to 0 if necessary
-        lastPacketSeq = (lastPacketSeq + 1) & 0xFF;
     }
 
     /**
@@ -64,14 +62,90 @@ public class MAVLinkStats /* implements Serializable */{
         crcErrorCount++;
     }
 
-    /**
-     * Resets statistics for this MAVLink.
-     */
-    public void mavlinkResetStats() {
-        lastPacketSeq = -1;
-        lostPacketCount = 0;
+    public void resetStats() {
         crcErrorCount = 0;
+        lostPacketCount = 0;
         receivedPacketCount = 0;
+        systemStats = new SystemStat[256];
+    }
+
+    // stat structure for every system id
+    private class SystemStat {
+        public int lostPacketCount; // the lost count for this source
+        public int receivedPacketCount;
+
+        // stats are nil for a component id until a packet has been received from a system
+        public ComponentStat[] componentStats; // stats for each component that is known
+
+        public SystemStat() {
+            resetStats();
+        }
+
+        public int newPacket(MAVLinkPacket packet) {
+            int newLostPackets = 0;
+            if (componentStats[packet.compid] == null) {
+                // only allocate stats for systems that exsist on the network
+                componentStats[packet.compid] = new ComponentStat();
+            }
+            newLostPackets = componentStats[packet.compid].newPacket(packet);
+            lostPacketCount += newLostPackets;
+            receivedPacketCount++;
+            return newLostPackets;
+        }
+
+        public void resetStats() {
+            lostPacketCount = 0;
+            receivedPacketCount = 0;
+            componentStats = new ComponentStat[256];
+        }
+    }
+
+    // stat structure for every system id
+    private class ComponentStat {
+        public int lastPacketSeq;
+        public int lostPacketCount; // the lost count for this source
+        public int receivedPacketCount;
+
+        public ComponentStat() {
+            resetStats();
+        }
+
+        public int newPacket(MAVLinkPacket packet) {
+            int newLostPackets = 0;
+            if (hasLostPackets(packet)) {
+                newLostPackets = updateLostPacketCount(packet);
+            }
+            lastPacketSeq = packet.seq;
+            advanceLastPacketSequence(packet.seq);
+            receivedPacketCount++;
+            return newLostPackets;
+        }
+
+        public void resetStats() {
+            lastPacketSeq = -1;
+            lostPacketCount = 0;
+            receivedPacketCount = 0;
+        }
+
+        private int updateLostPacketCount(MAVLinkPacket packet) {
+            int lostPackets;
+            if (packet.seq - lastPacketSeq < 0) {
+                lostPackets = (packet.seq - lastPacketSeq) + 255;
+            } else {
+                lostPackets = (packet.seq - lastPacketSeq);
+            }
+            lostPacketCount += lostPackets;
+            return lostPackets;
+        }
+
+        private void advanceLastPacketSequence(int lastSeq) {
+            // wrap from 255 to 0 if necessary
+            lastPacketSeq = (lastSeq + 1) & 0xFF;
+        }
+
+        private boolean hasLostPackets(MAVLinkPacket packet) {
+            return lastPacketSeq >=  0 && packet.seq != lastPacketSeq;
+        }
     }
 
 }

--- a/pymavlink/generator/java/lib/Parser.java
+++ b/pymavlink/generator/java/lib/Parser.java
@@ -22,8 +22,16 @@ public class Parser {
 
     static boolean msg_received;
 
-    public MAVLinkStats stats = new MAVLinkStats();
+    public MAVLinkStats stats;
     private MAVLinkPacket m;
+
+    public Parser() {
+        this(false);
+    }
+
+    public Parser(boolean ignoreRadioPacketStats) {
+        stats = new MAVLinkStats(ignoreRadioPacketStats);
+    }
 
     /**
      * This is a convenience function which handles the complete MAVLink


### PR DESCRIPTION
The current implementation can't track the stats correctly if there are multiple systems on the network. Also allows ignoring the radio status packets, but defaults to not ignoring them (to preserve the current behavior).