### PR TITLE
Px4 modes

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -490,6 +490,9 @@ class mavfile(object):
     def mode_mapping(self):
         '''return dictionary mapping mode names to numbers, or None if unknown'''
         mav_type = self.field('HEARTBEAT', 'type', self.mav_type)
+        mav_autopilot = self.field('HEARTBEAT', 'autopilot', None)
+        if mav_autopilot == mavlink.MAV_AUTOPILOT_PX4:
+            return px4_map
         if mav_type is None:
             return None
         map = None
@@ -1527,6 +1530,9 @@ def interpret_px4_mode(base_mode, custom_mode):
 
 def mode_mapping_byname(mav_type):
     '''return dictionary mapping mode names to numbers, or None if unknown'''
+    mav_autopilot = self.field('HEARTBEAT', 'autopilot', None)
+    if mav_autopilot == mavlink.MAV_AUTOPILOT_PX4:
+        return px4_map # no need to invert this map, it already is.
     map = None
     if mav_type in [mavlink.MAV_TYPE_QUADROTOR,
                     mavlink.MAV_TYPE_HELICOPTER,
@@ -1548,6 +1554,9 @@ def mode_mapping_byname(mav_type):
 
 def mode_mapping_bynumber(mav_type):
     '''return dictionary mapping mode numbers to name, or None if unknown'''
+    mav_autopilot = self.field('HEARTBEAT', 'autopilot', None)
+    if mav_autopilot == mavlink.MAV_AUTOPILOT_PX4:
+        return dict((a, b) for (b, a) in px4_map.items())
     map = None
     if mav_type in [mavlink.MAV_TYPE_QUADROTOR,
                     mavlink.MAV_TYPE_HELICOPTER,
@@ -1600,12 +1609,6 @@ def mode_string_acm(mode_number):
     '''return mode string for APM:Copter'''
     if mode_number in mode_mapping_acm:
         return mode_mapping_acm[mode_number]
-    return "Mode(%u)" % mode_number
-
-def mode_string_px4(mode_number):
-    '''return mode string for PX4 flight stack'''
-    if mode_number in mode_mapping_px4:
-        return mode_mapping_px4[mode_number]
     return "Mode(%u)" % mode_number
 
 class x25crc(object):

--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -511,17 +511,21 @@ class mavfile(object):
         inv_map = dict((a, b) for (b, a) in list(map.items()))
         return inv_map
 
-    def set_mode(self, mode):
+    def set_mode(self, mode, custom_mode = 0, custom_sub_mode = 0):
         '''enter arbitrary mode'''
+        print('setting mode')
         if isinstance(mode, str):
-            map = self.mode_mapping()
-            if map is None or mode not in map:
+            mode_map = self.mode_mapping()
+            if mode_map is None or mode not in mode_map:
                 print("Unknown mode '%s'" % mode)
                 return
-            mode = map[mode]
-        self.mav.set_mode_send(self.target_system,
-                               mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
-                               mode)
+            if type(mode_map[mode_map.keys()[0]]) == tuple: # PX4 uses two fields to define modes
+                mode, custom_mode, custom_sub_mode = px4_map[mode]
+            else:
+                mode = mode_map[mode]
+        print(mode, custom_mode)
+        self.mav.command_long_send(self.target_system, self.target_component,
+                                   mavlink.MAV_CMD_DO_SET_MODE, 0, mode, custom_mode, custom_sub_mode, 0, 0, 0, 0)
 
     def set_mode_rtl(self):
         '''enter RTL mode'''


### PR DESCRIPTION
adds support for px4 modes to pymavlink. It seems to work, but I would appreciate it if @LorenzMeier could check this out anyway.

This should allow dronekit-python and mavproxy to set and read modes on px4.