### PR TITLE
Camera and gimbal improvements

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3904,7 +3904,7 @@
             <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation) of camera direction</field>
             <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation) of camera direction</field>
             <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation) of camera direction</field>
-            <field type="uint8_t[210]" name="file_path">File path of image taken.</field>
+            <field type="char[210]" name="file_path">File path of image taken.</field>
         </message>
 
         <message id="264" name="FLIGHT_INFORMATION">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3884,7 +3884,7 @@
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
-            <field type="float" name="image_interval">Image capture interval in Hz</field>
+            <field type="float" name="image_interval">Image capture interval in seconds</field>
             <field type="float" name="video_framerate">Video frame rate in Hz</field>
             <field type="uint16_t" name="image_resolution_x">Image resolution in pixels horizontally</field>
             <field type="uint16_t" name="image_resolution_y">Image resolution in pixels vertically</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3838,6 +3838,7 @@
 
         <message id="259" name="CAMERA_INFORMATION">
             <description>Information about a camera</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
@@ -3850,6 +3851,7 @@
         </message>
         <message id="260" name="CAMERA_SETTINGS">
             <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="float" name="aperture">Aperture is 1/value</field>
             <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
@@ -3865,6 +3867,7 @@
         </message>
         <message id="261" name="STORAGE_INFORMATION">
             <description>Information about a storage medium</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
             <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
             <field type="float" name="total_capacity">Total capacity in MiB</field>
@@ -3875,6 +3878,7 @@
         </message>
         <message id="262" name="CAMERA_CAPTURE_STATUS">
             <description>Information about the status of a capture</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1322,26 +1322,42 @@
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
-               <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS">
-                 <description>Set the camera settings (CAMERA_SETTINGS)</description>
+               <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS_1">
+                 <description>Set the camera settings part 1 (CAMERA_SETTINGS)</description>
                  <param index="1">Camera ID</param>
-                 <param index="2">Apertue (1/value, NaN for auto)</param>
-                 <param index="3">Shutter speed in s (NaN for auto)</param>
-                 <param index="4">ISO sensitivity (NaN for auto)</param>
-                 <param index="5">White balance (colour temperature in K, NaN for auto)</param>
-                 <param index="6">Reserved for camera mode ID</param>
-                 <param index="7">Reserved for image format ID</param>
+                 <param index="2">Aperture (1/value)</param>
+                 <param index="3">Aperture locked (0: auto, 1: locked)</param>
+                 <param index="4">Shutter speed in s</param>
+                 <param index="5">Shutter speed locked (0: auto, 1: locked)</param>
+                 <param index="6">ISO sensitivity</param>
+                 <param index="7">ISO sensitivity locked (0: auto, 1: locked)</param>
                </entry>
-               <entry value="524" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
+               <entry value="524" name="MAV_CMD_SET_CAMERA_SETTINGS_2">
+                 <description>Set the camera settings part 2 (CAMERA_SETTINGS)</description>
+                 <param index="1">Camera ID</param>
+                 <param index="2">White balance locked (0: auto, 1: locked)</param>
+                 <param index="3">White balance (color temperature in K)</param>
+                 <param index="4">Reserved for camera mode ID</param>
+                 <param index="5">Reserved for color mode ID</param>
+                 <param index="6">Reserved for image format ID</param>
+                 <param index="7">Reserved</param>
+               </entry>
+               <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
                  <description>Request storage information (STORAGE_INFORMATION)</description>
                  <param index="1">1: Request storage information</param>
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
-               <entry value="525" name="MAV_CMD_STORAGE_FORMAT">
+               <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
                  <description>Format a storage medium</description>
                  <param index="1">1: Format storage</param>
                  <param index="2">Storage ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
+                 <description>Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
+                 <param index="1">1: Request camera capture status</param>
+                 <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
 
@@ -3813,7 +3829,7 @@
 
         <message id="259" name="CAMERA_INFORMATION">
             <description>Information about a camera</description>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t[16]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[16]" name="model_name">Name of the camera model</field>
             <field type="float" name="focal_length">Focal length in mm</field>
@@ -3824,17 +3840,22 @@
         </message>
         <message id="260" name="CAMERA_SETTINGS">
             <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="float" name="aperture">Aperture is 1/value</field>
+            <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
             <field type="float" name="shutter_speed">Shutter speed in s</field>
-            <field type="float" name="iso">ISO sensitivity</field>
+            <field type="uint8_t" name="shutter_speed_locked">Shutter speed locked (0: auto, 1: locked)</field>
+            <field type="float" name="iso_sensitivity">ISO sensitivity</field>
+            <field type="uint8_t" name="iso_sensitivity_locked">ISO sensitivity locked (0: auto, 1: locked)</field>
             <field type="float" name="white_balance">Color temperature in K</field>
