### PR TITLE
Add units and bitmask fields

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <mavlink>
     <include>common.xml</include>
     
@@ -1060,7 +1060,7 @@
             <field name="mag_ofs_x" type="int16_t">magnetometer X offset</field>
             <field name="mag_ofs_y" type="int16_t">magnetometer Y offset</field>
             <field name="mag_ofs_z" type="int16_t">magnetometer Z offset</field>
-            <field name="mag_declination" type="float">magnetic declination (radians)</field>
+               <field type="float" name="mag_declination" units="rad">magnetic declination (radians)</field>
             <field name="raw_press" type="int32_t">raw pressure from barometer</field>
             <field name="raw_temp" type="int32_t">raw temperature from barometer</field>
             <field name="gyro_cal_x" type="float">gyro X calibration</field>
@@ -1109,7 +1109,7 @@
             <field name="iso" type="uint8_t">ISO enumeration from 1 to N //e.g. 80, 100, 200, Etc (0 means ignore)</field>
             <field name="exposure_type" type="uint8_t">Exposure type enumeration from 1 to N (0 means ignore)</field>
             <field name="command_id" type="uint8_t">Command Identity (incremental loop: 0 to 255)//A command sent multiple times will be executed or pooled just once</field>
-            <field name="engine_cut_off" type="uint8_t">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</field>
+               <field type="uint8_t" name="engine_cut_off" units="ds">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</field>
             <field name="extra_param" type="uint8_t">Extra parameters enumeration (0 means ignore)</field>
             <field name="extra_value" type="float">Correspondent value to given extra_param</field>
         </message>
@@ -1153,9 +1153,9 @@
             <description>Message with some status from APM to GCS about camera or antenna mount</description>
             <field name="target_system" type="uint8_t">System ID</field>
             <field name="target_component" type="uint8_t">Component ID</field>
-            <field name="pointing_a" type="int32_t">pitch(deg*100)</field>
-            <field name="pointing_b" type="int32_t">roll(deg*100)</field>
-            <field name="pointing_c" type="int32_t">yaw(deg*100)</field>
+               <field type="int32_t" name="pointing_a" units="c°">pitch(deg*100)</field>
+               <field type="int32_t" name="pointing_b" units="c°">roll(deg*100)</field>
+               <field type="int32_t" name="pointing_c" units="c°">yaw(deg*100)</field>
         </message>
 
         <!-- geo-fence messages -->
@@ -1165,8 +1165,8 @@
             <field name="target_component" type="uint8_t">Component ID</field>
             <field name="idx" type="uint8_t">point index (first point is 1, 0 is for return point)</field>
             <field name="count" type="uint8_t">total number of points (for sanity checking)</field>
-            <field name="lat" type="float">Latitude of point</field>
-            <field name="lng" type="float">Longitude of point</field>
+               <field type="float" name="lat" units="°">Latitude of point</field>
+               <field type="float" name="lng" units="°">Longitude of point</field>
         </message>
 
         <message id="161" name="FENCE_FETCH_POINT">
@@ -1181,14 +1181,14 @@
             <field name="breach_status" type="uint8_t">0 if currently inside fence, 1 if outside</field>
             <field name="breach_count" type="uint16_t">number of fence breaches</field>
             <field enum="FENCE_BREACH" name="breach_type" type="uint8_t">last breach type (see FENCE_BREACH_* enum)</field>
-            <field name="breach_time" type="uint32_t">time of last breach in milliseconds since boot</field>
+               <field type="uint32_t" name="breach_time" units="ms">time of last breach in milliseconds since boot</field>
         </message>
 
         <message id="163" name="AHRS">
             <description>Status of DCM attitude estimator</description>
-            <field name="omegaIx" type="float">X gyro drift estimate rad/s</field>
-            <field name="omegaIy" type="float">Y gyro drift estimate rad/s</field>
-            <field name="omegaIz" type="float">Z gyro drift estimate rad/s</field>
+               <field type="float" name="omegaIx" units="rad/s">X gyro drift estimate rad/s</field>
+               <field type="float" name="omegaIy" units="rad/s">Y gyro drift estimate rad/s</field>
+               <field type="float" name="omegaIz" units="rad/s">Z gyro drift estimate rad/s</field>
             <field name="accel_weight" type="float">average accel_weight</field>
             <field name="renorm_val" type="float">average renormalisation value</field>
             <field name="error_rp" type="float">average error_roll_pitch value</field>
@@ -1197,22 +1197,22 @@
 
         <message id="164" name="SIMSTATE">
             <description>Status of simulation environment, if used</description>
-            <field name="roll" type="float">Roll angle (rad)</field>
-            <field name="pitch" type="float">Pitch angle (rad)</field>
-            <field name="yaw" type="float">Yaw angle (rad)</field>
-            <field name="xacc" type="float">X acceleration m/s/s</field>
-            <field name="yacc" type="float">Y acceleration m/s/s</field>
-            <field name="zacc" type="float">Z acceleration m/s/s</field>
-            <field name="xgyro" type="float">Angular speed around X axis rad/s</field>
-            <field name="ygyro" type="float">Angular speed around Y axis rad/s</field>
-            <field name="zgyro" type="float">Angular speed around Z axis rad/s</field>
-            <field name="lat" type="int32_t">Latitude in degrees * 1E7</field>
-            <field name="lng" type="int32_t">Longitude in degrees * 1E7</field>
+               <field type="float" name="roll" units="rad">Roll angle (rad)</field>
+               <field type="float" name="pitch" units="rad">Pitch angle (rad)</field>
+               <field type="float" name="yaw" units="rad">Yaw angle (rad)</field>
+               <field type="float" name="xacc" units="m/s²">X acceleration m/s/s</field>
+               <field type="float" name="yacc" units="m/s²">Y acceleration m/s/s</field>
+               <field type="float" name="zacc" units="m/s²">Z acceleration m/s/s</field>
+               <field type="float" name="xgyro" units="rad/s">Angular speed around X axis rad/s</field>
+               <field type="float" name="ygyro" units="rad/s">Angular speed around Y axis rad/s</field>
+               <field type="float" name="zgyro" units="rad/s">Angular speed around Z axis rad/s</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude in degrees * 1E7</field>
+               <field type="int32_t" name="lng" units="°E7">Longitude in degrees * 1E7</field>
         </message>
 
         <message id="165" name="HWSTATUS">
             <description>Status of key hardware</description>
-            <field name="Vcc" type="uint16_t">board voltage (mV)</field>
+               <field type="uint16_t" name="Vcc" units="mV">board voltage (mV)</field>
             <field name="I2Cerr" type="uint8_t">I2C error count</field>
         </message>
 
@@ -1220,7 +1220,7 @@
             <description>Status generated by radio</description>
             <field name="rssi" type="uint8_t">local signal strength</field>
             <field name="remrssi" type="uint8_t">remote signal strength</field>
-            <field name="txbuf" type="uint8_t">how full the tx buffer is as a percentage</field>
+               <field type="uint8_t" name="txbuf" units="%">how full the tx buffer is as a percentage</field>
             <field name="noise" type="uint8_t">background noise level</field>
             <field name="remnoise" type="uint8_t">remote background noise level</field>
             <field name="rxerrors" type="uint16_t">receive errors</field>
@@ -1231,63 +1231,63 @@
         <message id="167" name="LIMITS_STATUS">
             <description>Status of AP_Limits. Sent in extended status stream when AP_Limits is enabled</description>
             <field enum="LIMITS_STATE" name="limits_state" type="uint8_t">state of AP_Limits, (see enum LimitState, LIMITS_STATE)</field>
-            <field name="last_trigger" type="uint32_t">time of last breach in milliseconds since boot</field>
-            <field name="last_action" type="uint32_t">time of last recovery action in milliseconds since boot</field>
-            <field name="last_recovery" type="uint32_t">time of last successful recovery in milliseconds since boot</field>
-            <field name="last_clear" type="uint32_t">time of last all-clear in milliseconds since boot</field>
+               <field type="uint32_t" name="last_trigger" units="ms">time of last breach in milliseconds since boot</field>
+               <field type="uint32_t" name="last_action" units="ms">time of last recovery action in milliseconds since boot</field>
+               <field type="uint32_t" name="last_recovery" units="ms">time of last successful recovery in milliseconds since boot</field>
+               <field type="uint32_t" name="last_clear" units="ms">time of last all-clear in milliseconds since boot</field>
             <field name="breach_count" type="uint16_t">number of fence breaches</field>
-            <field name="mods_enabled" type="uint8_t">AP_Limit_Module bitfield of enabled modules, (see enum moduleid or LIMIT_MODULE)</field>
-            <field name="mods_required" type="uint8_t">AP_Limit_Module bitfield of required modules, (see enum moduleid or LIMIT_MODULE)</field>
-            <field name="mods_triggered" type="uint8_t">AP_Limit_Module bitfield of triggered modules, (see enum moduleid or LIMIT_MODULE)</field>
+               <field type="uint8_t" name="mods_enabled" bitmask="LIMIT_MODULE">AP_Limit_Module bitfield of enabled modules, (see enum moduleid or LIMIT_MODULE)</field>
+               <field type="uint8_t" name="mods_required" bitmask="LIMIT_MODULE">AP_Limit_Module bitfield of required modules, (see enum moduleid or LIMIT_MODULE)</field>
+               <field type="uint8_t" name="mods_triggered" bitmask="LIMIT_MODULE">AP_Limit_Module bitfield of triggered modules, (see enum moduleid or LIMIT_MODULE)</field>
         </message>
 
         <message id="168" name="WIND">
             <description>Wind estimation</description>
-            <field name="direction" type="float">wind direction that wind is coming from (degrees)</field>
-            <field name="speed" type="float">wind speed in ground plane (m/s)</field>
-            <field name="speed_z" type="float">vertical wind speed (m/s)</field>
+               <field type="float" name="direction" units="°">wind direction that wind is coming from (degrees)</field>
+               <field type="float" name="speed" units="m/s">wind speed in ground plane (m/s)</field>
+               <field type="float" name="speed_z" units="m/s">vertical wind speed (m/s)</field>
         </message>
 
         <message id="169" name="DATA16">
             <description>Data packet, size 16</description>
             <field name="type" type="uint8_t">data type</field>
-            <field name="len" type="uint8_t">data length</field>
+               <field type="uint8_t" name="len" units="bytes">data length</field>
             <field name="data" type="uint8_t[16]">raw data</field>
         </message>
 
         <message id="170" name="DATA32">
             <description>Data packet, size 32</description>
             <field name="type" type="uint8_t">data type</field>
-            <field name="len" type="uint8_t">data length</field>
+               <field type="uint8_t" name="len" units="bytes">data length</field>
             <field name="data" type="uint8_t[32]">raw data</field>
         </message>
 
         <message id="171" name="DATA64">
             <description>Data packet, size 64</description>
             <field name="type" type="uint8_t">data type</field>
-            <field name="len" type="uint8_t">data length</field>
+               <field type="uint8_t" name="len" units="bytes">data length</field>
             <field name="data" type="uint8_t[64]">raw data</field>
         </message>
 
         <message id="172" name="DATA96">
             <description>Data packet, size 96</description>
             <field name="type" type="uint8_t">data type</field>
-            <field name="len" type="uint8_t">data length</field>
+               <field type="uint8_t" name="len" units="bytes">data length</field>
             <field name="data" type="uint8_t[96]">raw data</field>
         </message>
 
         <message id="173" name="RANGEFINDER">
             <description>Rangefinder reporting</description>
-            <field name="distance" type="float">distance in meters</field>
-            <field name="voltage" type="float">raw voltage if available, zero otherwise</field>
+               <field type="float" name="distance" units="m">distance in meters</field>
+               <field type="float" name="voltage" units="V">raw voltage if available, zero otherwise</field>
         </message>
 
         <message id="174" name="AIRSPEED_AUTOCAL">
             <description>Airspeed auto-calibration</description>
-            <field name="vx" type="float">GPS velocity north m/s</field>
-            <field name="vy" type="float">GPS velocity east m/s</field>
-            <field name="vz" type="float">GPS velocity down m/s</field>
-            <field name="diff_pressure" type="float">Differential pressure pascals</field>
+               <field type="float" name="vx" units="m/s">GPS velocity north m/s</field>
+               <field type="float" name="vy" units="m/s">GPS velocity east m/s</field>
+               <field type="float" name="vz" units="m/s">GPS velocity down m/s</field>
+               <field type="float" name="diff_pressure" units="Pa">Differential pressure pascals</field>
             <field name="EAS2TAS" type="float">Estimated to true airspeed ratio</field>
             <field name="ratio" type="float">Airspeed ratio</field>
             <field name="state_x" type="float">EKF state x</field>
@@ -1305,13 +1305,13 @@
             <field name="target_component" type="uint8_t">Component ID</field>
             <field name="idx" type="uint8_t">point index (first point is 0)</field>
             <field name="count" type="uint8_t">total number of points (for sanity checking)</field>
-            <field name="lat" type="int32_t">Latitude of point in degrees * 1E7</field>
-            <field name="lng" type="int32_t">Longitude of point in degrees * 1E7</field>
-            <field name="alt" type="int16_t">Transit / loiter altitude in meters relative to home</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude of point in degrees * 1E7</field>
+               <field type="int32_t" name="lng" units="°E7">Longitude of point in degrees * 1E7</field>
+               <field type="int16_t" name="alt" units="m">Transit / loiter altitude in meters relative to home</field>
             <!-- Path planned landings are still in the future, but we want these fields ready: -->
-            <field name="break_alt" type="int16_t">Break altitude in meters relative to home</field>
-            <field name="land_dir" type="uint16_t">Heading to aim for when landing. In centi-degrees.</field>
-            <field name="flags" type="uint8_t">See RALLY_FLAGS enum for definition of the bitmask.</field>
+               <field type="int16_t" name="break_alt" units="m">Break altitude in meters relative to home</field>
+               <field type="uint16_t" name="land_dir" units="c°">Heading to aim for when landing. In centi-degrees.</field>
+               <field type="uint8_t" name="flags" bitmask="RALLY_FLAGS">See RALLY_FLAGS enum for definition of the bitmask.</field>
         </message>
 
         <message id="176" name="RALLY_FETCH_POINT">
@@ -1323,9 +1323,9 @@
 
         <message id="177" name="COMPASSMOT_STATUS">
             <description>Status of compassmot calibration</description>
-            <field name="throttle" type="uint16_t">throttle (percent*10)</field>
-            <field name="current" type="float">current (amps)</field>
-            <field name="interference" type="uint16_t">interference (percent)</field>
+               <field type="uint16_t" name="throttle" units="d%">throttle (percent*10)</field>
+               <field type="float" name="current" units="A">current (Ampere)</field>
+               <field type="uint16_t" name="interference" units="%">interference (percent)</field>
             <field name="CompensationX" type="float">Motor Compensation X</field>
             <field name="CompensationY" type="float">Motor Compensation Y</field>
             <field name="CompensationZ" type="float">Motor Compensation Z</field>
@@ -1334,25 +1334,25 @@
         <!-- Coming soon <message name="RALLY_LAND_POINT" id="177"> <description>A rally landing point. An aircraft loitering at a rally point may choose one of these points to land at.</description> <field name="target_system" type="uint8_t">System ID</field> <field name="target_component" type="uint8_t">Component ID</field> <field name="idx" type="uint8_t">point index (first point is 0)</field> <field name="count" type="uint8_t">total number of points (for sanity checking)</field> <field name="lat" type="int32_t">Latitude of point</field> <field name="lng" type="int32_t">Longitude of point</field> <field name="alt" type="uint16_t">Ground AGL (usually 0)</field> </message> <message name="RALLY_LAND_FETCH_POINT" id="178"> <description>Request a current rally land point from MAV</description> <field name="target_system" type="uint8_t">System ID</field> <field name="target_component" type="uint8_t">Component ID</field> <field name="idx" type="uint8_t">point index (first point is 0)</field> </message> -->
         <message id="178" name="AHRS2">
             <description>Status of secondary AHRS filter if available</description>
-            <field name="roll" type="float">Roll angle (rad)</field>
-            <field name="pitch" type="float">Pitch angle (rad)</field>
-            <field name="yaw" type="float">Yaw angle (rad)</field>
-            <field name="altitude" type="float">Altitude (MSL)</field>
-            <field name="lat" type="int32_t">Latitude in degrees * 1E7</field>
-            <field name="lng" type="int32_t">Longitude in degrees * 1E7</field>
+               <field type="float" name="roll" units="rad">Roll angle (rad)</field>
+               <field type="float" name="pitch" units="rad">Pitch angle (rad)</field>
+               <field type="float" name="yaw" units="rad">Yaw angle (rad)</field>
+               <field type="float" name="altitude" units="m">Altitude (MSL)</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude in degrees * 1E7</field>
+               <field type="int32_t" name="lng" units="°E7">Longitude in degrees * 1E7</field>
         </message>
 
         <!-- camera event message from CCB to autopilot: for image trigger events but also things like heartbeat, error, low power, full card, etc -->
         <message id="179" name="CAMERA_STATUS">
             <description>Camera Event</description>
-            <field name="time_usec" type="uint64_t">Image timestamp (microseconds since UNIX epoch, according to camera clock)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Image timestamp (microseconds since UNIX epoch, according to camera clock)</field>
             <field name="target_system" type="uint8_t">System ID</field>
             <!-- support multiple concurrent vehicles -->
             <field name="cam_idx" type="uint8_t">Camera ID</field>
             <!-- component ID, to support multiple cameras -->
             <field name="img_idx" type="uint16_t">Image index</field>
             <!-- per camera image index, should be unique+sequential within a mission, preferably non-wrapping -->
