### PR TITLE
GeoFence/Rally Point: Initial proposal [do not merge]

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1387,8 +1387,8 @@
                 <entry value="5001" name="MAV_CMD_FENCE_POLYGON_POINT">
                     <description>Fence polygon point. Minimum of 3 required.
                     </description>
-                    <param index="1">Point index (0-based)</param>
-                    <param index="2">Point count (for validation)</param>
+                    <param index="1">Reserved</param>
+                    <param index="2">Reserved</param>
                     <param index="3">Reserved</param>
                     <param index="4">Reserved</param>
                     <param index="5">Latitude</param>
@@ -2037,13 +2037,13 @@
           <enum name="MAV_MISSION_TYPE">
               <description>Type of mission items being requested/sent in mission protocol.</description>
               <entry value="0" name="MAV_MISSION_TYPE_MISSION">
-                  <description>Autopilot supports MISSION float message type.</description>
+                  <description>Items are mission commands for main mission.</description>
               </entry>
               <entry value="1" name="MAV_MISSION_TYPE_FENCE">
-                  <description>Autopilot supports MISSION float message type.</description>
+                  <description>Items are MAV_CMD_FENCE_ GeoFence items.</description>
               </entry>
               <entry value="2" name="MAV_MISSION_TYPE_RALLY">
-                  <description>Autopilot supports MISSION float message type.</description>
+                  <description>Items are MAV_CMD_RALLY_POINT rally point items.</description>
               </entry>
           </enum>
           <enum name="MAV_ESTIMATOR_TYPE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1372,6 +1372,42 @@
                   <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
               </entry>
 
+                <entry value="5000" name="MAV_CMD_FENCE_RETURN_POINT">
+                    <description>Fence return point. There can only be on fence return point.
+                    </description>
+                    <param index="1">Reserved</param>
+                    <param index="2">Reserved</param>
+                    <param index="3">Reserved</param>
+                    <param index="4">Reserved</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+                </entry>
+
+                <entry value="5001" name="MAV_CMD_FENCE_POLYGON_POINT">
+                    <description>Fence polygon point. Minimum of 3 required.
+                    </description>
+                    <param index="1">Point index (0-based)</param>
+                    <param index="2">Point count (for validation)</param>
+                    <param index="3">Reserved</param>
+                    <param index="4">Reserved</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Reserved</param>
+                </entry>
+
+                <entry value="5100" name="MAV_CMD_RALLY_POINT">
+                    <description>Rally point. You can have multiple rally points defined.
+                    </description>
+                    <param index="1">Reserved</param>
+                    <param index="2">Reserved</param>
+                    <param index="3">Reserved</param>
+                    <param index="4">Reserved</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+                </entry>
+
               <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
 
               <!-- BEGIN of payload range (30000 to 30999) -->
@@ -1991,6 +2027,24 @@
               <entry value="8192" name="MAV_PROTOCOL_CAPABILITY_MAVLINK2">
                   <description>Autopilot supports mavlink version 2.</description>
               </entry>
+              <entry value="16384" name="MAV_PROTOCOL_CAPABILITY_MISSION_FENCE">
+                  <description>Autopilot supports mission fence protocol.</description>
+              </entry>
+              <entry value="32768" name="MAV_PROTOCOL_CAPABILITY_MISSION_RALLY">
+                  <description>Autopilot supports mission rally point protocol.</description>
+              </entry>
+          </enum>
+          <enum name="MAV_MISSION_TYPE">
+              <description>Type of mission items being requested/sent in mission protocol.</description>
+              <entry value="0" name="MAV_MISSION_TYPE_MISSION">
+                  <description>Autopilot supports MISSION float message type.</description>
+              </entry>
+              <entry value="1" name="MAV_MISSION_TYPE_FENCE">
+                  <description>Autopilot supports MISSION float message type.</description>
+              </entry>
+              <entry value="2" name="MAV_MISSION_TYPE_RALLY">
+                  <description>Autopilot supports MISSION float message type.</description>
+              </entry>
           </enum>
           <enum name="MAV_ESTIMATOR_TYPE">
               <description>Enumeration of estimator types</description>
@@ -2515,6 +2569,8 @@
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="int16_t" name="start_index">Start index, 0 by default</field>
                <field type="int16_t" name="end_index">End index, -1 by default (-1: send list to end). Else a valid index of the list</field>
+               <extensions/>
+               <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
           </message>
           <message id="38" name="MISSION_WRITE_PARTIAL_LIST">
                <description>This message is sent to the MAV to write a partial list. If start index == end index, only one item will be transmitted / updated. If the start index is NOT 0 and above the current list size, this request should be REJECTED!</description>
@@ -2522,6 +2578,8 @@
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="int16_t" name="start_index">Start index, 0 by default and smaller / equal to the largest index of the current onboard list.</field>
                <field type="int16_t" name="end_index">End index, equal or greater than start index.</field>
+               <extensions/>
+               <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
           </message>
           <message id="39" name="MISSION_ITEM">
                <description>Message encoding a mission item. This message is emitted to announce
@@ -2546,6 +2604,8 @@
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint16_t" name="seq">Sequence</field>
+               <extensions/>
+               <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
           </message>
           <message id="41" name="MISSION_SET_CURRENT">
                <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
@@ -2561,17 +2621,23 @@
                <description>Request the overall list of mission items from the system/component.</description>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
+               <extensions/>
+               <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
           </message>
           <message id="44" name="MISSION_COUNT">
                <description>This message is emitted as response to MISSION_REQUEST_LIST by the MAV and to initiate a write transaction. The GCS can then request the individual mission item based on the knowledge of the total number of MISSIONs.</description>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint16_t" name="count">Number of mission items in the sequence</field>
+               <extensions/>
+               <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
           </message>
           <message id="45" name="MISSION_CLEAR_ALL">
                <description>Delete all mission items at once.</description>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
+               <extensions/>
+               <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
           </message>
           <message id="46" name="MISSION_ITEM_REACHED">
                <description>A certain mission item has been reached. The system will either hold this position (or circle on the orbit) or (if the autocontinue on the WP was set) continue to the next MISSION.</description>
@@ -2582,6 +2648,8 @@
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">See MAV_MISSION_RESULT enum</field>
+               <extensions/>
+               <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
           </message>
           <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
                <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
@@ -2613,6 +2681,8 @@
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint16_t" name="seq">Sequence</field>
+               <extensions/>
+               <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
           </message>
           <message id="54" name="SAFETY_SET_ALLOWED_AREA">
                <description>Set a safety zone (volume), which is defined by two corners of a cube. This message can be used to tell the MAV which setpoints/MISSIONs to accept and which to reject. Safety areas are often enforced by national or competition regulations.</description>


### PR DESCRIPTION
Think of this as a conceptual proposal for #617 as opposed to something that is completely worked out. The main concepts are:
- Fence and Rally support are a 2.0 extension of the existing mission protocol.
- Vehicle support is indicated by capability bits.
- Mission/Fence/Rally have their own separate command space. You can send/request/clear/update them independantly. Within that command space you use the normal mission send/request protocol. You just need to specify the "type" you are working with. So for example to get rally points, you do a MISSION_REQUEST_LIST with mission_type = MAV_MISSION_TYPE_RALLY.

There are many other things to discuss (actual commands supported, what about the things that are in parameters currently, ...), but we need to get this high level discussion done first. 
