### PR TITLE
pymavlink: correct mavtcp final-retry case

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -914,6 +914,7 @@ class mavtcp(mavfile):
             retries -= 1
             if retries <= 0:
                 self.port.connect(self.destination_addr)
+                break
             else:
                 try:
                     self.port.connect(self.destination_addr)


### PR DESCRIPTION
If the connection just happened to work on the last retry this
loop would fail with transport-endpoint-already-connected