-            <field name="event_id" type="uint8_t">See CAMERA_STATUS_TYPES enum for definition of the bitmask</field>
+               <field type="uint8_t" name="event_id" enum="CAMERA_STATUS_TYPES">See CAMERA_STATUS_TYPES enum for definition of the bitmask</field>
             <field name="p1" type="float">Parameter 1 (meaning depends on event, see CAMERA_STATUS_TYPES enum)</field>
             <field name="p2" type="float">Parameter 2 (meaning depends on event, see CAMERA_STATUS_TYPES enum)</field>
             <field name="p3" type="float">Parameter 3 (meaning depends on event, see CAMERA_STATUS_TYPES enum)</field>
@@ -1362,43 +1362,43 @@
         <!-- camera feedback message - can be originated from CCB (in response to a CAMERA_STATUS), or directly from the autopilot as part of a DO_DIGICAM_CONTROL-->
         <message id="180" name="CAMERA_FEEDBACK">
             <description>Camera Capture Feedback</description>
-            <field name="time_usec" type="uint64_t">Image timestamp (microseconds since UNIX epoch), as passed in by CAMERA_STATUS message (or autopilot if no CCB)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Image timestamp (microseconds since UNIX epoch), as passed in by CAMERA_STATUS message (or autopilot if no CCB)</field>
             <field name="target_system" type="uint8_t">System ID</field>
             <!-- support multiple concurrent vehicles -->
             <field name="cam_idx" type="uint8_t">Camera ID</field>
             <!-- component ID, to support multiple cameras -->
             <field name="img_idx" type="uint16_t">Image index</field>
             <!-- per camera image index, should be unique+sequential within a mission, preferably non-wrapping -->
-            <field name="lat" type="int32_t">Latitude in (deg * 1E7)</field>
-            <field name="lng" type="int32_t">Longitude in (deg * 1E7)</field>
-            <field name="alt_msl" type="float">Altitude Absolute (meters AMSL)</field>
-            <field name="alt_rel" type="float">Altitude Relative (meters above HOME location)</field>
-            <field name="roll" type="float">Camera Roll angle (earth frame, degrees, +-180)</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude in (deg * 1E7)</field>
+               <field type="int32_t" name="lng" units="°E7">Longitude in (deg * 1E7)</field>
+               <field type="float" name="alt_msl" units="m">Altitude Absolute (meters AMSL)</field>
+               <field type="float" name="alt_rel" units="m">Altitude Relative (meters above HOME location)</field>
+               <field type="float" name="roll" units="°">Camera Roll angle (earth frame, degrees, +-180)</field>
             <!-- initially only supporting fixed cameras, in future we'll need feedback messages from the gimbal so we can include that offset here -->
-            <field name="pitch" type="float">Camera Pitch angle (earth frame, degrees, +-180)</field>
+               <field type="float" name="pitch" units="°">Camera Pitch angle (earth frame, degrees, +-180)</field>
             <!-- initially only supporting fixed cameras, in future we'll need feedback messages from the gimbal so we can include that offset here -->
-            <field name="yaw" type="float">Camera Yaw (earth frame, degrees, 0-360, true)</field>
+               <field type="float" name="yaw" units="°">Camera Yaw (earth frame, degrees, 0-360, true)</field>
             <!-- initially only supporting fixed cameras, in future we'll need feedback messages from the gimbal so we can include that offset here -->
-            <field name="foc_len" type="float">Focal Length (mm)</field>
+               <field type="float" name="foc_len" units="mm">Focal Length (mm)</field>
             <!-- per-image to support zooms. Zero means fixed focal length or unknown. Should be true mm, not scaled to 35mm film equivalent -->
-            <field name="flags" type="uint8_t">See CAMERA_FEEDBACK_FLAGS enum for definition of the bitmask</field>
+               <field type="uint8_t" name="flags" enum="CAMERA_FEEDBACK_FLAGS" units="mm">See CAMERA_FEEDBACK_FLAGS enum for definition of the bitmask</field>
             <!-- future proofing -->
         </message>
 
         <message id="181" name="BATTERY2">
             <description>2nd Battery status</description>
-            <field name="voltage" type="uint16_t">voltage in millivolts</field>
-            <field name="current_battery" type="int16_t">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+               <field type="uint16_t" name="voltage" units="mV">voltage in millivolts</field>
+               <field type="int16_t" name="current_battery" units="cA">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
         </message>
 
         <message id="182" name="AHRS3">
             <description>Status of third AHRS filter if available. This is for ANU research group (Ali and Sean)</description>
-            <field name="roll" type="float">Roll angle (rad)</field>
-            <field name="pitch" type="float">Pitch angle (rad)</field>
-            <field name="yaw" type="float">Yaw angle (rad)</field>
+               <field type="float" name="roll" units="rad">Roll angle (rad)</field>
+               <field type="float" name="pitch" units="rad">Pitch angle (rad)</field>
+               <field type="float" name="yaw" units="rad">Yaw angle (rad)</field>
             <field name="altitude" type="float">Altitude (MSL)</field>
-            <field name="lat" type="int32_t">Latitude in degrees * 1E7</field>
-            <field name="lng" type="int32_t">Longitude in degrees * 1E7</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude in degrees * 1E7</field>
+               <field type="int32_t" name="lng" units="°E7">Longitude in degrees * 1E7</field>
             <field name="v1" type="float">test variable1</field>
             <field name="v2" type="float">test variable2</field>
             <field name="v3" type="float">test variable3</field>
@@ -1442,9 +1442,9 @@
             <description>Reports progress of compass calibration.</description>
             <field name="compass_id" type="uint8_t">Compass being calibrated</field>
             <field name="cal_mask" type="uint8_t">Bitmask of compasses being calibrated</field>
-            <field name="cal_status" type="uint8_t">Status (see MAG_CAL_STATUS enum)</field>
+               <field type="uint8_t" name="cal_status" enum="MAG_CAL_STATUS">Status (see MAG_CAL_STATUS enum)</field>
             <field name="attempt" type="uint8_t">Attempt number</field>
-            <field name="completion_pct" type="uint8_t">Completion percentage</field>
+               <field type="uint8_t" name="completion_pct" units="%">Completion percentage</field>
             <field name="completion_mask" type="uint8_t[10]">Bitmask of sphere sections (see http://en.wikipedia.org/wiki/Geodesic_grid)</field>
             <field name="direction_x" type="float">Body frame direction vector for display</field>
             <field name="direction_y" type="float">Body frame direction vector for display</field>
@@ -1455,9 +1455,9 @@
             <description>Reports results of completed compass calibration. Sent until MAG_CAL_ACK received.</description>
             <field name="compass_id" type="uint8_t">Compass being calibrated</field>
             <field name="cal_mask" type="uint8_t">Bitmask of compasses being calibrated</field>
-            <field name="cal_status" type="uint8_t">Status (see MAG_CAL_STATUS enum)</field>
+               <field type="uint8_t" name="cal_status" enum="MAG_CAL_STATUS">Status (see MAG_CAL_STATUS enum)</field>
             <field name="autosaved" type="uint8_t">0=requires a MAV_CMD_DO_ACCEPT_MAG_CAL, 1=saved to parameters</field>
-            <field name="fitness" type="float">RMS milligauss residuals</field>
+               <field type="float" name="fitness" units="mgauss">RMS milligauss residuals</field>
             <field name="ofs_x" type="float">X offset</field>
             <field name="ofs_y" type="float">Y offset</field>
             <field name="ofs_z" type="float">Z offset</field>
@@ -1486,8 +1486,8 @@
         <message id="194" name="PID_TUNING">
             <description>PID tuning information</description>
             <field enum="PID_TUNING_AXIS" name="axis" type="uint8_t">axis</field>
-            <field name="desired" type="float">desired rate (degrees/s)</field>
-            <field name="achieved" type="float">achieved rate (degrees/s)</field>
+               <field type="float" name="desired" units="°/s">desired rate (degrees/s)</field>
+               <field type="float" name="achieved" units="°/s">achieved rate (degrees/s)</field>
             <field name="FF" type="float">FF component</field>
             <field name="P" type="float">P component</field>
             <field name="I" type="float">I component</field>
@@ -1498,25 +1498,25 @@
             <description>3 axis gimbal mesuraments</description>
             <field name="target_system" type="uint8_t">System ID</field>
             <field name="target_component" type="uint8_t">Component ID</field>
-            <field name="delta_time" type="float">Time since last update (seconds)</field>
-            <field name="delta_angle_x" type="float">Delta angle X (radians)</field>
-            <field name="delta_angle_y" type="float">Delta angle Y (radians)</field>
-            <field name="delta_angle_z" type="float">Delta angle X (radians)</field>
-            <field name="delta_velocity_x" type="float">Delta velocity X (m/s)</field>
-            <field name="delta_velocity_y" type="float">Delta velocity Y (m/s)</field>
-            <field name="delta_velocity_z" type="float">Delta velocity Z (m/s)</field>
-            <field name="joint_roll" type="float">Joint ROLL (radians)</field>
-            <field name="joint_el" type="float">Joint EL (radians)</field>
-            <field name="joint_az" type="float">Joint AZ (radians)</field>
+               <field type="float" name="delta_time" units="s">Time since last update (seconds)</field>
+               <field type="float" name="delta_angle_x" units="rad">Delta angle X (radians)</field>
+               <field type="float" name="delta_angle_y" units="rad">Delta angle Y (radians)</field>
+               <field type="float" name="delta_angle_z" units="rad">Delta angle X (radians)</field>
+               <field type="float" name="delta_velocity_x" units="m/s">Delta velocity X (m/s)</field>
+               <field type="float" name="delta_velocity_y" units="m/s">Delta velocity Y (m/s)</field>
+               <field type="float" name="delta_velocity_z" units="m/s">Delta velocity Z (m/s)</field>
+               <field type="float" name="joint_roll" units="rad">Joint ROLL (radians)</field>
+               <field type="float" name="joint_el" units="rad">Joint EL (radians)</field>
+               <field type="float" name="joint_az" units="rad">Joint AZ (radians)</field>
         </message>
 
         <message id="201" name="GIMBAL_CONTROL">
             <description>Control message for rate gimbal</description>
             <field name="target_system" type="uint8_t">System ID</field>
             <field name="target_component" type="uint8_t">Component ID</field>
-            <field name="demanded_rate_x" type="float">Demanded angular rate X (rad/s)</field>
-            <field name="demanded_rate_y" type="float">Demanded angular rate Y (rad/s)</field>
-            <field name="demanded_rate_z" type="float">Demanded angular rate Z (rad/s)</field>
+               <field type="float" name="demanded_rate_x" units="rad/s">Demanded angular rate X (rad/s)</field>
+               <field type="float" name="demanded_rate_y" units="rad/s">Demanded angular rate Y (rad/s)</field>
+               <field type="float" name="demanded_rate_z" units="rad/s">Demanded angular rate Z (rad/s)</field>
         </message>
 
         <message id="214" name="GIMBAL_TORQUE_CMD_REPORT">
@@ -1533,7 +1533,7 @@
             <description>Heartbeat from a HeroBus attached GoPro</description>
             <field enum="GOPRO_HEARTBEAT_STATUS" name="status" type="uint8_t">Status</field>
             <field enum="GOPRO_CAPTURE_MODE" name="capture_mode" type="uint8_t">Current capture mode</field>
-            <field name="flags" type="uint8_t">additional status bits</field>
+               <field type="uint8_t" name="flags" enum="GOPRO_HEARTBEAT_FLAGS">additional status bits</field>
             <!-- see GOPRO_HEARTBEAT_FLAGS -->
         </message>
 
@@ -1619,8 +1619,8 @@
         <message id="11010" name="ADAP_TUNING">
           <description>Adaptive Controller tuning information</description>
           <field enum="PID_TUNING_AXIS" name="axis" type="uint8_t">axis</field>
-          <field name="desired" type="float">desired rate (degrees/s)</field>
-          <field name="achieved" type="float">achieved rate (degrees/s)</field>
+               <field type="float" name="desired" units="°/s">desired rate (degrees/s)</field>
+               <field type="float" name="achieved" units="°/s">achieved rate (degrees/s)</field>
           <field name="error" type="float">error between model and vehicle</field>
           <field name="theta" type="float">theta estimated state predictor</field>
           <field name="omega" type="float">omega estimated state predictor</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <mavlink>
      <version>3</version>
      <dialect>0</dialect>
@@ -2384,23 +2384,23 @@
      <messages>
           <message id="0" name="HEARTBEAT">
                <description>The heartbeat message shows that a system is present and responding. The type of the MAV and Autopilot hardware allow the receiving system to treat further messages from this system appropriate (e.g. by laying out the user interface based on the autopilot).</description>
-               <field type="uint8_t" name="type">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
-               <field type="uint8_t" name="autopilot">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
-               <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
+               <field type="uint8_t" name="type" enum="MAV_TYPE">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
+               <field type="uint8_t" name="autopilot" enum="MAV_AUTOPILOT">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
+               <field type="uint8_t" name="base_mode" bitmask="MAV_MODE_FLAG_DECODE_POSITION">System mode bitfield, see MAV_MODE_FLAG_DECODE_POSITION ENUM in mavlink/include/mavlink_types.h</field>
                <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
-               <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
+               <field type="uint8_t" name="system_status" enum="MAV_STATE">System status flag, see MAV_STATE ENUM</field>
                <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
           </message>
           <message id="1" name="SYS_STATUS">
                <description>The general system state. If the system is following the MAVLink standard, the system state is mainly defined by three orthogonal states/modes: The system mode, which is either LOCKED (motors shut down and locked), MANUAL (system under RC control), GUIDED (system with autonomous position control, position setpoint controlled manually) or AUTO (system guided by path/waypoint planner). The NAV_MODE defined the current flight state: LIFTOFF (often an open-loop maneuver), LANDING, WAYPOINTS or VECTOR. This represents the internal navigation state machine. The system status shows wether the system is currently active or not and if an emergency occured. During the CRITICAL and EMERGENCY states the MAV is still considered to be active, but should start emergency procedures autonomously. After a failure occured it should first move from active to critical to allow manual intervention and then move to emergency after a certain timeout.</description>
-               <field type="uint32_t" name="onboard_control_sensors_present" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are present. Value of 0: not present. Value of 1: present. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-               <field type="uint32_t" name="onboard_control_sensors_enabled" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are enabled:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-               <field type="uint32_t" name="onboard_control_sensors_health" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are operational or have an error:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-               <field type="uint16_t" name="load">Maximum usage in percent of the mainloop time, (0%: 0, 100%: 1000) should be always below 1000</field>
-               <field type="uint16_t" name="voltage_battery">Battery voltage, in millivolts (1 = 1 millivolt)</field>
-               <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
-               <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery</field>
-               <field type="uint16_t" name="drop_rate_comm">Communication drops in percent, (0%: 0, 100%: 10'000), (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
+               <field type="uint32_t" name="onboard_control_sensors_present" bitmask="MAV_SYS_STATUS_SENSOR" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are present. Value of 0: not present. Value of 1: present. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+               <field type="uint32_t" name="onboard_control_sensors_enabled" bitmask="MAV_SYS_STATUS_SENSOR" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are enabled:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+               <field type="uint32_t" name="onboard_control_sensors_health" bitmask="MAV_SYS_STATUS_SENSOR" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are operational or have an error:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+               <field type="uint16_t" name="load" units="d%">Maximum usage in percent of the mainloop time, (0%: 0, 100%: 1000) should be always below 1000</field>
+               <field type="uint16_t" name="voltage_battery" units="mV">Battery voltage, in millivolts (1 = 1 millivolt)</field>
+               <field type="int16_t" name="current_battery" units="cA">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+               <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery</field>
+               <field type="uint16_t" name="drop_rate_comm" units="c%">Communication drops in percent, (0%: 0, 100%: 10'000), (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
                <field type="uint16_t" name="errors_comm">Communication errors (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
                <field type="uint16_t" name="errors_count1">Autopilot-specific errors</field>
                <field type="uint16_t" name="errors_count2">Autopilot-specific errors</field>
@@ -2409,13 +2409,13 @@
           </message>
           <message id="2" name="SYSTEM_TIME">
                <description>The system time is the time of the master clock, typically the computer clock of the main onboard computer.</description>
-               <field type="uint64_t" name="time_unix_usec">Timestamp of the master clock in microseconds since UNIX epoch.</field>
-               <field type="uint32_t" name="time_boot_ms">Timestamp of the component clock since boot time in milliseconds.</field>
+               <field type="uint64_t" name="time_unix_usec" units="µs">Timestamp of the master clock in microseconds since UNIX epoch.</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp of the component clock since boot time in milliseconds.</field>
           </message>
           <!-- FIXME to be removed / merged with SYSTEM_TIME -->
           <message id="4" name="PING">
                <description>A ping message either requesting or responding to a ping. This allows to measure the system latencies, including serial port, radio modem and UDP connections.</description>
-               <field type="uint64_t" name="time_usec">Unix timestamp in microseconds or since system boot if smaller than MAVLink epoch (1.1.2009)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Unix timestamp in microseconds or since system boot if smaller than MAVLink epoch (1.1.2009)</field>
                <field type="uint32_t" name="seq">PING sequence</field>
                <field type="uint8_t" name="target_system">0: request ping from all receiving systems, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
                <field type="uint8_t" name="target_component">0: request ping from all receiving components, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
@@ -2424,7 +2424,7 @@
                <description>Request to control this MAV</description>
                <field type="uint8_t" name="target_system">System the GCS requests control for</field>
                <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
-               <field type="uint8_t" name="version">0: key as plaintext, 1-255: future, different hashing/encryption variants. The GCS should in general use the safest mode possible initially and then gradually move down the encryption level if it gets a NACK message indicating an encryption mismatch.</field>
+               <field type="uint8_t" name="version" units="rad">0: key as plaintext, 1-255: future, different hashing/encryption variants. The GCS should in general use the safest mode possible initially and then gradually move down the encryption level if it gets a NACK message indicating an encryption mismatch.</field>
                <field type="char[25]" name="passkey">Password / Key, depending on version plaintext or encrypted. 25 or less characters, NULL terminated. The characters may involve A-Z, a-z, 0-9, and "!?,.-"</field>
           </message>
           <message id="6" name="CHANGE_OPERATOR_CONTROL_ACK">
@@ -2475,15 +2475,15 @@
           <message id="24" name="GPS_RAW_INT">
                <description>The global position, as returned by the Global Positioning System (GPS). This is
                 NOT the global position estimate of the system, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
                <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
-               <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="alt">Altitude (AMSL, NOT WGS84), in meters * 1000 (positive for up). Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="alt" units="mm">Altitude (AMSL, NOT WGS84), in meters * 1000 (positive for up). Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.</field>
                <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
                <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
-               <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
-               <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+               <field type="uint16_t" name="vel" units="cm/s">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
+               <field type="uint16_t" name="cog" units="c°">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
                <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
           </message>
           <message id="25" name="GPS_STATUS">
@@ -2497,20 +2497,20 @@
           </message>
           <message id="26" name="SCALED_IMU">
                <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="int16_t" name="xacc">X acceleration (mg)</field>
-               <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-               <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-               <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-               <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-               <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-               <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-               <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-               <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="int16_t" name="xacc" units="mG">X acceleration (mg)</field>
+               <field type="int16_t" name="yacc" units="mG">Y acceleration (mg)</field>
+               <field type="int16_t" name="zacc" units="mG">Z acceleration (mg)</field>
+               <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis (millirad /sec)</field>
+               <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis (millirad /sec)</field>
+               <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis (millirad /sec)</field>
+               <field type="int16_t" name="xmag" units="mT">X Magnetic field (milli tesla)</field>
+               <field type="int16_t" name="ymag" units="mT">Y Magnetic field (milli tesla)</field>
+               <field type="int16_t" name="zmag" units="mT">Z Magnetic field (milli tesla)</field>
           </message>
           <message id="27" name="RAW_IMU">
                <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
                <field type="int16_t" name="xacc">X acceleration (raw)</field>
                <field type="int16_t" name="yacc">Y acceleration (raw)</field>
                <field type="int16_t" name="zacc">Z acceleration (raw)</field>
@@ -2523,7 +2523,7 @@
           </message>
           <message id="28" name="RAW_PRESSURE">
                <description>The RAW pressure readings for the typical setup of one absolute pressure and one differential pressure sensor. The sensor values should be the raw, UNSCALED ADC values.</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
                <field type="int16_t" name="press_abs">Absolute pressure (raw)</field>
                <field type="int16_t" name="press_diff1">Differential pressure 1 (raw, 0 if nonexistant)</field>
                <field type="int16_t" name="press_diff2">Differential pressure 2 (raw, 0 if nonexistant)</field>
@@ -2531,58 +2531,58 @@
           </message>
           <message id="29" name="SCALED_PRESSURE">
                <description>The pressure readings for the typical setup of one absolute and differential pressure sensor. The units are as specified in each field.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-               <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-               <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="press_abs" units="hPa">Absolute pressure (hectopascal)</field>
+               <field type="float" name="press_diff" units="hPa">Differential pressure 1 (hectopascal)</field>
+               <field type="int16_t" name="temperature" units="c°C">Temperature measurement (0.01 degrees celsius)</field>
           </message>
           <message id="30" name="ATTITUDE">
                <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="roll">Roll angle (rad, -pi..+pi)</field>
-               <field type="float" name="pitch">Pitch angle (rad, -pi..+pi)</field>
-               <field type="float" name="yaw">Yaw angle (rad, -pi..+pi)</field>
-               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="roll" units="rad">Roll angle (rad, -pi..+pi)</field>
+               <field type="float" name="pitch" units="rad">Pitch angle (rad, -pi..+pi)</field>
+               <field type="float" name="yaw" units="rad">Yaw angle (rad, -pi..+pi)</field>
+               <field type="float" name="rollspeed" units="rad/s">Roll angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed (rad/s)</field>
+               <field type="float" name="yawspeed" units="rad/s">Yaw angular speed (rad/s)</field>
           </message>
           <message id="31" name="ATTITUDE_QUATERNION">
                <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
                <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation)</field>
                <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation)</field>
                <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation)</field>
                <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation)</field>
