### PR TITLE
common.xml: hotfix for overflowing message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3855,7 +3855,7 @@
       <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
       <field type="int32_t" name="image_index">Zero based index of this image (image count since armed -1)</field>
       <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
-      <field type="char[210]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
+      <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
     </message>
     <message id="264" name="FLIGHT_INFORMATION">
       <description>WIP: Information about flight since last arming</description>


### PR DESCRIPTION
This fixes an overflow that occured because the message was 260 bytes
instead of 255 which is the maximum length.

The compiler error was:

```
mavlink_msg_camera_image_captured.h:22:54: warning: large integer implicitly truncated to unsigned type [-Woverflow]
 #define MAVLINK_MSG_ID_CAMERA_IMAGE_CAPTURED_MIN_LEN 260
```
We wonder why CI doesn't catch this.