### PR TITLE
Video streaming improvements v2

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1422,6 +1422,16 @@
         <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved</param>
       </entry>
+      <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING">
+        <description>WIP: Start video streaming</description>
+        <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
+        <param index="2">Reserved</param>
+      </entry>
+      <entry value="2503" name="MAV_CMD_VIDEO_STOP_STREAMING">
+        <description>WIP: Stop the current video streaming</description>
+        <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
+        <param index="2">Reserved</param>
+      </entry>
       <entry value="2510" name="MAV_CMD_LOGGING_START">
         <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
         <param index="1">Format: 0: ULog</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1432,6 +1432,12 @@
         <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved</param>
       </entry>
+      <entry value="2504" name="MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION">
+        <description>WIP: Request video stream information (VIDEO_STREAM_INFORMATION)</description>
+        <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
+        <param index="2">0: No Action 1: Request video stream information</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
       <entry value="2510" name="MAV_CMD_LOGGING_START">
         <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
         <param index="1">Format: 0: ULog</param>
@@ -4039,6 +4045,29 @@
       <field type="uint8_t" name="target_system">system ID of the target</field>
       <field type="uint8_t" name="target_component">component ID of the target</field>
       <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
+    </message>
+    <message id="269" name="VIDEO_STREAM_INFORMATION">
+      <description>WIP: Information about video stream</description>
+      <field type="uint8_t" name="camera_id">Camera ID (1 for first, 2 for second, etc.)</field>
+      <field type="uint8_t" name="status">Current status of video streaming (0: not running, 1: in progress)</field>
+      <field type="float" name="framerate" units="Hz">Frames per second</field>
+      <field type="uint16_t" name="resolution_h" units="pix">Resolution horizontal in pixels</field>
+      <field type="uint16_t" name="resolution_v" units="pix">Resolution vertical in pixels</field>
+      <field type="uint32_t" name="bitrate" units="b/s">Bit rate in bits per second</field>
+      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
+      <field type="char[230]" name="uri">Video stream URI</field>
+    </message>
+    <message id="270" name="SET_VIDEO_STREAM_SETTINGS">
+      <description>WIP: Message that sets video stream settings</description>
+      <field type="uint8_t" name="target_system">system ID of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint8_t" name="camera_id">Camera ID (1 for first, 2 for second, etc.)</field>
+      <field type="float" name="framerate" units="Hz">Frames per second (set to -1 for highest framerate possible)</field>
+      <field type="uint16_t" name="resolution_h" units="pix">Resolution horizontal in pixels (set to -1 for highest resolution possible)</field>
+      <field type="uint16_t" name="resolution_v" units="pix">Resolution vertical in pixels (set to -1 for highest resolution possible)</field>
+      <field type="uint32_t" name="bitrate" units="b/s">Bit rate in bits per second (set to -1 for auto)</field>
+      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
+      <field type="char[230]" name="uri">Video stream URI</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
v1 - https://github.com/mavlink/mavlink/pull/664
Changes:
1. Use separate commands to start/stop video streaming.
2. Use URL instead if IP and port.
3. Add a new capability for video streaming to MAV_PROTOCOL_CAPABILITY bitmask.

Unfortunately, I don’t see a clear and concise way to overcome the issue of dynamically requested camera capabilities. One of the options might be to add new MAVLink messages that request list for every capability. For example:
Command MAV_CMD_REQUEST_CAMERA_RESOLUTIONS requests mavlink message CAMERA_RESOLUTIONS which contains array of C strings with all possible values (i.e. [640x480 1280x720]).

@LorenzMeier @julianoes @dogmaphobic please review