-               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+               <field type="float" name="rollspeed" units="rad/s">Roll angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed (rad/s)</field>
+               <field type="float" name="yawspeed" units="rad/s">Yaw angular speed (rad/s)</field>
           </message>
           <message id="32" name="LOCAL_POSITION_NED">
                <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="x">X Position</field>
-               <field type="float" name="y">Y Position</field>
-               <field type="float" name="z">Z Position</field>
-               <field type="float" name="vx">X Speed</field>
-               <field type="float" name="vy">Y Speed</field>
-               <field type="float" name="vz">Z Speed</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="x" units="m">X Position</field>
+               <field type="float" name="y" units="m">Y Position</field>
+               <field type="float" name="z" units="m">Z Position</field>
+               <field type="float" name="vx" units="m/s">X Speed</field>
+               <field type="float" name="vy" units="m/s">Y Speed</field>
+               <field type="float" name="vz" units="m/s">Z Speed</field>
           </message>
           <message id="33" name="GLOBAL_POSITION_INT">
                <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It
                is designed as scaled integer message since the resolution of float is not sufficient.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-               <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
-               <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), AMSL (not WGS84 - note that virtually all GPS modules provide the AMSL as well)</field>
-               <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
-               <field type="int16_t" name="vx">Ground X Speed (Latitude, positive north), expressed as m/s * 100</field>
-               <field type="int16_t" name="vy">Ground Y Speed (Longitude, positive east), expressed as m/s * 100</field>
-               <field type="int16_t" name="vz">Ground Z Speed (Altitude, positive down), expressed as m/s * 100</field>
-               <field type="uint16_t" name="hdg">Vehicle heading (yaw angle) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="alt" units="mm">Altitude in meters, expressed as * 1000 (millimeters), AMSL (not WGS84 - note that virtually all GPS modules provide the AMSL as well)</field>
+               <field type="int32_t" name="relative_alt" units="mm">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+               <field type="int16_t" name="vx" units="cm/s">Ground X Speed (Latitude, positive north), expressed as m/s * 100</field>
+               <field type="int16_t" name="vy" units="cm/s">Ground Y Speed (Longitude, positive east), expressed as m/s * 100</field>
+               <field type="int16_t" name="vz" units="cm/s">Ground Z Speed (Altitude, positive down), expressed as m/s * 100</field>
+               <field type="uint16_t" name="hdg" units="c°">Vehicle heading (yaw angle) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
           </message>
           <message id="34" name="RC_CHANNELS_SCALED">
                <description>The scaled values of the RC channels received. (-100%) -10000, (0%) 0, (100%) 10000. Channels that are inactive should be set to UINT16_MAX.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
                <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
                <field type="int16_t" name="chan1_scaled">RC channel 1 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
                <field type="int16_t" name="chan2_scaled">RC channel 2 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
@@ -2592,43 +2592,43 @@
                <field type="int16_t" name="chan6_scaled">RC channel 6 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
                <field type="int16_t" name="chan7_scaled">RC channel 7 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
                <field type="int16_t" name="chan8_scaled">RC channel 8 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+               <field type="uint8_t" name="rssi" units="%">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
           </message>
           <message id="35" name="RC_CHANNELS_RAW">
                <description>The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
                <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
-               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+               <field type="uint16_t" name="chan1_raw" units="µs">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan2_raw" units="µs">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan3_raw" units="µs">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan4_raw" units="µs">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan5_raw" units="µs">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan6_raw" units="µs">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan7_raw" units="µs">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan8_raw" units="µs">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint8_t" name="rssi" units="%">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
           </message>
           <message id="36" name="SERVO_OUTPUT_RAW">
                <description>The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.</description>
-               <field type="uint32_t" name="time_usec">Timestamp (microseconds since system boot)</field>
+               <field type="uint32_t" name="time_usec" units="µs">Timestamp (microseconds since system boot)</field>
                <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.</field>
-               <field type="uint16_t" name="servo1_raw">Servo output 1 value, in microseconds</field>
-               <field type="uint16_t" name="servo2_raw">Servo output 2 value, in microseconds</field>
-               <field type="uint16_t" name="servo3_raw">Servo output 3 value, in microseconds</field>
-               <field type="uint16_t" name="servo4_raw">Servo output 4 value, in microseconds</field>
-               <field type="uint16_t" name="servo5_raw">Servo output 5 value, in microseconds</field>
-               <field type="uint16_t" name="servo6_raw">Servo output 6 value, in microseconds</field>
-               <field type="uint16_t" name="servo7_raw">Servo output 7 value, in microseconds</field>
-               <field type="uint16_t" name="servo8_raw">Servo output 8 value, in microseconds</field>
+               <field type="uint16_t" name="servo1_raw" units="µs">Servo output 1 value, in microseconds</field>
+               <field type="uint16_t" name="servo2_raw" units="µs">Servo output 2 value, in microseconds</field>
+               <field type="uint16_t" name="servo3_raw" units="µs">Servo output 3 value, in microseconds</field>
+               <field type="uint16_t" name="servo4_raw" units="µs">Servo output 4 value, in microseconds</field>
+               <field type="uint16_t" name="servo5_raw" units="µs">Servo output 5 value, in microseconds</field>
+               <field type="uint16_t" name="servo6_raw" units="µs">Servo output 6 value, in microseconds</field>
+               <field type="uint16_t" name="servo7_raw" units="µs">Servo output 7 value, in microseconds</field>
+               <field type="uint16_t" name="servo8_raw" units="µs">Servo output 8 value, in microseconds</field>
                <extensions/>
-               <field type="uint16_t" name="servo9_raw">Servo output 9 value, in microseconds</field>
-               <field type="uint16_t" name="servo10_raw">Servo output 10 value, in microseconds</field>
-               <field type="uint16_t" name="servo11_raw">Servo output 11 value, in microseconds</field>
-               <field type="uint16_t" name="servo12_raw">Servo output 12 value, in microseconds</field>
-               <field type="uint16_t" name="servo13_raw">Servo output 13 value, in microseconds</field>
-               <field type="uint16_t" name="servo14_raw">Servo output 14 value, in microseconds</field>
-               <field type="uint16_t" name="servo15_raw">Servo output 15 value, in microseconds</field>
-               <field type="uint16_t" name="servo16_raw">Servo output 16 value, in microseconds</field>
+               <field type="uint16_t" name="servo9_raw" units="µs">Servo output 9 value, in microseconds</field>
+               <field type="uint16_t" name="servo10_raw" units="µs">Servo output 10 value, in microseconds</field>
+               <field type="uint16_t" name="servo11_raw" units="µs">Servo output 11 value, in microseconds</field>
+               <field type="uint16_t" name="servo12_raw" units="µs">Servo output 12 value, in microseconds</field>
+               <field type="uint16_t" name="servo13_raw" units="µs">Servo output 13 value, in microseconds</field>
+               <field type="uint16_t" name="servo14_raw" units="µs">Servo output 14 value, in microseconds</field>
+               <field type="uint16_t" name="servo15_raw" units="µs">Servo output 15 value, in microseconds</field>
+               <field type="uint16_t" name="servo16_raw" units="µs">Servo output 16 value, in microseconds</field>
           </message>
           <message id="37" name="MISSION_REQUEST_PARTIAL_LIST">
                <description>Request a partial list of mission items from the system/component. http://qgroundcontrol.org/mavlink/waypoint_protocol. If start and end index are the same, just send one waypoint.</description>
@@ -2650,8 +2650,8 @@
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint16_t" name="seq">Sequence</field>
-               <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
-               <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
+               <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
+               <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
                <field type="uint8_t" name="current">false:0, true:1</field>
                <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
                <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
@@ -2707,15 +2707,15 @@
           <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
                <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
                <field type="uint8_t" name="target_system">System ID</field>
-               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+               <field type="int32_t" name="latitude" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="longitude" units="°E7">Longitude (WGS84, in degrees * 1E7</field>
+               <field type="int32_t" name="altitude" units="mm">Altitude (AMSL), in meters * 1000 (positive for up)</field>
           </message>
           <message id="49" name="GPS_GLOBAL_ORIGIN">
                <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
-               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="longitude">Longitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+               <field type="int32_t" name="latitude" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="longitude" units="°E7">Longitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="altitude" units="mm">Altitude (AMSL), in meters * 1000 (positive for up)</field>
           </message>
           <message id="50" name="PARAM_MAP_RC">
                <description>Bind a RC channel to a parameter. The parameter should change accoding to the RC channel value.</description>
@@ -2740,94 +2740,94 @@
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
-               <field type="float" name="p1x">x position 1 / Latitude 1</field>
-               <field type="float" name="p1y">y position 1 / Longitude 1</field>
-               <field type="float" name="p1z">z position 1 / Altitude 1</field>
-               <field type="float" name="p2x">x position 2 / Latitude 2</field>
-               <field type="float" name="p2y">y position 2 / Longitude 2</field>
-               <field type="float" name="p2z">z position 2 / Altitude 2</field>
+               <field type="float" name="p1x" units="m">x position 1 / Latitude 1</field>
+               <field type="float" name="p1y" units="m">y position 1 / Longitude 1</field>
+               <field type="float" name="p1z" units="m">z position 1 / Altitude 1</field>
+               <field type="float" name="p2x" units="m">x position 2 / Latitude 2</field>
+               <field type="float" name="p2y" units="m">y position 2 / Longitude 2</field>
+               <field type="float" name="p2z" units="m">z position 2 / Altitude 2</field>
           </message>
           <message id="55" name="SAFETY_ALLOWED_AREA">
                <description>Read out the safety zone the MAV currently assumes.</description>
                <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
-               <field type="float" name="p1x">x position 1 / Latitude 1</field>
-               <field type="float" name="p1y">y position 1 / Longitude 1</field>
-               <field type="float" name="p1z">z position 1 / Altitude 1</field>
-               <field type="float" name="p2x">x position 2 / Latitude 2</field>
-               <field type="float" name="p2y">y position 2 / Longitude 2</field>
-               <field type="float" name="p2z">z position 2 / Altitude 2</field>
+               <field type="float" name="p1x" units="m">x position 1 / Latitude 1</field>
+               <field type="float" name="p1y" units="m">y position 1 / Longitude 1</field>
+               <field type="float" name="p1z" units="m">z position 1 / Altitude 1</field>
+               <field type="float" name="p2x" units="m">x position 2 / Latitude 2</field>
+               <field type="float" name="p2y" units="m">y position 2 / Longitude 2</field>
+               <field type="float" name="p2z" units="m">z position 2 / Altitude 2</field>
           </message>
           <message id="61" name="ATTITUDE_QUATERNION_COV">
                <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since system boot or since UNIX epoch)</field>
                <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
-               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+               <field type="float" name="rollspeed" units="rad/s">Roll angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed (rad/s)</field>
+               <field type="float" name="yawspeed" units="rad/s">Yaw angular speed (rad/s)</field>
                <field type="float[9]" name="covariance">Attitude covariance</field>
           </message>
           <message id="62" name="NAV_CONTROLLER_OUTPUT">
                <description>The state of the fixed wing navigation and position controller.</description>
-               <field type="float" name="nav_roll">Current desired roll in degrees</field>
-               <field type="float" name="nav_pitch">Current desired pitch in degrees</field>
-               <field type="int16_t" name="nav_bearing">Current desired heading in degrees</field>
-               <field type="int16_t" name="target_bearing">Bearing to current MISSION/target in degrees</field>
-               <field type="uint16_t" name="wp_dist">Distance to active MISSION in meters</field>
-               <field type="float" name="alt_error">Current altitude error in meters</field>
-               <field type="float" name="aspd_error">Current airspeed error in meters/second</field>
-               <field type="float" name="xtrack_error">Current crosstrack error on x-y plane in meters</field>
+               <field type="float" name="nav_roll" units="°">Current desired roll in degrees</field>
+               <field type="float" name="nav_pitch" units="°">Current desired pitch in degrees</field>
+               <field type="int16_t" name="nav_bearing" units="°">Current desired heading in degrees</field>
+               <field type="int16_t" name="target_bearing" units="°">Bearing to current MISSION/target in degrees</field>
+               <field type="uint16_t" name="wp_dist" units="m">Distance to active MISSION in meters</field>
+               <field type="float" name="alt_error" units="m">Current altitude error in meters</field>
+               <field type="float" name="aspd_error" units="m/s">Current airspeed error in meters/second</field>
+               <field type="float" name="xtrack_error" units="m">Current crosstrack error on x-y plane in meters</field>
           </message>
           <message id="63" name="GLOBAL_POSITION_INT_COV">
               <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.</description>
-              <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since system boot or since UNIX epoch)</field>
               <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
-              <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-              <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
-              <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), above MSL</field>
-              <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
-              <field type="float" name="vx">Ground X Speed (Latitude), expressed as m/s</field>
-              <field type="float" name="vy">Ground Y Speed (Longitude), expressed as m/s</field>
-              <field type="float" name="vz">Ground Z Speed (Altitude), expressed as m/s</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="alt" units="mm">Altitude in meters, expressed as * 1000 (millimeters), above MSL</field>
+               <field type="int32_t" name="relative_alt" units="mm">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+               <field type="float" name="vx" units="m/s">Ground X Speed (Latitude), expressed as m/s</field>
+               <field type="float" name="vy" units="m/s">Ground Y Speed (Longitude), expressed as m/s</field>
+               <field type="float" name="vz" units="m/s">Ground Z Speed (Altitude), expressed as m/s</field>
               <field type="float[36]" name="covariance">Covariance matrix (first six entries are the first ROW, next six entries are the second row, etc.)</field>
           </message>
           <message id="64" name="LOCAL_POSITION_NED_COV">
               <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-              <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since system boot or since UNIX epoch)</field>
               <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
