### PR TITLE
common.xml: ignore FLAG_SAFETY_ARMED in DO_SET_MODE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -169,7 +169,7 @@
           <enum name="MAV_MODE_FLAG">
                 <description>These flags encode the MAV mode.</description>
                 <entry value="128" name="MAV_MODE_FLAG_SAFETY_ARMED">
-                     <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly.</description>
+                     <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignore when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
                 </entry>
                 <entry value="64" name="MAV_MODE_FLAG_MANUAL_INPUT_ENABLED">
                      <description>0b01000000 remote control input is enabled.</description>


### PR DESCRIPTION
This adds an additional comment to the flag MAV_MODE_FLAG_SAFETY_ARMED
which deprecates its use as a command. Instead the command
MAV_CMD_COMPONENT_ARM_DISARM should always be used to change the armed
state like it is already the case for most (if not all) ground sattions.

The reasoning behind the change is that it is:
- not intuitive to change the armed/disarmed state in a "mode",
- it is dangerous if forgotten because the vehicle can fall from the sky
  or equally bad suddenly arm,
- it can lead to race conditions because the flag needs to be set using
  the base_mode which arrives by the heartbeat (usually at only 1Hz), so
  by the time a DO_SET_MODE command is sent, the state might have
  changes on the vehicle.