### PR TITLE
Photos/Videos: use -1 for max resolution

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1379,7 +1379,7 @@
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
         <description>Starts video capture</description>
         <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
-        <param index="2">Frames per second</param>
+        <param index="2">Frames per second, set to -1 for highest framerate possible.</param>
         <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
         <param index="4">WIP: Resolution horizontal in pixels</param>
         <param index="5">WIP: Resolution horizontal in pixels</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1360,7 +1360,7 @@
         <description>Start image capture sequence</description>
         <param index="1">Duration between two consecutive pictures (in seconds)</param>
         <param index="2">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
+        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
         <param index="4">WIP: Resolution horizontal in pixels</param>
         <param index="5">WIP: Resolution horizontal in pixels</param>
         <param index="6">WIP: Camera ID</param>
@@ -1380,7 +1380,7 @@
         <description>Starts video capture</description>
         <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
         <param index="2">Frames per second</param>
-        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
+        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
         <param index="4">WIP: Resolution horizontal in pixels</param>
         <param index="5">WIP: Resolution horizontal in pixels</param>
       </entry>


### PR DESCRIPTION
Most times when shooting a picture or recording a video, the full
resolution is what a user wants. It therefore makes sense to inclue this
in the spec and make it easy to do just this.

@AndreasAntener this should be what we discussed, please review.
@LorenzMeier any objections?