-              <field type="float" name="x">X Position</field>
-              <field type="float" name="y">Y Position</field>
-              <field type="float" name="z">Z Position</field>
-              <field type="float" name="vx">X Speed (m/s)</field>
-              <field type="float" name="vy">Y Speed (m/s)</field>
-              <field type="float" name="vz">Z Speed (m/s)</field>
-              <field type="float" name="ax">X Acceleration (m/s^2)</field>
-              <field type="float" name="ay">Y Acceleration (m/s^2)</field>
-              <field type="float" name="az">Z Acceleration (m/s^2)</field>
+               <field type="float" name="x" units="m">X Position</field>
+               <field type="float" name="y" units="m">Y Position</field>
+               <field type="float" name="z" units="m">Z Position</field>
+               <field type="float" name="vx" units="m/s">X Speed (m/s)</field>
+               <field type="float" name="vy" units="m/s">Y Speed (m/s)</field>
+               <field type="float" name="vz" units="m/s">Z Speed (m/s)</field>
+               <field type="float" name="ax" units="m/s²">X Acceleration (m/s^2)</field>
+               <field type="float" name="ay" units="m/s²">Y Acceleration (m/s^2)</field>
+               <field type="float" name="az" units="m/s²">Z Acceleration (m/s^2)</field>
               <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first nine entries are the first ROW, next eight entries are the second row, etc.)</field>
           </message>
           <message id="65" name="RC_CHANNELS">
                <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
                <field type="uint8_t" name="chancount">Total number of RC channels being received. This can be larger than 18, indicating that more channels are available but not given in this message. This value should be 0 when no RC channels are available.</field>
-               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan13_raw">RC channel 13 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan14_raw">RC channel 14 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan15_raw">RC channel 15 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan16_raw">RC channel 16 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan17_raw">RC channel 17 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan18_raw">RC channel 18 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+               <field type="uint16_t" name="chan1_raw" units="µs">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan2_raw" units="µs">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan3_raw" units="µs">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan4_raw" units="µs">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan5_raw" units="µs">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan6_raw" units="µs">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan7_raw" units="µs">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan8_raw" units="µs">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan9_raw" units="µs">RC channel 9 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan10_raw" units="µs">RC channel 10 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan11_raw" units="µs">RC channel 11 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan12_raw" units="µs">RC channel 12 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan13_raw" units="µs">RC channel 13 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan14_raw" units="µs">RC channel 14 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan15_raw" units="µs">RC channel 15 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan16_raw" units="µs">RC channel 16 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan17_raw" units="µs">RC channel 17 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan18_raw" units="µs">RC channel 18 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint8_t" name="rssi" units="%">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
           </message>
           <message id="66" name="REQUEST_DATA_STREAM">
                <description>THIS INTERFACE IS DEPRECATED. USE SET_MESSAGE_INTERVAL INSTEAD.</description>
@@ -2856,14 +2856,14 @@
                <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. A value of UINT16_MAX means no change to that channel. A value of 0 means control of that channel should be released back to the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan1_raw" units="µs">RC channel 1 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan2_raw" units="µs">RC channel 2 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan3_raw" units="µs">RC channel 3 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan4_raw" units="µs">RC channel 4 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan5_raw" units="µs">RC channel 5 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan6_raw" units="µs">RC channel 6 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan7_raw" units="µs">RC channel 7 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan8_raw" units="µs">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
           </message>
           <message id="73" name="MISSION_ITEM_INT">
               <description>Message encoding a mission item. This message is emitted to announce
@@ -2871,8 +2871,8 @@
               <field type="uint8_t" name="target_system">System ID</field>
               <field type="uint8_t" name="target_component">Component ID</field>
               <field type="uint16_t" name="seq">Waypoint ID (sequence number). Starts at zero. Increases monotonically for each waypoint, no gaps in the sequence (0,1,2,3,4).</field>
-              <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
-              <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
+               <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
+               <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
               <field type="uint8_t" name="current">false:0, true:1</field>
               <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
               <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
@@ -2885,19 +2885,19 @@
           </message>
           <message id="74" name="VFR_HUD">
                <description>Metrics typically displayed on a HUD for fixed wing aircraft</description>
-               <field type="float" name="airspeed">Current airspeed in m/s</field>
-               <field type="float" name="groundspeed">Current ground speed in m/s</field>
-               <field type="int16_t" name="heading">Current heading in degrees, in compass units (0..360, 0=north)</field>
-               <field type="uint16_t" name="throttle">Current throttle setting in integer percent, 0 to 100</field>
-               <field type="float" name="alt">Current altitude (MSL), in meters</field>
-               <field type="float" name="climb">Current climb rate in meters/second</field>
+               <field type="float" name="airspeed" units="m/s">Current airspeed in m/s</field>
+               <field type="float" name="groundspeed" units="m/s">Current ground speed in m/s</field>
+               <field type="int16_t" name="heading" units="°">Current heading in degrees, in compass units (0..360, 0=north)</field>
+               <field type="uint16_t" name="throttle" units="%">Current throttle setting in integer percent, 0 to 100</field>
+               <field type="float" name="alt" units="m">Current altitude (MSL), in meters</field>
+               <field type="float" name="climb" units="m/s">Current climb rate in meters/second</field>
           </message>
           <message id="75" name="COMMAND_INT">
               <description>Message encoding a command with parameters as scaled integers. Scaling depends on the actual command value.</description>
               <field type="uint8_t" name="target_system">System ID</field>
               <field type="uint8_t" name="target_component">Component ID</field>
-              <field type="uint8_t" name="frame">The coordinate system of the COMMAND. see MAV_FRAME in mavlink_types.h</field>
-              <field type="uint16_t" name="command">The scheduled action for the mission item. see MAV_CMD in common.xml MAVLink specs</field>
+               <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND. see MAV_FRAME in mavlink_types.h</field>
+               <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the mission item. see MAV_CMD in common.xml MAVLink specs</field>
               <field type="uint8_t" name="current">false:0, true:1</field>
               <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
               <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
@@ -2925,144 +2925,144 @@
           <message id="77" name="COMMAND_ACK">
                <description>Report status of a command. Includes feedback wether the command was executed.</description>
                <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
-               <field type="uint8_t" name="result">See MAV_RESULT enum</field>
+               <field type="uint8_t" name="result" enum="MAV_RESULT">See MAV_RESULT enum</field>
           </message>
          <message id="81" name="MANUAL_SETPOINT">
              <description>Setpoint in roll, pitch, yaw and thrust from the operator</description>
-             <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-             <field type="float" name="roll">Desired roll rate in radians per second</field>
-             <field type="float" name="pitch">Desired pitch rate in radians per second</field>
-             <field type="float" name="yaw">Desired yaw rate in radians per second</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp in milliseconds since system boot</field>
+               <field type="float" name="roll" units="rad/s">Desired roll rate in radians per second</field>
+               <field type="float" name="pitch" units="rad/s">Desired pitch rate in radians per second</field>
+               <field type="float" name="yaw" units="rad/s">Desired yaw rate in radians per second</field>
              <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1</field>
              <field type="uint8_t" name="mode_switch">Flight mode switch position, 0.. 255</field>
              <field type="uint8_t" name="manual_override_switch">Override mode switch position, 0.. 255</field>
          </message>
           <message id="82" name="SET_ATTITUDE_TARGET">
                <description>Sets a desired vehicle attitude. Used by an external controller to command the vehicle (manual controller or other system).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp in milliseconds since system boot</field>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 6: reserved, bit 7: throttle, bit 8: attitude</field>
                <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-               <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
-               <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
-               <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
+               <field type="float" name="body_roll_rate" units="rad/s">Body roll rate in radians per second</field>
+               <field type="float" name="body_pitch_rate" units="rad/s">Body roll rate in radians per second</field>
+               <field type="float" name="body_yaw_rate" units="rad/s">Body roll rate in radians per second</field>
                <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
           </message>
           <message id="83" name="ATTITUDE_TARGET">
                <description>Reports the current commanded attitude of the vehicle as specified by the autopilot. This should match the commands sent in a SET_ATTITUDE_TARGET message if the vehicle is being controlled this way.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp in milliseconds since system boot</field>
                <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 7: reserved, bit 8: attitude</field>
                <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-               <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
-               <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
-               <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
+               <field type="float" name="body_roll_rate" units="rad/s">Body roll rate in radians per second</field>
+               <field type="float" name="body_pitch_rate" units="rad/s">Body pitch rate in radians per second</field>
+               <field type="float" name="body_yaw_rate" units="rad/s">Body yaw rate in radians per second</field>
                <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
           </message>
           <message id="84" name="SET_POSITION_TARGET_LOCAL_NED">
                <description>Sets a desired vehicle position in a local north-east-down coordinate frame. Used by an external controller to command the vehicle (manual controller or other system).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp in milliseconds since system boot</field>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
                <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-               <field type="float" name="x">X Position in NED frame in meters</field>
-               <field type="float" name="y">Y Position in NED frame in meters</field>
-               <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
-               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="yaw">yaw setpoint in rad</field>
-               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+               <field type="float" name="x" units="m">X Position in NED frame in meters</field>
+               <field type="float" name="y" units="m">Y Position in NED frame in meters</field>
+               <field type="float" name="z" units="m">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
+               <field type="float" name="vx" units="m/s">X velocity in NED frame in meter / s</field>
+               <field type="float" name="vy" units="m/s">Y velocity in NED frame in meter / s</field>
+               <field type="float" name="vz" units="m/s">Z velocity in NED frame in meter / s</field>
+               <field type="float" name="afx" units="m/s²">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afy" units="m/s²">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afz" units="m/s²">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="yaw" units="rad">yaw setpoint in rad</field>
+               <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint in rad/s</field>
           </message>
           <message id="85" name="POSITION_TARGET_LOCAL_NED">
                <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_LOCAL_NED if the vehicle is being controlled this way.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp in milliseconds since system boot</field>
                <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
                <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-               <field type="float" name="x">X Position in NED frame in meters</field>
-               <field type="float" name="y">Y Position in NED frame in meters</field>
-               <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
-               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="yaw">yaw setpoint in rad</field>
-               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+               <field type="float" name="x" units="m">X Position in NED frame in meters</field>
+               <field type="float" name="y" units="m">Y Position in NED frame in meters</field>
+               <field type="float" name="z" units="m">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
+               <field type="float" name="vx" units="m/s">X velocity in NED frame in meter / s</field>
+               <field type="float" name="vy" units="m/s">Y velocity in NED frame in meter / s</field>
+               <field type="float" name="vz" units="m/s">Z velocity in NED frame in meter / s</field>
+               <field type="float" name="afx" units="m/s²">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afy" units="m/s²">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afz" units="m/s²">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="yaw" units="rad">yaw setpoint in rad</field>
+               <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint in rad/s</field>
           </message>
           <message id="86" name="SET_POSITION_TARGET_GLOBAL_INT">
                <description>Sets a desired vehicle position, velocity, and/or acceleration in a global coordinate system (WGS84). Used by an external controller to command the vehicle (manual controller or other system).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
                <field type="uint8_t" name="target_system">System ID</field>
                <field type="uint8_t" name="target_component">Component ID</field>
                <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
                <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-               <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
-               <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
-               <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
-               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="yaw">yaw setpoint in rad</field>
-               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+               <field type="int32_t" name="lat_int" units="°E7">X Position in WGS84 frame in 1e7 * meters</field>
+               <field type="int32_t" name="lon_int" units="°E7">Y Position in WGS84 frame in 1e7 * meters</field>
+               <field type="float" name="alt" units="m">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+               <field type="float" name="vx" units="m/s">X velocity in NED frame in meter / s</field>
+               <field type="float" name="vy" units="m/s">Y velocity in NED frame in meter / s</field>
+               <field type="float" name="vz" units="m/s">Z velocity in NED frame in meter / s</field>
+               <field type="float" name="afx" units="m/s²">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afy" units="m/s²">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afz" units="m/s²">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="yaw" units="rad">yaw setpoint in rad</field>
+               <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint in rad/s</field>
           </message>
           <message id="87" name="POSITION_TARGET_GLOBAL_INT">
                <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_GLOBAL_INT if the vehicle is being controlled this way.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
                <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
                <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-               <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
-               <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
-               <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
-               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="yaw">yaw setpoint in rad</field>
-               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+               <field type="int32_t" name="lat_int" units="°E7">X Position in WGS84 frame in 1e7 * meters</field>
+               <field type="int32_t" name="lon_int" units="°E7">Y Position in WGS84 frame in 1e7 * meters</field>
+               <field type="float" name="alt" units="m">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+               <field type="float" name="vx" units="m/s">X velocity in NED frame in meter / s</field>
+               <field type="float" name="vy" units="m/s">Y velocity in NED frame in meter / s</field>
+               <field type="float" name="vz" units="m/s">Z velocity in NED frame in meter / s</field>
+               <field type="float" name="afx" units="m/s²">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afy" units="m/s²">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afz" units="m/s²">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="yaw" units="rad">yaw setpoint in rad</field>
+               <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint in rad/s</field>
           </message>
           <message id="89" name="LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET">
                <description>The offset in X, Y, Z and yaw between the LOCAL_POSITION_NED messages of MAV X and the global coordinate frame in NED coordinates. Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="x">X Position</field>
-               <field type="float" name="y">Y Position</field>
-               <field type="float" name="z">Z Position</field>
-               <field type="float" name="roll">Roll</field>
-               <field type="float" name="pitch">Pitch</field>
-               <field type="float" name="yaw">Yaw</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="x" units="m">X Position</field>
+               <field type="float" name="y" units="m">Y Position</field>
+               <field type="float" name="z" units="m">Z Position</field>
+               <field type="float" name="roll" units="rad">Roll</field>
+               <field type="float" name="pitch" units="rad">Pitch</field>
+               <field type="float" name="yaw" units="rad">Yaw</field>
           </message>
           <message id="90" name="HIL_STATE">
                <description>DEPRECATED PACKET! Suffers from missing airspeed fields and singularities due to Euler angles. Please use HIL_STATE_QUATERNION instead. Sent from simulation to autopilot. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field type="float" name="roll">Roll angle (rad)</field>
-               <field type="float" name="pitch">Pitch angle (rad)</field>
-               <field type="float" name="yaw">Yaw angle (rad)</field>
-               <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
-               <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
-               <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="float" name="roll" units="rad">Roll angle (rad)</field>
+               <field type="float" name="pitch" units="rad">Pitch angle (rad)</field>
+               <field type="float" name="yaw" units="rad">Yaw angle (rad)</field>
+               <field type="float" name="rollspeed" units="rad/s">Body frame roll / phi angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed" units="rad/s">Body frame pitch / theta angular speed (rad/s)</field>
+               <field type="float" name="yawspeed" units="rad/s">Body frame yaw / psi angular speed (rad/s)</field>
                <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
                <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
-               <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
-               <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
-               <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
-               <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
-               <field type="int16_t" name="xacc">X acceleration (mg)</field>
-               <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-               <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+               <field type="int32_t" name="alt" units="mm">Altitude in meters, expressed as * 1000 (millimeters)</field>
+               <field type="int16_t" name="vx" units="cm/s">Ground X Speed (Latitude), expressed as m/s * 100</field>
+               <field type="int16_t" name="vy" units="cm/s">Ground Y Speed (Longitude), expressed as m/s * 100</field>
+               <field type="int16_t" name="vz" units="cm/s">Ground Z Speed (Altitude), expressed as m/s * 100</field>
+               <field type="int16_t" name="xacc" units="mG">X acceleration (mg)</field>
+               <field type="int16_t" name="yacc" units="mG">Y acceleration (mg)</field>
+               <field type="int16_t" name="zacc" units="mG">Z acceleration (mg)</field>
           </message>
           <message id="91" name="HIL_CONTROLS">
                <description>Sent from autopilot to simulation. Hardware in the loop control outputs</description>
-               <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
                <field name="roll_ailerons" type="float">Control output -1 .. 1</field>
                <field name="pitch_elevator" type="float">Control output -1 .. 1</field>
                <field name="yaw_rudder" type="float">Control output -1 .. 1</field>
@@ -3071,126 +3071,126 @@
                <field name="aux2" type="float">Aux 2, -1 .. 1</field>
                <field name="aux3" type="float">Aux 3, -1 .. 1</field>
                <field name="aux4" type="float">Aux 4, -1 .. 1</field>
-               <field name="mode" type="uint8_t">System mode (MAV_MODE)</field>
+               <field type="uint8_t" name="mode" bitmask="MAV_MODE_FLAG_DECODE_POSITION">System mode (MAV_MODE_FLAG_DECODE_POSITION)</field>
                <field name="nav_mode" type="uint8_t">Navigation mode (MAV_NAV_MODE)</field>
           </message>
           <message id="92" name="HIL_RC_INPUTS_RAW">
                <description>Sent from simulation to autopilot. The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds</field>
-               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds</field>
-               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds</field>
-               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds</field>
-               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds</field>
-               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds</field>
-               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds</field>
-               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds</field>
-               <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds</field>
-               <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds</field>
-               <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds</field>
-               <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint16_t" name="chan1_raw" units="µs">RC channel 1 value, in microseconds</field>
+               <field type="uint16_t" name="chan2_raw" units="µs">RC channel 2 value, in microseconds</field>
+               <field type="uint16_t" name="chan3_raw" units="µs">RC channel 3 value, in microseconds</field>
+               <field type="uint16_t" name="chan4_raw" units="µs">RC channel 4 value, in microseconds</field>
+               <field type="uint16_t" name="chan5_raw" units="µs">RC channel 5 value, in microseconds</field>
+               <field type="uint16_t" name="chan6_raw" units="µs">RC channel 6 value, in microseconds</field>
+               <field type="uint16_t" name="chan7_raw" units="µs">RC channel 7 value, in microseconds</field>
+               <field type="uint16_t" name="chan8_raw" units="µs">RC channel 8 value, in microseconds</field>
+               <field type="uint16_t" name="chan9_raw" units="µs">RC channel 9 value, in microseconds</field>
+               <field type="uint16_t" name="chan10_raw" units="µs">RC channel 10 value, in microseconds</field>
+               <field type="uint16_t" name="chan11_raw" units="µs">RC channel 11 value, in microseconds</field>
+               <field type="uint16_t" name="chan12_raw" units="µs">RC channel 12 value, in microseconds</field>
                <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 255: 100%</field>
           </message>
           <message id="93" name="HIL_ACTUATOR_CONTROLS">
                <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>
