### PR TITLE
add MAV_CMD_DO_CHANGE_ALTITUDE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -949,6 +949,16 @@
                     <param index="6">Empty</param>
                     <param index="7">Empty</param>
                 </entry>
+                <entry value="186" name="MAV_CMD_DO_CHANGE_ALTITUDE">
+                    <description>Change altitude set point.</description>
+                    <param index="1">Altitude in meters</param>
+                    <param index="2">Mav frame of new altitude (see MAV_FRAME)</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+                </entry>
                 <entry value="189" name="MAV_CMD_DO_LAND_START">
                     <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0/0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>
                     <param index="1">Empty</param>


### PR DESCRIPTION
This is a slight improvement over a previous pull request that wasn't merged. https://github.com/mavlink/mavlink/pull/533
I've recreated it due to new interest.

Looking at the existing mavlink commands I just don't think MAV_CMD_DO_REPOSITION, MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT, etc are quite right. Changing only your altitude while respecting whatever mode you're in is pretty common.

PX4 issue: https://github.com/PX4/Firmware/issues/5001

@superware FYI