### PR TITLE
HIGH_LATENCY message for Iridium connections

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3570,6 +3570,37 @@
            <field type="uint8_t" name="len">data length</field>
            <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>
         </message>
+        <message id="234" name="HIGH_LATENCY">
+            <description>Message appropriate for high latency connections like Iridium</description>
+            <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch)</field>
+            <field name="base_mode" type="uint8_t">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
+            <field name="custom_mode" type="uint32_t">A bitfield for use for autopilot-specific flags.</field>
+            <field name="landed_state" type="uint8_t" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+            <field name="roll" type="int16_t">roll (centidegrees)</field>
+            <field name="pitch" type="int16_t">pitch (centidegrees)</field>
+            <field name="heading" type="uint16_t">heading (centidegrees)</field>
+            <field name="throttle" type="int8_t">throttle (percentage)</field>
+            <field name="roll_sp" type="int16_t">roll setpoint (centidegrees)</field>
+            <field name="pitch_sp" type="int16_t">pitch setpoint (centidegrees)</field>
+            <field name="heading_sp" type="int16_t">heading setpoint (centidegrees)</field>
+            <field name="latitude" type="int32_t">Latitude, expressed as degrees * 1E7</field>
+            <field name="longitude" type="int32_t">Longitude, expressed as degrees * 1E7</field>
+            <field name="altitude_home" type="int16_t">Altitude above the home position (meters)</field>
+            <field name="altitude_amsl" type="int16_t">Altitude above mean sea level (meters)</field>
+            <field name="altitude_sp" type="int16_t">Altitude setpoint relative to the home position (meters)</field>
+            <field name="airspeed" type="uint8_t">airspeed (m/s)</field>
+            <field name="airspeed_sp" type="uint8_t">airspeed setpoint (m/s)</field>
+            <field name="groundspeed" type="uint8_t">groundspeed (m/s)</field>
+            <field name="climb_rate" type="int8_t">climb rate (m/s)</field>
+            <field name="gps_nsat" type="uint8_t">Number of satellites visible. If unknown, set to 255</field>
+            <field name="gps_fix_type" type="uint8_t">See the GPS_FIX_TYPE enum.</field>
+            <field name="battery_remaining" type="uint8_t">Remaining battery (percentage)</field>
+            <field name="temperature" type="int8_t">Autopilot temperature (degrees C)</field>
+            <field name="temperature_air" type="int8_t">Air temperature (degrees C) from airspeed sensor</field>
+            <field name="failsafe" type="uint8_t">failsafe (each bit represents a failsafe where 0=ok, 1=failsafe active (bit0:RC, bit1:batt, bit2:GPS, bit3:GCS, bit4:fence)</field>
+            <field name="wp_num" type="uint8_t">current waypoint number</field>
+            <field name="wp_distance" type="uint16_t">distance to target (meters)</field>
+        </message>
         <message id="241" name="VIBRATION">
             <description>Vibration levels and accelerometer clipping</description>
             <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>


### PR DESCRIPTION
First pass at creating a single message appropriate for Iridium connections.

Based on @LorenzMeier's proposal here - https://groups.google.com/forum/#!searchin/mavlink/iridium%7Csort:relevance/mavlink/hv7zJ5Xdwcc/lHhZ4lXXBwAJ

TODO:
 - EKF status?
 - bitmap for actuator health?
 - max size? Should we aim for 50 bytes?