-               <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
                <field name="controls" type="float[16]">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
-               <field name="mode" type="uint8_t">System mode (MAV_MODE), includes arming state.</field>
+               <field type="uint8_t" name="mode" bitmask="MAV_MODE_FLAG_DECODE_POSITION">System mode (MAV_MODE), includes arming state.</field>
                <field name="flags" type="uint64_t">Flags as bitfield, reserved for future use.</field>
           </message>
           <message id="100" name="OPTICAL_FLOW">
                <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
-               <field type="uint64_t" name="time_usec">Timestamp (UNIX)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (UNIX)</field>
                <field type="uint8_t" name="sensor_id">Sensor ID</field>
-              <field type="int16_t" name="flow_x">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
-               <field type="int16_t" name="flow_y">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
-               <field type="float" name="flow_comp_m_x">Flow in meters in x-sensor direction, angular-speed compensated</field>
-               <field type="float" name="flow_comp_m_y">Flow in meters in y-sensor direction, angular-speed compensated</field>
+               <field type="int16_t" name="flow_x" units="dpixels">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
+               <field type="int16_t" name="flow_y" units="dpixels">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
+               <field type="float" name="flow_comp_m_x" units="m">Flow in meters in x-sensor direction, angular-speed compensated</field>
+               <field type="float" name="flow_comp_m_y" units="m">Flow in meters in y-sensor direction, angular-speed compensated</field>
                <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
-               <field type="float" name="ground_distance">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
+               <field type="float" name="ground_distance" units="m">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
           </message>
           <message id="101" name="GLOBAL_VISION_POSITION_ESTIMATE">
-               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-               <field type="float" name="x">Global X position</field>
-               <field type="float" name="y">Global Y position</field>
-               <field type="float" name="z">Global Z position</field>
-               <field type="float" name="roll">Roll angle in rad</field>
-               <field type="float" name="pitch">Pitch angle in rad</field>
-               <field type="float" name="yaw">Yaw angle in rad</field>
+               <field type="uint64_t" name="usec" units="µs">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="x" units="m">Global X position</field>
+               <field type="float" name="y" units="m">Global Y position</field>
+               <field type="float" name="z" units="m">Global Z position</field>
+               <field type="float" name="roll" units="rad">Roll angle in rad</field>
+               <field type="float" name="pitch" units="rad">Pitch angle in rad</field>
+               <field type="float" name="yaw" units="rad">Yaw angle in rad</field>
           </message>
           <message id="102" name="VISION_POSITION_ESTIMATE">
-               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-               <field type="float" name="x">Global X position</field>
-               <field type="float" name="y">Global Y position</field>
-               <field type="float" name="z">Global Z position</field>
-               <field type="float" name="roll">Roll angle in rad</field>
-               <field type="float" name="pitch">Pitch angle in rad</field>
-               <field type="float" name="yaw">Yaw angle in rad</field>
+               <field type="uint64_t" name="usec" units="µs">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="x" units="m">Global X position</field>
+               <field type="float" name="y" units="m">Global Y position</field>
+               <field type="float" name="z" units="m">Global Z position</field>
+               <field type="float" name="roll" units="rad">Roll angle in rad</field>
+               <field type="float" name="pitch" units="rad">Pitch angle in rad</field>
+               <field type="float" name="yaw" units="rad">Yaw angle in rad</field>
           </message>
           <message id="103" name="VISION_SPEED_ESTIMATE">
-               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-               <field type="float" name="x">Global X speed</field>
-               <field type="float" name="y">Global Y speed</field>
-               <field type="float" name="z">Global Z speed</field>
+               <field type="uint64_t" name="usec" units="µs">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="x" units="m/s">Global X speed</field>
+               <field type="float" name="y" units="m/s">Global Y speed</field>
+               <field type="float" name="z" units="m/s">Global Z speed</field>
           </message>
           <message id="104" name="VICON_POSITION_ESTIMATE">
-               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-               <field type="float" name="x">Global X position</field>
-               <field type="float" name="y">Global Y position</field>
-               <field type="float" name="z">Global Z position</field>
-               <field type="float" name="roll">Roll angle in rad</field>
-               <field type="float" name="pitch">Pitch angle in rad</field>
-               <field type="float" name="yaw">Yaw angle in rad</field>
+               <field type="uint64_t" name="usec" units="µs">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="x" units="m">Global X position</field>
+               <field type="float" name="y" units="m">Global Y position</field>
+               <field type="float" name="z" units="m">Global Z position</field>
+               <field type="float" name="roll" units="rad">Roll angle in rad</field>
+               <field type="float" name="pitch" units="rad">Pitch angle in rad</field>
+               <field type="float" name="yaw" units="rad">Yaw angle in rad</field>
           </message>
           <message id="105" name="HIGHRES_IMU">
              <description>The IMU readings in SI units in NED body frame</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-             <field type="float" name="xacc">X acceleration (m/s^2)</field>
-             <field type="float" name="yacc">Y acceleration (m/s^2)</field>
-             <field type="float" name="zacc">Z acceleration (m/s^2)</field>
-             <field type="float" name="xgyro">Angular speed around X axis (rad / sec)</field>
-             <field type="float" name="ygyro">Angular speed around Y axis (rad / sec)</field>
-             <field type="float" name="zgyro">Angular speed around Z axis (rad / sec)</field>
-             <field type="float" name="xmag">X Magnetic field (Gauss)</field>
-             <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
-             <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
-             <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
-             <field type="float" name="diff_pressure">Differential pressure in millibar</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="xacc" units="m/s²">X acceleration (m/s^2)</field>
+               <field type="float" name="yacc" units="m/s²">Y acceleration (m/s^2)</field>
+               <field type="float" name="zacc" units="m/s²">Z acceleration (m/s^2)</field>
+               <field type="float" name="xgyro" units="rad/s">Angular speed around X axis (rad / sec)</field>
+               <field type="float" name="ygyro" units="rad/s">Angular speed around Y axis (rad / sec)</field>
+               <field type="float" name="zgyro" units="rad/s">Angular speed around Z axis (rad / sec)</field>
+               <field type="float" name="xmag" units="gauss">X Magnetic field (Gauss)</field>
+               <field type="float" name="ymag" units="gauss">Y Magnetic field (Gauss)</field>
+               <field type="float" name="zmag" units="gauss">Z Magnetic field (Gauss)</field>
+               <field type="float" name="abs_pressure" units="mbar">Absolute pressure in millibar</field>
+               <field type="float" name="diff_pressure" units="mbar">Differential pressure in millibar</field>
              <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
-             <field type="float" name="temperature">Temperature in degrees celsius</field>
+               <field type="float" name="temperature" units="°C">Temperature in degrees celsius</field>
              <field type="uint16_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature</field>
          </message>
          <message id="106" name="OPTICAL_FLOW_RAD">
              <description>Optical flow from an angular rate flow sensor (e.g. PX4FLOW or mouse sensor)</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
              <field type="uint8_t" name="sensor_id">Sensor ID</field>
-             <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
-             <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
-             <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
-             <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
-             <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
-             <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
-             <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
+               <field type="uint32_t" name="integration_time_us" units="µs">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
+               <field type="float" name="integrated_x" units="rad">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
+               <field type="float" name="integrated_y" units="rad">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
+               <field type="float" name="integrated_xgyro" units="rad">RH rotation around X axis (rad)</field>
+               <field type="float" name="integrated_ygyro" units="rad">RH rotation around Y axis (rad)</field>
+               <field type="float" name="integrated_zgyro" units="rad">RH rotation around Z axis (rad)</field>
+               <field type="int16_t" name="temperature" units="c°C">Temperature * 100 in centi-degrees Celsius</field>
              <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
-             <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
-             <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
+               <field type="uint32_t" name="time_delta_distance_us" units="µs">Time in microseconds since the distance was sampled.</field>
+               <field type="float" name="distance" units="m">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
          </message>
 
          <message id="107" name="HIL_SENSOR"> <description>The IMU readings in SI units in NED body frame</description>
-           <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-           <field type="float" name="xacc">X acceleration (m/s^2)</field>
-           <field type="float" name="yacc">Y acceleration (m/s^2)</field>
-           <field type="float" name="zacc">Z acceleration (m/s^2)</field>
-           <field type="float" name="xgyro">Angular speed around X axis in body frame (rad / sec)</field>
-           <field type="float" name="ygyro">Angular speed around Y axis in body frame (rad / sec)</field>
-           <field type="float" name="zgyro">Angular speed around Z axis in body frame (rad / sec)</field>
-           <field type="float" name="xmag">X Magnetic field (Gauss)</field>
-           <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
-           <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
-           <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
-           <field type="float" name="diff_pressure">Differential pressure (airspeed) in millibar</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="xacc" units="m/s²">X acceleration (m/s^2)</field>
+               <field type="float" name="yacc" units="m/s²">Y acceleration (m/s^2)</field>
+               <field type="float" name="zacc" units="m/s²">Z acceleration (m/s^2)</field>
+               <field type="float" name="xgyro" units="rad/s">Angular speed around X axis in body frame (rad / sec)</field>
+               <field type="float" name="ygyro" units="rad/s">Angular speed around Y axis in body frame (rad / sec)</field>
+               <field type="float" name="zgyro" units="rad/s">Angular speed around Z axis in body frame (rad / sec)</field>
+               <field type="float" name="xmag" units="gauss">X Magnetic field (Gauss)</field>
+               <field type="float" name="ymag" units="gauss">Y Magnetic field (Gauss)</field>
+               <field type="float" name="zmag" units="gauss">Z Magnetic field (Gauss)</field>
+               <field type="float" name="abs_pressure" units="mbar">Absolute pressure in millibar</field>
+               <field type="float" name="diff_pressure" units="mbar">Differential pressure (airspeed) in millibar</field>
            <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
-           <field type="float" name="temperature">Temperature in degrees celsius</field>
+               <field type="float" name="temperature" units="°C">Temperature in degrees celsius</field>
            <field type="uint32_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature, bit 31: full reset of attitude/position/velocities/etc was performed in sim.</field>
          </message>
 
@@ -3203,27 +3203,27 @@
             <field type="float" name="roll">Attitude roll expressed as Euler angles, not recommended except for human-readable outputs</field>
             <field type="float" name="pitch">Attitude pitch expressed as Euler angles, not recommended except for human-readable outputs</field>
             <field type="float" name="yaw">Attitude yaw expressed as Euler angles, not recommended except for human-readable outputs</field>
-            <field type="float" name="xacc">X acceleration m/s/s</field>
-            <field type="float" name="yacc">Y acceleration m/s/s</field>
-            <field type="float" name="zacc">Z acceleration m/s/s</field>
-            <field type="float" name="xgyro">Angular speed around X axis rad/s</field>
-            <field type="float" name="ygyro">Angular speed around Y axis rad/s</field>
-            <field type="float" name="zgyro">Angular speed around Z axis rad/s</field>
-            <field type="float" name="lat">Latitude in degrees</field>
-            <field type="float" name="lon">Longitude in degrees</field>
-            <field type="float" name="alt">Altitude in meters</field>
+               <field type="float" name="xacc" units="m/s²">X acceleration m/s/s</field>
+               <field type="float" name="yacc" units="m/s²">Y acceleration m/s/s</field>
+               <field type="float" name="zacc" units="m/s²">Z acceleration m/s/s</field>
+               <field type="float" name="xgyro" units="rad/s">Angular speed around X axis rad/s</field>
+               <field type="float" name="ygyro" units="rad/s">Angular speed around Y axis rad/s</field>
+               <field type="float" name="zgyro" units="rad/s">Angular speed around Z axis rad/s</field>
+               <field type="float" name="lat" units="°">Latitude in degrees</field>
+               <field type="float" name="lon" units="°">Longitude in degrees</field>
+               <field type="float" name="alt" units="m">Altitude in meters</field>
             <field type="float" name="std_dev_horz">Horizontal position standard deviation</field>
             <field type="float" name="std_dev_vert">Vertical position standard deviation</field>
-            <field type="float" name="vn">True velocity in m/s in NORTH direction in earth-fixed NED frame</field>
-            <field type="float" name="ve">True velocity in m/s in EAST direction in earth-fixed NED frame</field>
-            <field type="float" name="vd">True velocity in m/s in DOWN direction in earth-fixed NED frame</field>
+               <field type="float" name="vn" units="m/s">True velocity in m/s in NORTH direction in earth-fixed NED frame</field>
+               <field type="float" name="ve" units="m/s">True velocity in m/s in EAST direction in earth-fixed NED frame</field>
+               <field type="float" name="vd" units="m/s">True velocity in m/s in DOWN direction in earth-fixed NED frame</field>
 	  </message>
 
     	  <message name="RADIO_STATUS" id="109">
     	      <description>Status generated by radio and injected into MAVLink stream.</description>
             <field type="uint8_t" name="rssi">Local signal strength</field>
             <field type="uint8_t" name="remrssi">Remote signal strength</field>
-            <field type="uint8_t" name="txbuf">Remaining free buffer space in percent.</field>
+               <field type="uint8_t" name="txbuf" units="%">Remaining free buffer space in percent.</field>
             <field type="uint8_t" name="noise">Background noise level</field>
             <field type="uint8_t" name="remnoise">Remote background noise level</field>
             <field type="uint16_t" name="rxerrors">Receive errors</field>
@@ -3243,72 +3243,72 @@
         </message>
         <message id="112" name="CAMERA_TRIGGER">
             <description>Camera-IMU triggering and synchronisation message.</description>
-            <field type="uint64_t" name="time_usec">Timestamp for the image frame in microseconds</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp for the image frame in microseconds</field>
             <field type="uint32_t" name="seq">Image frame sequence</field>
         </message>
          <message id="113" name="HIL_GPS">
              <description>The global position, as returned by the Global Positioning System (GPS). This is
                  NOT the global position estimate of the sytem, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
              <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.</field>
-             <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-             <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-             <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="alt" units="mm">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
              <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: 65535</field>
              <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: 65535</field>
-             <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: 65535</field>
-             <field type="int16_t" name="vn">GPS velocity in cm/s in NORTH direction in earth-fixed NED frame</field>
-             <field type="int16_t" name="ve">GPS velocity in cm/s in EAST direction in earth-fixed NED frame</field>
-             <field type="int16_t" name="vd">GPS velocity in cm/s in DOWN direction in earth-fixed NED frame</field>
-             <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: 65535</field>
+               <field type="uint16_t" name="vel" units="cm/s">GPS ground speed in cm/s. If unknown, set to: 65535</field>
+               <field type="int16_t" name="vn" units="cm/s">GPS velocity in cm/s in NORTH direction in earth-fixed NED frame</field>
+               <field type="int16_t" name="ve" units="cm/s">GPS velocity in cm/s in EAST direction in earth-fixed NED frame</field>
+               <field type="int16_t" name="vd" units="cm/s">GPS velocity in cm/s in DOWN direction in earth-fixed NED frame</field>
+               <field type="uint16_t" name="cog" units="c°">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: 65535</field>
              <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
          </message>
          <message id="114" name="HIL_OPTICAL_FLOW">
              <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
              <field type="uint8_t" name="sensor_id">Sensor ID</field>
-             <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
-             <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
-             <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
-             <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
-             <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
-             <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
-             <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
+               <field type="uint32_t" name="integration_time_us" units="µs">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
+               <field type="float" name="integrated_x" units="rad">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
+               <field type="float" name="integrated_y" units="rad">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
+               <field type="float" name="integrated_xgyro" units="rad">RH rotation around X axis (rad)</field>
+               <field type="float" name="integrated_ygyro" units="rad">RH rotation around Y axis (rad)</field>
+               <field type="float" name="integrated_zgyro" units="rad">RH rotation around Z axis (rad)</field>
+               <field type="int16_t" name="temperature" units="c°C">Temperature * 100 in centi-degrees Celsius</field>
              <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
-             <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
-             <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
+               <field type="uint32_t" name="time_delta_distance_us" units="µs">Time in microseconds since the distance was sampled.</field>
+               <field type="float" name="distance" units="m">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
          </message>
          <message id="115" name="HIL_STATE_QUATERNION">
              <description>Sent from simulation to autopilot, avoids in contrast to HIL_STATE singularities. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
              <field type="float[4]" name="attitude_quaternion">Vehicle attitude expressed as normalized quaternion in w, x, y, z order (with 1 0 0 0 being the null-rotation)</field>
-             <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
-             <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
-             <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
+               <field type="float" name="rollspeed" units="rad/s">Body frame roll / phi angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed" units="rad/s">Body frame pitch / theta angular speed (rad/s)</field>
+               <field type="float" name="yawspeed" units="rad/s">Body frame yaw / psi angular speed (rad/s)</field>
              <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
              <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
-             <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
-             <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
-             <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
-             <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
-             <field type="uint16_t" name="ind_airspeed">Indicated airspeed, expressed as m/s * 100</field>
-             <field type="uint16_t" name="true_airspeed">True airspeed, expressed as m/s * 100</field>
-             <field type="int16_t" name="xacc">X acceleration (mg)</field>
-             <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-             <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+               <field type="int32_t" name="alt" units="mm">Altitude in meters, expressed as * 1000 (millimeters)</field>
+               <field type="int16_t" name="vx" units="cm/s">Ground X Speed (Latitude), expressed as cm/s</field>
+               <field type="int16_t" name="vy" units="cm/s">Ground Y Speed (Longitude), expressed as cm/s</field>
+               <field type="int16_t" name="vz" units="cm/s">Ground Z Speed (Altitude), expressed as cm/s</field>
+               <field type="uint16_t" name="ind_airspeed" units="cm/s">Indicated airspeed, expressed as cm/s</field>
+               <field type="uint16_t" name="true_airspeed" units="cm/s">True airspeed, expressed as cm/s</field>
+               <field type="int16_t" name="xacc" units="mG">X acceleration (mg)</field>
+               <field type="int16_t" name="yacc" units="mG">Y acceleration (mg)</field>
+               <field type="int16_t" name="zacc" units="mG">Z acceleration (mg)</field>
          </message>
          <message id="116" name="SCALED_IMU2">
            <description>The RAW IMU readings for secondary 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-           <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-           <field type="int16_t" name="xacc">X acceleration (mg)</field>
