### PR TITLE
Update README.md w/ steps for pymavlink submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository is largely Python scripts that convert XML files into language-s
     * Tkinter (if GUI functionality is desired)
 
 ### Installation ###
-  1. Clone into a user-writable directory.
+  1. Clone into a user-writable directory. Make sure to use the git "--recursive" option since pymavlink is a submodule. Alternately, run "git submodule init" and "git submodule update" after cloning to get pymavlink.
   2. Add the repository directory to your `PYTHONPATH`
   3. Generate MAVLink parser files following the instructions in the next section *AND/OR* run included helper scripts described in the Scripts/Examples secion.
 


### PR DESCRIPTION
Pretty self-explanatory. I had a colleague who was getting the python error "No module named pymavlink.generator"

When I looked in the pymavlink directory, it was empty. This is because the submodule was not cloned by the simple "git clone https://github.com/mavlink/mavlink"

I'm sure lots of users new to git get bitten by this one. This simple documentation fix should prevent some frustration from newbies.