### PR TITLE
added vehicle command for position control submodes

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1298,6 +1298,22 @@
                   <param index="1">The target VTOL state, as defined by ENUM MAV_VTOL_STATE. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
               </entry>
 
+              <entry value="4000" name="MAV_CMD_SET_GUIDED_SUBMODE_STANDARD">
+                  <description>This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
+                  </description>
+              </entry>
+
+              <entry value="4001" name="MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE">
+                  <description>This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
+                  </description>
+                  <param index="1">Radius of desired circle in CIRCLE_MODE</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Unscaled target latitude of center of circle in CIRCLE_MODE</param>
+                  <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
+              </entry>
+
               <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
 
               <!-- BEGIN of payload range (30000 to 30999) -->


### PR DESCRIPTION
the new command introduces submodes for manual position control mode.
examples are circle mode or zoom out.

Signed-off-by: Roman <bapstr@ethz.ch>