-           <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-           <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-           <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-           <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-           <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-           <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-           <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-           <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="int16_t" name="xacc" units="mG">X acceleration (mg)</field>
+               <field type="int16_t" name="yacc" units="mG">Y acceleration (mg)</field>
+               <field type="int16_t" name="zacc" units="mG">Z acceleration (mg)</field>
+               <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis (millirad /sec)</field>
+               <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis (millirad /sec)</field>
+               <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis (millirad /sec)</field>
+               <field type="int16_t" name="xmag" units="mT">X Magnetic field (milli tesla)</field>
+               <field type="int16_t" name="ymag" units="mT">Y Magnetic field (milli tesla)</field>
+               <field type="int16_t" name="zmag" units="mT">Z Magnetic field (milli tesla)</field>
          </message>
          <message id="117" name="LOG_REQUEST_LIST">
           <description>Request a list of available logs. On some systems calling this may stop on-board logging until LOG_REQUEST_END is called.</description>
@@ -3322,8 +3322,8 @@
            <field type="uint16_t" name="id">Log id</field>
            <field type="uint16_t" name="num_logs">Total number of logs</field>
            <field type="uint16_t" name="last_log_num">High log number</field>
-           <field type="uint32_t" name="time_utc">UTC timestamp of log in seconds since 1970, or 0 if not available</field>
-           <field type="uint32_t" name="size">Size of the log (may be approximate) in bytes</field>
+               <field type="uint32_t" name="time_utc" units="s">UTC timestamp of log in seconds since 1970, or 0 if not available</field>
+               <field type="uint32_t" name="size" units="bytes">Size of the log (may be approximate) in bytes</field>
          </message>
          <message id="119" name="LOG_REQUEST_DATA">
            <description>Request a chunk of a log</description>
@@ -3331,13 +3331,13 @@
            <field type="uint8_t" name="target_component">Component ID</field>
            <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
            <field type="uint32_t" name="ofs">Offset into the log</field>
-           <field type="uint32_t" name="count">Number of bytes</field>
+               <field type="uint32_t" name="count" units="bytes">Number of bytes</field>
          </message>
          <message id="120" name="LOG_DATA">
            <description>Reply to LOG_REQUEST_DATA</description>
            <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
            <field type="uint32_t" name="ofs">Offset into the log</field>
-           <field type="uint8_t" name="count">Number of bytes (zero for end of log)</field>
+               <field type="uint8_t" name="count" units="bytes">Number of bytes (zero for end of log)</field>
            <field type="uint8_t[90]" name="data">log data</field>
          </message>
          <message id="121" name="LOG_ERASE">
@@ -3354,91 +3354,91 @@
            <description>data for injecting into the onboard GPS (used for DGPS)</description>
            <field type="uint8_t" name="target_system">System ID</field>
            <field type="uint8_t" name="target_component">Component ID</field>
-           <field type="uint8_t" name="len">data length</field>
+               <field type="uint8_t" name="len" units="bytes">data length</field>
            <field type="uint8_t[110]" name="data">raw data (110 is enough for 12 satellites of RTCMv2)</field>
          </message>
          <message id="124" name="GPS2_RAW">
            <description>Second GPS data. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-           <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
            <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
-           <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-           <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-           <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
-           <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
-           <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
-           <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
-           <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="alt" units="mm">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
+               <field type="uint16_t" name="eph" units="cm">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
+               <field type="uint16_t" name="epv" units="cm">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
+               <field type="uint16_t" name="vel" units="cm/s">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
+               <field type="uint16_t" name="cog" units="c°">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
            <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
            <field type="uint8_t" name="dgps_numch">Number of DGPS satellites</field>
            <field type="uint32_t" name="dgps_age">Age of DGPS info</field>
          </message>
          <message id="125" name="POWER_STATUS">
                <description>Power supply status</description>
-               <field type="uint16_t" name="Vcc">5V rail voltage in millivolts</field>
-               <field type="uint16_t" name="Vservo">servo rail voltage in millivolts</field>
-               <field type="uint16_t" name="flags">power supply status flags (see MAV_POWER_STATUS enum)</field>
+               <field type="uint16_t" name="Vcc" units="mV">5V rail voltage in millivolts</field>
+               <field type="uint16_t" name="Vservo" units="mV">servo rail voltage in millivolts</field>
+               <field type="uint16_t" name="flags" enum="MAV_POWER_STATUS">power supply status flags (see MAV_POWER_STATUS enum)</field>
          </message>
          <message name="SERIAL_CONTROL" id="126">
            <description>Control a serial port. This can be used for raw access to an onboard serial peripheral such as a GPS or telemetry radio. It is designed to make it possible to update the devices firmware via MAVLink messages or change the devices settings. A message with zero bytes can be used to change just the baudrate.</description>
-           <field type="uint8_t" name="device">See SERIAL_CONTROL_DEV enum</field>
-           <field type="uint8_t" name="flags">See SERIAL_CONTROL_FLAG enum</field>
-           <field type="uint16_t" name="timeout">Timeout for reply data in milliseconds</field>
+               <field type="uint8_t" name="device" enum="SERIAL_CONTROL_DEV">See SERIAL_CONTROL_DEV enum</field>
+               <field type="uint8_t" name="flags" enum="SERIAL_CONTROL_FLAG">See SERIAL_CONTROL_FLAG enum</field>
+               <field type="uint16_t" name="timeout" units="ms">Timeout for reply data in milliseconds</field>
            <field type="uint32_t" name="baudrate">Baudrate of transfer. Zero means no change.</field>
-           <field type="uint8_t" name="count">how many bytes in this transfer</field>
+               <field type="uint8_t" name="count" units="bytes">how many bytes in this transfer</field>
            <field type="uint8_t[70]" name="data">serial data</field>
          </message>
          <message id="127" name="GPS_RTK">
             <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
-            <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
+               <field type="uint32_t" name="time_last_baseline_ms" units="ms">Time since boot of last baseline message received in ms.</field>
             <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
             <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
-            <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
+               <field type="uint32_t" name="tow" units="ms">GPS Time of Week of last baseline</field>
             <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
-            <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
+               <field type="uint8_t" name="rtk_rate" units="Hz">Rate of baseline messages being received by GPS, in HZ</field>
             <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
             <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
-            <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
-            <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
-            <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
+               <field type="int32_t" name="baseline_a_mm" units="mm">Current baseline in ECEF x or NED north component in mm.</field>
+               <field type="int32_t" name="baseline_b_mm" units="mm">Current baseline in ECEF y or NED east component in mm.</field>
+               <field type="int32_t" name="baseline_c_mm" units="mm">Current baseline in ECEF z or NED down component in mm.</field>
             <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
             <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
          </message>
          <message id="128" name="GPS2_RTK">
             <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
-            <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
+               <field type="uint32_t" name="time_last_baseline_ms" units="ms">Time since boot of last baseline message received in ms.</field>
             <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
             <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
-            <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
+               <field type="uint32_t" name="tow" units="ms">GPS Time of Week of last baseline</field>
             <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
-            <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
+               <field type="uint8_t" name="rtk_rate" units="Hz">Rate of baseline messages being received by GPS, in HZ</field>
             <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
             <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
-            <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
-            <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
-            <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
+               <field type="int32_t" name="baseline_a_mm" units="mm">Current baseline in ECEF x or NED north component in mm.</field>
+               <field type="int32_t" name="baseline_b_mm" units="mm">Current baseline in ECEF y or NED east component in mm.</field>
+               <field type="int32_t" name="baseline_c_mm" units="mm">Current baseline in ECEF z or NED down component in mm.</field>
             <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
             <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
         </message>
         <message id="129" name="SCALED_IMU3">
           <description>The RAW IMU readings for 3rd 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-          <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-          <field type="int16_t" name="xacc">X acceleration (mg)</field>
-          <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-          <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-          <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-          <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-          <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-          <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-          <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-          <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="int16_t" name="xacc" units="mG">X acceleration (mg)</field>
+               <field type="int16_t" name="yacc" units="mG">Y acceleration (mg)</field>
+               <field type="int16_t" name="zacc" units="mG">Z acceleration (mg)</field>
+               <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis (millirad /sec)</field>
+               <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis (millirad /sec)</field>
+               <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis (millirad /sec)</field>
+               <field type="int16_t" name="xmag" units="mT">X Magnetic field (milli tesla)</field>
+               <field type="int16_t" name="ymag" units="mT">Y Magnetic field (milli tesla)</field>
+               <field type="int16_t" name="zmag" units="mT">Z Magnetic field (milli tesla)</field>
         </message>
         <message id="130" name="DATA_TRANSMISSION_HANDSHAKE">
             <field type="uint8_t" name="type">type of requested/acknowledged data (as defined in ENUM DATA_TYPES in mavlink/include/mavlink_types.h)</field>
-            <field type="uint32_t" name="size">total data size in bytes (set on ACK only)</field>
+               <field type="uint32_t" name="size" units="bytes">total data size in bytes (set on ACK only)</field>
             <field type="uint16_t" name="width">Width of a matrix or image</field>
             <field type="uint16_t" name="height">Height of a matrix or image</field>
             <field type="uint16_t" name="packets">number of packets beeing sent (set on ACK only)</field>
-            <field type="uint8_t" name="payload">payload size per packet (normally 253 byte, see DATA field size in message ENCAPSULATED_DATA) (set on ACK only)</field>
+               <field type="uint8_t" name="payload" units="bytes">payload size per packet (normally 253 byte, see DATA field size in message ENCAPSULATED_DATA) (set on ACK only)</field>
             <field type="uint8_t" name="jpg_quality">JPEG quality out of [1,100]</field>
         </message>
         <message id="131" name="ENCAPSULATED_DATA">
@@ -3446,63 +3446,63 @@
             <field type="uint8_t[253]" name="data">image data bytes</field>
         </message>
         <message id="132" name="DISTANCE_SENSOR">
-            <field type="uint32_t" name="time_boot_ms">Time since system boot</field>
-            <field type="uint16_t" name="min_distance">Minimum distance the sensor can measure in centimeters</field>
-            <field type="uint16_t" name="max_distance">Maximum distance the sensor can measure in centimeters</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Time since system boot</field>
+               <field type="uint16_t" name="min_distance" units="cm">Minimum distance the sensor can measure in centimeters</field>
+               <field type="uint16_t" name="max_distance" units="cm">Maximum distance the sensor can measure in centimeters</field>
             <field type="uint16_t" name="current_distance">Current distance reading</field>
-            <field type="uint8_t" name="type">Type from MAV_DISTANCE_SENSOR enum.</field>
+               <field type="uint8_t" name="type" enum="MAV_DISTANCE_SENSOR">Type from MAV_DISTANCE_SENSOR enum.</field>
             <field type="uint8_t" name="id">Onboard ID of the sensor</field>
-            <field type="uint8_t" name="orientation">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
-            <field type="uint8_t" name="covariance">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
+               <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
+               <field type="uint8_t" name="covariance" units="cm">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
          </message>
          <message id="133" name="TERRAIN_REQUEST">
             <description>Request for terrain data and terrain status</description>
-            <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
-            <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
-            <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude of SW corner of first grid (degrees *10^7)</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude of SW corner of first grid (in degrees *10^7)</field>
+               <field type="uint16_t" name="grid_spacing" units="m">Grid spacing in meters</field>
             <field type="uint64_t" name="mask" print_format="0x%07x">Bitmask of requested 4x4 grids (row major 8x7 array of grids, 56 bits)</field>
          </message>
          <message id="134" name="TERRAIN_DATA">
             <description>Terrain data sent from GCS. The lat/lon and grid_spacing must be the same as a lat/lon from a TERRAIN_REQUEST</description>
-            <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
-            <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
-            <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude of SW corner of first grid (degrees *10^7)</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude of SW corner of first grid (in degrees *10^7)</field>
+               <field type="uint16_t" name="grid_spacing" units="m">Grid spacing in meters</field>
             <field type="uint8_t" name="gridbit">bit within the terrain request mask</field>
-            <field type="int16_t[16]" name="data">Terrain data in meters AMSL</field>
+               <field type="int16_t[16]" name="data" units="m">Terrain data in meters AMSL</field>
          </message>
          <message id="135" name="TERRAIN_CHECK">
             <description>Request that the vehicle report terrain height at the given location. Used by GCS to check if vehicle has all terrain data needed for a mission.</description>
-            <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
-            <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude (degrees *10^7)</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude (degrees *10^7)</field>
          </message>
          <message id="136" name="TERRAIN_REPORT">
             <description>Response from a TERRAIN_CHECK request</description>
-            <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
-            <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude (degrees *10^7)</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude (degrees *10^7)</field>
             <field type="uint16_t" name="spacing">grid spacing (zero if terrain at this location unavailable)</field>
-            <field type="float" name="terrain_height">Terrain height in meters AMSL</field>
-            <field type="float" name="current_height">Current vehicle height above lat/lon terrain height (meters)</field>
+               <field type="float" name="terrain_height" units="m">Terrain height in meters AMSL</field>
+               <field type="float" name="current_height" units="m">Current vehicle height above lat/lon terrain height (meters)</field>
             <field type="uint16_t" name="pending">Number of 4x4 terrain blocks waiting to be received or read from disk</field>
             <field type="uint16_t" name="loaded">Number of 4x4 terrain blocks in memory</field>
          </message>
          <message id="137" name="SCALED_PRESSURE2">
            <description>Barometer readings for 2nd barometer</description>
-           <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-           <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-           <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-           <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="press_abs" units="hPa">Absolute pressure (hectopascal)</field>
+               <field type="float" name="press_diff" units="hPa">Differential pressure 1 (hectopascal)</field>
+               <field type="int16_t" name="temperature" units="c°C">Temperature measurement (0.01 degrees celsius)</field>
          </message>
         <message id="138" name="ATT_POS_MOCAP">
           <description>Motion capture attitude and position</description>
-          <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
           <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-          <field type="float" name="x">X position in meters (NED)</field>
-          <field type="float" name="y">Y position in meters (NED)</field>
-          <field type="float" name="z">Z position in meters (NED)</field>
+               <field type="float" name="x" units="m">X position in meters (NED)</field>
+               <field type="float" name="y" units="m">Y position in meters (NED)</field>
+               <field type="float" name="z" units="m">Z position in meters (NED)</field>
         </message>
         <message id="139" name="SET_ACTUATOR_CONTROL_TARGET">
             <description>Set the vehicle attitude and body angular rates.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
             <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
             <field type="uint8_t" name="target_system">System ID</field>
             <field type="uint8_t" name="target_component">Component ID</field>
@@ -3510,19 +3510,19 @@
         </message>
         <message id="140" name="ACTUATOR_CONTROL_TARGET">
             <description>Set the vehicle attitude and body angular rates.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
             <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
             <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
         </message>
         <message id="141" name="ALTITUDE">
             <description>The current system altitude.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="float" name="altitude_monotonic">This altitude measure is initialized on system boot and monotonic (it is never reset, but represents the local altitude change). The only guarantee on this field is that it will never be reset and is consistent within a flight. The recommended value for this field is the uncorrected barometric altitude at boot time. This altitude will also drift and vary between flights.</field>
-            <field type="float" name="altitude_amsl">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output AMSL by default and not the WGS84 altitude.</field>
-            <field type="float" name="altitude_local">This is the local altitude in the local coordinate frame. It is not the altitude above home, but in reference to the coordinate origin (0, 0, 0). It is up-positive.</field>
-            <field type="float" name="altitude_relative">This is the altitude above the home position. It resets on each change of the current home position.</field>
-            <field type="float" name="altitude_terrain">This is the altitude above terrain. It might be fed by a terrain database or an altimeter. Values smaller than -1000 should be interpreted as unknown.</field>
-            <field type="float" name="bottom_clearance">This is not the altitude, but the clear space below the system according to the fused clearance estimate. It generally should max out at the maximum range of e.g. the laser altimeter. It is generally a moving target. A negative value indicates no measurement available.</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="float" name="altitude_monotonic" units="m">This altitude measure is initialized on system boot and monotonic (it is never reset, but represents the local altitude change). The only guarantee on this field is that it will never be reset and is consistent within a flight. The recommended value for this field is the uncorrected barometric altitude at boot time. This altitude will also drift and vary between flights.</field>
+               <field type="float" name="altitude_amsl" units="m">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output AMSL by default and not the WGS84 altitude.</field>
+               <field type="float" name="altitude_local" units="m">This is the local altitude in the local coordinate frame. It is not the altitude above home, but in reference to the coordinate origin (0, 0, 0). It is up-positive.</field>
+               <field type="float" name="altitude_relative" units="m">This is the altitude above the home position. It resets on each change of the current home position.</field>
+               <field type="float" name="altitude_terrain" units="m">This is the altitude above terrain. It might be fed by a terrain database or an altimeter. Values smaller than -1000 should be interpreted as unknown.</field>
+               <field type="float" name="bottom_clearance" units="m">This is not the altitude, but the clear space below the system according to the fused clearance estimate. It generally should max out at the maximum range of e.g. the laser altimeter. It is generally a moving target. A negative value indicates no measurement available.</field>
         </message>
         <message id="142" name="RESOURCE_REQUEST">
             <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
@@ -3534,20 +3534,20 @@
         </message>
         <message id="143" name="SCALED_PRESSURE3">
           <description>Barometer readings for 3rd barometer</description>
