### PR TITLE
Proposal: Change MAV_CMD xml format to support UI generation

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -578,7 +578,7 @@
                <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data.</description>
                <entry value="16" name="MAV_CMD_NAV_WAYPOINT">
                     <description>Navigate to MISSION.</description>
-                    <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
+                    <param index="1" label="Hold" units="s" decimalPlaces="0" defaultValue="0" minValue="0">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
                     <param index="2">Acceptance radius in meters (if the sphere with this radius is hit, the MISSION counts as reached)</param>
                     <param index="3">0 to pass through the WP, if > 0 radius in meters to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
                     <param index="4">Desired yaw angle at MISSION (rotary wing)</param>


### PR DESCRIPTION
This is not really meant to be a pull. Just a place to start discussion. Easiest way to explain this is to show how QGroundControl works with respect to editing mission items. In QGC when you are creating a mission you see something like this:
![](https://cloud.githubusercontent.com/assets/5876851/18654391/9dbeaaca-7e95-11e6-89a6-c364df8f63bb.png)

The little editor panels on the right (currently showing a Waypoint/MAV_CMD_NAV_WAYPOINT editor) are generated from a json specification. The json for MAV_CMD_NAV_WAYPOINT looks like this:

```
{
"id": 16,
"rawName": "MAV_CMD_NAV_WAYPOINT",
"friendlyName": "Waypoint",
"description": "Travel to a position in 3D space.",
"specifiesCoordinate": true,
"friendlyEdit": true,
"category": "Basic",
"param1": {
"label": "Hold:",
"units": "secs",
"default": 0,
"decimalPlaces": 0
},
"param2": {
"label": "Acceptance:",
"units": "m",
"default": 3,
"decimalPlaces": 2
},
"param3": {
"label": "PassThru:",
"units": "m",
"default": 0,
"decimalPlaces": 2
},
"param4": {
"label": "Heading:",
"units": "radians",
"default": 0.0,
"decimalPlaces": 2
}
},
```

If you look at this you'll see that it looks somewhat similar to the mavlink xml message definition with some extra attributes.

What I'd like to be able to do is to change the xml spec for mavlink MAV_CMD specification to include these extra attributes. That will then provide what I think is useful additional detail to the usage of the command parameters. But it also gives a ground station enough information to generate a user interface for the command as well.

The xsd for a param would change to this:

```
<xs:element name="param">
<xs:complexType mixed="true">
<xs:attribute ref="index" use="required"/>
<xs:attribute ref="label"/>
<xs:attribute ref="units"/>
<xs:attribute ref="decimalPlaces"/>
<xs:attribute ref="defaultValue"/>
<xs:attribute ref="minValue"/>
<xs:attribute ref="maxValue"/>
<xs:attribute ref="noLocation"/>
<xs:attribute ref="standaloneLocation"/>
</xs:complexType>
</xs:element>
```

With the additional attributes specified like this:

```
<xs:attribute name="label" type="xs:string"/> <!-- param -->
<xs:attribute name="decimalPlaces" type="xs:unsignedByte"/> <!-- param -->
<xs:attribute name="defaultValue" type="xs:float"/> <!-- param -->
<xs:attribute name="minValue" type="xs:float"/> <!-- param -->
<xs:attribute name="maxValue" type="xs:float"/> <!-- param -->
<xs:attribute name="units" type="xs:string"/> <!-- param -->
<xs:attribute name="noLocation" type="xs:boolean"/> <!-- param -->
<xs:attribute name="standaloneLocation" type="xs:boolean"/> <!-- param -->
```

The description for the new attributes is as follows:

* label - A short label for use next to a text field entry box
* decimalPlaces - The number of decimal places to show when display/editing the value
* defaultValue - Default value for the param when when a new mission item
* minValue - Minimum value for validation
* maxValue - Maximum value for validation
* units - Units for value, both for display to use and to allow for conversion "m" -> "ft"
* noLocation - true: This mission item does not specify a lat/lon location
* standaloneLocation - true: The vehicle does not fly through this item. This is so a ground station knows how to draw waypoint lines with respect to this item.

As an example, the xml message def for param 1 of MAV_CMD_NAV_WAYPOINT would change to something like this:

```
<param index="1" label="Hold" units="s" decimalPlaces="0" defaultValue="0" minValue="0">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
```

If folks are ok with this I can go through and update all the message definitions since I already have all the data in the QGC json file. As well as create real pulls for the work.