+            <field type="uint8_t" name="white_balance_locked">Color temperature locked (0: auto, 1: locked)</field>
             <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
+            <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
             <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
         </message>
         <message id="261" name="STORAGE_INFORMATION">
             <description>Information about a storage medium</description>
-            <field type="uint8_t" name="storage_id">Storage ID if there are multiple.</field>
+            <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
             <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
             <field type="float" name="total_capacity">Total capacity in MiB</field>
             <field type="float" name="used_capacity">Used capacity in MiB</field>
@@ -3843,11 +3864,25 @@
             <field type="float" name="write_speed">Write speed in MiB/s</field>
         </message>
         <message id="262" name="CAMERA_CAPTURE_STATUS">
-            <description>Information about a storage medium</description>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <description>Information about the status of a capture</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
             <field type="uint8_t" name="video_status">Current status of video capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
-            <field type="uint8_t[128]" name="file_path">File path of current or last file.</field>
+        </message>
+        <message id="263" name="CAMERA_IMAGE_CAPTURED">
+            <description>Information about a captured image</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+            <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7 where image was taken</field>
+            <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7 where capture was taken</field>
+            <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
+            <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
+            <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation) of camera direction</field>
+            <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation) of camera direction</field>
+            <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation) of camera direction</field>
+            <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation) of camera direction</field>
+            <field type="uint8_t[210]" name="file_path">File path of image taken.</field>
         </message>
 
         <message id="266" name="LOGGING_DATA">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1372,8 +1372,8 @@
                   <param index="1">Duration between two consecutive pictures (in seconds)</param>
                   <param index="2">Number of images to capture total - 0 for unlimited capture</param>
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
-                  <param index="4">Resolution horizontally in pixels</param>
-                  <param index="5">Resolution horizontally in pixels</param>
+                  <param index="4">Resolution horizontal in pixels</param>
+                  <param index="5">Resolution horizontal in pixels</param>
                   <param index="6">Camera ID</param>
               </entry>
 
@@ -1395,8 +1395,8 @@
                   <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
                   <param index="2">Frames per second</param>
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
-                  <param index="4">Resolution horizontally in pixels</param>
-                  <param index="5">Resolution horizontally in pixels</param>
+                  <param index="4">Resolution horizontal in pixels</param>
+                  <param index="5">Resolution horizontal in pixels</param>
               </entry>
 
               <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
@@ -3845,10 +3845,10 @@
             <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
             <field type="float" name="focal_length">Focal length in mm</field>
-            <field type="float" name="sensor_size_h">Image sensor size horizontally in mm</field>
-            <field type="float" name="sensor_size_v">Image sensor size vertically in mm</field>
-            <field type="uint16_t" name="resolution_h">Image resolution in pixels horizontally</field>
-            <field type="uint16_t" name="resolution_v">Image resolution in pixels vertically</field>
+            <field type="float" name="sensor_size_h">Image sensor size horizontal in mm</field>
+            <field type="float" name="sensor_size_v">Image sensor size vertical in mm</field>
+            <field type="uint16_t" name="resolution_h">Image resolution in pixels horizontal</field>
+            <field type="uint16_t" name="resolution_v">Image resolution in pixels vertical</field>
             <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
         </message>
         <message id="260" name="CAMERA_SETTINGS">
@@ -3886,10 +3886,10 @@
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
             <field type="float" name="image_interval">Image capture interval in seconds</field>
             <field type="float" name="video_framerate">Video frame rate in Hz</field>
-            <field type="uint16_t" name="image_resolution_h">Image resolution in pixels horizontally</field>
-            <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertically</field>
-            <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontally</field>
-            <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertically</field>
+            <field type="uint16_t" name="image_resolution_h">Image resolution in pixels horizontal</field>
+            <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
+            <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
+            <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
             <description>Information about a captured image</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3917,9 +3917,6 @@
             <description>Status and orientation of a mount</description>
                 <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
                <field type="uint8_t" name="mav_mount_mode">Mount operation mode (see MAV_MOUNT_MODE enum)</field>
