### PR TITLE
common.xml: simplify mount status

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3912,16 +3912,12 @@
             <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
         </message>
 
-        <message id="265" name="MOUNT_STATUS">
-            <description>WIP: Status and orientation of a mount</description>
+        <message id="265" name="MOUNT_ORIENTATION">
+            <description>WIP: Orientation of a mount</description>
                 <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="uint8_t" name="mode" enum="MAV_MOUNT_MODE">Mount operation mode (see MAV_MOUNT_MODE enum)</field>
-               <field type="float" name="roll">Roll in degrees, set if appropriate mount mode.</field>
-               <field type="float" name="pitch">Pitch in degrees, set if appropriate mount mode.</field>
-               <field type="float" name="yaw">Yaw in degrees, set if appropriate mount mode.</field>
-               <field type="int32_t" name="lat">Latitude, in degrees * 1E7, set if appropriate mount mode.</field>
-               <field type="int32_t" name="lon">Longitude, in degrees * 1E7, set if appropriate mount mode.</field>
-               <field type="float" name="alt">Altitude in meters, set if appropriate mount mode.</field>
+               <field type="float" name="roll">Roll in degrees</field>
+               <field type="float" name="pitch">Pitch in degrees</field>
+               <field type="float" name="yaw">Yaw in degrees</field>
         </message>
 
         <message id="266" name="LOGGING_DATA">


### PR DESCRIPTION
We don't actually need all the mount mode and lat/lon/alt information
because it is all set from outside using MAV_CMD_DO_MOUNT_CONFIGURE and
MAV_CMD_DO_MOUNT_CONTROL.

As discussed with @bkueng.

@LorenzMeier please review.