### PR TITLE
Fixes MAVLink UDP example to compile on Ubuntu 14.04.  Also updates t…

### DIFF
--- a/examples/linux/README
+++ b/examples/linux/README
@@ -9,7 +9,11 @@ MAVLink UDP Example for *nix system (Linux, MacOS, BSD, etc.)
 
 To compile with GCC, just enter:
 
-gcc -I ../../include/common -o mavlink_udp mavlink_udp.c
+gcc -std=c99 -I ../../include/common -o mavlink_udp mavlink_udp.c
+
+The MAVLink header directory must be added to the include path, as shown above. 
+Be sure to use version 1.0 of the MAVLink headers for this example, otherwise
+the ground control software may be unable to connect.
 
 To run, type:
 

--- a/examples/linux/mavlink_udp.c
+++ b/examples/linux/mavlink_udp.c
@@ -46,6 +46,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <arpa/inet.h>
+#include <stdbool.h> /* required for the definition of bool in C99 */
 #endif
 
 /* This assumes you have the mavlink headers on your include path
@@ -115,7 +116,12 @@ int main(int argc, char* argv[])
     } 
 	
 	/* Attempt to make it non blocking */
+#if (defined __QNX__) | (defined __QNXNTO__)
 	if (fcntl(sock, F_SETFL, O_NONBLOCK | FASYNC) < 0)
+#else
+	if (fcntl(sock, F_SETFL, O_NONBLOCK | O_ASYNC) < 0)
+#endif
+
     {
 		fprintf(stderr, "error setting nonblocking: %s\n", strerror(errno));
 		close(sock);


### PR DESCRIPTION
…he README file to remind the user to reference version 1.0 of the MAVLink header files in the include path.