-               <field type="uint8_t" name="roll_stabilized">Roll stabilized (1: yes, 0: no)</field>
-               <field type="uint8_t" name="pitch_stabilized">Pitch stabilized (1: yes, 0: no)</field>
-               <field type="uint8_t" name="yaw_stabilized">Yaw stabilized (1: yes, 0: no)</field>
                <field type="float" name="roll">Roll in degrees, set if appropriate mount mode.</field>
                <field type="float" name="pitch">Pitch in degrees, set if appropriate mount mode.</field>
                <field type="float" name="yaw">Yaw in degrees, set if appropriate mount mode.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1082,12 +1082,12 @@
 
                <entry name="MAV_CMD_DO_MOUNT_CONTROL" value="205">
                    <description>Mission command to control a camera or antenna mount</description>
-                   <param index="1">pitch (DEPRECATED: or lat in degrees) depending on mount mode.</param>
-                   <param index="2">roll (DEPRECATED: or lon in degrees) depending on mount mode.</param>
-                   <param index="3">yaw (DEPRECATED: or alt in meters) depending on mount mode.</param>
-                   <param index="4">alt in meters depending on mount mode.</param>
-                   <param index="5">latitude in degrees * 1E7, set if appropriate mount mode.</param>
-                   <param index="6">longitude in degrees * 1E7, set if appropriate mount mode.</param>
+                   <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode.</param>
+                   <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode.</param>
+                   <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode.</param>
+                   <param index="4">WIP: alt in meters depending on mount mode.</param>
+                   <param index="5">WIP: latitude in degrees * 1E7, set if appropriate mount mode.</param>
+                   <param index="6">WIP: longitude in degrees * 1E7, set if appropriate mount mode.</param>
                    <param index="7">MAV_MOUNT_MODE enum value</param>
                </entry>
 
@@ -1257,11 +1257,11 @@
                     <description>Request the reboot or shutdown of system components.</description>
                     <param index="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
                     <param index="2">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
-                    <param index="3">0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
-                    <param index="4">0: Do nothing for mount (e.g. gimbal), 1: Reboot mount, 2: Shutdown mount, 3: Reboot mount and keep it in the bootloader until upgraded</param>
+                    <param index="3">WIP: 0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
+                    <param index="4">WIP: 0: Do nothing for mount (e.g. gimbal), 1: Reboot mount, 2: Shutdown mount, 3: Reboot mount and keep it in the bootloader until upgraded</param>
                     <param index="5">Reserved, send 0</param>
                     <param index="6">Reserved, send 0</param>
-                    <param index="7">ID (e.g. camera ID -1 for all IDs)</param>
+                    <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
                </entry>
                <entry value="252" name="MAV_CMD_OVERRIDE_GOTO">
                     <description>Hold / continue the current action</description>
@@ -1312,19 +1312,19 @@
                  <param index="2">Reserved (all remaining params)</param>
                </entry>
                <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
-                 <description>Request camera information (CAMERA_INFORMATION)</description>
+                 <description>WIP: Request camera information (CAMERA_INFORMATION)</description>
                  <param index="1">1: Request camera capabilities</param>
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
                <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
-                 <description>Request camera settings (CAMERA_SETTINGS)</description>
+                 <description>WIP: Request camera settings (CAMERA_SETTINGS)</description>
                  <param index="1">1: Request camera settings</param>
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
                <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS_1">
-                 <description>Set the camera settings part 1 (CAMERA_SETTINGS)</description>
+                 <description>WIP: Set the camera settings part 1 (CAMERA_SETTINGS)</description>
                  <param index="1">Camera ID</param>
                  <param index="2">Aperture (1/value)</param>
                  <param index="3">Aperture locked (0: auto, 1: locked)</param>
@@ -1334,7 +1334,7 @@
                  <param index="7">ISO sensitivity locked (0: auto, 1: locked)</param>
                </entry>
                <entry value="524" name="MAV_CMD_SET_CAMERA_SETTINGS_2">
-                 <description>Set the camera settings part 2 (CAMERA_SETTINGS)</description>
+                 <description>WIP: Set the camera settings part 2 (CAMERA_SETTINGS)</description>
                  <param index="1">Camera ID</param>
                  <param index="2">White balance locked (0: auto, 1: locked)</param>
                  <param index="3">White balance (color temperature in K)</param>
@@ -1344,25 +1344,25 @@
                  <param index="7">Reserved</param>
                </entry>
                <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
-                 <description>Request storage information (STORAGE_INFORMATION)</description>
+                 <description>WIP: Request storage information (STORAGE_INFORMATION)</description>
                  <param index="1">1: Request storage information</param>
                  <param index="2">Storage ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
                <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
-                 <description>Format a storage medium</description>
+                 <description>WIP: Format a storage medium</description>
                  <param index="1">1: Format storage</param>
                  <param index="2">Storage ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
                <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
