### PR TITLE
Cleanup of ASLUAV message specification

### DIFF
--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -167,7 +167,8 @@
               <field type="float" name="ThermalGSNorth">Thermal drift (from estimator prediction step only) [m/s]</field>
               <field type="float" name="ThermalGSEast">Thermal drift (from estimator prediction step only) [m/s]</field>
               <field type="float" name="TSE_dot"> Total specific energy change (filtered) [m/s]</field>
-              <field type="float" name="TSE_dot_uf"> Total specific energy change (unfiltered) [m/s]</field>
+              <field type="float" name="DebugVar1"> Debug variable 1</field>
+              <field type="float" name="DebugVar2"> Debug variable 2</field>
               <field type="uint8_t" name="ControlMode">Control Mode [-]</field>
               <field type="uint8_t" name="valid">Data valid [-]</field>
            </message>
@@ -187,11 +188,6 @@
               <field type="uint64_t" name="timestamp">Timestamp</field>
               <field type="uint8_t" name="pwr_brd_status">Power board status register</field>
               <field type="uint8_t" name="pwr_brd_led_status">Power board leds status</field>
-              <field type="uint8_t" name="pwr_brd_blink_reg">Power board blink reg</field>
-              <field type="uint8_t" name="pwr_brd_led_1_pwr">Power board led 1 power</field>
-              <field type="uint8_t" name="pwr_brd_led_2_pwr">Power board led 2 power</field>
-              <field type="uint8_t" name="pwr_brd_led_3_pwr">Power board led 3 power</field>
-              <field type="uint8_t" name="pwr_brd_led_4_pwr">Power board led 4 power</field>
               <field type="float" name="pwr_brd_system_volt">Power board system voltage</field>
               <field type="float" name="pwr_brd_servo_volt">Power board servo voltage</field>
               <field type="float" name="pwr_brd_mot_l_amp">Power board left motor current sensor</field>


### PR DESCRIPTION
Cleanup of the ASLUAV message specification, which brings the FW_SOARING_DATA and SENS_POWER_BOARD messages close to their final definition. 

_Note that this is not deployed through the common.xml message specification, i.e. does not affect the standard Pixhawk (&etc.) firmwares and ground stations._