### PR TITLE
PREFLIGHT_CALIBRATION: deconflict APM/PX4 param def for airspeed calibration

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1210,7 +1210,7 @@
         <param index="3">1: ground pressure calibration</param>
         <param index="4">1: radio RC calibration, 2: RC trim calibration</param>
         <param index="5">1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration</param>
-        <param index="6">1: APM: compass/motor interference calibration / PX4: airspeed calibration</param>
+        <param index="6">1: APM: compass/motor interference calibration (PX4: airspeed calibration, deprecated), 2: airspeed calibration</param>
         <param index="7">1: ESC calibration, 3: barometer temperature calibration</param>
       </entry>
       <entry value="242" name="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS">


### PR DESCRIPTION
This makes airspeed calibration use a new param value and deprecates the PX4's conflicting definition.
Follow-up to #673

@tridge fyi, no changes needed for APM

@DonLakeFlyer fyi