-                 <description>Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
+                 <description>WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
                  <param index="1">1: Request camera capture status</param>
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
                <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
-                 <description>Request flight information (FLIGHT_INFORMATION)</description>
+                 <description>WIP: Request flight information (FLIGHT_INFORMATION)</description>
                  <param index="1">1: Request flight information</param>
                  <param index="2">Reserved (all remaining params)</param>
                </entry>
@@ -1372,9 +1372,9 @@
                   <param index="1">Duration between two consecutive pictures (in seconds)</param>
                   <param index="2">Number of images to capture total - 0 for unlimited capture</param>
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
-                  <param index="4">Resolution horizontal in pixels</param>
-                  <param index="5">Resolution horizontal in pixels</param>
-                  <param index="6">Camera ID</param>
+                  <param index="4">WIP: Resolution horizontal in pixels</param>
+                  <param index="5">WIP: Resolution horizontal in pixels</param>
+                  <param index="6">WIP: Camera ID</param>
               </entry>
 
               <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
@@ -1395,13 +1395,13 @@
                   <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
                   <param index="2">Frames per second</param>
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
-                  <param index="4">Resolution horizontal in pixels</param>
-                  <param index="5">Resolution horizontal in pixels</param>
+                  <param index="4">WIP: Resolution horizontal in pixels</param>
+                  <param index="5">WIP: Resolution horizontal in pixels</param>
               </entry>
 
               <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
                   <description>Stop the current video capture</description>
-                  <param index="1">Camera ID</param>
+                  <param index="1">WIP: Camera ID</param>
                   <param index="2">Reserved</param>
               </entry>
 
@@ -3839,7 +3839,7 @@
           </message>
 
         <message id="259" name="CAMERA_INFORMATION">
-            <description>Information about a camera</description>
+            <description>WIP: Information about a camera</description>
             <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
@@ -3852,7 +3852,7 @@
             <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
         </message>
         <message id="260" name="CAMERA_SETTINGS">
-            <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
+            <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
             <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="float" name="aperture">Aperture is 1/value</field>
@@ -3868,7 +3868,7 @@
             <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
         </message>
         <message id="261" name="STORAGE_INFORMATION">
-            <description>Information about a storage medium</description>
+            <description>WIP: Information about a storage medium</description>
             <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
             <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
@@ -3879,7 +3879,7 @@
             <field type="float" name="write_speed">Write speed in MiB/s</field>
         </message>
         <message id="262" name="CAMERA_CAPTURE_STATUS">
-            <description>Information about the status of a capture</description>
+            <description>WIP: Information about the status of a capture</description>
             <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
@@ -3892,7 +3892,7 @@
             <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
-            <description>Information about a captured image</description>
+            <description>WIP: Information about a captured image</description>
             <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
@@ -3905,7 +3905,7 @@
         </message>
 
         <message id="264" name="FLIGHT_INFORMATION">
-            <description>Information about flight since last arming</description>
+            <description>WIP: Information about flight since last arming</description>
             <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint64_t" name="arming_time_utc">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
             <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
@@ -3913,7 +3913,7 @@
         </message>
 
         <message id="265" name="MOUNT_STATUS">
-            <description>Status and orientation of a mount</description>
+            <description>WIP: Status and orientation of a mount</description>
                 <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
                <field type="uint8_t" name="mode" enum="MAV_MOUNT_MODE">Mount operation mode (see MAV_MOUNT_MODE enum)</field>
                <field type="float" name="roll">Roll in degrees, set if appropriate mount mode.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3913,6 +3913,21 @@
             <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
         </message>
 
+        <message id="265" name="MOUNT_STATUS">
+            <description>Status and orientation of a mount</description>
+                <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint8_t" name="mav_mount_mode">Mount operation mode (see MAV_MOUNT_MODE enum)</field>
+               <field type="uint8_t" name="roll_stabilized">Roll stabilized (1: yes, 0: no)</field>
+               <field type="uint8_t" name="pitch_stabilized">Pitch stabilized (1: yes, 0: no)</field>
+               <field type="uint8_t" name="yaw_stabilized">Yaw stabilized (1: yes, 0: no)</field>
+               <field type="float" name="roll">Roll in degrees, set if appropriate mount mode.</field>
+               <field type="float" name="pitch">Pitch in degrees, set if appropriate mount mode.</field>
+               <field type="float" name="yaw">Yaw in degrees, set if appropriate mount mode.</field>
+               <field type="int32_t" name="lat">Latitude, in degrees * 1E7, set if appropriate mount mode.</field>
+               <field type="int32_t" name="lon">Longitude, in degrees * 1E7, set if appropriate mount mode.</field>
+               <field type="float" name="alt">Altitude in meters, set if appropriate mount mode.</field>
+        </message>
+
         <message id="266" name="LOGGING_DATA">
                <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>
                <field type="uint8_t" name="target_system">system ID of the target</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1372,8 +1372,8 @@
                   <param index="1">Duration between two consecutive pictures (in seconds)</param>
                   <param index="2">Number of images to capture total - 0 for unlimited capture</param>
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
-                  <param index="4">Resolution horizontally (x) in pixels</param>
-                  <param index="5">Resolution horizontally (y) in pixels</param>
+                  <param index="4">Resolution horizontally in pixels</param>
+                  <param index="5">Resolution horizontally in pixels</param>
                   <param index="6">Camera ID</param>
               </entry>
 
