### PR TITLE
mavgen: Generate c sharp code only; don't require a .Net Assembler for code generation

### DIFF
--- a/pymavlink/generator/mavgen_cs.py
+++ b/pymavlink/generator/mavgen_cs.py
@@ -254,23 +254,7 @@ namespace MavLink
 def generate(basename, xml):
     '''generate complete MAVLink CSharp implemenation'''
     structsfilename = basename + '.generated.cs'
-
-     # Some build commands depend on the platform - eg MS .NET Windows Vs Mono on Linux
-    if platform.system() == "Windows":
-        winpath=os.environ['WinDir']
-        cscCommand = winpath + "\\Microsoft.NET\\Framework\\v4.0.30319\\csc.exe"
-        
-        if (os.path.exists(cscCommand)==False):
-            print("\nError: CS compiler not found. .Net Assembly generation skipped")
-            return   
-    else:
-        print("Error:.Net Assembly generation not yet supported on non Windows platforms")
-        return
-        cscCommand = "csc"
-    
-    
-    
-    
+   
     msgs = []
     enums = []
     filelist = []
@@ -323,7 +307,18 @@ using System.Reflection;
     
     outf.close()
     
-   
+    # Some build commands depend on the platform - eg MS .NET Windows Vs Mono on Linux
+    if platform.system() == "Windows":
+        winpath=os.environ['WinDir']
+        cscCommand = winpath + "\\Microsoft.NET\\Framework\\v4.0.30319\\csc.exe"
+        
+        if (os.path.exists(cscCommand)==False):
+            print("\nError: CS compiler not found. .Net Assembly generation skipped")
+            return   
+    else:
+        print("Error:.Net Assembly generation not yet supported on non Windows platforms")
+        return
+        cscCommand = "csc"
 
     print("Compiling Assembly for .Net Framework 4.0")
     
@@ -335,7 +330,6 @@ using System.Reflection;
     
     compileCommand = "%s %s" % (cscCommand, "/target:library /debug /out:" + outputLibraryPath)
     compileCommand = compileCommand + " /doc:" + os.path.normpath(dir + "/mavlink.xml")  
-    
     
     for csFile in generatedCsFiles + includedCsFiles:
         compileCommand = compileCommand + " " + os.path.normpath(csFile)


### PR DESCRIPTION
This PR allows CS code to be generated from Linux.  The .Net assembler does not build a library, but the CS code is at least available after running, e.g.,

mavgen.py -o="/home/user/devel/mav_gen/cs/ardupilotmega" --lang=CS --wire-protocol=1.0 "/home/user/devel/mavlink/message_definitions/v1.0/ardupilotmega.xml"

Prior to this patch the check for a .Net assembler was done before generating the c sharp code.  In that case, code that can be generated from Linux is not (edit: in other words, before this patch it is not possible to generate C# code on Linux).