-          <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-          <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-          <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-           <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="press_abs" units="hPa">Absolute pressure (hectopascal)</field>
+               <field type="float" name="press_diff" units="hPa">Differential pressure 1 (hectopascal)</field>
+               <field type="int16_t" name="temperature" units="c°C">Temperature measurement (0.01 degrees celsius)</field>
         </message>
         <message id="144" name="FOLLOW_TARGET">
               <description>current motion information from a designated system</description>
-              <field type="uint64_t" name="timestamp">Timestamp in milliseconds since system boot</field>
+               <field type="uint64_t" name="timestamp" units="ms">Timestamp in milliseconds since system boot</field>
               <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
-              <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-              <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-              <field type="float" name="alt">AMSL, in meters</field>
-              <field type="float[3]" name="vel">target velocity (0,0,0) for unknown</field>
-              <field type="float[3]" name="acc">linear target acceleration (0,0,0) for unknown</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude (WGS84), in degrees * 1E7</field>
+               <field type="float" name="alt" units="m">AMSL, in meters</field>
+               <field type="float[3]" name="vel" units="m/s">target velocity (0,0,0) for unknown</field>
+               <field type="float[3]" name="acc" units="m/s²">linear target acceleration (0,0,0) for unknown</field>
               <field type="float[4]" name="attitude_q">(1 0 0 0 for unknown)</field>
               <field type="float[3]" name="rates">(0 0 0 for unknown)</field>
               <field type="float[3]" name="position_cov">eph epv</field>
@@ -3555,39 +3555,39 @@
         </message>
         <message id="146" name="CONTROL_SYSTEM_STATE">
             <description>The smoothed, monotonic system state used to feed the control loops of the system.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="float" name="x_acc">X acceleration in body frame</field>
-            <field type="float" name="y_acc">Y acceleration in body frame</field>
-            <field type="float" name="z_acc">Z acceleration in body frame</field>
-            <field type="float" name="x_vel">X velocity in body frame</field>
-            <field type="float" name="y_vel">Y velocity in body frame</field>
-            <field type="float" name="z_vel">Z velocity in body frame</field>
-            <field type="float" name="x_pos">X position in local frame</field>
-            <field type="float" name="y_pos">Y position in local frame</field>
-            <field type="float" name="z_pos">Z position in local frame</field>
-            <field type="float" name="airspeed">Airspeed, set to -1 if unknown</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="float" name="x_acc" units="m/s²">X acceleration in body frame</field>
+               <field type="float" name="y_acc" units="m/s²">Y acceleration in body frame</field>
+               <field type="float" name="z_acc" units="m/s²">Z acceleration in body frame</field>
+               <field type="float" name="x_vel" units="m/s">X velocity in body frame</field>
+               <field type="float" name="y_vel" units="m/s">Y velocity in body frame</field>
+               <field type="float" name="z_vel" units="m/s">Z velocity in body frame</field>
+               <field type="float" name="x_pos" units="m">X position in local frame</field>
+               <field type="float" name="y_pos" units="m">Y position in local frame</field>
+               <field type="float" name="z_pos" units="m">Z position in local frame</field>
+               <field type="float" name="airspeed" units="m/s">Airspeed, set to -1 if unknown</field>
             <field type="float[3]" name="vel_variance">Variance of body velocity estimate</field>
             <field type="float[3]" name="pos_variance">Variance in local position</field>
             <field type="float[4]" name="q">The attitude, represented as Quaternion</field>
-            <field type="float" name="roll_rate">Angular rate in roll axis</field>
-            <field type="float" name="pitch_rate">Angular rate in pitch axis</field>
-            <field type="float" name="yaw_rate">Angular rate in yaw axis</field>
+               <field type="float" name="roll_rate" units="rad/s">Angular rate in roll axis</field>
+               <field type="float" name="pitch_rate" units="rad/s">Angular rate in pitch axis</field>
+               <field type="float" name="yaw_rate" units="rad/s">Angular rate in yaw axis</field>
         </message>
         <message id="147" name="BATTERY_STATUS">
             <description>Battery information</description>
             <field type="uint8_t" name="id">Battery ID</field>
             <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
             <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
-            <field type="int16_t" name="temperature">Temperature of the battery in centi-degrees celsius. INT16_MAX for unknown temperature.</field>
-            <field type="uint16_t[10]" name="voltages">Battery voltage of cells, in millivolts (1 = 1 millivolt). Cells above the valid cell count for this battery should have the UINT16_MAX value.</field>
-            <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
-            <field type="int32_t" name="current_consumed">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
-            <field type="int32_t" name="energy_consumed">Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
-            <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
+               <field type="int16_t" name="temperature" units="c°C">Temperature of the battery in centi-degrees celsius. INT16_MAX for unknown temperature.</field>
+               <field type="uint16_t[10]" name="voltages" units="mV">Battery voltage of cells, in millivolts (1 = 1 millivolt). Cells above the valid cell count for this battery should have the UINT16_MAX value.</field>
+               <field type="int16_t" name="current_battery" units="cA">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+               <field type="int32_t" name="current_consumed" units="mAh">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
+               <field type="int32_t" name="energy_consumed" units="hJ">Consumed energy, in 100*Joules (intergrated U*I*dt)  (100 = 1 Joule), -1: autopilot does not provide energy consumption estimate</field>
+               <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
         </message>
         <message id="148" name="AUTOPILOT_VERSION">
             <description>Version and capability of autopilot software</description>
-            <field type="uint64_t" name="capabilities">bitmask of capabilities (see MAV_PROTOCOL_CAPABILITY enum)</field>
+               <field type="uint64_t" name="capabilities" enum="MAV_PROTOCOL_CAPABILITY">bitmask of capabilities (see MAV_PROTOCOL_CAPABILITY enum)</field>
             <field type="uint32_t" name="flight_sw_version">Firmware version number</field>
             <field type="uint32_t" name="middleware_sw_version">Middleware version number</field>
             <field type="uint32_t" name="os_sw_version">Operating system version number</field>
@@ -3601,98 +3601,98 @@
         </message>
         <message id="149" name="LANDING_TARGET">
             <description>The location of a landing area captured from a downward facing camera</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
             <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
-            <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
-            <field type="float" name="angle_x">X-axis angular offset (in radians) of the target from the center of the image</field>
-            <field type="float" name="angle_y">Y-axis angular offset (in radians) of the target from the center of the image</field>
-            <field type="float" name="distance">Distance to the target from the vehicle in meters</field>
-            <field type="float" name="size_x">Size in radians of target along x-axis</field>
-            <field type="float" name="size_y">Size in radians of target along y-axis</field>
+               <field type="uint8_t" name="frame" enum="MAV_FRAME">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
+               <field type="float" name="angle_x" units="rad">X-axis angular offset (in radians) of the target from the center of the image</field>
+               <field type="float" name="angle_y" units="rad">Y-axis angular offset (in radians) of the target from the center of the image</field>
+               <field type="float" name="distance" units="m">Distance to the target from the vehicle in meters</field>
+               <field type="float" name="size_x" units="rad">Size in radians of target along x-axis</field>
+               <field type="float" name="size_y" units="rad">Size in radians of target along y-axis</field>
         </message>
 
         <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
         <message id="230" name="ESTIMATOR_STATUS">
             <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovaton test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovaton test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field name="flags" type="uint16_t" enum="ESTIMATOR_STATUS_FLAGS">Integer bitmask indicating which EKF outputs are valid. See definition for ESTIMATOR_STATUS_FLAGS.</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="uint16_t" name="flags" bitmask="ESTIMATOR_STATUS_FLAGS">Integer bitmask indicating which EKF outputs are valid. See definition for ESTIMATOR_STATUS_FLAGS.</field>
             <field name="vel_ratio" type="float">Velocity innovation test ratio</field>
             <field name="pos_horiz_ratio" type="float">Horizontal position innovation test ratio</field>
             <field name="pos_vert_ratio" type="float">Vertical position innovation test ratio</field>
             <field name="mag_ratio" type="float">Magnetometer innovation test ratio</field>
             <field name="hagl_ratio" type="float">Height above terrain innovation test ratio</field>
-            <field name="tas_ratio" type="float">True airspeed innovation test ratio</field>
-            <field name="pos_horiz_accuracy" type="float">Horizontal position 1-STD accuracy relative to the EKF local origin (m)</field>
-            <field name="pos_vert_accuracy" type="float">Vertical position 1-STD accuracy relative to the EKF local origin (m)</field>
+               <field type="float" name="tas_ratio" units="Hz">True airspeed innovation test ratio</field>
+               <field type="float" name="pos_horiz_accuracy" units="m">Horizontal position 1-STD accuracy relative to the EKF local origin (m)</field>
+               <field type="float" name="pos_vert_accuracy" units="m">Vertical position 1-STD accuracy relative to the EKF local origin (m)</field>
         </message>
         <message id="231" name="WIND_COV">
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="float" name="wind_x">Wind in X (NED) direction in m/s</field>
-            <field type="float" name="wind_y">Wind in Y (NED) direction in m/s</field>
-            <field type="float" name="wind_z">Wind in Z (NED) direction in m/s</field>
-            <field type="float" name="var_horiz">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
-            <field type="float" name="var_vert">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
-            <field type="float" name="wind_alt">AMSL altitude (m) this measurement was taken at</field>
-            <field name="horiz_accuracy" type="float">Horizontal speed 1-STD accuracy</field>
-            <field name="vert_accuracy" type="float">Vertical speed 1-STD accuracy</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="float" name="wind_x" units="m/s">Wind in X (NED) direction in m/s</field>
+               <field type="float" name="wind_y" units="m/s">Wind in Y (NED) direction in m/s</field>
+               <field type="float" name="wind_z" units="m/s">Wind in Z (NED) direction in m/s</field>
+               <field type="float" name="var_horiz" units="m/s">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
+               <field type="float" name="var_vert" units="m/s">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
+               <field type="float" name="wind_alt" units="m">AMSL altitude (m) this measurement was taken at</field>
+               <field type="float" name="horiz_accuracy" units="m">Horizontal speed 1-STD accuracy</field>
+               <field type="float" name="vert_accuracy" units="m">Vertical speed 1-STD accuracy</field>
         </message>
         <message id="232" name="GPS_INPUT">
             <description>GPS sensor input message.  This is a raw sensor value sent by the GPS. This is NOT the global position estimate of the sytem.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
             <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS inputs</field>
-            <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_INPUT_IGNORE_FLAGS enum).  All other fields must be provided.</field>
-            <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
+               <field type="uint16_t" name="ignore_flags" bitmask="GPS_INPUT_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_INPUT_IGNORE_FLAGS enum).  All other fields must be provided.</field>
+               <field type="uint32_t" name="time_week_ms" units="ms">GPS time (milliseconds from start of GPS week)</field>
             <field type="uint16_t" name="time_week">GPS week number</field>
             <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
-            <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-            <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-            <field type="float" name="alt">Altitude (AMSL, not WGS84), in m (positive for up)</field>
-            <field type="float" name="hdop">GPS HDOP horizontal dilution of position in m</field>
-            <field type="float" name="vdop">GPS VDOP vertical dilution of position in m</field>
-            <field type="float" name="vn">GPS velocity in m/s in NORTH direction in earth-fixed NED frame</field>
-            <field type="float" name="ve">GPS velocity in m/s in EAST direction in earth-fixed NED frame</field>
-            <field type="float" name="vd">GPS velocity in m/s in DOWN direction in earth-fixed NED frame</field>
-            <field type="float" name="speed_accuracy">GPS speed accuracy in m/s</field>
-            <field type="float" name="horiz_accuracy">GPS horizontal accuracy in m</field>
-            <field type="float" name="vert_accuracy">GPS vertical accuracy in m</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude (WGS84), in degrees * 1E7</field>
+               <field type="float" name="alt" units="m">Altitude (AMSL, not WGS84), in m (positive for up)</field>
+               <field type="float" name="hdop" units="m">GPS HDOP horizontal dilution of position in m</field>
+               <field type="float" name="vdop" units="m">GPS VDOP vertical dilution of position in m</field>
+               <field type="float" name="vn" units="m/s">GPS velocity in m/s in NORTH direction in earth-fixed NED frame</field>
+               <field type="float" name="ve" units="m/s">GPS velocity in m/s in EAST direction in earth-fixed NED frame</field>
+               <field type="float" name="vd" units="m/s">GPS velocity in m/s in DOWN direction in earth-fixed NED frame</field>
+               <field type="float" name="speed_accuracy" units="m/s">GPS speed accuracy in m/s</field>
+               <field type="float" name="horiz_accuracy" units="m">GPS horizontal accuracy in m</field>
+               <field type="float" name="vert_accuracy" units="m">GPS vertical accuracy in m</field>
             <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
         </message>
         <message id="233" name="GPS_RTCM_DATA">
            <description>WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)</description>
            <field type="uint8_t" name="flags">LSB: 1 means message is fragmented</field>
-           <field type="uint8_t" name="len">data length</field>
+               <field type="uint8_t" name="len" units="bytes">data length</field>
            <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>
         </message>
         <message id="234" name="HIGH_LATENCY">
             <description>Message appropriate for high latency connections like Iridium</description>
-            <field name="base_mode" type="uint8_t">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
+               <field type="uint8_t" name="base_mode" bitmask="MAV_MODE_FLAG">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
             <field name="custom_mode" type="uint32_t">A bitfield for use for autopilot-specific flags.</field>
             <field name="landed_state" type="uint8_t" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
-            <field name="roll" type="int16_t">roll (centidegrees)</field>
-            <field name="pitch" type="int16_t">pitch (centidegrees)</field>
-            <field name="heading" type="uint16_t">heading (centidegrees)</field>
-            <field name="throttle" type="int8_t">throttle (percentage)</field>
-            <field name="heading_sp" type="int16_t">heading setpoint (centidegrees)</field>
-            <field name="latitude" type="int32_t">Latitude, expressed as degrees * 1E7</field>
-            <field name="longitude" type="int32_t">Longitude, expressed as degrees * 1E7</field>
-            <field name="altitude_amsl" type="int16_t">Altitude above mean sea level (meters)</field>
-            <field name="altitude_sp" type="int16_t">Altitude setpoint relative to the home position (meters)</field>
-            <field name="airspeed" type="uint8_t">airspeed (m/s)</field>
-            <field name="airspeed_sp" type="uint8_t">airspeed setpoint (m/s)</field>
-            <field name="groundspeed" type="uint8_t">groundspeed (m/s)</field>
-            <field name="climb_rate" type="int8_t">climb rate (m/s)</field>
+               <field type="int16_t" name="roll" units="c°">roll (centidegrees)</field>
+               <field type="int16_t" name="pitch" units="c°">pitch (centidegrees)</field>
+               <field type="uint16_t" name="heading" units="c°">heading (centidegrees)</field>
+               <field type="int8_t" name="throttle" units="%">throttle (percentage)</field>
+               <field type="int16_t" name="heading_sp" units="c°">heading setpoint (centidegrees)</field>
+               <field type="int32_t" name="latitude" units="°E7">Latitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="longitude" units="°E7">Longitude, expressed as degrees * 1E7</field>
+               <field type="int16_t" name="altitude_amsl" units="m">Altitude above mean sea level (meters)</field>
+               <field type="int16_t" name="altitude_sp" units="m">Altitude setpoint relative to the home position (meters)</field>
+               <field type="uint8_t" name="airspeed" units="m/s">airspeed (m/s)</field>
+               <field type="uint8_t" name="airspeed_sp" units="m/s">airspeed setpoint (m/s)</field>
+               <field type="uint8_t" name="groundspeed" units="m/s">groundspeed (m/s)</field>
+               <field type="int8_t" name="climb_rate" units="m/s">climb rate (m/s)</field>
             <field name="gps_nsat" type="uint8_t">Number of satellites visible. If unknown, set to 255</field>