@@ -1395,8 +1395,8 @@
                   <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
                   <param index="2">Frames per second</param>
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
-                  <param index="4">Resolution horizontally (x) in pixels</param>
-                  <param index="5">Resolution horizontally (y) in pixels</param>
+                  <param index="4">Resolution horizontally in pixels</param>
+                  <param index="5">Resolution horizontally in pixels</param>
               </entry>
 
               <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
@@ -3845,10 +3845,10 @@
             <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
             <field type="float" name="focal_length">Focal length in mm</field>
-            <field type="float" name="sensor_size_x">Image sensor size horizontally in mm</field>
-            <field type="float" name="sensor_size_y">Image sensor size vertically in mm</field>
-            <field type="uint16_t" name="resolution_x">Image resolution in pixels horizontally</field>
-            <field type="uint16_t" name="resolution_y">Image resolution in pixels vertically</field>
+            <field type="float" name="sensor_size_h">Image sensor size horizontally in mm</field>
+            <field type="float" name="sensor_size_v">Image sensor size vertically in mm</field>
+            <field type="uint16_t" name="resolution_h">Image resolution in pixels horizontally</field>
+            <field type="uint16_t" name="resolution_v">Image resolution in pixels vertically</field>
             <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
         </message>
         <message id="260" name="CAMERA_SETTINGS">
@@ -3886,10 +3886,10 @@
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
             <field type="float" name="image_interval">Image capture interval in seconds</field>
             <field type="float" name="video_framerate">Video frame rate in Hz</field>
-            <field type="uint16_t" name="image_resolution_x">Image resolution in pixels horizontally</field>
-            <field type="uint16_t" name="image_resolution_y">Image resolution in pixels vertically</field>
-            <field type="uint16_t" name="video_resolution_x">Video resolution in pixels horizontally</field>
-            <field type="uint16_t" name="video_resolution_y">Video resolution in pixels vertically</field>
+            <field type="uint16_t" name="image_resolution_h">Image resolution in pixels horizontally</field>
+            <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertically</field>
+            <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontally</field>
+            <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertically</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
             <description>Information about a captured image</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1365,7 +1365,9 @@
                   <description>Start image capture sequence</description>
                   <param index="1">Duration between two consecutive pictures (in seconds)</param>
                   <param index="2">Number of images to capture total - 0 for unlimited capture</param>
-                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc)</param>
+                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
+                  <param index="4">Resolution horizontally (x) in pixels</param>
+                  <param index="5">Resolution horizontally (y) in pixels</param>
               </entry>
 
               <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
@@ -1385,7 +1387,9 @@
                   <description>Starts video capture</description>
                   <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
                   <param index="2">Frames per second</param>
-                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc)</param>
+                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
+                  <param index="4">Resolution horizontally (x) in pixels</param>
+                  <param index="5">Resolution horizontally (y) in pixels</param>
               </entry>
 
               <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1258,10 +1258,10 @@
                     <param index="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
                     <param index="2">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
                     <param index="3">0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
-                    <param index="4">0: Do nothing for gimbal, 1: Reboot gimbal, 2: Shutdown gimbal, 3: Reboot gimbal and keep it in the bootloader until upgraded</param>
+                    <param index="4">0: Do nothing for mount (e.g. gimbal), 1: Reboot mount, 2: Shutdown mount, 3: Reboot mount and keep it in the bootloader until upgraded</param>
                     <param index="5">Reserved, send 0</param>
                     <param index="6">Reserved, send 0</param>
-                    <param index="7">Reserved, send 0</param>
+                    <param index="7">ID (e.g. camera ID -1 for all IDs)</param>
                </entry>
                <entry value="252" name="MAV_CMD_OVERRIDE_GOTO">
                     <description>Hold / continue the current action</description>
