### PR TITLE
Adding the MAV_GPS message (from allanm84)

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3389,6 +3389,7 @@
         </message>
         <message id="232" name="GPS_MAV">
             <description>GPS sensor input message for the AP_GPS_MAV type</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
             <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS_MAV inputs</field>
             <field type="uint16_t" name="ignore">Flags indicating which fields to ignore: bit0:alt, bit1:hdop, bit2:vdop, bit3:vel_horiz(vn+ve), bit4:vel_vert(vd), bit5:speed_accuracy, bit6:horiz_accuracy, bit7:vert_accuracy. All other fields must be provided.</field>
             <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2146,6 +2146,34 @@
                   <description>throttle pass-through from pilot's transmitter</description>
               </entry>
           </enum>
+
+          <!-- GPS_MAV ignore flags enum -->
+          <enum name="GPS_MAV_IGNORE_FLAGS">
+              <entry name="GPS_MAV_IGNORE_FLAG_ALT" value="1">
+                  <description>ignore altitude field</description>
+              </entry>
+              <entry name="GPS_MAV_IGNORE_FLAG_HDOP" value="2">
+                  <description>ignore hdop field</description>
+              </entry>
+              <entry name="GPS_MAV_IGNORE_FLAG_VDOP" value="4">
+                  <description>ignore vdop field</description>
+              </entry>
+              <entry name="GPS_MAV_IGNORE_FLAG_VEL_HORIZ" value="8">
+                  <description>ignore horizontal velocity field (vn and ve)</description>
+              </entry>
+              <entry name="GPS_MAV_IGNORE_FLAG_VEL_VERT" value="16">
+                  <description>ignore vertical velocity field (vd)</description>
+              </entry>
+              <entry name="GPS_MAV_IGNORE_FLAG_SPEED_ACCURACY" value="32">
+                  <description>ignore speed accuracy field</description>
+              </entry>
+              <entry name="GPS_MAV_IGNORE_FLAG_HORIZONTAL_ACCURACY" value="64">
+                  <description>ignore horizontal accuracy field</description>
+              </entry>
+              <entry name="GPS_MAV_IGNORE_FLAG_VERTICAL_ACCURACY" value="128">
+                  <description>ignore vertical accuracy field</description>
+              </entry>
+          </enum>
      </enums>
      <messages>
           <message id="0" name="HEARTBEAT">
@@ -3391,7 +3419,7 @@
             <description>GPS sensor input message for the AP_GPS_MAV type</description>
             <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
             <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS_MAV inputs</field>
-            <field type="uint16_t" name="ignore">Flags indicating which fields to ignore: bit0:alt, bit1:hdop, bit2:vdop, bit3:vel_horiz(vn+ve), bit4:vel_vert(vd), bit5:speed_accuracy, bit6:horiz_accuracy, bit7:vert_accuracy. All other fields must be provided.</field>
+            <field type="uint16_t" name="ignore_flags" enum="GPS_MAV_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_MAV_IGNORE_FLAGS enum).  All other fields must be provided.</field>
             <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
             <field type="uint16_t" name="time_week">GPS week number</field>
             <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3387,6 +3387,26 @@
             <field name="horiz_accuracy" type="float">Horizontal speed 1-STD accuracy</field>
             <field name="vert_accuracy" type="float">Vertical speed 1-STD accuracy</field>
         </message>
+        <message id="232" name="GPS_MAV">
+            <description>GPS sensor input message for the AP_GPS_MAV type</description>
+            <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS_MAV inputs</field>
+            <field type="uint16_t" name="ignore">Flags indicating which fields to ignore: bit0:alt, bit1:hdop, bit2:vdop, bit3:vel_horiz(vn+ve), bit4:vel_vert(vd), bit5:speed_accuracy, bit6:horiz_accuracy, bit7:vert_accuracy. All other fields must be provided.</field>
+            <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
+            <field type="uint16_t" name="time_week">GPS week number</field>
+            <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
+            <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+            <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+            <field type="float" name="alt">Altitude (AMSL, not WGS84), in m (positive for up)</field>
+            <field type="float" name="hdop">GPS HDOP horizontal dilution of position in m</field>
+            <field type="float" name="vdop">GPS VDOP vertical dilution of position in m</field>
+            <field type="float" name="vn">GPS velocity in m/s in NORTH direction in earth-fixed NED frame</field>
+            <field type="float" name="ve">GPS velocity in m/s in EAST direction in earth-fixed NED frame</field>
+            <field type="float" name="vd">GPS velocity in m/s in DOWN direction in earth-fixed NED frame</field>
+            <field type="float" name="speed_accuracy">GPS speed accuracy in m/s</field>
+            <field type="float" name="horiz_accuracy">GPS horizontal accuracy in m</field>
+            <field type="float" name="vert_accuracy">GPS vertical accuracy in m</field>
+            <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
+        </message>
         <message id="233" name="GPS_RTCM_DATA">
            <description>WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)</description>
            <field type="uint8_t" name="flags">LSB: 1 means message is fragmented</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2147,30 +2147,30 @@
               </entry>
           </enum>
 
