### PR TITLE
Some tweaks and additions to Video/Photo capture.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1357,7 +1357,7 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
-        <description>Start image capture sequence</description>
+        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture.</description>
         <param index="1">Duration between two consecutive pictures (in seconds)</param>
         <param index="2">Number of images to capture total - 0 for unlimited capture</param>
         <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
@@ -1377,15 +1377,16 @@
         <param index="3">Reserved</param>
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
-        <description>Starts video capture</description>
+        <description>Starts video capture (recording)</description>
         <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
         <param index="2">Frames per second, set to -1 for highest framerate possible.</param>
         <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
         <param index="4">WIP: Resolution horizontal in pixels</param>
         <param index="5">WIP: Resolution horizontal in pixels</param>
+        <param index="6">WIP: Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise time in Hz)</param>
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
-        <description>Stop the current video capture</description>
+        <description>Stop the current video capture (recording)</description>
         <param index="1">WIP: Camera ID</param>
         <param index="2">Reserved</param>
       </entry>
@@ -3839,6 +3840,8 @@
       <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
       <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
       <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
+      <field type="uint32_t" name="recording_time_s">Time in seconds since recording started</field>
+      <field type="float" name="available_capacity">Available storage capacity in MiB</field>
     </message>
     <message id="263" name="CAMERA_IMAGE_CAPTURED">
       <description>WIP: Information about a captured image</description>
@@ -3850,7 +3853,7 @@
       <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
       <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
       <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
-      <field type="char[210]" name="file_path">File path of image taken.</field>
+      <field type="char[210]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
     </message>
     <message id="264" name="FLIGHT_INFORMATION">
       <description>WIP: Information about flight since last arming</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3853,6 +3853,8 @@
       <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
       <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
       <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
+      <field type="int32_t" name="image_index">Zero based index of this image (count since started -1)</field>
+      <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
       <field type="char[210]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
     </message>
     <message id="264" name="FLIGHT_INFORMATION">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3853,7 +3853,7 @@
       <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
       <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
       <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
-      <field type="int32_t" name="image_index">Zero based index of this image (count since started -1)</field>
+      <field type="int32_t" name="image_index">Zero based index of this image (image count since armed -1)</field>
       <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
       <field type="char[210]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3840,7 +3840,7 @@
       <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
       <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
       <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
-      <field type="uint32_t" name="recording_time_s">Time in seconds since recording started</field>
+      <field type="uint32_t" name="recording_time_ms">Time in milliseconds since recording started</field>
       <field type="float" name="available_capacity">Available storage capacity in MiB</field>
     </message>
     <message id="263" name="CAMERA_IMAGE_CAPTURED">


### PR DESCRIPTION
- Establishes that a `CAMERA_IMAGE_CAPTURED` message is sent after each image captured as a result of `MAV_CMD_IMAGE_START_CAPTURE`.
- Clarifies that `MAV_CMD_VIDEO_START_CAPTURE` and `MAV_CMD_VIDEO_STOP_CAPTURE ` means “Recording”.
- Add the ability to request CAMERA_CAPTURE_STATUS messages to be sent automatically during video recording.
- Add a field to `CAMERA_CAPTURE_STATUS` telling the current recording time.
- Add a field to `CAMERA_CAPTURE_STATUS` telling the current remaining storage capacity.
- Changed the `file_path` in `CAMERA_IMAGE_CAPTURED` to `file_url` as this is more appropriate. A local storage path is of limited use. But if the camera supports image requests through an HTTP interface, this can be used to send the URL to obtain the image.