@@ -1314,7 +1314,8 @@
                <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
                  <description>Request camera information (CAMERA_INFORMATION)</description>
                  <param index="1">1: Request camera capabilities</param>
-                 <param index="2">Reserved (all remaining params)</param>
+                 <param index="2">Camera ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
                </entry>
                <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
                  <description>Request camera settings (CAMERA_SETTINGS)</description>
@@ -1345,7 +1346,7 @@
                <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
                  <description>Request storage information (STORAGE_INFORMATION)</description>
                  <param index="1">1: Request storage information</param>
-                 <param index="2">Camera ID</param>
+                 <param index="2">Storage ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
                <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
@@ -1373,11 +1374,12 @@
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
                   <param index="4">Resolution horizontally (x) in pixels</param>
                   <param index="5">Resolution horizontally (y) in pixels</param>
+                  <param index="6">Camera ID</param>
               </entry>
 
               <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
                   <description>Stop image capture sequence</description>
-                  <param index="1">Reserved</param>
+                  <param index="1">Camera ID</param>
                   <param index="2">Reserved</param>
               </entry>
 
@@ -1399,7 +1401,7 @@
 
               <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
                   <description>Stop the current video capture</description>
-                  <param index="1">Reserved</param>
+                  <param index="1">Camera ID</param>
                   <param index="2">Reserved</param>
               </entry>
 

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3869,7 +3869,7 @@
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
-            <field type="float" name="image_framerate">Image interval capture in Hz</field>
+            <field type="float" name="image_interval">Image capture interval in Hz</field>
             <field type="float" name="video_framerate">Video frame rate in Hz</field>
             <field type="float" name="image_resolution">Resolution in megapixels</field>
             <field type="float" name="video_resolution">Resolution in megapixels</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1045,6 +1045,7 @@
                </entry>
 
                <!-- Camera Controller Mission Commands Enumeration -->
+               <!-- MAV_CMD_DO_DIGICAM_CONFIGURE should be deprecated and replaced with CAMERA_SETTINGS -->
                <entry name="MAV_CMD_DO_DIGICAM_CONFIGURE" value="202">
                    <description>Mission command to configure an on-board camera controller system.</description>
                    <param index="1">Modes: P, TV, AV, M, Etc</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3550,6 +3550,7 @@
             <field type="float" name="size_x">Size in radians of target along x-axis</field>
             <field type="float" name="size_y">Size in radians of target along y-axis</field>
         </message>
+
         <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
         <message id="230" name="ESTIMATOR_STATUS">
             <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovaton test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovaton test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3900,10 +3900,7 @@
             <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7 where capture was taken</field>
             <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
             <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
-            <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation) of camera direction</field>
-            <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation) of camera direction</field>
-            <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation) of camera direction</field>
-            <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation) of camera direction</field>
+            <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
             <field type="char[210]" name="file_path">File path of image taken.</field>
         </message>
 

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3918,7 +3918,7 @@
         <message id="265" name="MOUNT_STATUS">
             <description>Status and orientation of a mount</description>
                 <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="uint8_t" name="mav_mount_mode">Mount operation mode (see MAV_MOUNT_MODE enum)</field>
+               <field type="uint8_t" name="mode" enum="MAV_MOUNT_MODE">Mount operation mode (see MAV_MOUNT_MODE enum)</field>
                <field type="float" name="roll">Roll in degrees, set if appropriate mount mode.</field>
                <field type="float" name="pitch">Pitch in degrees, set if appropriate mount mode.</field>
                <field type="float" name="yaw">Yaw in degrees, set if appropriate mount mode.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3871,8 +3871,10 @@
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
             <field type="float" name="image_interval">Image capture interval in Hz</field>
             <field type="float" name="video_framerate">Video frame rate in Hz</field>
-            <field type="float" name="image_resolution">Resolution in megapixels</field>
-            <field type="float" name="video_resolution">Resolution in megapixels</field>
+            <field type="uint16_t" name="image_resolution_x">Image resolution in pixels horizontally</field>
+            <field type="uint16_t" name="image_resolution_y">Image resolution in pixels vertically</field>
+            <field type="uint16_t" name="video_resolution_x">Video resolution in pixels horizontally</field>
+            <field type="uint16_t" name="video_resolution_y">Video resolution in pixels vertically</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
             <description>Information about a captured image</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1082,12 +1082,12 @@
 
                <entry name="MAV_CMD_DO_MOUNT_CONTROL" value="205">
                    <description>Mission command to control a camera or antenna mount</description>
