### PR TITLE
C# generator fixes for array misinterpretation and size miscalculation

### DIFF
--- a/pymavlink/generator/CS/common/ByteArrayUtil.cs
+++ b/pymavlink/generator/CS/common/ByteArrayUtil.cs
@@ -58,7 +58,7 @@ namespace MavLink
         {
             var arr = new UInt32[size];
             for (int i = 0; i < size; i++)
-                arr[i] = bitConverter.ToUInt16(source, sourceOffset + (i * sizeof(UInt32)));
+                arr[i] = bitConverter.ToUInt32(source, sourceOffset + (i * sizeof(UInt32)));
             return arr;
         }
 
@@ -66,7 +66,7 @@ namespace MavLink
         {
             var arr = new Int32[size];
             for (int i = 0; i < size; i++)
-                arr[i] = bitConverter.ToInt16(source, sourceOffset + (i * sizeof(Int32)));
+                arr[i] = bitConverter.ToInt32(source, sourceOffset + (i * sizeof(Int32)));
             return arr;
         }
 
@@ -74,7 +74,7 @@ namespace MavLink
         {
             var arr = new UInt64[size];
             for (int i = 0; i < size; i++)
-                arr[i] = bitConverter.ToUInt16(source, sourceOffset + (i * sizeof(UInt64)));
+                arr[i] = bitConverter.ToUInt64(source, sourceOffset + (i * sizeof(UInt64)));
             return arr;
         }
 
@@ -82,7 +82,7 @@ namespace MavLink
         {
             var arr = new Int64[size];
             for (int i = 0; i < size; i++)
-                arr[i] = bitConverter.ToInt16(source, sourceOffset + (i * sizeof(Int64)));
+                arr[i] = bitConverter.ToInt64(source, sourceOffset + (i * sizeof(Int64)));
             return arr;
         }
 
@@ -90,7 +90,7 @@ namespace MavLink
         {
             var arr = new Single[size];
             for (int i = 0; i < size; i++)
-                arr[i] = bitConverter.ToUInt16(source, sourceOffset + (i * sizeof(Single)));
+                arr[i] = bitConverter.ToSingle(source, sourceOffset + (i * sizeof(Single)));
             return arr;
         }
 
@@ -98,7 +98,7 @@ namespace MavLink
         {
             var arr = new Double[size];
             for (int i = 0; i < size; i++)
-                arr[i] = bitConverter.ToInt16(source, sourceOffset + (i * sizeof(Double)));
+                arr[i] = bitConverter.ToDouble(source, sourceOffset + (i * sizeof(Double)));
             return arr;
         }
 

--- a/pymavlink/generator/mavgen_cs.py
+++ b/pymavlink/generator/mavgen_cs.py
@@ -138,7 +138,7 @@ def generate_Deserialization(outf, messages):
         for f in m.ordered_fields:
             if (f.array_length):
                 outf.write("\t\t\t\t%s =  ByteArrayUtil.%s(bytes, offset + %s, %s),\n" % (mapFieldName.get(f.name, f.name), mapType[f.type][0], offset, f.array_length))
-                offset += f.array_length
+                offset += (f.array_length * mapType[f.type][1])
                 continue
           
             # mapping 'char' to byte here since there is no real equivalent in the CLR


### PR DESCRIPTION
This fixes two errors in generated C# code:

- Arrays of certain data types were being misinterpreted as other data types.
- Generated deserialization methods weren't properly calculating the size of arrays, which caused wrong offsets to be calculated for subsequent data fields