-          <!-- GPS_MAV ignore flags enum -->
-          <enum name="GPS_MAV_IGNORE_FLAGS">
-              <entry name="GPS_MAV_IGNORE_FLAG_ALT" value="1">
+          <!-- GPS_INPUT ignore flags enum -->
+          <enum name="GPS_INPUT_IGNORE_FLAGS">
+              <entry name="GPS_INPUT_IGNORE_FLAG_ALT" value="1">
                   <description>ignore altitude field</description>
               </entry>
-              <entry name="GPS_MAV_IGNORE_FLAG_HDOP" value="2">
+              <entry name="GPS_INPUT_IGNORE_FLAG_HDOP" value="2">
                   <description>ignore hdop field</description>
               </entry>
-              <entry name="GPS_MAV_IGNORE_FLAG_VDOP" value="4">
+              <entry name="GPS_INPUT_IGNORE_FLAG_VDOP" value="4">
                   <description>ignore vdop field</description>
               </entry>
-              <entry name="GPS_MAV_IGNORE_FLAG_VEL_HORIZ" value="8">
+              <entry name="GPS_INPUT_IGNORE_FLAG_VEL_HORIZ" value="8">
                   <description>ignore horizontal velocity field (vn and ve)</description>
               </entry>
-              <entry name="GPS_MAV_IGNORE_FLAG_VEL_VERT" value="16">
+              <entry name="GPS_INPUT_IGNORE_FLAG_VEL_VERT" value="16">
                   <description>ignore vertical velocity field (vd)</description>
               </entry>
-              <entry name="GPS_MAV_IGNORE_FLAG_SPEED_ACCURACY" value="32">
+              <entry name="GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY" value="32">
                   <description>ignore speed accuracy field</description>
               </entry>
-              <entry name="GPS_MAV_IGNORE_FLAG_HORIZONTAL_ACCURACY" value="64">
+              <entry name="GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY" value="64">
                   <description>ignore horizontal accuracy field</description>
               </entry>
-              <entry name="GPS_MAV_IGNORE_FLAG_VERTICAL_ACCURACY" value="128">
+              <entry name="GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY" value="128">
                   <description>ignore vertical accuracy field</description>
               </entry>
           </enum>
@@ -3415,11 +3415,11 @@
             <field name="horiz_accuracy" type="float">Horizontal speed 1-STD accuracy</field>
             <field name="vert_accuracy" type="float">Vertical speed 1-STD accuracy</field>
         </message>
-        <message id="232" name="GPS_MAV">
-            <description>GPS sensor input message for the AP_GPS_MAV type</description>
+        <message id="232" name="GPS_INPUT">
+            <description>GPS sensor input message.  This is a raw sensor value sent by the GPS. This is NOT the global position estimate of the sytem.</description>
             <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS_MAV inputs</field>
-            <field type="uint16_t" name="ignore_flags" enum="GPS_MAV_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_MAV_IGNORE_FLAGS enum).  All other fields must be provided.</field>
+            <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS inputs</field>
+            <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_INPUT_IGNORE_FLAGS enum).  All other fields must be provided.</field>
             <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
             <field type="uint16_t" name="time_week">GPS week number</field>
             <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>


### PR DESCRIPTION
This replaces Allan's MAV_GPS PR: https://github.com/mavlink/mavlink/pull/555
and addresses Lorenz's (hopefully final concern) that we're missing a time_usec field.