-                   <param index="1">pitch or lat in degrees, depending on mount mode.</param>
-                   <param index="2">roll or lon in degrees depending on mount mode</param>
-                   <param index="3">yaw or alt (in meters) depending on mount mode</param>
-                   <param index="4">reserved</param>
-                   <param index="5">reserved</param>
-                   <param index="6">reserved</param>
+                   <param index="1">pitch (DEPRECATED: or lat in degrees) depending on mount mode.</param>
+                   <param index="2">roll (DEPRECATED: or lon in degrees) depending on mount mode.</param>
+                   <param index="3">yaw (DEPRECATED: or alt in meters) depending on mount mode.</param>
+                   <param index="4">alt in meters depending on mount mode.</param>
+                   <param index="5">latitude in degrees * 1E7, set if appropriate mount mode.</param>
+                   <param index="6">longitude in degrees * 1E7, set if appropriate mount mode.</param>
                    <param index="7">MAV_MOUNT_MODE enum value</param>
                </entry>
 

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1256,8 +1256,8 @@
                     <description>Request the reboot or shutdown of system components.</description>
                     <param index="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
                     <param index="2">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
-                    <param index="3">Reserved, send 0</param>
-                    <param index="4">Reserved, send 0</param>
+                    <param index="3">0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
+                    <param index="4">0: Do nothing for gimbal, 1: Reboot gimbal, 2: Shutdown gimbal, 3: Reboot gimbal and keep it in the bootloader until upgraded</param>
                     <param index="5">Reserved, send 0</param>
                     <param index="6">Reserved, send 0</param>
                     <param index="7">Reserved, send 0</param>
@@ -1310,6 +1310,40 @@
                  <param index="1">1: Request autopilot version</param>
                  <param index="2">Reserved (all remaining params)</param>
                </entry>
+               <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
+                 <description>Request camera information (CAMERA_INFORMATION)</description>
+                 <param index="1">1: Request camera capabilities</param>
+                 <param index="2">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
+                 <description>Request camera settings (CAMERA_SETTINGS)</description>
+                 <param index="1">1: Request camera settings</param>
+                 <param index="2">Camera ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS">
+                 <description>Set the camera settings (CAMERA_SETTINGS)</description>
+                 <param index="1">Camera ID</param>
+                 <param index="2">Apertue (1/value, NaN for auto)</param>
+                 <param index="3">Shutter speed in s (NaN for auto)</param>
+                 <param index="4">ISO sensitivity (NaN for auto)</param>
+                 <param index="5">White balance (colour temperature in K, NaN for auto)</param>
+                 <param index="6">Reserved for camera mode ID</param>
+                 <param index="7">Reserved for image format ID</param>
+               </entry>
+               <entry value="524" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
+                 <description>Request storage information (STORAGE_INFORMATION)</description>
+                 <param index="1">1: Request storage information</param>
+                 <param index="2">Camera ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="525" name="MAV_CMD_STORAGE_FORMAT">
+                 <description>Format a storage medium</description>
+                 <param index="1">1: Format storage</param>
+                 <param index="2">Storage ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+
               <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
                   <description>Start image capture sequence</description>
                   <param index="1">Duration between two consecutive pictures (in seconds)</param>
@@ -3776,7 +3810,46 @@
             <field name="tune" type="char[30]">tune in board specific format</field>
           </message>
 
-          <message id="266" name="LOGGING_DATA">
+        <message id="259" name="CAMERA_INFORMATION">
+            <description>Information about a camera</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="uint8_t[16]" name="vendor_name">Name of the camera vendor</field>
+            <field type="uint8_t[16]" name="model_name">Name of the camera model</field>
+            <field type="float" name="focal_length">Focal length in mm</field>
+            <field type="float" name="sensor_size">Image sensor size in mm</field>
+            <field type="uint16_t" name="resolution_x">Image resolution in pixels horizontally</field>
+            <field type="uint16_t" name="resolution_y">Image resolution in pixels vertically</field>
+            <field type="uint8_t" name="lense_id">reserved for a lense ID</field>
+        </message>
+        <message id="260" name="CAMERA_SETTINGS">
+            <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="float" name="aperture">Aperture is 1/value</field>
+            <field type="float" name="shutter_speed">Shutter speed in s</field>
+            <field type="float" name="iso">ISO sensitivity</field>
+            <field type="float" name="white_balance">Color temperature in K</field>
+            <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
+            <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
+        </message>
+        <message id="261" name="STORAGE_INFORMATION">
+            <description>Information about a storage medium</description>
+            <field type="uint8_t" name="storage_id">Storage ID if there are multiple.</field>
+            <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
+            <field type="float" name="total_capacity">Total capacity in MiB</field>
+            <field type="float" name="used_capacity">Used capacity in MiB</field>
+            <field type="float" name="available_capacity">Available capacity in MiB</field>
+            <field type="float" name="read_speed">Read speed in MiB/s</field>
+            <field type="float" name="write_speed">Write speed in MiB/s</field>
+        </message>
+        <message id="262" name="CAMERA_CAPTURE_STATUS">
+            <description>Information about a storage medium</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="uint8_t" name="image_status">Current status of image capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
+            <field type="uint8_t" name="video_status">Current status of video capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
+            <field type="uint8_t[128]" name="file_path">File path of current or last file.</field>
+        </message>
+
+        <message id="266" name="LOGGING_DATA">
                <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>
                <field type="uint8_t" name="target_system">system ID of the target</field>
                <field type="uint8_t" name="target_component">component ID of the target</field>