-            <field name="gps_fix_type" type="uint8_t">See the GPS_FIX_TYPE enum.</field>
-            <field name="battery_remaining" type="uint8_t">Remaining battery (percentage)</field>
-            <field name="temperature" type="int8_t">Autopilot temperature (degrees C)</field>
-            <field name="temperature_air" type="int8_t">Air temperature (degrees C) from airspeed sensor</field>
+               <field type="uint8_t" name="gps_fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
+               <field type="uint8_t" name="battery_remaining" units="%">Remaining battery (percentage)</field>
+               <field type="int8_t" name="temperature" units="°C">Autopilot temperature (degrees C)</field>
+               <field type="int8_t" name="temperature_air" units="°C">Air temperature (degrees C) from airspeed sensor</field>
             <field name="failsafe" type="uint8_t">failsafe (each bit represents a failsafe where 0=ok, 1=failsafe active (bit0:RC, bit1:batt, bit2:GPS, bit3:GCS, bit4:fence)</field>
             <field name="wp_num" type="uint8_t">current waypoint number</field>
-            <field name="wp_distance" type="uint16_t">distance to target (meters)</field>
+               <field type="uint16_t" name="wp_distance" units="m">distance to target (meters)</field>
         </message>
         <message id="241" name="VIBRATION">
             <description>Vibration levels and accelerometer clipping</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp (micros since boot or Unix epoch)</field>
             <field type="float" name="vibration_x">Vibration levels on X-axis</field>
             <field type="float" name="vibration_y">Vibration levels on Y-axis</field>
             <field type="float" name="vibration_z">Vibration levels on Z-axis</field>
@@ -3702,35 +3702,35 @@
         </message>
         <message id="242" name="HOME_POSITION">
                <description>This message can be requested by sending the MAV_CMD_GET_HOME_POSITION command. The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The position the system will return to and land on. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
-               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-               <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
-               <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
-               <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
+               <field type="int32_t" name="latitude" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="longitude" units="°E7">Longitude (WGS84, in degrees * 1E7</field>
+               <field type="int32_t" name="altitude" units="mm">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+               <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame</field>
+               <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame</field>
+               <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame</field>
                <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
-               <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-               <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-               <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_x" units="m">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_y" units="m">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_z" units="m">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
         </message>
         <message id="243" name="SET_HOME_POSITION">
                <description>The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
                <field type="uint8_t" name="target_system">System ID.</field>
-               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-               <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
-               <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
-               <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
+               <field type="int32_t" name="latitude" units="°E7">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="longitude" units="°E7">Longitude (WGS84, in degrees * 1E7</field>
+               <field type="int32_t" name="altitude" units="mm">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+               <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame</field>
+               <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame</field>
+               <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame</field>
                <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
-               <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-               <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-               <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_x" units="m">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_y" units="m">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_z" units="m">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
         </message>
         <message id="244" name="MESSAGE_INTERVAL">
             <description>This interface replaces DATA_STREAM</description>
             <field type="uint16_t" name="message_id">The ID of the requested MAVLink message. v1.0 is limited to 254 messages.</field>
-            <field type="int32_t" name="interval_us">The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, > 0 indicates the interval at which it is sent.</field>
+               <field type="int32_t" name="interval_us" units="µs">The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, &gt; 0 indicates the interval at which it is sent.</field>
         </message>
         <message id="245" name="EXTENDED_SYS_STATE">
             <description>Provides state for additional features</description>
@@ -3740,17 +3740,17 @@
         <message id="246" name="ADSB_VEHICLE">
           <description>The location and information of an ADSB vehicle</description>
           <field type="uint32_t" name="ICAO_address">ICAO address</field>
-          <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-          <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude, expressed as degrees * 1E7</field>
           <field type="uint8_t" name="altitude_type" enum="ADSB_ALTITUDE_TYPE">Type from ADSB_ALTITUDE_TYPE enum</field>
-          <field type="int32_t" name="altitude">Altitude(ASL) in millimeters</field>
-          <field type="uint16_t" name="heading">Course over ground in centidegrees</field>
-          <field type="uint16_t" name="hor_velocity">The horizontal velocity in centimeters/second</field>
-          <field type="int16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
+               <field type="int32_t" name="altitude" units="mm">Altitude(ASL) in millimeters</field>
+               <field type="uint16_t" name="heading" units="c°">Course over ground in centidegrees</field>
+               <field type="uint16_t" name="hor_velocity" units="cm/s">The horizontal velocity in centimeters/second</field>
+               <field type="int16_t" name="ver_velocity" units="cm/s">The vertical velocity in centimeters/second, positive is up</field>
           <field type="char[9]" name="callsign">The callsign, 8+null</field>
           <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">Type from ADSB_EMITTER_TYPE enum</field>
-          <field type="uint8_t" name="tslc">Time since last communication in seconds</field>
-          <field type="uint16_t" name="flags" enum="ADSB_FLAGS">Flags to indicate various statuses including valid data fields</field>
+               <field type="uint8_t" name="tslc" units="s">Time since last communication in seconds</field>
+               <field type="uint16_t" name="flags" bitmask="ADSB_FLAGS">Flags to indicate various statuses including valid data fields</field>
           <field type="uint16_t" name="squawk">Squawk code</field>
         </message>
         <message id="247" name="COLLISION">
@@ -3759,9 +3759,9 @@
           <field type="uint32_t" name="id">Unique identifier, domain based on src field</field>
           <field type="uint8_t" name="action" enum="MAV_COLLISION_ACTION">Action that is being taken to avoid this collision</field>
           <field type="uint8_t" name="threat_level" enum="MAV_COLLISION_THREAT_LEVEL">How concerned the aircraft is about this collision</field>
-          <field type="float" name="time_to_minimum_delta">Estimated time until collision occurs (seconds)</field>
-          <field type="float" name="altitude_minimum_delta">Closest vertical distance in meters between vehicle and object</field>
-          <field type="float" name="horizontal_minimum_delta">Closest horizontal distance in meteres between vehicle and object</field>
+               <field type="float" name="time_to_minimum_delta" units="s">Estimated time until collision occurs (seconds)</field>
+               <field type="float" name="altitude_minimum_delta" units="m">Closest vertical distance in meters between vehicle and object</field>
+               <field type="float" name="horizontal_minimum_delta" units="m">Closest horizontal distance in meteres between vehicle and object</field>
         </message>
         <message id="248" name="V2_EXTENSION">
             <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
@@ -3780,20 +3780,20 @@
           </message>
           <message id="250" name="DEBUG_VECT">
                <field type="char[10]" name="name">Name</field>
-               <field type="uint64_t" name="time_usec">Timestamp</field>
+               <field type="uint64_t" name="time_usec" units="µs">Timestamp</field>
                <field type="float" name="x">x</field>
                <field type="float" name="y">y</field>
                <field type="float" name="z">z</field>
           </message>
           <message id="251" name="NAMED_VALUE_FLOAT">
                <description>Send a key-value pair as float. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
                <field type="char[10]" name="name">Name of the debug variable</field>
                <field type="float" name="value">Floating point value</field>
           </message>
           <message id="252" name="NAMED_VALUE_INT">
                <description>Send a key-value pair as integer. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
                <field type="char[10]" name="name">Name of the debug variable</field>
                <field type="int32_t" name="value">Signed integer value</field>
           </message>
@@ -3804,7 +3804,7 @@
           </message>
           <message id="254" name="DEBUG">
                <description>Send a debug value. The index is used to discriminate between values. These values show up in the plot of QGroundControl as DEBUG N.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
                <field type="uint8_t" name="ind">index of debug variable</field>
                <field type="float" name="value">DEBUG value</field>
           </message>
@@ -3820,8 +3820,8 @@
 
 	  <message id="257" name="BUTTON_CHANGE">
             <description>Report button state change</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field name="last_change_ms" type="uint32_t">Time of last change of button state</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="last_change_ms" units="ms">Time of last change of button state</field>
             <field name="state" type="uint8_t">Bitmap state of buttons</field>
           </message>
 
@@ -3834,28 +3834,28 @@
 
         <message id="259" name="CAMERA_INFORMATION">
             <description>WIP: Information about a camera</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
-            <field type="float" name="focal_length">Focal length in mm</field>
-            <field type="float" name="sensor_size_h">Image sensor size horizontal in mm</field>
-            <field type="float" name="sensor_size_v">Image sensor size vertical in mm</field>
-            <field type="uint16_t" name="resolution_h">Image resolution in pixels horizontal</field>
-            <field type="uint16_t" name="resolution_v">Image resolution in pixels vertical</field>
+               <field type="float" name="focal_length" units="mm">Focal length in mm</field>
+               <field type="float" name="sensor_size_h" units="mm">Image sensor size horizontal in mm</field>
+               <field type="float" name="sensor_size_v" units="mm">Image sensor size vertical in mm</field>
+               <field type="uint16_t" name="resolution_h" units="pix">Image resolution in pixels horizontal</field>
+               <field type="uint16_t" name="resolution_v" units="pix">Image resolution in pixels vertical</field>
             <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
         </message>
         <message id="260" name="CAMERA_SETTINGS">
             <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="float" name="aperture">Aperture is 1/value</field>
             <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
-            <field type="float" name="shutter_speed">Shutter speed in s</field>
+               <field type="float" name="shutter_speed" units="s">Shutter speed in s</field>
             <field type="uint8_t" name="shutter_speed_locked">Shutter speed locked (0: auto, 1: locked)</field>
             <field type="float" name="iso_sensitivity">ISO sensitivity</field>
             <field type="uint8_t" name="iso_sensitivity_locked">ISO sensitivity locked (0: auto, 1: locked)</field>
-            <field type="float" name="white_balance">Color temperature in K</field>
+               <field type="float" name="white_balance" units="K">Color temperature in K</field>
             <field type="uint8_t" name="white_balance_locked">Color temperature locked (0: auto, 1: locked)</field>
             <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
             <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
@@ -3863,55 +3863,55 @@
         </message>
         <message id="261" name="STORAGE_INFORMATION">
             <description>WIP: Information about a storage medium</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
             <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
-            <field type="float" name="total_capacity">Total capacity in MiB</field>
-            <field type="float" name="used_capacity">Used capacity in MiB</field>
-            <field type="float" name="available_capacity">Available capacity in MiB</field>
-            <field type="float" name="read_speed">Read speed in MiB/s</field>
-            <field type="float" name="write_speed">Write speed in MiB/s</field>
+               <field type="float" name="total_capacity" units="Mibytes">Total capacity in MiB</field>
+               <field type="float" name="used_capacity" units="Mibytes">Used capacity in MiB</field>
+               <field type="float" name="available_capacity" units="Mibytes">Available capacity in MiB</field>
+               <field type="float" name="read_speed" units="Mibytes/s">Read speed in MiB/s</field>
+               <field type="float" name="write_speed" units="Mibytes/s">Write speed in MiB/s</field>
         </message>
         <message id="262" name="CAMERA_CAPTURE_STATUS">
             <description>WIP: Information about the status of a capture</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
-            <field type="float" name="image_interval">Image capture interval in seconds</field>
-            <field type="float" name="video_framerate">Video frame rate in Hz</field>
-            <field type="uint16_t" name="image_resolution_h">Image resolution in pixels horizontal</field>
-            <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
-            <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
-            <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
+               <field type="float" name="image_interval" units="s">Image capture interval in seconds</field>
+               <field type="float" name="video_framerate" units="Hz">Video frame rate in Hz</field>
+               <field type="uint16_t" name="image_resolution_h" units="pix">Image resolution in pixels horizontal</field>
+               <field type="uint16_t" name="image_resolution_v" units="pix">Image resolution in pixels vertical</field>
+               <field type="uint16_t" name="video_resolution_h" units="pix">Video resolution in pixels horizontal</field>
+               <field type="uint16_t" name="video_resolution_v" units="pix">Video resolution in pixels vertical</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
             <description>WIP: Information about a captured image</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint64_t" name="time_utc" units="µs">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7 where image was taken</field>
-            <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7 where capture was taken</field>
-            <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
-            <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
+               <field type="int32_t" name="lat" units="°E7">Latitude, expressed as degrees * 1E7 where image was taken</field>
+               <field type="int32_t" name="lon" units="°E7">Longitude, expressed as degrees * 1E7 where capture was taken</field>
+               <field type="int32_t" name="alt" units="m">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
+               <field type="int32_t" name="relative_alt" units="m">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
             <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
             <field type="char[210]" name="file_path">File path of image taken.</field>
         </message>
 
         <message id="264" name="FLIGHT_INFORMATION">
             <description>WIP: Information about flight since last arming</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field type="uint64_t" name="arming_time_utc">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
-            <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint64_t" name="arming_time_utc" units="µs">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+               <field type="uint64_t" name="takeoff_time_utc" units="µs">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
             <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
         </message>
 
         <message id="265" name="MOUNT_ORIENTATION">
             <description>WIP: Orientation of a mount</description>
-                <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="roll">Roll in degrees</field>
-               <field type="float" name="pitch">Pitch in degrees</field>
-               <field type="float" name="yaw">Yaw in degrees</field>
+               <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="roll" units="°">Roll in degrees</field>
+               <field type="float" name="pitch" units="°">Pitch in degrees</field>
+               <field type="float" name="yaw" units="°">Yaw in degrees</field>
         </message>
 
         <message id="266" name="LOGGING_DATA">
@@ -3919,8 +3919,8 @@
                <field type="uint8_t" name="target_system">system ID of the target</field>
                <field type="uint8_t" name="target_component">component ID of the target</field>
                <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
-               <field type="uint8_t" name="length">data length</field>
-               <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
+               <field type="uint8_t" name="length" units="bytes">data length</field>
+               <field type="uint8_t" name="first_message_offset" units="bytes">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
                <field type="uint8_t[249]" name="data">logged data</field>
           </message>
           <message id="267" name="LOGGING_DATA_ACKED">
@@ -3928,8 +3928,8 @@
                <field type="uint8_t" name="target_system">system ID of the target</field>
                <field type="uint8_t" name="target_component">component ID of the target</field>
                <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
-               <field type="uint8_t" name="length">data length</field>
-               <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
+               <field type="uint8_t" name="length" units="bytes">data length</field>
+               <field type="uint8_t" name="first_message_offset" units="bytes">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
                <field type="uint8_t[249]" name="data">logged data</field>
           </message>
           <message id="268" name="LOGGING_ACK">

--- a/message_definitions/v1.0/uAvionix.xml
+++ b/message_definitions/v1.0/uAvionix.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <mavlink>
      
     <!-- uAvionix contact info:                                     -->
@@ -93,26 +93,26 @@
 			<field type="uint8_t" name="aircraftSize" enum="UAVIONIX_ADSB_OUT_CFG_AIRCRAFT_SIZE">Aircraft length and width encoding (table 2-35 of DO-282B)</field>
 			<field type="uint8_t" name="gpsOffsetLat" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT">GPS antenna lateral offset (table 2-36 of DO-282B)</field>
 			<field type="uint8_t" name="gpsOffsetLon" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON">GPS antenna longitudinal offset from nose [if non-zero, take position (in meters) divide by 2 and add one] (table 2-37 DO-282B)</field>
-			<field type="uint16_t" name="stallSpeed">Aircraft stall speed in cm/s</field>
+               <field type="uint16_t" name="stallSpeed" units="cm/s">Aircraft stall speed in cm/s</field>
 			<field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT">ADS-B transponder reciever and transmit enable flags</field>
 		</message>
 		<message id="10002" name="UAVIONIX_ADSB_OUT_DYNAMIC">
 			<description>Dynamic data used to generate ADS-B out transponder data (send at 5Hz)</description>
-			<field type="uint32_t" name="utcTime">UTC time in seconds since GPS epoch (Jan 6, 1980). If unknown set to UINT32_MAX</field>
-			<field type="int32_t" name="gpsLat">Latitude WGS84 (deg * 1E7). If unknown set to INT32_MAX</field>
-			<field type="int32_t" name="gpsLon">Longitude WGS84 (deg * 1E7). If unknown set to INT32_MAX</field>
-			<field type="int32_t" name="gpsAlt">Altitude in mm (m * 1E-3) UP +ve. WGS84 altitude. If unknown set to INT32_MAX</field>
+               <field type="uint32_t" name="utcTime" units="s">UTC time in seconds since GPS epoch (Jan 6, 1980). If unknown set to UINT32_MAX</field>
+               <field type="int32_t" name="gpsLat" units="°E7">Latitude WGS84 (deg * 1E7). If unknown set to INT32_MAX</field>
+               <field type="int32_t" name="gpsLon" units="°E7">Longitude WGS84 (deg * 1E7). If unknown set to INT32_MAX</field>
+               <field type="int32_t" name="gpsAlt" units="mm">Altitude in mm (m * 1E-3) UP +ve. WGS84 altitude. If unknown set to INT32_MAX</field>
 			<field type="uint8_t" name="gpsFix" enum="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX">0-1: no fix, 2: 2D fix, 3: 3D fix, 4: DGPS, 5: RTK</field>
 			<field type="uint8_t" name="numSats">Number of satellites visible. If unknown set to UINT8_MAX</field>
-			<field type="int32_t" name="baroAltMSL">Barometric pressure altitude relative to a standard atmosphere of 1013.2 mBar and NOT bar corrected altitude (m * 1E-3). (up +ve). If unknown set to INT32_MAX</field>
-			<field type="uint32_t" name="accuracyHor">Horizontal accuracy in mm (m * 1E-3). If unknown set to UINT32_MAX</field>
-			<field type="uint16_t" name="accuracyVert">Vertical accuracy in cm. If unknown set to UINT16_MAX</field>
-			<field type="uint16_t" name="accuracyVel">Velocity accuracy in mm/s (m * 1E-3). If unknown set to UINT16_MAX</field>
-			<field type="int16_t" name="velVert">GPS vertical speed in cm/s. If unknown set to INT16_MAX</field>
-			<field type="int16_t" name="velNS">North-South velocity over ground in cm/s North +ve. If unknown set to INT16_MAX</field>
-			<field type="int16_t" name="VelEW">East-West velocity over ground in cm/s East +ve. If unknown set to INT16_MAX</field>
+               <field type="int32_t" name="baroAltMSL" units="mbar">Barometric pressure altitude relative to a standard atmosphere of 1013.2 mBar and NOT bar corrected altitude (m * 1E-3). (up +ve). If unknown set to INT32_MAX</field>
+               <field type="uint32_t" name="accuracyHor" units="mm">Horizontal accuracy in mm (m * 1E-3). If unknown set to UINT32_MAX</field>
+               <field type="uint16_t" name="accuracyVert" units="cm">Vertical accuracy in cm. If unknown set to UINT16_MAX</field>
+               <field type="uint16_t" name="accuracyVel" units="mm/s">Velocity accuracy in mm/s (m * 1E-3). If unknown set to UINT16_MAX</field>
+               <field type="int16_t" name="velVert" units="cm/s">GPS vertical speed in cm/s. If unknown set to INT16_MAX</field>
+               <field type="int16_t" name="velNS" units="cm/s">North-South velocity over ground in cm/s North +ve. If unknown set to INT16_MAX</field>
+               <field type="int16_t" name="VelEW" units="cm/s">East-West velocity over ground in cm/s East +ve. If unknown set to INT16_MAX</field>
 			<field type="uint8_t" name="emergencyStatus" enum="UAVIONIX_ADSB_EMERGENCY_STATUS">Emergency status</field>
-			<field type="uint16_t" name="state" enum="UAVIONIX_ADSB_OUT_DYNAMIC_STATE">ADS-B transponder dynamic input state flags</field>
+               <field type="uint16_t" name="state" bitmask="UAVIONIX_ADSB_OUT_DYNAMIC_STATE">ADS-B transponder dynamic input state flags</field>
 			<field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
 		</message>
 		<message id="10003" name="UAVIONIX_ADSB_TRANSCEIVER_HEALTH_REPORT">


### PR DESCRIPTION
For machine parsing and presentation, it is good to have a units field that presents SI units.
Enums are nice but sometimes the users use a bitmask with bit numbers instead, therefore introduce a new bitmask field
Many enums where not fully used, this patch also corrects that

I have another patch that will indent the entire .xml files, so ignore indentation here