### PR TITLE
HIGH_LATENCY reduce size

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3665,7 +3665,6 @@
         </message>
         <message id="234" name="HIGH_LATENCY">
             <description>Message appropriate for high latency connections like Iridium</description>
-            <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch)</field>
             <field name="base_mode" type="uint8_t">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
             <field name="custom_mode" type="uint32_t">A bitfield for use for autopilot-specific flags.</field>
             <field name="landed_state" type="uint8_t" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
@@ -3673,12 +3672,9 @@
             <field name="pitch" type="int16_t">pitch (centidegrees)</field>
             <field name="heading" type="uint16_t">heading (centidegrees)</field>
             <field name="throttle" type="int8_t">throttle (percentage)</field>
-            <field name="roll_sp" type="int16_t">roll setpoint (centidegrees)</field>
-            <field name="pitch_sp" type="int16_t">pitch setpoint (centidegrees)</field>
             <field name="heading_sp" type="int16_t">heading setpoint (centidegrees)</field>
             <field name="latitude" type="int32_t">Latitude, expressed as degrees * 1E7</field>
             <field name="longitude" type="int32_t">Longitude, expressed as degrees * 1E7</field>
-            <field name="altitude_home" type="int16_t">Altitude above the home position (meters)</field>
             <field name="altitude_amsl" type="int16_t">Altitude above mean sea level (meters)</field>
             <field name="altitude_sp" type="int16_t">Altitude setpoint relative to the home position (meters)</field>
             <field name="airspeed" type="uint8_t">airspeed (m/s)</field>


### PR DESCRIPTION
Reduce HIGH_LATENCY so that the encoded mavlink message is < 50 bytes to fit within a single RockBlock billing credit.

I know generally we can't change messages after they're published, but this was only recently added and hasn't been implemented yet.

The timestamp would have been nice, but we can get that from RockBlock if the message actually goes through.