@@ -3800,6 +3873,6 @@
                <field type="uint8_t" name="target_component">component ID of the target</field>
                <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
           </message>
-
-        </messages>
+        </message>
+    </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3830,8 +3830,8 @@
         <message id="259" name="CAMERA_INFORMATION">
             <description>Information about a camera</description>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="uint8_t[16]" name="vendor_name">Name of the camera vendor</field>
-            <field type="uint8_t[16]" name="model_name">Name of the camera model</field>
+            <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
+            <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
             <field type="float" name="focal_length">Focal length in mm</field>
             <field type="float" name="sensor_size">Image sensor size in mm</field>
             <field type="uint16_t" name="resolution_x">Image resolution in pixels horizontally</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3867,8 +3867,12 @@
         <message id="262" name="CAMERA_CAPTURE_STATUS">
             <description>Information about the status of a capture</description>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="uint8_t" name="image_status">Current status of image capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
-            <field type="uint8_t" name="video_status">Current status of video capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
+            <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
+            <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
+            <field type="float" name="image_framerate">Image interval capture in Hz</field>
+            <field type="float" name="video_framerate">Video frame rate in Hz</field>
+            <field type="float" name="image_resolution">Resolution in megapixels</field>
+            <field type="float" name="video_resolution">Resolution in megapixels</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
             <description>Information about a captured image</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1360,6 +1360,11 @@
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
+               <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
+                 <description>Request flight information (FLIGHT_INFORMATION)</description>
+                 <param index="1">1: Request flight information</param>
+                 <param index="2">Reserved (all remaining params)</param>
+               </entry>
 
               <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
                   <description>Start image capture sequence</description>
@@ -3896,6 +3901,14 @@
             <field type="uint8_t[210]" name="file_path">File path of image taken.</field>
         </message>
 
+        <message id="264" name="FLIGHT_INFORMATION">
+            <description>Information about flight since last arming</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint64_t" name="arming_time_utc">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+            <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+            <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
+        </message>
+
         <message id="266" name="LOGGING_DATA">
                <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>
                <field type="uint8_t" name="target_system">system ID of the target</field>
@@ -3920,6 +3933,5 @@
                <field type="uint8_t" name="target_component">component ID of the target</field>
                <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
           </message>
-        </message>
     </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3833,10 +3833,11 @@
             <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
             <field type="float" name="focal_length">Focal length in mm</field>
-            <field type="float" name="sensor_size">Image sensor size in mm</field>
+            <field type="float" name="sensor_size_x">Image sensor size horizontally in mm</field>
+            <field type="float" name="sensor_size_y">Image sensor size vertically in mm</field>
             <field type="uint16_t" name="resolution_x">Image resolution in pixels horizontally</field>
             <field type="uint16_t" name="resolution_y">Image resolution in pixels vertically</field>
-            <field type="uint8_t" name="lense_id">reserved for a lense ID</field>
+            <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
         </message>
         <message id="260" name="CAMERA_SETTINGS">
             <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>


### PR DESCRIPTION
This is an attempt to improve and extend the mavlink camera and gimbal API.

The command `DIGICAM_CONFIGURE` is deprecated in favor of `CAMERA_INFORMATION`, `CAMERA_CAPTURE_STATUS`, `CAMERA_SETTINGS_1`, and `CAMERA_SETTINGS_2`.

For the camera storage `STORAGE_INFORMATION` and `STORAGE_FORMAT` has been added.

To control the gimbal, the lat/lon fields have been moved to param5/param6 for int32 accuracy, and a `MOUNT_STATUS` is added for the realtime feedback about a gimbal (or other mount).

Please review:
@LorenzMeier, @mcharleb
