### PR TITLE
[WIP] Mixer Tuning with Mixer Specific Parameters

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2401,6 +2401,15 @@
         <description>Mixers on a failsafe device</description>
       </entry>
     </enum>    
+   <enum name="MIXER_PARAM_FLAGS">
+      <description>Flags for different parameter qualities and states</description>
+      <entry value="1" name="MIXER_PARAM_READ_ONLY">
+        <description>Parameter is read only</description>
+      </entry>
+    </enum>    
+    
+    
+    
      </enums>
      <messages>
           <message id="0" name="HEARTBEAT">
@@ -3713,6 +3722,7 @@
         </message>
     <message id="235" name="MIXER_PARAM_VALUE">
       <description>Mixer parameter values emitted after a read or set request</description>
+      <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
       <field type="int16_t" name="count">Total number of onboard parameters</field>
       <field type="uint16_t" name="index">Index of this onboard parameter</field>      
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1,3984 +1,4025 @@
-<?xml version="1.0"?>
+<?xml version='1.0'?>
 <mavlink>
-  <version>3</version>
-  <dialect>0</dialect>
-  <enums>
-    <enum name="MAV_AUTOPILOT">
-      <description>Micro air vehicle / autopilot classes. This identifies the individual model.</description>
-      <entry value="0" name="MAV_AUTOPILOT_GENERIC">
-        <description>Generic autopilot, full support for everything</description>
-      </entry>
-      <entry value="1" name="MAV_AUTOPILOT_RESERVED">
-        <description>Reserved for future use.</description>
-      </entry>
-      <entry value="2" name="MAV_AUTOPILOT_SLUGS">
-        <description>SLUGS autopilot, http://slugsuav.soe.ucsc.edu</description>
-      </entry>
-      <entry value="3" name="MAV_AUTOPILOT_ARDUPILOTMEGA">
-        <description>ArduPilotMega / ArduCopter, http://diydrones.com</description>
-      </entry>
-      <entry value="4" name="MAV_AUTOPILOT_OPENPILOT">
-        <description>OpenPilot, http://openpilot.org</description>
-      </entry>
-      <entry value="5" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_ONLY">
-        <description>Generic autopilot only supporting simple waypoints</description>
-      </entry>
-      <entry value="6" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_AND_SIMPLE_NAVIGATION_ONLY">
-        <description>Generic autopilot supporting waypoints and other simple navigation commands</description>
-      </entry>
-      <entry value="7" name="MAV_AUTOPILOT_GENERIC_MISSION_FULL">
-        <description>Generic autopilot supporting the full mission command set</description>
-      </entry>
-      <entry value="8" name="MAV_AUTOPILOT_INVALID">
-        <description>No valid autopilot, e.g. a GCS or other MAVLink component</description>
-      </entry>
-      <entry value="9" name="MAV_AUTOPILOT_PPZ">
-        <description>PPZ UAV - http://nongnu.org/paparazzi</description>
-      </entry>
-      <entry value="10" name="MAV_AUTOPILOT_UDB">
-        <description>UAV Dev Board</description>
-      </entry>
-      <entry value="11" name="MAV_AUTOPILOT_FP">
-        <description>FlexiPilot</description>
-      </entry>
-      <entry value="12" name="MAV_AUTOPILOT_PX4">
-        <description>PX4 Autopilot - http://pixhawk.ethz.ch/px4/</description>
-      </entry>
-      <entry value="13" name="MAV_AUTOPILOT_SMACCMPILOT">
-        <description>SMACCMPilot - http://smaccmpilot.org</description>
-      </entry>
-      <entry value="14" name="MAV_AUTOPILOT_AUTOQUAD">
-        <description>AutoQuad -- http://autoquad.org</description>
-      </entry>
-      <entry value="15" name="MAV_AUTOPILOT_ARMAZILA">
-        <description>Armazila -- http://armazila.com</description>
-      </entry>
-      <entry value="16" name="MAV_AUTOPILOT_AEROB">
-        <description>Aerob -- http://aerob.ru</description>
-      </entry>
-      <entry value="17" name="MAV_AUTOPILOT_ASLUAV">
-        <description>ASLUAV autopilot -- http://www.asl.ethz.ch</description>
-      </entry>
-    </enum>
-    <enum name="MAV_TYPE">
-      <entry value="0" name="MAV_TYPE_GENERIC">
-        <description>Generic micro air vehicle.</description>
-      </entry>
-      <entry value="1" name="MAV_TYPE_FIXED_WING">
-        <description>Fixed wing aircraft.</description>
-      </entry>
-      <entry value="2" name="MAV_TYPE_QUADROTOR">
-        <description>Quadrotor</description>
-      </entry>
-      <entry value="3" name="MAV_TYPE_COAXIAL">
-        <description>Coaxial helicopter</description>
-      </entry>
-      <entry value="4" name="MAV_TYPE_HELICOPTER">
-        <description>Normal helicopter with tail rotor.</description>
-      </entry>
-      <entry value="5" name="MAV_TYPE_ANTENNA_TRACKER">
-        <description>Ground installation</description>
-      </entry>
-      <entry value="6" name="MAV_TYPE_GCS">
-        <description>Operator control unit / ground control station</description>
-      </entry>
-      <entry value="7" name="MAV_TYPE_AIRSHIP">
-        <description>Airship, controlled</description>
-      </entry>
-      <entry value="8" name="MAV_TYPE_FREE_BALLOON">
-        <description>Free balloon, uncontrolled</description>
-      </entry>
-      <entry value="9" name="MAV_TYPE_ROCKET">
-        <description>Rocket</description>
-      </entry>
-      <entry value="10" name="MAV_TYPE_GROUND_ROVER">
-        <description>Ground rover</description>
-      </entry>
-      <entry value="11" name="MAV_TYPE_SURFACE_BOAT">
-        <description>Surface vessel, boat, ship</description>
-      </entry>
-      <entry value="12" name="MAV_TYPE_SUBMARINE">
-        <description>Submarine</description>
-      </entry>
-      <entry value="13" name="MAV_TYPE_HEXAROTOR">
-        <description>Hexarotor</description>
-      </entry>
-      <entry value="14" name="MAV_TYPE_OCTOROTOR">
-        <description>Octorotor</description>
-      </entry>
-      <entry value="15" name="MAV_TYPE_TRICOPTER">
-        <description>Tricopter</description>
-      </entry>
-      <entry value="16" name="MAV_TYPE_FLAPPING_WING">
-        <description>Flapping wing</description>
-      </entry>
-      <entry value="17" name="MAV_TYPE_KITE">
-        <description>Kite</description>
-      </entry>
-      <entry value="18" name="MAV_TYPE_ONBOARD_CONTROLLER">
-        <description>Onboard companion controller</description>
-      </entry>
-      <entry value="19" name="MAV_TYPE_VTOL_DUOROTOR">
-        <description>Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter.</description>
-      </entry>
-      <entry value="20" name="MAV_TYPE_VTOL_QUADROTOR">
-        <description>Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter.</description>
-      </entry>
-      <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
-        <description>Tiltrotor VTOL</description>
-      </entry>
-      <!-- Entries up to 25 reserved for other VTOL airframes -->
-      <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
-        <description>VTOL reserved 2</description>
-      </entry>
-      <entry value="23" name="MAV_TYPE_VTOL_RESERVED3">
-        <description>VTOL reserved 3</description>
-      </entry>
-      <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
-        <description>VTOL reserved 4</description>
-      </entry>
-      <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
-        <description>VTOL reserved 5</description>
-      </entry>
-      <entry value="26" name="MAV_TYPE_GIMBAL">
-        <description>Onboard gimbal</description>
-      </entry>
-      <entry value="27" name="MAV_TYPE_ADSB">
-        <description>Onboard ADSB peripheral</description>
-      </entry>
-    </enum>
-    <enum name="FIRMWARE_VERSION_TYPE">
-      <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>
-      <entry value="0" name="FIRMWARE_VERSION_TYPE_DEV">
-        <description>development release</description>
-      </entry>
-      <entry value="64" name="FIRMWARE_VERSION_TYPE_ALPHA">
-        <description>alpha release</description>
-      </entry>
-      <entry value="128" name="FIRMWARE_VERSION_TYPE_BETA">
-        <description>beta release</description>
-      </entry>
-      <entry value="192" name="FIRMWARE_VERSION_TYPE_RC">
-        <description>release candidate</description>
-      </entry>
-      <entry value="255" name="FIRMWARE_VERSION_TYPE_OFFICIAL">
-        <description>official stable release</description>
-      </entry>
-    </enum>
-    <!-- WARNING: MAV_ACTION Enum is no longer supported - has been removed. Please use MAV_CMD -->
-    <enum name="MAV_MODE_FLAG">
-      <description>These flags encode the MAV mode.</description>
-      <entry value="128" name="MAV_MODE_FLAG_SAFETY_ARMED">
-        <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignore when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
-      </entry>
-      <entry value="64" name="MAV_MODE_FLAG_MANUAL_INPUT_ENABLED">
-        <description>0b01000000 remote control input is enabled.</description>
-      </entry>
-      <entry value="32" name="MAV_MODE_FLAG_HIL_ENABLED">
-        <description>0b00100000 hardware in the loop simulation. All motors / actuators are blocked, but internal software is full operational.</description>
-      </entry>
-      <entry value="16" name="MAV_MODE_FLAG_STABILIZE_ENABLED">
-        <description>0b00010000 system stabilizes electronically its attitude (and optionally position). It needs however further control inputs to move around.</description>
-      </entry>
-      <entry value="8" name="MAV_MODE_FLAG_GUIDED_ENABLED">
-        <description>0b00001000 guided mode enabled, system flies MISSIONs / mission items.</description>
-      </entry>
-      <entry value="4" name="MAV_MODE_FLAG_AUTO_ENABLED">
-        <description>0b00000100 autonomous mode enabled, system finds its own goal positions. Guided flag can be set or not, depends on the actual implementation.</description>
-      </entry>
-      <entry value="2" name="MAV_MODE_FLAG_TEST_ENABLED">
-        <description>0b00000010 system has a test mode enabled. This flag is intended for temporary system tests and should not be used for stable implementations.</description>
-      </entry>
-      <entry value="1" name="MAV_MODE_FLAG_CUSTOM_MODE_ENABLED">
-        <description>0b00000001 Reserved for future use.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_MODE_FLAG_DECODE_POSITION">
-      <description>These values encode the bit positions of the decode position. These values can be used to read the value of a flag bit by combining the base_mode variable with AND with the flag position value. The result will be either 0 or 1, depending on if the flag is set or not.</description>
-      <entry value="128" name="MAV_MODE_FLAG_DECODE_POSITION_SAFETY">
-        <description>First bit:  10000000</description>
-      </entry>
-      <entry value="64" name="MAV_MODE_FLAG_DECODE_POSITION_MANUAL">
-        <description>Second bit: 01000000</description>
-      </entry>
-      <entry value="32" name="MAV_MODE_FLAG_DECODE_POSITION_HIL">
-        <description>Third bit:  00100000</description>
-      </entry>
-      <entry value="16" name="MAV_MODE_FLAG_DECODE_POSITION_STABILIZE">
-        <description>Fourth bit: 00010000</description>
-      </entry>
-      <entry value="8" name="MAV_MODE_FLAG_DECODE_POSITION_GUIDED">
-        <description>Fifth bit:  00001000</description>
-      </entry>
-      <entry value="4" name="MAV_MODE_FLAG_DECODE_POSITION_AUTO">
-        <description>Sixt bit:   00000100</description>
-      </entry>
-      <entry value="2" name="MAV_MODE_FLAG_DECODE_POSITION_TEST">
-        <description>Seventh bit: 00000010</description>
-      </entry>
-      <entry value="1" name="MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE">
-        <description>Eighth bit: 00000001</description>
-      </entry>
-    </enum>
-    <enum name="MAV_GOTO">
-      <description>Override command, pauses current mission execution and moves immediately to a position</description>
-      <entry value="0" name="MAV_GOTO_DO_HOLD">
-        <description>Hold at the current position.</description>
-      </entry>
-      <entry value="1" name="MAV_GOTO_DO_CONTINUE">
-        <description>Continue with the next item in mission execution.</description>
-      </entry>
-      <entry value="2" name="MAV_GOTO_HOLD_AT_CURRENT_POSITION">
-        <description>Hold at the current position of the system</description>
-      </entry>
-      <entry value="3" name="MAV_GOTO_HOLD_AT_SPECIFIED_POSITION">
-        <description>Hold at the position specified in the parameters of the DO_HOLD action</description>
-      </entry>
-    </enum>
-    <enum name="MAV_MODE">
-      <description>These defines are predefined OR-combined mode flags. There is no need to use values from this enum, but it
+     <version>3</version>
+     <dialect>0</dialect>
+     <enums>
+          <enum name="MAV_AUTOPILOT">
+               <description>Micro air vehicle / autopilot classes. This identifies the individual model.</description>
+               <entry value="0" name="MAV_AUTOPILOT_GENERIC">
+                    <description>Generic autopilot, full support for everything</description>
+               </entry>
+               <entry value="1" name="MAV_AUTOPILOT_RESERVED">
+                    <description>Reserved for future use.</description>
+               </entry>
+               <entry value="2" name="MAV_AUTOPILOT_SLUGS">
+                    <description>SLUGS autopilot, http://slugsuav.soe.ucsc.edu</description>
+               </entry>
+               <entry value="3" name="MAV_AUTOPILOT_ARDUPILOTMEGA">
+                    <description>ArduPilotMega / ArduCopter, http://diydrones.com</description>
+               </entry>
+               <entry value="4" name="MAV_AUTOPILOT_OPENPILOT">
+                    <description>OpenPilot, http://openpilot.org</description>
+               </entry>
+               <entry value="5" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_ONLY">
+                    <description>Generic autopilot only supporting simple waypoints</description>
+               </entry>
+               <entry value="6" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_AND_SIMPLE_NAVIGATION_ONLY">
+                    <description>Generic autopilot supporting waypoints and other simple navigation commands</description>
+               </entry>
+               <entry value="7" name="MAV_AUTOPILOT_GENERIC_MISSION_FULL">
+                    <description>Generic autopilot supporting the full mission command set</description>
+               </entry>
+               <entry value="8" name="MAV_AUTOPILOT_INVALID">
+                    <description>No valid autopilot, e.g. a GCS or other MAVLink component</description>
+               </entry>
+               <entry value="9" name="MAV_AUTOPILOT_PPZ">
+                    <description>PPZ UAV - http://nongnu.org/paparazzi</description>
+               </entry>
+               <entry value="10" name="MAV_AUTOPILOT_UDB">
+                    <description>UAV Dev Board</description>
+               </entry>
+               <entry value="11" name="MAV_AUTOPILOT_FP">
+                    <description>FlexiPilot</description>
+               </entry>
+               <entry value="12" name="MAV_AUTOPILOT_PX4">
+                   <description>PX4 Autopilot - http://pixhawk.ethz.ch/px4/</description>
+               </entry>
+               <entry value="13" name="MAV_AUTOPILOT_SMACCMPILOT">
+                   <description>SMACCMPilot - http://smaccmpilot.org</description>
+               </entry>
+               <entry value="14" name="MAV_AUTOPILOT_AUTOQUAD">
+                    <description>AutoQuad -- http://autoquad.org</description>
+               </entry>
+               <entry value="15" name="MAV_AUTOPILOT_ARMAZILA">
+                    <description>Armazila -- http://armazila.com</description>
+               </entry>
+               <entry value="16" name="MAV_AUTOPILOT_AEROB">
+                    <description>Aerob -- http://aerob.ru</description>
+               </entry>
+               <entry value="17" name="MAV_AUTOPILOT_ASLUAV">
+                    <description>ASLUAV autopilot -- http://www.asl.ethz.ch</description>
+               </entry>
+          </enum>
+          <enum name="MAV_TYPE">
+               <entry value="0" name="MAV_TYPE_GENERIC">
+                    <description>Generic micro air vehicle.</description>
+               </entry>
+               <entry value="1" name="MAV_TYPE_FIXED_WING">
+                    <description>Fixed wing aircraft.</description>
+               </entry>
+               <entry value="2" name="MAV_TYPE_QUADROTOR">
+                    <description>Quadrotor</description>
+               </entry>
+               <entry value="3" name="MAV_TYPE_COAXIAL">
+                    <description>Coaxial helicopter</description>
+               </entry>
+               <entry value="4" name="MAV_TYPE_HELICOPTER">
+                    <description>Normal helicopter with tail rotor.</description>
+               </entry>
+               <entry value="5" name="MAV_TYPE_ANTENNA_TRACKER">
+                    <description>Ground installation</description>
+               </entry>
+               <entry value="6" name="MAV_TYPE_GCS">
+                    <description>Operator control unit / ground control station</description>
+               </entry>
+               <entry value="7" name="MAV_TYPE_AIRSHIP">
+                    <description>Airship, controlled</description>
+               </entry>
+               <entry value="8" name="MAV_TYPE_FREE_BALLOON">
+                    <description>Free balloon, uncontrolled</description>
+               </entry>
+               <entry value="9" name="MAV_TYPE_ROCKET">
+                    <description>Rocket</description>
+               </entry>
+               <entry value="10" name="MAV_TYPE_GROUND_ROVER">
+                    <description>Ground rover</description>
+               </entry>
+               <entry value="11" name="MAV_TYPE_SURFACE_BOAT">
+                    <description>Surface vessel, boat, ship</description>
+               </entry>
+               <entry value="12" name="MAV_TYPE_SUBMARINE">
+                    <description>Submarine</description>
+               </entry>
+               <entry value="13" name="MAV_TYPE_HEXAROTOR">
+                    <description>Hexarotor</description>
+               </entry>
+               <entry value="14" name="MAV_TYPE_OCTOROTOR">
+                    <description>Octorotor</description>
+               </entry>
+               <entry value="15" name="MAV_TYPE_TRICOPTER">
+                    <description>Tricopter</description>
+               </entry>
+               <entry value="16" name="MAV_TYPE_FLAPPING_WING">
+                    <description>Flapping wing</description>
+               </entry>
+               <entry value="17" name="MAV_TYPE_KITE">
+                    <description>Kite</description>
+               </entry>
+               <entry value="18" name="MAV_TYPE_ONBOARD_CONTROLLER">
+                    <description>Onboard companion controller</description>
+               </entry>
+               <entry value="19" name="MAV_TYPE_VTOL_DUOROTOR">
+                    <description>Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter.</description>
+               </entry>
+               <entry value="20" name="MAV_TYPE_VTOL_QUADROTOR">
+                    <description>Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter.</description>
+               </entry>
+               <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
+                    <description>Tiltrotor VTOL</description>
+               </entry>
+               <!-- Entries up to 25 reserved for other VTOL airframes -->
+               <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
+                    <description>VTOL reserved 2</description>
+               </entry>
+               <entry value="23" name="MAV_TYPE_VTOL_RESERVED3">
+                    <description>VTOL reserved 3</description>
+               </entry>
+               <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
+                    <description>VTOL reserved 4</description>
+               </entry>
+               <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
+                    <description>VTOL reserved 5</description>
+               </entry>
+               <entry value="26" name="MAV_TYPE_GIMBAL">
+                    <description>Onboard gimbal</description>
+               </entry>
+               <entry value="27" name="MAV_TYPE_ADSB">
+                    <description>Onboard ADSB peripheral</description>
+               </entry>
+          </enum>
+          <enum name="FIRMWARE_VERSION_TYPE">
+              <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>
+              <entry value="0" name="FIRMWARE_VERSION_TYPE_DEV">
+                  <description>development release</description>
+              </entry>
+              <entry value="64" name="FIRMWARE_VERSION_TYPE_ALPHA">
+                  <description>alpha release</description>
+              </entry>
+              <entry value="128" name="FIRMWARE_VERSION_TYPE_BETA">
+                  <description>beta release</description>
+              </entry>
+              <entry value="192" name="FIRMWARE_VERSION_TYPE_RC">
+                  <description>release candidate</description>
+              </entry>
+              <entry value="255" name="FIRMWARE_VERSION_TYPE_OFFICIAL">
+                  <description>official stable release</description>
+              </entry>
+          </enum>
+          <!-- WARNING: MAV_ACTION Enum is no longer supported - has been removed. Please use MAV_CMD -->
+          <enum name="MAV_MODE_FLAG">
+                <description>These flags encode the MAV mode.</description>
+                <entry value="128" name="MAV_MODE_FLAG_SAFETY_ARMED">
+                     <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignore when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
+                </entry>
+                <entry value="64" name="MAV_MODE_FLAG_MANUAL_INPUT_ENABLED">
+                     <description>0b01000000 remote control input is enabled.</description>
+                </entry>
+                <entry value="32" name="MAV_MODE_FLAG_HIL_ENABLED">
+                      <description>0b00100000 hardware in the loop simulation. All motors / actuators are blocked, but internal software is full operational.</description>
+                </entry>
+                <entry value="16" name="MAV_MODE_FLAG_STABILIZE_ENABLED">
+                     <description>0b00010000 system stabilizes electronically its attitude (and optionally position). It needs however further control inputs to move around.</description>
+                </entry>
+                <entry value="8" name="MAV_MODE_FLAG_GUIDED_ENABLED">
+                     <description>0b00001000 guided mode enabled, system flies MISSIONs / mission items.</description>
+                </entry>
+                <entry value="4" name="MAV_MODE_FLAG_AUTO_ENABLED">
+                     <description>0b00000100 autonomous mode enabled, system finds its own goal positions. Guided flag can be set or not, depends on the actual implementation.</description>
+                </entry>
+                <entry value="2" name="MAV_MODE_FLAG_TEST_ENABLED">
+                     <description>0b00000010 system has a test mode enabled. This flag is intended for temporary system tests and should not be used for stable implementations.</description>
+                </entry>
+                <entry value="1" name="MAV_MODE_FLAG_CUSTOM_MODE_ENABLED">
+                     <description>0b00000001 Reserved for future use.</description>
+                </entry>
+          </enum>
+          <enum name="MAV_MODE_FLAG_DECODE_POSITION">
+               <description>These values encode the bit positions of the decode position. These values can be used to read the value of a flag bit by combining the base_mode variable with AND with the flag position value. The result will be either 0 or 1, depending on if the flag is set or not.</description>
+                <entry value="128" name="MAV_MODE_FLAG_DECODE_POSITION_SAFETY">
+                     <description>First bit:  10000000</description>
+                </entry>
+                <entry value="64" name="MAV_MODE_FLAG_DECODE_POSITION_MANUAL">
+                     <description>Second bit: 01000000</description>
+                </entry>
+                <entry value="32" name="MAV_MODE_FLAG_DECODE_POSITION_HIL">
+                     <description>Third bit:  00100000</description>
+                </entry>
+                <entry value="16" name="MAV_MODE_FLAG_DECODE_POSITION_STABILIZE">
+                     <description>Fourth bit: 00010000</description>
+                </entry>
+                <entry value="8" name="MAV_MODE_FLAG_DECODE_POSITION_GUIDED">
+                     <description>Fifth bit:  00001000</description>
+                </entry>
+                <entry value="4" name="MAV_MODE_FLAG_DECODE_POSITION_AUTO">
+                     <description>Sixt bit:   00000100</description>
+                </entry>
+                <entry value="2" name="MAV_MODE_FLAG_DECODE_POSITION_TEST">
+                     <description>Seventh bit: 00000010</description>
+                </entry>
+                <entry value="1" name="MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE">
+                     <description>Eighth bit: 00000001</description>
+                </entry>
+          </enum>
+          <enum name="MAV_GOTO">
+               <description>Override command, pauses current mission execution and moves immediately to a position</description>
+               <entry value="0" name="MAV_GOTO_DO_HOLD">
+                    <description>Hold at the current position.</description>
+               </entry>
+               <entry value="1" name="MAV_GOTO_DO_CONTINUE">
+                    <description>Continue with the next item in mission execution.</description>
+               </entry>
+               <entry value="2" name="MAV_GOTO_HOLD_AT_CURRENT_POSITION">
+                    <description>Hold at the current position of the system</description>
+               </entry>
+               <entry value="3" name="MAV_GOTO_HOLD_AT_SPECIFIED_POSITION">
+                    <description>Hold at the position specified in the parameters of the DO_HOLD action</description>
+               </entry>
+          </enum>
+          <enum name="MAV_MODE">
+               <description>These defines are predefined OR-combined mode flags. There is no need to use values from this enum, but it
                simplifies the use of the mode flags. Note that manual input is enabled in all modes as a safety override.</description>
-      <entry value="0" name="MAV_MODE_PREFLIGHT">
-        <description>System is not ready to fly, booting, calibrating, etc. No flag is set.</description>
-      </entry>
-      <entry value="80" name="MAV_MODE_STABILIZE_DISARMED">
-        <description>System is allowed to be active, under assisted RC control.</description>
-      </entry>
-      <entry value="208" name="MAV_MODE_STABILIZE_ARMED">
-        <description>System is allowed to be active, under assisted RC control.</description>
-      </entry>
-      <entry value="64" name="MAV_MODE_MANUAL_DISARMED">
-        <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
-      </entry>
-      <entry value="192" name="MAV_MODE_MANUAL_ARMED">
-        <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
-      </entry>
-      <entry value="88" name="MAV_MODE_GUIDED_DISARMED">
-        <description>System is allowed to be active, under autonomous control, manual setpoint</description>
-      </entry>
-      <entry value="216" name="MAV_MODE_GUIDED_ARMED">
-        <description>System is allowed to be active, under autonomous control, manual setpoint</description>
-      </entry>
-      <entry value="92" name="MAV_MODE_AUTO_DISARMED">
-        <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by MISSIONs)</description>
-      </entry>
-      <entry value="220" name="MAV_MODE_AUTO_ARMED">
-        <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by MISSIONs)</description>
-      </entry>
-      <entry value="66" name="MAV_MODE_TEST_DISARMED">
-        <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
-      </entry>
-      <entry value="194" name="MAV_MODE_TEST_ARMED">
-        <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_STATE">
-      <entry value="0" name="MAV_STATE_UNINIT">
-        <description>Uninitialized system, state is unknown.</description>
-      </entry>
-      <entry name="MAV_STATE_BOOT">
-        <description>System is booting up.</description>
-      </entry>
-      <entry name="MAV_STATE_CALIBRATING">
-        <description>System is calibrating and not flight-ready.</description>
-      </entry>
-      <entry name="MAV_STATE_STANDBY">
-        <description>System is grounded and on standby. It can be launched any time.</description>
-      </entry>
-      <entry name="MAV_STATE_ACTIVE">
-        <description>System is active and might be already airborne. Motors are engaged.</description>
-      </entry>
-      <entry name="MAV_STATE_CRITICAL">
-        <description>System is in a non-normal flight mode. It can however still navigate.</description>
-      </entry>
-      <entry name="MAV_STATE_EMERGENCY">
-        <description>System is in a non-normal flight mode. It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
-      </entry>
-      <entry name="MAV_STATE_POWEROFF">
-        <description>System just initialized its power-down sequence, will shut down now.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_COMPONENT">
-      <entry value="0" name="MAV_COMP_ID_ALL">
-        <description/>
-      </entry>
-      <entry value="220" name="MAV_COMP_ID_GPS">
-        <description/>
-      </entry>
-      <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
-        <description/>
-      </entry>
-      <entry value="195" name="MAV_COMP_ID_PATHPLANNER">
-        <description/>
-      </entry>
-      <entry value="180" name="MAV_COMP_ID_MAPPER">
-        <description/>
-      </entry>
-      <entry value="100" name="MAV_COMP_ID_CAMERA">
-        <description/>
-      </entry>
-      <entry value="200" name="MAV_COMP_ID_IMU">
-        <description/>
-      </entry>
-      <entry value="201" name="MAV_COMP_ID_IMU_2">
-        <description/>
-      </entry>
-      <entry value="202" name="MAV_COMP_ID_IMU_3">
-        <description/>
-      </entry>
-      <entry value="240" name="MAV_COMP_ID_UDP_BRIDGE">
-        <description/>
-      </entry>
-      <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
-        <description/>
-      </entry>
-      <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
-        <description/>
-      </entry>
-      <entry value="140" name="MAV_COMP_ID_SERVO1">
-        <description/>
-      </entry>
-      <entry value="141" name="MAV_COMP_ID_SERVO2">
-        <description/>
-      </entry>
-      <entry value="142" name="MAV_COMP_ID_SERVO3">
-        <description/>
-      </entry>
-      <entry value="143" name="MAV_COMP_ID_SERVO4">
-        <description/>
-      </entry>
-      <entry value="144" name="MAV_COMP_ID_SERVO5">
-        <description/>
-      </entry>
-      <entry value="145" name="MAV_COMP_ID_SERVO6">
-        <description/>
-      </entry>
-      <entry value="146" name="MAV_COMP_ID_SERVO7">
-        <description/>
-      </entry>
-      <entry value="147" name="MAV_COMP_ID_SERVO8">
-        <description/>
-      </entry>
-      <entry value="148" name="MAV_COMP_ID_SERVO9">
-        <description/>
-      </entry>
-      <entry value="149" name="MAV_COMP_ID_SERVO10">
-        <description/>
-      </entry>
-      <entry value="150" name="MAV_COMP_ID_SERVO11">
-        <description/>
-      </entry>
-      <entry value="151" name="MAV_COMP_ID_SERVO12">
-        <description/>
-      </entry>
-      <entry value="152" name="MAV_COMP_ID_SERVO13">
-        <description/>
-      </entry>
-      <entry value="153" name="MAV_COMP_ID_SERVO14">
-        <description/>
-      </entry>
-      <entry value="154" name="MAV_COMP_ID_GIMBAL">
-        <description/>
-      </entry>
-      <entry value="155" name="MAV_COMP_ID_LOG">
-        <description/>
-      </entry>
-      <entry value="156" name="MAV_COMP_ID_ADSB">
-        <description/>
-      </entry>
-      <entry value="157" name="MAV_COMP_ID_OSD">
-        <description>On Screen Display (OSD) devices for video links</description>
-      </entry>
-      <entry value="158" name="MAV_COMP_ID_PERIPHERAL">
-        <description>Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter sub-protocol</description>
-      </entry>
-      <entry value="159" name="MAV_COMP_ID_QX1_GIMBAL">
-        <description/>
-      </entry>
-    </enum>
-    <enum name="MAV_SYS_STATUS_SENSOR">
-      <description>These encode the sensors whose status is sent as part of the SYS_STATUS message.</description>
-      <entry value="1" name="MAV_SYS_STATUS_SENSOR_3D_GYRO">
-        <description>0x01 3D gyro</description>
-      </entry>
-      <entry value="2" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL">
-        <description>0x02 3D accelerometer</description>
-      </entry>
-      <entry value="4" name="MAV_SYS_STATUS_SENSOR_3D_MAG">
-        <description>0x04 3D magnetometer</description>
-      </entry>
-      <entry value="8" name="MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE">
-        <description>0x08 absolute pressure</description>
-      </entry>
-      <entry value="16" name="MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE">
-        <description>0x10 differential pressure</description>
-      </entry>
-      <entry value="32" name="MAV_SYS_STATUS_SENSOR_GPS">
-        <description>0x20 GPS</description>
-      </entry>
-      <entry value="64" name="MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW">
-        <description>0x40 optical flow</description>
-      </entry>
-      <entry value="128" name="MAV_SYS_STATUS_SENSOR_VISION_POSITION">
-        <description>0x80 computer vision position</description>
-      </entry>
-      <entry value="256" name="MAV_SYS_STATUS_SENSOR_LASER_POSITION">
-        <description>0x100 laser based position</description>
-      </entry>
-      <entry value="512" name="MAV_SYS_STATUS_SENSOR_EXTERNAL_GROUND_TRUTH">
-        <description>0x200 external ground truth (Vicon or Leica)</description>
-      </entry>
-      <entry value="1024" name="MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL">
-        <description>0x400 3D angular rate control</description>
-      </entry>
-      <entry value="2048" name="MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION">
-        <description>0x800 attitude stabilization</description>
-      </entry>
-      <entry value="4096" name="MAV_SYS_STATUS_SENSOR_YAW_POSITION">
-        <description>0x1000 yaw position</description>
-      </entry>
-      <entry value="8192" name="MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL">
-        <description>0x2000 z/altitude control</description>
-      </entry>
-      <entry value="16384" name="MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL">
-        <description>0x4000 x/y position control</description>
-      </entry>
-      <entry value="32768" name="MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS">
-        <description>0x8000 motor outputs / control</description>
-      </entry>
-      <entry value="65536" name="MAV_SYS_STATUS_SENSOR_RC_RECEIVER">
-        <description>0x10000 rc receiver</description>
-      </entry>
-      <entry value="131072" name="MAV_SYS_STATUS_SENSOR_3D_GYRO2">
-        <description>0x20000 2nd 3D gyro</description>
-      </entry>
-      <entry value="262144" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL2">
-        <description>0x40000 2nd 3D accelerometer</description>
-      </entry>
-      <entry value="524288" name="MAV_SYS_STATUS_SENSOR_3D_MAG2">
-        <description>0x80000 2nd 3D magnetometer</description>
-      </entry>
-      <entry value="1048576" name="MAV_SYS_STATUS_GEOFENCE">
-        <description>0x100000 geofence</description>
-      </entry>
-      <entry value="2097152" name="MAV_SYS_STATUS_AHRS">
-        <description>0x200000 AHRS subsystem health</description>
-      </entry>
-      <entry value="4194304" name="MAV_SYS_STATUS_TERRAIN">
-        <description>0x400000 Terrain subsystem health</description>
-      </entry>
-      <entry value="8388608" name="MAV_SYS_STATUS_REVERSE_MOTOR">
-        <description>0x800000 Motors are reversed</description>
-      </entry>
-      <entry value="16777216" name="MAV_SYS_STATUS_LOGGING">
-        <description>0x1000000 Logging</description>
-      </entry>
-    </enum>
-    <enum name="MAV_FRAME">
-      <entry value="0" name="MAV_FRAME_GLOBAL">
-        <description>Global coordinate frame, WGS84 coordinate system. First value / x: latitude, second value / y: longitude, third value / z: positive altitude over mean sea level (MSL)</description>
-      </entry>
-      <entry value="1" name="MAV_FRAME_LOCAL_NED">
-        <description>Local coordinate frame, Z-up (x: north, y: east, z: down).</description>
-      </entry>
-      <entry value="2" name="MAV_FRAME_MISSION">
-        <description>NOT a coordinate frame, indicates a mission command.</description>
-      </entry>
-      <entry value="3" name="MAV_FRAME_GLOBAL_RELATIVE_ALT">
-        <description>Global coordinate frame, WGS84 coordinate system, relative altitude over ground with respect to the home position. First value / x: latitude, second value / y: longitude, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
-      </entry>
-      <entry value="4" name="MAV_FRAME_LOCAL_ENU">
-        <description>Local coordinate frame, Z-down (x: east, y: north, z: up)</description>
-      </entry>
-      <entry value="5" name="MAV_FRAME_GLOBAL_INT">
-        <description>Global coordinate frame, WGS84 coordinate system. First value / x: latitude in degrees*1.0e-7, second value / y: longitude in degrees*1.0e-7, third value / z: positive altitude over mean sea level (MSL)</description>
-      </entry>
-      <entry value="6" name="MAV_FRAME_GLOBAL_RELATIVE_ALT_INT">
-        <description>Global coordinate frame, WGS84 coordinate system, relative altitude over ground with respect to the home position. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
-      </entry>
-      <entry value="7" name="MAV_FRAME_LOCAL_OFFSET_NED">
-        <description>Offset to the current local frame. Anything expressed in this frame should be added to the current local frame position.</description>
-      </entry>
-      <entry value="8" name="MAV_FRAME_BODY_NED">
-        <description>Setpoint in body NED frame. This makes sense if all position control is externalized - e.g. useful to command 2 m/s^2 acceleration to the right.</description>
-      </entry>
-      <entry value="9" name="MAV_FRAME_BODY_OFFSET_NED">
-        <description>Offset in body NED frame. This makes sense if adding setpoints to the current flight path, to avoid an obstacle - e.g. useful to command 2 m/s^2 acceleration to the east.</description>
-      </entry>
-      <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">
-        <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
-      </entry>
-      <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
-        <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
-      </entry>
-    </enum>
-    <enum name="MAVLINK_DATA_STREAM_TYPE">
-      <entry name="MAVLINK_DATA_STREAM_IMG_JPEG">
-        <description/>
-      </entry>
-      <entry name="MAVLINK_DATA_STREAM_IMG_BMP">
-        <description/>
-      </entry>
-      <entry name="MAVLINK_DATA_STREAM_IMG_RAW8U">
-        <description/>
-      </entry>
-      <entry name="MAVLINK_DATA_STREAM_IMG_RAW32U">
-        <description/>
-      </entry>
-      <entry name="MAVLINK_DATA_STREAM_IMG_PGM">
-        <description/>
-      </entry>
-      <entry name="MAVLINK_DATA_STREAM_IMG_PNG">
-        <description/>
-      </entry>
-    </enum>
-    <!-- fenced mode enums -->
-    <enum name="FENCE_ACTION">
-      <entry name="FENCE_ACTION_NONE" value="0">
-        <description>Disable fenced mode</description>
-      </entry>
-      <entry name="FENCE_ACTION_GUIDED" value="1">
-        <description>Switched to guided mode to return point (fence point 0)</description>
-      </entry>
-      <entry name="FENCE_ACTION_REPORT" value="2">
-        <description>Report fence breach, but don't take action</description>
-      </entry>
-      <entry name="FENCE_ACTION_GUIDED_THR_PASS" value="3">
-        <description>Switched to guided mode to return point (fence point 0) with manual throttle control</description>
-      </entry>
-      <entry name="FENCE_ACTION_RTL" value="4">
-        <description>Switch to RTL (return to launch) mode and head for the return point.</description>
-      </entry>
-    </enum>
-    <enum name="FENCE_BREACH">
-      <entry name="FENCE_BREACH_NONE" value="0">
-        <description>No last fence breach</description>
-      </entry>
-      <entry name="FENCE_BREACH_MINALT" value="1">
-        <description>Breached minimum altitude</description>
-      </entry>
-      <entry name="FENCE_BREACH_MAXALT" value="2">
-        <description>Breached maximum altitude</description>
-      </entry>
-      <entry name="FENCE_BREACH_BOUNDARY" value="3">
-        <description>Breached fence boundary</description>
-      </entry>
-    </enum>
-    <!-- Camera Mount mode Enumeration -->
-    <enum name="MAV_MOUNT_MODE">
-      <description>Enumeration of possible mount operation modes</description>
-      <entry name="MAV_MOUNT_MODE_RETRACT" value="0">
-        <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
-      </entry>
-      <entry name="MAV_MOUNT_MODE_NEUTRAL" value="1">
-        <description>Load and keep neutral position (Roll,Pitch,Yaw) from permanent memory.</description>
-      </entry>
-      <entry name="MAV_MOUNT_MODE_MAVLINK_TARGETING" value="2">
-        <description>Load neutral position and start MAVLink Roll,Pitch,Yaw control with stabilization</description>
-      </entry>
-      <entry name="MAV_MOUNT_MODE_RC_TARGETING" value="3">
-        <description>Load neutral position and start RC Roll,Pitch,Yaw control with stabilization</description>
-      </entry>
-      <entry name="MAV_MOUNT_MODE_GPS_POINT" value="4">
-        <description>Load neutral position and start to point to Lat,Lon,Alt</description>
-      </entry>
-    </enum>
-    <enum name="MAV_CMD">
-      <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data.</description>
-      <entry value="16" name="MAV_CMD_NAV_WAYPOINT">
-        <description>Navigate to MISSION.</description>
-        <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
-        <param index="2">Acceptance radius in meters (if the sphere with this radius is hit, the MISSION counts as reached)</param>
-        <param index="3">0 to pass through the WP, if &gt; 0 radius in meters to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
-        <param index="4">Desired yaw angle at MISSION (rotary wing)</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="17" name="MAV_CMD_NAV_LOITER_UNLIM">
-        <description>Loiter around this MISSION an unlimited amount of time</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-        <param index="4">Desired yaw angle.</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="18" name="MAV_CMD_NAV_LOITER_TURNS">
-        <description>Loiter around this MISSION for X turns</description>
-        <param index="1">Turns</param>
-        <param index="2">Empty</param>
-        <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-        <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="19" name="MAV_CMD_NAV_LOITER_TIME">
-        <description>Loiter around this MISSION for X seconds</description>
-        <param index="1">Seconds (decimal)</param>
-        <param index="2">Empty</param>
-        <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-        <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="20" name="MAV_CMD_NAV_RETURN_TO_LAUNCH">
-        <description>Return to launch location</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="21" name="MAV_CMD_NAV_LAND">
-        <description>Land at location</description>
-        <param index="1">Abort Alt</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Desired yaw angle</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="22" name="MAV_CMD_NAV_TAKEOFF">
-        <description>Takeoff from ground / hand</description>
-        <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Yaw angle (if magnetometer present), ignored without magnetometer</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="23" name="MAV_CMD_NAV_LAND_LOCAL">
-        <description>Land at local position (local frame only)</description>
-        <param index="1">Landing target number (if available)</param>
-        <param index="2">Maximum accepted offset from desired landing position [m] - computed magnitude from spherical coordinates: d = sqrt(x^2 + y^2 + z^2), which gives the maximum accepted distance between the desired landing position and the position where the vehicle is about to land</param>
-        <param index="3">Landing descend rate [ms^-1]</param>
-        <param index="4">Desired yaw angle [rad]</param>
-        <param index="5">Y-axis position [m]</param>
-        <param index="6">X-axis position [m]</param>
-        <param index="7">Z-axis / ground level position [m]</param>
-      </entry>
-      <entry value="24" name="MAV_CMD_NAV_TAKEOFF_LOCAL">
-        <description>Takeoff from local position (local frame only)</description>
-        <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor [rad]</param>
-        <param index="2">Empty</param>
-        <param index="3">Takeoff ascend rate [ms^-1]</param>
-        <param index="4">Yaw angle [rad] (if magnetometer or another yaw estimation source present), ignored without one of these</param>
-        <param index="5">Y-axis position [m]</param>
-        <param index="6">X-axis position [m]</param>
-        <param index="7">Z-axis position [m]</param>
-      </entry>
-      <entry value="25" name="MAV_CMD_NAV_FOLLOW">
-        <description>Vehicle following, i.e. this waypoint represents the position of a moving vehicle</description>
-        <param index="1">Following logic to use (e.g. loitering or sinusoidal following) - depends on specific autopilot implementation</param>
-        <param index="2">Ground speed of vehicle to be followed</param>
-        <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-        <param index="4">Desired yaw angle.</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT">
-        <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
-        <param index="1">Climb or Descend (0 = Neutral, command completes when within 5m of this command's altitude, 1 = Climbing, command completes when at or above this command's altitude, 2 = Descending, command completes when at or below this command's altitude. </param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Desired altitude in meters</param>
-      </entry>
-      <entry value="31" name="MAV_CMD_NAV_LOITER_TO_ALT">
-        <description>Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint. </description>
-        <param index="1">Heading Required (0 = False)</param>
-        <param index="2">Radius in meters. If positive loiter clockwise, negative counter-clockwise, 0 means no change to standard loiter.</param>
-        <param index="3">Empty</param>
-        <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="32" name="MAV_CMD_DO_FOLLOW">
-        <description>Being following a target</description>
-        <param index="1">System ID (the system ID of the FOLLOW_TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode</param>
-        <param index="2">RESERVED</param>
-        <param index="3">RESERVED</param>
-        <param index="4">altitude flag: 0: Keep current altitude, 1: keep altitude difference to target, 2: go to a fixed altitude above home</param>
-        <param index="5">altitude</param>
-        <param index="6">RESERVED</param>
-        <param index="7">TTL in seconds in which the MAV should go to the default position hold mode after a message rx timeout</param>
-      </entry>
-      <entry value="33" name="MAV_CMD_DO_FOLLOW_REPOSITION">
-        <description>Reposition the MAV after a follow target command has been sent</description>
-        <param index="1">Camera q1 (where 0 is on the ray from the camera to the tracking device)</param>
-        <param index="2">Camera q2</param>
-        <param index="3">Camera q3</param>
-        <param index="4">Camera q4</param>
-        <param index="5">altitude offset from target (m)</param>
-        <param index="6">X offset from target (m)</param>
-        <param index="7">Y offset from target (m)</param>
-      </entry>
-      <entry value="80" name="MAV_CMD_NAV_ROI">
-        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
-        <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
-        <param index="2">MISSION index/ target ID. (see MAV_ROI enum)</param>
-        <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
-        <param index="4">Empty</param>
-        <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
-        <param index="6">y</param>
-        <param index="7">z</param>
-      </entry>
-      <entry value="81" name="MAV_CMD_NAV_PATHPLANNING">
-        <description>Control autonomous path planning on the MAV.</description>
-        <param index="1">0: Disable local obstacle avoidance / local path planning (without resetting map), 1: Enable local path planning, 2: Enable and reset local path planning</param>
-        <param index="2">0: Disable full path planning (without resetting map), 1: Enable, 2: Enable and reset map/occupancy grid, 3: Enable and reset planned route, but not occupancy grid</param>
-        <param index="3">Empty</param>
-        <param index="4">Yaw angle at goal, in compass degrees, [0..360]</param>
-        <param index="5">Latitude/X of goal</param>
-        <param index="6">Longitude/Y of goal</param>
-        <param index="7">Altitude/Z of goal</param>
-      </entry>
-      <entry value="82" name="MAV_CMD_NAV_SPLINE_WAYPOINT">
-        <description>Navigate to MISSION using a spline path.</description>
-        <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Latitude/X of goal</param>
-        <param index="6">Longitude/Y of goal</param>
-        <param index="7">Altitude/Z of goal</param>
-      </entry>
-      <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
-        <description>Takeoff from ground using VTOL mode</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Yaw angle in degrees</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="85" name="MAV_CMD_NAV_VTOL_LAND">
-        <description>Land using VTOL mode</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Yaw angle in degrees</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <!-- IDs 90 and 91 are reserved until the end of 2014,
+               <entry value="0" name="MAV_MODE_PREFLIGHT">
+                    <description>System is not ready to fly, booting, calibrating, etc. No flag is set.</description>
+               </entry>
+               <entry value="80" name="MAV_MODE_STABILIZE_DISARMED">
+                    <description>System is allowed to be active, under assisted RC control.</description>
+               </entry>
+               <entry value="208" name="MAV_MODE_STABILIZE_ARMED">
+                    <description>System is allowed to be active, under assisted RC control.</description>
+               </entry>
+               <entry value="64" name="MAV_MODE_MANUAL_DISARMED">
+                    <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
+               </entry>
+               <entry value="192" name="MAV_MODE_MANUAL_ARMED">
+                    <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
+               </entry>
+               <entry value="88" name="MAV_MODE_GUIDED_DISARMED">
+                    <description>System is allowed to be active, under autonomous control, manual setpoint</description>
+               </entry>
+               <entry value="216" name="MAV_MODE_GUIDED_ARMED">
+                    <description>System is allowed to be active, under autonomous control, manual setpoint</description>
+               </entry>
+               <entry value="92" name="MAV_MODE_AUTO_DISARMED">
+                    <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by MISSIONs)</description>
+               </entry>
+               <entry value="220" name="MAV_MODE_AUTO_ARMED">
+                    <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by MISSIONs)</description>
+               </entry>
+               <entry value="66" name="MAV_MODE_TEST_DISARMED">
+                    <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
+               </entry>
+               <entry value="194" name="MAV_MODE_TEST_ARMED">
+                    <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
+               </entry>
+          </enum>
+          <enum name="MAV_STATE">
+               <entry value="0" name="MAV_STATE_UNINIT">
+                    <description>Uninitialized system, state is unknown.</description>
+               </entry>
+               <entry name="MAV_STATE_BOOT">
+                    <description>System is booting up.</description>
+               </entry>
+               <entry name="MAV_STATE_CALIBRATING">
+                    <description>System is calibrating and not flight-ready.</description>
+               </entry>
+               <entry name="MAV_STATE_STANDBY">
+                    <description>System is grounded and on standby. It can be launched any time.</description>
+               </entry>
+               <entry name="MAV_STATE_ACTIVE">
+                    <description>System is active and might be already airborne. Motors are engaged.</description>
+               </entry>
+               <entry name="MAV_STATE_CRITICAL">
+                    <description>System is in a non-normal flight mode. It can however still navigate.</description>
+               </entry>
+               <entry name="MAV_STATE_EMERGENCY">
+                    <description>System is in a non-normal flight mode. It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
+               </entry>
+               <entry name="MAV_STATE_POWEROFF">
+                    <description>System just initialized its power-down sequence, will shut down now.</description>
+               </entry>
+          </enum>
+          <enum name="MAV_COMPONENT">
+               <entry value="0" name="MAV_COMP_ID_ALL">
+                    <description/>
+               </entry>
+               <entry value="220" name="MAV_COMP_ID_GPS">
+                    <description/>
+               </entry>
+               <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
+                    <description/>
+               </entry>
+               <entry value="195" name="MAV_COMP_ID_PATHPLANNER">
+                    <description/>
+               </entry>
+               <entry value="180" name="MAV_COMP_ID_MAPPER">
+                    <description/>
+               </entry>
+               <entry value="100" name="MAV_COMP_ID_CAMERA">
+                    <description/>
+               </entry>
+               <entry value="200" name="MAV_COMP_ID_IMU">
+                    <description/>
+               </entry>
+               <entry value="201" name="MAV_COMP_ID_IMU_2">
+                    <description/>
+               </entry>
+               <entry value="202" name="MAV_COMP_ID_IMU_3">
+                    <description/>
+               </entry>
+               <entry value="240" name="MAV_COMP_ID_UDP_BRIDGE">
+                    <description/>
+               </entry>
+               <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
+                    <description/>
+               </entry>
+               <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
+                    <description/>
+               </entry>
+               <entry value="140" name="MAV_COMP_ID_SERVO1">
+                    <description/>
+               </entry>
+               <entry value="141" name="MAV_COMP_ID_SERVO2">
+                    <description/>
+               </entry>
+               <entry value="142" name="MAV_COMP_ID_SERVO3">
+                    <description/>
+               </entry>
+               <entry value="143" name="MAV_COMP_ID_SERVO4">
+                    <description/>
+               </entry>
+               <entry value="144" name="MAV_COMP_ID_SERVO5">
+                    <description/>
+               </entry>
+               <entry value="145" name="MAV_COMP_ID_SERVO6">
+                    <description/>
+               </entry>
+               <entry value="146" name="MAV_COMP_ID_SERVO7">
+                    <description/>
+               </entry>
+               <entry value="147" name="MAV_COMP_ID_SERVO8">
+                    <description/>
+               </entry>
+               <entry value="148" name="MAV_COMP_ID_SERVO9">
+                    <description/>
+               </entry>
+               <entry value="149" name="MAV_COMP_ID_SERVO10">
+                    <description/>
+               </entry>
+               <entry value="150" name="MAV_COMP_ID_SERVO11">
+                    <description/>
+               </entry>
+               <entry value="151" name="MAV_COMP_ID_SERVO12">
+                    <description/>
+               </entry>
+               <entry value="152" name="MAV_COMP_ID_SERVO13">
+                    <description/>
+               </entry>
+               <entry value="153" name="MAV_COMP_ID_SERVO14">
+                    <description/>
+               </entry>
+               <entry value="154" name="MAV_COMP_ID_GIMBAL">
+                    <description/>
+               </entry>
+               <entry value="155" name="MAV_COMP_ID_LOG">
+                    <description/>
+               </entry>
+               <entry value="156" name="MAV_COMP_ID_ADSB">
+                    <description/>
+               </entry>
+               <entry value="157" name="MAV_COMP_ID_OSD">
+                    <description>On Screen Display (OSD) devices for video links</description>
+               </entry>
+               <entry value="158" name="MAV_COMP_ID_PERIPHERAL">
+                    <description>Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter sub-protocol</description>
+               </entry>
+               <entry value="159" name="MAV_COMP_ID_QX1_GIMBAL">
+                    <description/>
+               </entry>
+          </enum>
+          <enum name="MAV_SYS_STATUS_SENSOR">
+               <description>These encode the sensors whose status is sent as part of the SYS_STATUS message.</description>
+               <entry value="1" name="MAV_SYS_STATUS_SENSOR_3D_GYRO">
+                    <description>0x01 3D gyro</description>
+               </entry>
+               <entry value="2" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL">
+                    <description>0x02 3D accelerometer</description>
+               </entry>
+               <entry value="4" name="MAV_SYS_STATUS_SENSOR_3D_MAG">
+                    <description>0x04 3D magnetometer</description>
+               </entry>
+               <entry value="8" name="MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE">
+                    <description>0x08 absolute pressure</description>
+               </entry>
+               <entry value="16" name="MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE">
+                    <description>0x10 differential pressure</description>
+               </entry>
+               <entry value="32" name="MAV_SYS_STATUS_SENSOR_GPS">
+                    <description>0x20 GPS</description>
+               </entry>
+               <entry value="64" name="MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW">
+                    <description>0x40 optical flow</description>
+               </entry>
+               <entry value="128" name="MAV_SYS_STATUS_SENSOR_VISION_POSITION">
+                    <description>0x80 computer vision position</description>
+               </entry>
+               <entry value="256" name="MAV_SYS_STATUS_SENSOR_LASER_POSITION">
+                    <description>0x100 laser based position</description>
+               </entry>
+               <entry value="512" name="MAV_SYS_STATUS_SENSOR_EXTERNAL_GROUND_TRUTH">
+                    <description>0x200 external ground truth (Vicon or Leica)</description>
+               </entry>
+               <entry value="1024" name="MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL">
+                    <description>0x400 3D angular rate control</description>
+               </entry>
+               <entry value="2048" name="MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION">
+                    <description>0x800 attitude stabilization</description>
+               </entry>
+               <entry value="4096" name="MAV_SYS_STATUS_SENSOR_YAW_POSITION">
+                    <description>0x1000 yaw position</description>
+               </entry>
+               <entry value="8192" name="MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL">
+                    <description>0x2000 z/altitude control</description>
+               </entry>
+               <entry value="16384" name="MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL">
+                    <description>0x4000 x/y position control</description>
+               </entry>
+               <entry value="32768" name="MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS">
+                    <description>0x8000 motor outputs / control</description>
+               </entry>
+               <entry value="65536" name="MAV_SYS_STATUS_SENSOR_RC_RECEIVER">
+                    <description>0x10000 rc receiver</description>
+               </entry>
+               <entry value="131072" name="MAV_SYS_STATUS_SENSOR_3D_GYRO2">
+                    <description>0x20000 2nd 3D gyro</description>
+               </entry>
+               <entry value="262144" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL2">
+                    <description>0x40000 2nd 3D accelerometer</description>
+               </entry>
+               <entry value="524288" name="MAV_SYS_STATUS_SENSOR_3D_MAG2">
+                    <description>0x80000 2nd 3D magnetometer</description>
+               </entry>
+               <entry value="1048576" name="MAV_SYS_STATUS_GEOFENCE">
+                    <description>0x100000 geofence</description>
+               </entry>
+               <entry value="2097152" name="MAV_SYS_STATUS_AHRS">
+                    <description>0x200000 AHRS subsystem health</description>
+               </entry>
+               <entry value="4194304" name="MAV_SYS_STATUS_TERRAIN">
+                    <description>0x400000 Terrain subsystem health</description>
+               </entry>
+               <entry value="8388608" name="MAV_SYS_STATUS_REVERSE_MOTOR">
+                    <description>0x800000 Motors are reversed</description>
+               </entry>
+               <entry value="16777216" name="MAV_SYS_STATUS_LOGGING">
+                    <description>0x1000000 Logging</description>
+               </entry>
+          </enum>
+          <enum name="MAV_FRAME">
+               <entry value="0" name="MAV_FRAME_GLOBAL">
+                    <description>Global coordinate frame, WGS84 coordinate system. First value / x: latitude, second value / y: longitude, third value / z: positive altitude over mean sea level (MSL)</description>
+               </entry>
+               <entry value="1" name="MAV_FRAME_LOCAL_NED">
+                    <description>Local coordinate frame, Z-up (x: north, y: east, z: down).</description>
+               </entry>
+               <entry value="2" name="MAV_FRAME_MISSION">
+                    <description>NOT a coordinate frame, indicates a mission command.</description>
+               </entry>
+               <entry value="3" name="MAV_FRAME_GLOBAL_RELATIVE_ALT">
+                    <description>Global coordinate frame, WGS84 coordinate system, relative altitude over ground with respect to the home position. First value / x: latitude, second value / y: longitude, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
+               </entry>
+               <entry value="4" name="MAV_FRAME_LOCAL_ENU">
+                    <description>Local coordinate frame, Z-down (x: east, y: north, z: up)</description>
+               </entry>
+               <entry value="5" name="MAV_FRAME_GLOBAL_INT">
+                   <description>Global coordinate frame, WGS84 coordinate system. First value / x: latitude in degrees*1.0e-7, second value / y: longitude in degrees*1.0e-7, third value / z: positive altitude over mean sea level (MSL)</description>
+               </entry>
+               <entry value="6" name="MAV_FRAME_GLOBAL_RELATIVE_ALT_INT">
+                   <description>Global coordinate frame, WGS84 coordinate system, relative altitude over ground with respect to the home position. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
+               </entry>
+               <entry value="7" name="MAV_FRAME_LOCAL_OFFSET_NED">
+                   <description>Offset to the current local frame. Anything expressed in this frame should be added to the current local frame position.</description>
+               </entry>
+               <entry value="8" name="MAV_FRAME_BODY_NED">
+                   <description>Setpoint in body NED frame. This makes sense if all position control is externalized - e.g. useful to command 2 m/s^2 acceleration to the right.</description>
+               </entry>
+               <entry value="9" name="MAV_FRAME_BODY_OFFSET_NED">
+                   <description>Offset in body NED frame. This makes sense if adding setpoints to the current flight path, to avoid an obstacle - e.g. useful to command 2 m/s^2 acceleration to the east.</description>
+               </entry>
+               <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">
+                   <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+               </entry>
+               <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
+                   <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+               </entry>
+          </enum>
+          <enum name="MAVLINK_DATA_STREAM_TYPE">
+               <entry name="MAVLINK_DATA_STREAM_IMG_JPEG">
+                    <description/>
+               </entry>
+               <entry name="MAVLINK_DATA_STREAM_IMG_BMP">
+                    <description/>
+               </entry>
+               <entry name="MAVLINK_DATA_STREAM_IMG_RAW8U">
+                    <description/>
+               </entry>
+               <entry name="MAVLINK_DATA_STREAM_IMG_RAW32U">
+                    <description/>
+               </entry>
+               <entry name="MAVLINK_DATA_STREAM_IMG_PGM">
+                    <description/>
+               </entry>
+               <entry name="MAVLINK_DATA_STREAM_IMG_PNG">
+                    <description/>
+               </entry>
+          </enum>
+          <!-- fenced mode enums -->
+          <enum name="FENCE_ACTION">
+              <entry name="FENCE_ACTION_NONE" value="0">
+                  <description>Disable fenced mode</description>
+              </entry>
+              <entry name="FENCE_ACTION_GUIDED" value="1">
+                  <description>Switched to guided mode to return point (fence point 0)</description>
+              </entry>
+              <entry name="FENCE_ACTION_REPORT" value="2">
+                  <description>Report fence breach, but don't take action</description>
+              </entry>
+              <entry name="FENCE_ACTION_GUIDED_THR_PASS" value="3">
+                  <description>Switched to guided mode to return point (fence point 0) with manual throttle control</description>
+              </entry>
+              <entry name="FENCE_ACTION_RTL" value="4">
+                  <description>Switch to RTL (return to launch) mode and head for the return point.</description>
+              </entry>
+          </enum>
+
+          <enum name="FENCE_BREACH">
+              <entry name="FENCE_BREACH_NONE" value="0">
+                  <description>No last fence breach</description>
+              </entry>
+              <entry name="FENCE_BREACH_MINALT" value="1">
+                  <description>Breached minimum altitude</description>
+              </entry>
+              <entry name="FENCE_BREACH_MAXALT" value="2">
+                  <description>Breached maximum altitude</description>
+              </entry>
+              <entry name="FENCE_BREACH_BOUNDARY" value="3">
+                  <description>Breached fence boundary</description>
+              </entry>
+          </enum>
+          <!-- Camera Mount mode Enumeration -->
+          <enum name="MAV_MOUNT_MODE">
+              <description>Enumeration of possible mount operation modes</description>
+              <entry name="MAV_MOUNT_MODE_RETRACT" value="0"><description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description></entry>
+              <entry name="MAV_MOUNT_MODE_NEUTRAL" value="1"><description>Load and keep neutral position (Roll,Pitch,Yaw) from permanent memory.</description></entry>
+              <entry name="MAV_MOUNT_MODE_MAVLINK_TARGETING" value="2"><description>Load neutral position and start MAVLink Roll,Pitch,Yaw control with stabilization</description></entry>
+              <entry name="MAV_MOUNT_MODE_RC_TARGETING" value="3"><description>Load neutral position and start RC Roll,Pitch,Yaw control with stabilization</description></entry>
+              <entry name="MAV_MOUNT_MODE_GPS_POINT" value="4"><description>Load neutral position and start to point to Lat,Lon,Alt</description></entry>
+          </enum>
+          <enum name="MAV_CMD">
+               <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data.</description>
+               <entry value="16" name="MAV_CMD_NAV_WAYPOINT">
+                    <description>Navigate to MISSION.</description>
+                    <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
+                    <param index="2">Acceptance radius in meters (if the sphere with this radius is hit, the MISSION counts as reached)</param>
+                    <param index="3">0 to pass through the WP, if > 0 radius in meters to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
+                    <param index="4">Desired yaw angle at MISSION (rotary wing)</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="17" name="MAV_CMD_NAV_LOITER_UNLIM">
+                    <description>Loiter around this MISSION an unlimited amount of time</description>
+                    <param index="1">Empty</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
+                    <param index="4">Desired yaw angle.</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="18" name="MAV_CMD_NAV_LOITER_TURNS">
+                    <description>Loiter around this MISSION for X turns</description>
+                    <param index="1">Turns</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
+                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="19" name="MAV_CMD_NAV_LOITER_TIME">
+                    <description>Loiter around this MISSION for X seconds</description>
+                    <param index="1">Seconds (decimal)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
+                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="20" name="MAV_CMD_NAV_RETURN_TO_LAUNCH">
+                    <description>Return to launch location</description>
+                    <param index="1">Empty</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="21" name="MAV_CMD_NAV_LAND">
+                    <description>Land at location</description>
+                    <param index="1">Abort Alt</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Desired yaw angle</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="22" name="MAV_CMD_NAV_TAKEOFF">
+                    <description>Takeoff from ground / hand</description>
+                    <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Yaw angle (if magnetometer present), ignored without magnetometer</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="23" name="MAV_CMD_NAV_LAND_LOCAL">
+                    <description>Land at local position (local frame only)</description>
+                    <param index="1">Landing target number (if available)</param>
+                    <param index="2">Maximum accepted offset from desired landing position [m] - computed magnitude from spherical coordinates: d = sqrt(x^2 + y^2 + z^2), which gives the maximum accepted distance between the desired landing position and the position where the vehicle is about to land</param>
+                    <param index="3">Landing descend rate [ms^-1]</param>
+                    <param index="4">Desired yaw angle [rad]</param>
+                    <param index="5">Y-axis position [m]</param>
+                    <param index="6">X-axis position [m]</param>
+                    <param index="7">Z-axis / ground level position [m]</param>
+               </entry>
+               <entry value="24" name="MAV_CMD_NAV_TAKEOFF_LOCAL">
+                    <description>Takeoff from local position (local frame only)</description>
+                    <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor [rad]</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Takeoff ascend rate [ms^-1]</param>
+                    <param index="4">Yaw angle [rad] (if magnetometer or another yaw estimation source present), ignored without one of these</param>
+                    <param index="5">Y-axis position [m]</param>
+                    <param index="6">X-axis position [m]</param>
+                    <param index="7">Z-axis position [m]</param>
+               </entry>
+               <entry value="25" name="MAV_CMD_NAV_FOLLOW">
+                    <description>Vehicle following, i.e. this waypoint represents the position of a moving vehicle</description>
+                    <param index="1">Following logic to use (e.g. loitering or sinusoidal following) - depends on specific autopilot implementation</param>
+                    <param index="2">Ground speed of vehicle to be followed</param>
+                    <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
+                    <param index="4">Desired yaw angle.</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT">
+                   <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
+                   <param index="1">Climb or Descend (0 = Neutral, command completes when within 5m of this command's altitude, 1 = Climbing, command completes when at or above this command's altitude, 2 = Descending, command completes when at or below this command's altitude. </param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Desired altitude in meters</param>
+               </entry>
+                <entry value="31" name="MAV_CMD_NAV_LOITER_TO_ALT">
+                    <description>Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint. </description>
+                    <param index="1">Heading Required (0 = False)</param>
+                    <param index="2">Radius in meters. If positive loiter clockwise, negative counter-clockwise, 0 means no change to standard loiter.</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="32" name="MAV_CMD_DO_FOLLOW">
+                    <description>Being following a target</description>
+                    <param index="1">System ID (the system ID of the FOLLOW_TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode</param>
+                    <param index="2">RESERVED</param>
+                    <param index="3">RESERVED</param>
+                    <param index="4">altitude flag: 0: Keep current altitude, 1: keep altitude difference to target, 2: go to a fixed altitude above home</param>
+                    <param index="5">altitude</param>
+                    <param index="6">RESERVED</param>
+                    <param index="7">TTL in seconds in which the MAV should go to the default position hold mode after a message rx timeout</param>
+               </entry>
+               <entry value="33" name="MAV_CMD_DO_FOLLOW_REPOSITION">
+                    <description>Reposition the MAV after a follow target command has been sent</description>
+                    <param index="1">Camera q1 (where 0 is on the ray from the camera to the tracking device)</param>
+                    <param index="2">Camera q2</param>
+                    <param index="3">Camera q3</param>
+                    <param index="4">Camera q4</param>
+                    <param index="5">altitude offset from target (m)</param>
+                    <param index="6">X offset from target (m)</param>
+                    <param index="7">Y offset from target (m)</param>
+               </entry>
+               <entry value="80" name="MAV_CMD_NAV_ROI">
+                    <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+                    <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
+                    <param index="2">MISSION index/ target ID. (see MAV_ROI enum)</param>
+                    <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
+                    <param index="4">Empty</param>
+                    <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
+                    <param index="6">y</param>
+                    <param index="7">z</param>
+               </entry>
+               <entry value="81" name="MAV_CMD_NAV_PATHPLANNING">
+                    <description>Control autonomous path planning on the MAV.</description>
+                    <param index="1">0: Disable local obstacle avoidance / local path planning (without resetting map), 1: Enable local path planning, 2: Enable and reset local path planning</param>
+                    <param index="2">0: Disable full path planning (without resetting map), 1: Enable, 2: Enable and reset map/occupancy grid, 3: Enable and reset planned route, but not occupancy grid</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Yaw angle at goal, in compass degrees, [0..360]</param>
+                    <param index="5">Latitude/X of goal</param>
+                    <param index="6">Longitude/Y of goal</param>
+                    <param index="7">Altitude/Z of goal</param>
+               </entry>
+               <entry value="82" name="MAV_CMD_NAV_SPLINE_WAYPOINT">
+                    <description>Navigate to MISSION using a spline path.</description>
+                    <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Latitude/X of goal</param>
+                    <param index="6">Longitude/Y of goal</param>
+                    <param index="7">Altitude/Z of goal</param>
+               </entry>
+               <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
+                    <description>Takeoff from ground using VTOL mode</description>
+                    <param index="1">Empty</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Yaw angle in degrees</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="85" name="MAV_CMD_NAV_VTOL_LAND">
+                    <description>Land using VTOL mode</description>
+                    <param index="1">Empty</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Yaw angle in degrees</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+
+               <!-- IDs 90 and 91 are reserved until the end of 2014,
                     as they were used in some conflicting proposals
                     between PX4 and ardupilot and need to be kept
                     unused to prevent errors -->
-      <entry value="92" name="MAV_CMD_NAV_GUIDED_ENABLE">
-        <description>hand control over to an external controller</description>
-        <param index="1">On / Off (&gt; 0.5f on)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="93" name="MAV_CMD_NAV_DELAY">
-        <description>Delay the next navigation command a number of seconds or until a specified time</description>
-        <param index="1">Delay in seconds (decimal, -1 to enable time-of-day fields)</param>
-        <param index="2">hour (24h format, UTC, -1 to ignore)</param>
-        <param index="3">minute (24h format, UTC, -1 to ignore)</param>
-        <param index="4">second (24h format, UTC)</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="95" name="MAV_CMD_NAV_LAST">
-        <description>NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="112" name="MAV_CMD_CONDITION_DELAY">
-        <description>Delay mission state machine.</description>
-        <param index="1">Delay in seconds (decimal)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="113" name="MAV_CMD_CONDITION_CHANGE_ALT">
-        <description>Ascend/descend at rate.  Delay mission state machine until desired altitude reached.</description>
-        <param index="1">Descent / Ascend rate (m/s)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Finish Altitude</param>
-      </entry>
-      <entry value="114" name="MAV_CMD_CONDITION_DISTANCE">
-        <description>Delay mission state machine until within desired distance of next NAV point.</description>
-        <param index="1">Distance (meters)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="115" name="MAV_CMD_CONDITION_YAW">
-        <description>Reach a certain target angle.</description>
-        <param index="1">target angle: [0-360], 0 is north</param>
-        <param index="2">speed during yaw change:[deg per second]</param>
-        <param index="3">direction: negative: counter clockwise, positive: clockwise [-1,1]</param>
-        <param index="4">relative offset or absolute angle: [ 1,0]</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="159" name="MAV_CMD_CONDITION_LAST">
-        <description>NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="176" name="MAV_CMD_DO_SET_MODE">
-        <description>Set system mode.</description>
-        <param index="1">Mode, as defined by ENUM MAV_MODE</param>
-        <param index="2">Custom mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
-        <param index="3">Custom sub mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="177" name="MAV_CMD_DO_JUMP">
-        <description>Jump to the desired command in the mission list.  Repeat this action only the specified number of times</description>
-        <param index="1">Sequence number</param>
-        <param index="2">Repeat count</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="178" name="MAV_CMD_DO_CHANGE_SPEED">
-        <description>Change speed and/or throttle set points.</description>
-        <param index="1">Speed type (0=Airspeed, 1=Ground Speed)</param>
-        <param index="2">Speed  (m/s, -1 indicates no change)</param>
-        <param index="3">Throttle  ( Percent, -1 indicates no change)</param>
-        <param index="4">absolute or relative [0,1]</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="179" name="MAV_CMD_DO_SET_HOME">
-        <description>Changes the home location either to the current location or a specified location.</description>
-        <param index="1">Use current (1=use current location, 0=use specified location)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <entry value="180" name="MAV_CMD_DO_SET_PARAMETER">
-        <description>Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.</description>
-        <param index="1">Parameter number</param>
-        <param index="2">Parameter value</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="181" name="MAV_CMD_DO_SET_RELAY">
-        <description>Set a relay to a condition.</description>
-        <param index="1">Relay number</param>
-        <param index="2">Setting (1=on, 0=off, others possible depending on system hardware)</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="182" name="MAV_CMD_DO_REPEAT_RELAY">
-        <description>Cycle a relay on and off for a desired number of cyles with a desired period.</description>
-        <param index="1">Relay number</param>
-        <param index="2">Cycle count</param>
-        <param index="3">Cycle time (seconds, decimal)</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="183" name="MAV_CMD_DO_SET_SERVO">
-        <description>Set a servo to a desired PWM value.</description>
-        <param index="1">Servo number</param>
-        <param index="2">PWM (microseconds, 1000 to 2000 typical)</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="184" name="MAV_CMD_DO_REPEAT_SERVO">
-        <description>Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.</description>
-        <param index="1">Servo number</param>
-        <param index="2">PWM (microseconds, 1000 to 2000 typical)</param>
-        <param index="3">Cycle count</param>
-        <param index="4">Cycle time (seconds)</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="185" name="MAV_CMD_DO_FLIGHTTERMINATION">
-        <description>Terminate flight immediately</description>
-        <param index="1">Flight termination activated if &gt; 0.5</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="186" name="MAV_CMD_DO_CHANGE_ALTITUDE">
-        <description>Change altitude set point.</description>
-        <param index="1">Altitude in meters</param>
-        <param index="2">Mav frame of new altitude (see MAV_FRAME)</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="189" name="MAV_CMD_DO_LAND_START">
-        <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0/0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="190" name="MAV_CMD_DO_RALLY_LAND">
-        <description>Mission command to perform a landing from a rally point.</description>
-        <param index="1">Break altitude (meters)</param>
-        <param index="2">Landing speed (m/s)</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="191" name="MAV_CMD_DO_GO_AROUND">
-        <description>Mission command to safely abort an autonmous landing.</description>
-        <param index="1">Altitude (meters)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="192" name="MAV_CMD_DO_REPOSITION">
-        <description>Reposition the vehicle to a specific WGS84 global position.</description>
-        <param index="1">Ground speed, less than 0 (-1) for default</param>
-        <param index="2">Bitmask of option flags, see the MAV_DO_REPOSITION_FLAGS enum.</param>
-        <param index="3">Reserved</param>
-        <param index="4">Yaw heading, NaN for unchanged. For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
-        <param index="5">Latitude (deg * 1E7)</param>
-        <param index="6">Longitude (deg * 1E7)</param>
-        <param index="7">Altitude (meters)</param>
-      </entry>
-      <entry value="193" name="MAV_CMD_DO_PAUSE_CONTINUE">
-        <description>If in a GPS controlled position mode, hold the current position or continue.</description>
-        <param index="1">0: Pause current mission or reposition command, hold current position. 1: Continue mission. A VTOL capable vehicle should enter hover mode (multicopter and VTOL planes). A plane should loiter with the default loiter radius.</param>
-        <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Reserved</param>
-        <param index="6">Reserved</param>
-        <param index="7">Reserved</param>
-      </entry>
-      <entry value="194" name="MAV_CMD_DO_SET_REVERSE">
-        <description>Set moving direction to forward or reverse.</description>
-        <param index="1">Direction (0=Forward, 1=Reverse)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="200" name="MAV_CMD_DO_CONTROL_VIDEO">
-        <description>Control onboard camera system.</description>
-        <param index="1">Camera ID (-1 for all)</param>
-        <param index="2">Transmission: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
-        <param index="3">Transmission mode: 0: video stream, &gt;0: single images every n seconds (decimal)</param>
-        <param index="4">Recording: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="201" name="MAV_CMD_DO_SET_ROI">
-        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
-        <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
-        <param index="2">MISSION index/ target ID. (see MAV_ROI enum)</param>
-        <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
-        <param index="4">Empty</param>
-        <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
-        <param index="6">y</param>
-        <param index="7">z</param>
-      </entry>
-      <!-- Camera Controller Mission Commands Enumeration -->
-      <!-- MAV_CMD_DO_DIGICAM_CONFIGURE should be deprecated and replaced with CAMERA_SETTINGS -->
-      <entry name="MAV_CMD_DO_DIGICAM_CONFIGURE" value="202">
-        <description>Mission command to configure an on-board camera controller system.</description>
-        <param index="1">Modes: P, TV, AV, M, Etc</param>
-        <param index="2">Shutter speed: Divisor number for one second</param>
-        <param index="3">Aperture: F stop number</param>
-        <param index="4">ISO number e.g. 80, 100, 200, Etc</param>
-        <param index="5">Exposure type enumerator</param>
-        <param index="6">Command Identity</param>
-        <param index="7">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</param>
-      </entry>
-      <entry name="MAV_CMD_DO_DIGICAM_CONTROL" value="203">
-        <description>Mission command to control an on-board camera controller system.</description>
-        <param index="1">Session control e.g. show/hide lens</param>
-        <param index="2">Zoom's absolute position</param>
-        <param index="3">Zooming step value to offset zoom from the current position</param>
-        <param index="4">Focus Locking, Unlocking or Re-locking</param>
-        <param index="5">Shooting Command</param>
-        <param index="6">Command Identity</param>
-        <param index="7">Empty</param>
-      </entry>
-      <!-- Camera Mount Mission Commands Enumeration -->
-      <entry name="MAV_CMD_DO_MOUNT_CONFIGURE" value="204">
-        <description>Mission command to configure a camera or antenna mount</description>
-        <param index="1">Mount operation mode (see MAV_MOUNT_MODE enum)</param>
-        <param index="2">stabilize roll? (1 = yes, 0 = no)</param>
-        <param index="3">stabilize pitch? (1 = yes, 0 = no)</param>
-        <param index="4">stabilize yaw? (1 = yes, 0 = no)</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry name="MAV_CMD_DO_MOUNT_CONTROL" value="205">
-        <description>Mission command to control a camera or antenna mount</description>
-        <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode.</param>
-        <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode.</param>
-        <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode.</param>
-        <param index="4">WIP: alt in meters depending on mount mode.</param>
-        <param index="5">WIP: latitude in degrees * 1E7, set if appropriate mount mode.</param>
-        <param index="6">WIP: longitude in degrees * 1E7, set if appropriate mount mode.</param>
-        <param index="7">MAV_MOUNT_MODE enum value</param>
-      </entry>
-      <entry name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" value="206">
-        <description>Mission command to set CAM_TRIGG_DIST for this flight</description>
-        <param index="1">Camera trigger distance (meters)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry name="MAV_CMD_DO_FENCE_ENABLE" value="207">
-        <description>Mission command to enable the geofence</description>
-        <param index="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry name="MAV_CMD_DO_PARACHUTE" value="208">
-        <description>Mission command to trigger a parachute</description>
-        <param index="1">action (0=disable, 1=enable, 2=release, for some systems see PARACHUTE_ACTION enum, not in general message set.)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry name="MAV_CMD_DO_MOTOR_TEST" value="209">
-        <description>Mission command to perform motor test</description>
-        <param index="1">motor sequence number (a number from 1 to max number of motors on the vehicle)</param>
-        <param index="2">throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)</param>
-        <param index="3">throttle</param>
-        <param index="4">timeout (in seconds)</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry name="MAV_CMD_DO_INVERTED_FLIGHT" value="210">
-        <description>Change to/from inverted flight</description>
-        <param index="1">inverted (0=normal, 1=inverted)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry name="MAV_CMD_NAV_SET_YAW_SPEED" value="213">
-        <description>Sets a desired vehicle turn angle and speed change</description>
-        <param index="1">yaw angle to adjust steering by in centidegress</param>
-        <param index="2">speed - normalized to 0 .. 1</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT">
-        <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
-        <param index="1">q1 - quaternion param #1, w (1 in null-rotation)</param>
-        <param index="2">q2 - quaternion param #2, x (0 in null-rotation)</param>
-        <param index="3">q3 - quaternion param #3, y (0 in null-rotation)</param>
-        <param index="4">q4 - quaternion param #4, z (0 in null-rotation)</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="221" name="MAV_CMD_DO_GUIDED_MASTER">
-        <description>set id of master controller</description>
-        <param index="1">System ID</param>
-        <param index="2">Component ID</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="222" name="MAV_CMD_DO_GUIDED_LIMITS">
-        <description>set limits for external control</description>
-        <param index="1">timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout</param>
-        <param index="2">absolute altitude min (in meters, AMSL) - if vehicle moves below this alt, the command will be aborted and the mission will continue.  0 means no lower altitude limit</param>
-        <param index="3">absolute altitude max (in meters)- if vehicle moves above this alt, the command will be aborted and the mission will continue.  0 means no upper altitude limit</param>
-        <param index="4">horizontal move limit (in meters, AMSL) - if vehicle moves more than this distance from it's location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal altitude limit</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="223" name="MAV_CMD_DO_ENGINE_CONTROL">
-        <description>Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines</description>
-        <param index="1">0: Stop engine, 1:Start Engine</param>
-        <param index="2">0: Warm start, 1:Cold start. Controls use of choke where applicable</param>
-        <param index="3">Height delay (meters). This is for commanding engine start only after the vehicle has gained the specified height. Used in VTOL vehicles during takeoff to start engine after the aircraft is off the ground. Zero for no delay.</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="240" name="MAV_CMD_DO_LAST">
-        <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="241" name="MAV_CMD_PREFLIGHT_CALIBRATION">
-        <description>Trigger calibration. This command will be only accepted if in pre-flight mode. Except for Temperature Calibration, only one sensor should be set in a single message and all others should be zero.</description>
-        <param index="1">1: gyro calibration, 3: gyro temperature calibration</param>
-        <param index="2">1: magnetometer calibration</param>
-        <param index="3">1: ground pressure calibration</param>
-        <param index="4">1: radio RC calibration, 2: RC trim calibration</param>
-        <param index="5">1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration</param>
-        <param index="6">1: APM: compass/motor interference calibration / PX4: airspeed calibration</param>
-        <param index="7">1: ESC calibration, 3: barometer temperature calibration</param>
-      </entry>
-      <entry value="242" name="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS">
-        <description>Set sensor offsets. This command will be only accepted if in pre-flight mode.</description>
-        <param index="1">Sensor to adjust the offsets for: 0: gyros, 1: accelerometer, 2: magnetometer, 3: barometer, 4: optical flow, 5: second magnetometer, 6: third magnetometer</param>
-        <param index="2">X axis offset (or generic dimension 1), in the sensor's raw units</param>
-        <param index="3">Y axis offset (or generic dimension 2), in the sensor's raw units</param>
-        <param index="4">Z axis offset (or generic dimension 3), in the sensor's raw units</param>
-        <param index="5">Generic dimension 4, in the sensor's raw units</param>
-        <param index="6">Generic dimension 5, in the sensor's raw units</param>
-        <param index="7">Generic dimension 6, in the sensor's raw units</param>
-      </entry>
-      <entry value="243" name="MAV_CMD_PREFLIGHT_UAVCAN">
-        <description>Trigger UAVCAN config. This command will be only accepted if in pre-flight mode.</description>
-        <param index="1">1: Trigger actuator ID assignment and direction mapping.</param>
-        <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Reserved</param>
-        <param index="6">Reserved</param>
-        <param index="7">Reserved</param>
-      </entry>
-      <entry value="245" name="MAV_CMD_PREFLIGHT_STORAGE">
-        <description>Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.</description>
-        <param index="1">Parameter storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
-        <param index="2">Mission storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
-        <param index="3">Onboard logging: 0: Ignore, 1: Start default rate logging, -1: Stop logging, &gt; 1: start logging with rate of param 3 in Hz (e.g. set to 1000 for 1000 Hz logging)</param>
-        <param index="4">Reserved</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="246" name="MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN">
-        <description>Request the reboot or shutdown of system components.</description>
-        <param index="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
-        <param index="2">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
-        <param index="3">WIP: 0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
-        <param index="4">WIP: 0: Do nothing for mount (e.g. gimbal), 1: Reboot mount, 2: Shutdown mount, 3: Reboot mount and keep it in the bootloader until upgraded</param>
-        <param index="5">Reserved, send 0</param>
-        <param index="6">Reserved, send 0</param>
-        <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
-      </entry>
-      <entry value="252" name="MAV_CMD_OVERRIDE_GOTO">
-        <description>Hold / continue the current action</description>
-        <param index="1">MAV_GOTO_DO_HOLD: hold MAV_GOTO_DO_CONTINUE: continue with next item in mission plan</param>
-        <param index="2">MAV_GOTO_HOLD_AT_CURRENT_POSITION: Hold at current position MAV_GOTO_HOLD_AT_SPECIFIED_POSITION: hold at specified position</param>
-        <param index="3">MAV_FRAME coordinate frame of hold point</param>
-        <param index="4">Desired yaw angle in degrees</param>
-        <param index="5">Latitude / X position</param>
-        <param index="6">Longitude / Y position</param>
-        <param index="7">Altitude / Z position</param>
-      </entry>
-      <entry value="300" name="MAV_CMD_MISSION_START">
-        <description>start running a mission</description>
-        <param index="1">first_item: the first mission item to run</param>
-        <param index="2">last_item:  the last mission item to run (after this item is run, the mission ends)</param>
-      </entry>
-      <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM">
-        <description>Arms / Disarms a component</description>
-        <param index="1">1 to arm, 0 to disarm</param>
-      </entry>
-      <entry value="410" name="MAV_CMD_GET_HOME_POSITION">
-        <description>Request the home position from the vehicle.</description>
-        <param index="1">Reserved</param>
-        <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Reserved</param>
-        <param index="6">Reserved</param>
-        <param index="7">Reserved</param>
-      </entry>
-      <entry value="500" name="MAV_CMD_START_RX_PAIR">
-        <description>Starts receiver pairing</description>
-        <param index="1">0:Spektrum</param>
-        <param index="2">0:Spektrum DSM2, 1:Spektrum DSMX</param>
-      </entry>
-      <entry value="510" name="MAV_CMD_GET_MESSAGE_INTERVAL">
-        <description>Request the interval between messages for a particular MAVLink message ID</description>
-        <param index="1">The MAVLink message ID</param>
-      </entry>
-      <entry value="511" name="MAV_CMD_SET_MESSAGE_INTERVAL">
-        <description>Request the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM</description>
-        <param index="1">The MAVLink message ID</param>
-        <param index="2">The interval between two messages, in microseconds. Set to -1 to disable and 0 to request default rate.</param>
-      </entry>
-      <entry value="520" name="MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES">
-        <description>Request autopilot capabilities</description>
-        <param index="1">1: Request autopilot version</param>
-        <param index="2">Reserved (all remaining params)</param>
-      </entry>
-      <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
-        <description>WIP: Request camera information (CAMERA_INFORMATION)</description>
-        <param index="1">1: Request camera capabilities</param>
-        <param index="2">Camera ID</param>
-        <param index="3">Reserved (all remaining params)</param>
-      </entry>
-      <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
-        <description>WIP: Request camera settings (CAMERA_SETTINGS)</description>
-        <param index="1">1: Request camera settings</param>
-        <param index="2">Camera ID</param>
-        <param index="3">Reserved (all remaining params)</param>
-      </entry>
-      <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS_1">
-        <description>WIP: Set the camera settings part 1 (CAMERA_SETTINGS)</description>
-        <param index="1">Camera ID</param>
-        <param index="2">Aperture (1/value)</param>
-        <param index="3">Aperture locked (0: auto, 1: locked)</param>
-        <param index="4">Shutter speed in s</param>
-        <param index="5">Shutter speed locked (0: auto, 1: locked)</param>
-        <param index="6">ISO sensitivity</param>
-        <param index="7">ISO sensitivity locked (0: auto, 1: locked)</param>
-      </entry>
-      <entry value="524" name="MAV_CMD_SET_CAMERA_SETTINGS_2">
-        <description>WIP: Set the camera settings part 2 (CAMERA_SETTINGS)</description>
-        <param index="1">Camera ID</param>
-        <param index="2">White balance locked (0: auto, 1: locked)</param>
-        <param index="3">White balance (color temperature in K)</param>
-        <param index="4">Reserved for camera mode ID</param>
-        <param index="5">Reserved for color mode ID</param>
-        <param index="6">Reserved for image format ID</param>
-        <param index="7">Reserved</param>
-      </entry>
-      <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
-        <description>WIP: Request storage information (STORAGE_INFORMATION)</description>
-        <param index="1">1: Request storage information</param>
-        <param index="2">Storage ID</param>
-        <param index="3">Reserved (all remaining params)</param>
-      </entry>
-      <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
-        <description>WIP: Format a storage medium</description>
-        <param index="1">1: Format storage</param>
-        <param index="2">Storage ID</param>
-        <param index="3">Reserved (all remaining params)</param>
-      </entry>
-      <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
-        <description>WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
-        <param index="1">1: Request camera capture status</param>
-        <param index="2">Camera ID</param>
-        <param index="3">Reserved (all remaining params)</param>
-      </entry>
-      <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
-        <description>WIP: Request flight information (FLIGHT_INFORMATION)</description>
-        <param index="1">1: Request flight information</param>
-        <param index="2">Reserved (all remaining params)</param>
-      </entry>
-      <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
-        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture.</description>
-        <param index="1">Duration between two consecutive pictures (in seconds)</param>
-        <param index="2">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
-        <param index="4">WIP: Resolution horizontal in pixels</param>
-        <param index="5">WIP: Resolution horizontal in pixels</param>
-        <param index="6">WIP: Camera ID</param>
-      </entry>
-      <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
-        <description>Stop image capture sequence</description>
-        <param index="1">Camera ID</param>
-        <param index="2">Reserved</param>
-      </entry>
-      <entry name="MAV_CMD_DO_TRIGGER_CONTROL" value="2003">
-        <description>Enable or disable on-board camera triggering system.</description>
-        <param index="1">Trigger enable/disable (0 for disable, 1 for start)</param>
-        <param index="2">Shutter integration time (in ms)</param>
-        <param index="3">Reserved</param>
-      </entry>
-      <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
-        <description>Starts video capture (recording)</description>
-        <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
-        <param index="2">Frames per second, set to -1 for highest framerate possible.</param>
-        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
-        <param index="4">WIP: Resolution horizontal in pixels</param>
-        <param index="5">WIP: Resolution horizontal in pixels</param>
-        <param index="6">WIP: Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise time in Hz)</param>
-      </entry>
-      <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
-        <description>Stop the current video capture (recording)</description>
-        <param index="1">WIP: Camera ID</param>
-        <param index="2">Reserved</param>
-      </entry>
-      <entry value="2510" name="MAV_CMD_LOGGING_START">
-        <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
-        <param index="1">Format: 0: ULog</param>
-        <param index="2">Reserved (set to 0)</param>
-        <param index="3">Reserved (set to 0)</param>
-        <param index="4">Reserved (set to 0)</param>
-        <param index="5">Reserved (set to 0)</param>
-        <param index="6">Reserved (set to 0)</param>
-        <param index="7">Reserved (set to 0)</param>
-      </entry>
-      <entry value="2511" name="MAV_CMD_LOGGING_STOP">
-        <description>Request to stop streaming log data over MAVLink</description>
-        <param index="1">Reserved (set to 0)</param>
-        <param index="2">Reserved (set to 0)</param>
-        <param index="3">Reserved (set to 0)</param>
-        <param index="4">Reserved (set to 0)</param>
-        <param index="5">Reserved (set to 0)</param>
-        <param index="6">Reserved (set to 0)</param>
-        <param index="7">Reserved (set to 0)</param>
-      </entry>
-      <entry value="2520" name="MAV_CMD_AIRFRAME_CONFIGURATION">
-        <description/>
-        <param index="1">Landing gear ID (default: 0, -1 for all)</param>
-        <param index="2">Landing gear position (Down: 0, Up: 1, NAN for no change)</param>
-        <param index="3">Reserved, set to NAN</param>
-        <param index="4">Reserved, set to NAN</param>
-        <param index="5">Reserved, set to NAN</param>
-        <param index="6">Reserved, set to NAN</param>
-        <param index="7">Reserved, set to NAN</param>
-      </entry>
-      <entry value="2800" name="MAV_CMD_PANORAMA_CREATE">
-        <description>Create a panorama at the current position</description>
-        <param index="1">Viewing angle horizontal of the panorama (in degrees, +- 0.5 the total angle)</param>
-        <param index="2">Viewing angle vertical of panorama (in degrees)</param>
-        <param index="3">Speed of the horizontal rotation (in degrees per second)</param>
-        <param index="4">Speed of the vertical rotation (in degrees per second)</param>
-      </entry>
-      <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION">
-        <description>Request VTOL transition</description>
-        <param index="1">The target VTOL state, as defined by ENUM MAV_VTOL_STATE. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
-      </entry>
-      <entry value="4000" name="MAV_CMD_SET_GUIDED_SUBMODE_STANDARD">
-        <description>This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
+
+               <entry value="92" name="MAV_CMD_NAV_GUIDED_ENABLE">
+                    <description>hand control over to an external controller</description>
+                    <param index="1">On / Off (> 0.5f on)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="93" name="MAV_CMD_NAV_DELAY">
+                    <description>Delay the next navigation command a number of seconds or until a specified time</description>
+                    <param index="1">Delay in seconds (decimal, -1 to enable time-of-day fields)</param>
+                    <param index="2">hour (24h format, UTC, -1 to ignore)</param>
+                    <param index="3">minute (24h format, UTC, -1 to ignore)</param>
+                    <param index="4">second (24h format, UTC)</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="95" name="MAV_CMD_NAV_LAST">
+                    <description>NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration</description>
+                    <param index="1">Empty</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="112" name="MAV_CMD_CONDITION_DELAY">
+                    <description>Delay mission state machine.</description>
+                    <param index="1">Delay in seconds (decimal)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="113" name="MAV_CMD_CONDITION_CHANGE_ALT">
+                    <description>Ascend/descend at rate.  Delay mission state machine until desired altitude reached.</description>
+                    <param index="1">Descent / Ascend rate (m/s)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Finish Altitude</param>
+               </entry>
+               <entry value="114" name="MAV_CMD_CONDITION_DISTANCE">
+                    <description>Delay mission state machine until within desired distance of next NAV point.</description>
+                    <param index="1">Distance (meters)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="115" name="MAV_CMD_CONDITION_YAW">
+                    <description>Reach a certain target angle.</description>
+                    <param index="1">target angle: [0-360], 0 is north</param>
+                    <param index="2">speed during yaw change:[deg per second]</param>
+                    <param index="3">direction: negative: counter clockwise, positive: clockwise [-1,1]</param>
+                    <param index="4">relative offset or absolute angle: [ 1,0]</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="159" name="MAV_CMD_CONDITION_LAST">
+                    <description>NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration</description>
+                    <param index="1">Empty</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="176" name="MAV_CMD_DO_SET_MODE">
+                    <description>Set system mode.</description>
+                    <param index="1">Mode, as defined by ENUM MAV_MODE</param>
+                    <param index="2">Custom mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
+                    <param index="3">Custom sub mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="177" name="MAV_CMD_DO_JUMP">
+                    <description>Jump to the desired command in the mission list.  Repeat this action only the specified number of times</description>
+                    <param index="1">Sequence number</param>
+                    <param index="2">Repeat count</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="178" name="MAV_CMD_DO_CHANGE_SPEED">
+                    <description>Change speed and/or throttle set points.</description>
+                    <param index="1">Speed type (0=Airspeed, 1=Ground Speed)</param>
+                    <param index="2">Speed  (m/s, -1 indicates no change)</param>
+                    <param index="3">Throttle  ( Percent, -1 indicates no change)</param>
+                    <param index="4">absolute or relative [0,1]</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="179" name="MAV_CMD_DO_SET_HOME">
+                    <description>Changes the home location either to the current location or a specified location.</description>
+                    <param index="1">Use current (1=use current location, 0=use specified location)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Altitude</param>
+               </entry>
+               <entry value="180" name="MAV_CMD_DO_SET_PARAMETER">
+                    <description>Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.</description>
+                    <param index="1">Parameter number</param>
+                    <param index="2">Parameter value</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="181" name="MAV_CMD_DO_SET_RELAY">
+                    <description>Set a relay to a condition.</description>
+                    <param index="1">Relay number</param>
+                    <param index="2">Setting (1=on, 0=off, others possible depending on system hardware)</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="182" name="MAV_CMD_DO_REPEAT_RELAY">
+                    <description>Cycle a relay on and off for a desired number of cyles with a desired period.</description>
+                    <param index="1">Relay number</param>
+                    <param index="2">Cycle count</param>
+                    <param index="3">Cycle time (seconds, decimal)</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="183" name="MAV_CMD_DO_SET_SERVO">
+                    <description>Set a servo to a desired PWM value.</description>
+                    <param index="1">Servo number</param>
+                    <param index="2">PWM (microseconds, 1000 to 2000 typical)</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="184" name="MAV_CMD_DO_REPEAT_SERVO">
+                    <description>Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.</description>
+                    <param index="1">Servo number</param>
+                    <param index="2">PWM (microseconds, 1000 to 2000 typical)</param>
+                    <param index="3">Cycle count</param>
+                    <param index="4">Cycle time (seconds)</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="185" name="MAV_CMD_DO_FLIGHTTERMINATION">
+                    <description>Terminate flight immediately</description>
+                    <param index="1">Flight termination activated if > 0.5</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+                </entry>
+                <entry value="186" name="MAV_CMD_DO_CHANGE_ALTITUDE">
+                    <description>Change altitude set point.</description>
+                    <param index="1">Altitude in meters</param>
+                    <param index="2">Mav frame of new altitude (see MAV_FRAME)</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+                </entry>
+                <entry value="189" name="MAV_CMD_DO_LAND_START">
+                    <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0/0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>
+                    <param index="1">Empty</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Latitude</param>
+                    <param index="6">Longitude</param>
+                    <param index="7">Empty</param>
+                </entry>
+                <entry value="190" name="MAV_CMD_DO_RALLY_LAND">
+                    <description>Mission command to perform a landing from a rally point.</description>
+                    <param index="1">Break altitude (meters)</param>
+                    <param index="2">Landing speed (m/s)</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+                </entry>
+                <entry value="191" name="MAV_CMD_DO_GO_AROUND">
+                    <description>Mission command to safely abort an autonmous landing.</description>
+                    <param index="1">Altitude (meters)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+                </entry>
+
+               <entry value="192" name="MAV_CMD_DO_REPOSITION">
+                    <description>Reposition the vehicle to a specific WGS84 global position.</description>
+                    <param index="1">Ground speed, less than 0 (-1) for default</param>
+                    <param index="2">Bitmask of option flags, see the MAV_DO_REPOSITION_FLAGS enum.</param>
+                    <param index="3">Reserved</param>
+                    <param index="4">Yaw heading, NaN for unchanged. For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
+                    <param index="5">Latitude (deg * 1E7)</param>
+                    <param index="6">Longitude (deg * 1E7)</param>
+                    <param index="7">Altitude (meters)</param>
+               </entry>
+               <entry value="193" name="MAV_CMD_DO_PAUSE_CONTINUE">
+                    <description>If in a GPS controlled position mode, hold the current position or continue.</description>
+                    <param index="1">0: Pause current mission or reposition command, hold current position. 1: Continue mission. A VTOL capable vehicle should enter hover mode (multicopter and VTOL planes). A plane should loiter with the default loiter radius.</param>
+                    <param index="2">Reserved</param>
+                    <param index="3">Reserved</param>
+                    <param index="4">Reserved</param>
+                    <param index="5">Reserved</param>
+                    <param index="6">Reserved</param>
+                    <param index="7">Reserved</param>
+               </entry>
+               <entry value="194" name="MAV_CMD_DO_SET_REVERSE">
+                    <description>Set moving direction to forward or reverse.</description>
+                    <param index="1">Direction (0=Forward, 1=Reverse)</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="200" name="MAV_CMD_DO_CONTROL_VIDEO">
+                    <description>Control onboard camera system.</description>
+                    <param index="1">Camera ID (-1 for all)</param>
+                    <param index="2">Transmission: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
+                    <param index="3">Transmission mode: 0: video stream, >0: single images every n seconds (decimal)</param>
+                    <param index="4">Recording: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="201" name="MAV_CMD_DO_SET_ROI">
+                    <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+                    <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
+                    <param index="2">MISSION index/ target ID. (see MAV_ROI enum)</param>
+                    <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
+                    <param index="4">Empty</param>
+                    <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
+                    <param index="6">y</param>
+                    <param index="7">z</param>
+               </entry>
+
+               <!-- Camera Controller Mission Commands Enumeration -->
+               <!-- MAV_CMD_DO_DIGICAM_CONFIGURE should be deprecated and replaced with CAMERA_SETTINGS -->
+               <entry name="MAV_CMD_DO_DIGICAM_CONFIGURE" value="202">
+                   <description>Mission command to configure an on-board camera controller system.</description>
+                   <param index="1">Modes: P, TV, AV, M, Etc</param>
+                   <param index="2">Shutter speed: Divisor number for one second</param>
+                   <param index="3">Aperture: F stop number</param>
+                   <param index="4">ISO number e.g. 80, 100, 200, Etc</param>
+                   <param index="5">Exposure type enumerator</param>
+                   <param index="6">Command Identity</param>
+                   <param index="7">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</param>
+               </entry>
+
+               <entry name="MAV_CMD_DO_DIGICAM_CONTROL" value="203">
+                   <description>Mission command to control an on-board camera controller system.</description>
+                   <param index="1">Session control e.g. show/hide lens</param>
+                   <param index="2">Zoom's absolute position</param>
+                   <param index="3">Zooming step value to offset zoom from the current position</param>
+                   <param index="4">Focus Locking, Unlocking or Re-locking</param>
+                   <param index="5">Shooting Command</param>
+                   <param index="6">Command Identity</param>
+                   <param index="7">Empty</param>
+               </entry>
+
+               <!-- Camera Mount Mission Commands Enumeration -->
+               <entry name="MAV_CMD_DO_MOUNT_CONFIGURE" value="204">
+                   <description>Mission command to configure a camera or antenna mount</description>
+                   <param index="1">Mount operation mode (see MAV_MOUNT_MODE enum)</param>
+                   <param index="2">stabilize roll? (1 = yes, 0 = no)</param>
+                   <param index="3">stabilize pitch? (1 = yes, 0 = no)</param>
+                   <param index="4">stabilize yaw? (1 = yes, 0 = no)</param>
+                   <param index="5">Empty</param>
+                   <param index="6">Empty</param>
+                   <param index="7">Empty</param>
+               </entry>
+
+               <entry name="MAV_CMD_DO_MOUNT_CONTROL" value="205">
+                   <description>Mission command to control a camera or antenna mount</description>
+                   <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode.</param>
+                   <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode.</param>
+                   <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode.</param>
+                   <param index="4">WIP: alt in meters depending on mount mode.</param>
+                   <param index="5">WIP: latitude in degrees * 1E7, set if appropriate mount mode.</param>
+                   <param index="6">WIP: longitude in degrees * 1E7, set if appropriate mount mode.</param>
+                   <param index="7">MAV_MOUNT_MODE enum value</param>
+               </entry>
+
+               <entry name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" value="206">
+                   <description>Mission command to set CAM_TRIGG_DIST for this flight</description>
+                   <param index="1">Camera trigger distance (meters)</param>
+                   <param index="2">Empty</param>
+                   <param index="3">Empty</param>
+                   <param index="4">Empty</param>
+                   <param index="5">Empty</param>
+                   <param index="6">Empty</param>
+                   <param index="7">Empty</param>
+               </entry>
+
+               <entry name="MAV_CMD_DO_FENCE_ENABLE" value="207">
+                   <description>Mission command to enable the geofence</description>
+                   <param index="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
+                   <param index="2">Empty</param>
+                   <param index="3">Empty</param>
+                   <param index="4">Empty</param>
+                   <param index="5">Empty</param>
+                   <param index="6">Empty</param>
+                   <param index="7">Empty</param>
+               </entry>
+
+               <entry name="MAV_CMD_DO_PARACHUTE" value="208">
+                   <description>Mission command to trigger a parachute</description>
+                   <param index="1">action (0=disable, 1=enable, 2=release, for some systems see PARACHUTE_ACTION enum, not in general message set.)</param>
+                   <param index="2">Empty</param>
+                   <param index="3">Empty</param>
+                   <param index="4">Empty</param>
+                   <param index="5">Empty</param>
+                   <param index="6">Empty</param>
+                   <param index="7">Empty</param>
+               </entry>
+
+               <entry name="MAV_CMD_DO_MOTOR_TEST" value="209">
+                   <description>Mission command to perform motor test</description>
+                   <param index="1">motor sequence number (a number from 1 to max number of motors on the vehicle)</param>
+                   <param index="2">throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)</param>
+                   <param index="3">throttle</param>
+                   <param index="4">timeout (in seconds)</param>
+                   <param index="5">Empty</param>
+                   <param index="6">Empty</param>
+                   <param index="7">Empty</param>
+               </entry>
+
+               <entry name="MAV_CMD_DO_INVERTED_FLIGHT" value="210">
+                   <description>Change to/from inverted flight</description>
+                   <param index="1">inverted (0=normal, 1=inverted)</param>
+                   <param index="2">Empty</param>
+                   <param index="3">Empty</param>
+                   <param index="4">Empty</param>
+                   <param index="5">Empty</param>
+                   <param index="6">Empty</param>
+                   <param index="7">Empty</param>
+               </entry>
+
+               <entry name="MAV_CMD_NAV_SET_YAW_SPEED" value="213">
+                    <description>Sets a desired vehicle turn angle and speed change</description>
+                    <param index="1">yaw angle to adjust steering by in centidegress</param>
+                    <param index="2">speed - normalized to 0 .. 1</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+
+
+              <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT">
+                <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
+                <param index="1">q1 - quaternion param #1, w (1 in null-rotation)</param>
+                <param index="2">q2 - quaternion param #2, x (0 in null-rotation)</param>
+                <param index="3">q3 - quaternion param #3, y (0 in null-rotation)</param>
+                <param index="4">q4 - quaternion param #4, z (0 in null-rotation)</param>
+                <param index="5">Empty</param>
+                <param index="6">Empty</param>
+                <param index="7">Empty</param>
+              </entry>
+
+               <entry value="221" name="MAV_CMD_DO_GUIDED_MASTER">
+                    <description>set id of master controller</description>
+                    <param index="1">System ID</param>
+                    <param index="2">Component ID</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+
+               <entry value="222" name="MAV_CMD_DO_GUIDED_LIMITS">
+                 <description>set limits for external control</description>
+                 <param index="1">timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout</param>
+                 <param index="2">absolute altitude min (in meters, AMSL) - if vehicle moves below this alt, the command will be aborted and the mission will continue.  0 means no lower altitude limit</param>
+                 <param index="3">absolute altitude max (in meters)- if vehicle moves above this alt, the command will be aborted and the mission will continue.  0 means no upper altitude limit</param>
+                 <param index="4">horizontal move limit (in meters, AMSL) - if vehicle moves more than this distance from it's location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal altitude limit</param>
+                 <param index="5">Empty</param>
+                 <param index="6">Empty</param>
+                 <param index="7">Empty</param>
+               </entry>
+
+               <entry value="223" name="MAV_CMD_DO_ENGINE_CONTROL">
+                 <description>Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines</description>
+                 <param index="1">0: Stop engine, 1:Start Engine</param>
+                 <param index="2">0: Warm start, 1:Cold start. Controls use of choke where applicable</param>
+                 <param index="3">Height delay (meters). This is for commanding engine start only after the vehicle has gained the specified height. Used in VTOL vehicles during takeoff to start engine after the aircraft is off the ground. Zero for no delay.</param>
+                 <param index="4">Empty</param>
+                 <param index="5">Empty</param>
+                 <param index="5">Empty</param>
+                 <param index="6">Empty</param>
+                 <param index="7">Empty</param>
+               </entry>
+
+               <entry value="240" name="MAV_CMD_DO_LAST">
+                    <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
+                    <param index="1">Empty</param>
+                    <param index="2">Empty</param>
+                    <param index="3">Empty</param>
+                    <param index="4">Empty</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="241" name="MAV_CMD_PREFLIGHT_CALIBRATION">
+                    <description>Trigger calibration. This command will be only accepted if in pre-flight mode.</description>
+                    <param index="1">Gyro calibration: 0: no, 1: yes</param>
+                    <param index="2">Magnetometer calibration: 0: no, 1: yes</param>
+                    <param index="3">Ground pressure: 0: no, 1: yes</param>
+                    <param index="4">Radio calibration: 0: no, 1: yes</param>
+                    <param index="5">Accelerometer calibration: 0: no, 1: yes</param>
+                    <param index="6">Compass/Motor interference calibration: 0: no, 1: yes</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="242" name="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS">
+                    <description>Set sensor offsets. This command will be only accepted if in pre-flight mode.</description>
+                    <param index="1">Sensor to adjust the offsets for: 0: gyros, 1: accelerometer, 2: magnetometer, 3: barometer, 4: optical flow, 5: second magnetometer, 6: third magnetometer</param>
+                    <param index="2">X axis offset (or generic dimension 1), in the sensor's raw units</param>
+                    <param index="3">Y axis offset (or generic dimension 2), in the sensor's raw units</param>
+                    <param index="4">Z axis offset (or generic dimension 3), in the sensor's raw units</param>
+                    <param index="5">Generic dimension 4, in the sensor's raw units</param>
+                    <param index="6">Generic dimension 5, in the sensor's raw units</param>
+                    <param index="7">Generic dimension 6, in the sensor's raw units</param>
+               </entry>
+               <entry value="243" name="MAV_CMD_PREFLIGHT_UAVCAN">
+                    <description>Trigger UAVCAN config. This command will be only accepted if in pre-flight mode.</description>
+                    <param index="1">1: Trigger actuator ID assignment and direction mapping.</param>
+                    <param index="2">Reserved</param>
+                    <param index="3">Reserved</param>
+                    <param index="4">Reserved</param>
+                    <param index="5">Reserved</param>
+                    <param index="6">Reserved</param>
+                    <param index="7">Reserved</param>
+               </entry>
+               <entry value="245" name="MAV_CMD_PREFLIGHT_STORAGE">
+                    <description>Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.</description>
+                    <param index="1">Parameter storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
+                    <param index="2">Mission storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
+                    <param index="3">Onboard logging: 0: Ignore, 1: Start default rate logging, -1: Stop logging, > 1: start logging with rate of param 3 in Hz (e.g. set to 1000 for 1000 Hz logging)</param>
+                    <param index="4">Reserved</param>
+                    <param index="5">Empty</param>
+                    <param index="6">Empty</param>
+                    <param index="7">Empty</param>
+               </entry>
+               <entry value="246" name="MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN">
+                    <description>Request the reboot or shutdown of system components.</description>
+                    <param index="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
+                    <param index="2">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
+                    <param index="3">WIP: 0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
+                    <param index="4">WIP: 0: Do nothing for mount (e.g. gimbal), 1: Reboot mount, 2: Shutdown mount, 3: Reboot mount and keep it in the bootloader until upgraded</param>
+                    <param index="5">Reserved, send 0</param>
+                    <param index="6">Reserved, send 0</param>
+                    <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
+               </entry>
+               <entry value="252" name="MAV_CMD_OVERRIDE_GOTO">
+                    <description>Hold / continue the current action</description>
+                    <param index="1">MAV_GOTO_DO_HOLD: hold MAV_GOTO_DO_CONTINUE: continue with next item in mission plan</param>
+                    <param index="2">MAV_GOTO_HOLD_AT_CURRENT_POSITION: Hold at current position MAV_GOTO_HOLD_AT_SPECIFIED_POSITION: hold at specified position</param>
+                    <param index="3">MAV_FRAME coordinate frame of hold point</param>
+                    <param index="4">Desired yaw angle in degrees</param>
+                    <param index="5">Latitude / X position</param>
+                    <param index="6">Longitude / Y position</param>
+                    <param index="7">Altitude / Z position</param>
+               </entry>
+               <entry value="300" name="MAV_CMD_MISSION_START">
+                    <description>start running a mission</description>
+                    <param index="1">first_item: the first mission item to run</param>
+                    <param index="2">last_item:  the last mission item to run (after this item is run, the mission ends)</param>
+               </entry>
+               <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM">
+                    <description>Arms / Disarms a component</description>
+                    <param index="1">1 to arm, 0 to disarm</param>
+               </entry>
+               <entry value="410" name="MAV_CMD_GET_HOME_POSITION">
+                    <description>Request the home position from the vehicle.</description>
+                    <param index="1">Reserved</param>
+                    <param index="2">Reserved</param>
+                    <param index="3">Reserved</param>
+                    <param index="4">Reserved</param>
+                    <param index="5">Reserved</param>
+                    <param index="6">Reserved</param>
+                    <param index="7">Reserved</param>
+               </entry>
+               <entry value="500" name="MAV_CMD_START_RX_PAIR">
+                    <description>Starts receiver pairing</description>
+                    <param index="1">0:Spektrum</param>
+                    <param index="2">0:Spektrum DSM2, 1:Spektrum DSMX</param>
+               </entry>
+               <entry value="510" name="MAV_CMD_GET_MESSAGE_INTERVAL">
+                    <description>Request the interval between messages for a particular MAVLink message ID</description>
+                    <param index="1">The MAVLink message ID</param>
+               </entry>
+               <entry value="511" name="MAV_CMD_SET_MESSAGE_INTERVAL">
+                    <description>Request the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM</description>
+                    <param index="1">The MAVLink message ID</param>
+                    <param index="2">The interval between two messages, in microseconds. Set to -1 to disable and 0 to request default rate.</param>
+               </entry>
+               <entry value="520" name="MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES">
+                 <description>Request autopilot capabilities</description>
+                 <param index="1">1: Request autopilot version</param>
+                 <param index="2">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
+                 <description>WIP: Request camera information (CAMERA_INFORMATION)</description>
+                 <param index="1">1: Request camera capabilities</param>
+                 <param index="2">Camera ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
+                 <description>WIP: Request camera settings (CAMERA_SETTINGS)</description>
+                 <param index="1">1: Request camera settings</param>
+                 <param index="2">Camera ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS_1">
+                 <description>WIP: Set the camera settings part 1 (CAMERA_SETTINGS)</description>
+                 <param index="1">Camera ID</param>
+                 <param index="2">Aperture (1/value)</param>
+                 <param index="3">Aperture locked (0: auto, 1: locked)</param>
+                 <param index="4">Shutter speed in s</param>
+                 <param index="5">Shutter speed locked (0: auto, 1: locked)</param>
+                 <param index="6">ISO sensitivity</param>
+                 <param index="7">ISO sensitivity locked (0: auto, 1: locked)</param>
+               </entry>
+               <entry value="524" name="MAV_CMD_SET_CAMERA_SETTINGS_2">
+                 <description>WIP: Set the camera settings part 2 (CAMERA_SETTINGS)</description>
+                 <param index="1">Camera ID</param>
+                 <param index="2">White balance locked (0: auto, 1: locked)</param>
+                 <param index="3">White balance (color temperature in K)</param>
+                 <param index="4">Reserved for camera mode ID</param>
+                 <param index="5">Reserved for color mode ID</param>
+                 <param index="6">Reserved for image format ID</param>
+                 <param index="7">Reserved</param>
+               </entry>
+               <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
+                 <description>WIP: Request storage information (STORAGE_INFORMATION)</description>
+                 <param index="1">1: Request storage information</param>
+                 <param index="2">Storage ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
+                 <description>WIP: Format a storage medium</description>
+                 <param index="1">1: Format storage</param>
+                 <param index="2">Storage ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
+                 <description>WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
+                 <param index="1">1: Request camera capture status</param>
+                 <param index="2">Camera ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
+                 <description>WIP: Request flight information (FLIGHT_INFORMATION)</description>
+                 <param index="1">1: Request flight information</param>
+                 <param index="2">Reserved (all remaining params)</param>
+               </entry>
+
+              <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
+                  <description>Start image capture sequence</description>
+                  <param index="1">Duration between two consecutive pictures (in seconds)</param>
+                  <param index="2">Number of images to capture total - 0 for unlimited capture</param>
+                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
+                  <param index="4">WIP: Resolution horizontal in pixels</param>
+                  <param index="5">WIP: Resolution horizontal in pixels</param>
+                  <param index="6">WIP: Camera ID</param>
+              </entry>
+
+              <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
+                  <description>Stop image capture sequence</description>
+                  <param index="1">Camera ID</param>
+                  <param index="2">Reserved</param>
+              </entry>
+
+              <entry name="MAV_CMD_DO_TRIGGER_CONTROL" value="2003">
+                   <description>Enable or disable on-board camera triggering system.</description>
+                   <param index="1">Trigger enable/disable (0 for disable, 1 for start)</param>
+                   <param index="2">Shutter integration time (in ms)</param>
+                   <param index="3">Reserved</param>
+              </entry>
+
+              <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
+                  <description>Starts video capture</description>
+                  <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
+                  <param index="2">Frames per second</param>
+                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
+                  <param index="4">WIP: Resolution horizontal in pixels</param>
+                  <param index="5">WIP: Resolution horizontal in pixels</param>
+              </entry>
+
+              <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
+                  <description>Stop the current video capture</description>
+                  <param index="1">WIP: Camera ID</param>
+                  <param index="2">Reserved</param>
+              </entry>
+
+              <entry value="2510" name="MAV_CMD_LOGGING_START">
+                   <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
+                   <param index="1">Format: 0: ULog</param>
+                   <param index="2">Reserved (set to 0)</param>
+                   <param index="3">Reserved (set to 0)</param>
+                   <param index="4">Reserved (set to 0)</param>
+                   <param index="5">Reserved (set to 0)</param>
+                   <param index="6">Reserved (set to 0)</param>
+                   <param index="7">Reserved (set to 0)</param>
+              </entry>
+              <entry value="2511" name="MAV_CMD_LOGGING_STOP">
+                   <description>Request to stop streaming log data over MAVLink</description>
+                   <param index="1">Reserved (set to 0)</param>
+                   <param index="2">Reserved (set to 0)</param>
+                   <param index="3">Reserved (set to 0)</param>
+                   <param index="4">Reserved (set to 0)</param>
+                   <param index="5">Reserved (set to 0)</param>
+                   <param index="6">Reserved (set to 0)</param>
+                   <param index="7">Reserved (set to 0)</param>
+              </entry>
+
+              <entry value="2520" name="MAV_CMD_AIRFRAME_CONFIGURATION">
+                  <description></description>
+                  <param index="1">Landing gear ID (default: 0, -1 for all)</param>
+                  <param index="2">Landing gear position (Down: 0, Up: 1, NAN for no change)</param>
+                  <param index="3">Reserved, set to NAN</param>
+                  <param index="4">Reserved, set to NAN</param>
+                  <param index="5">Reserved, set to NAN</param>
+                  <param index="6">Reserved, set to NAN</param>
+                  <param index="7">Reserved, set to NAN</param>
+              </entry>
+
+              <entry value="2800" name="MAV_CMD_PANORAMA_CREATE">
+                  <description>Create a panorama at the current position</description>
+                  <param index="1">Viewing angle horizontal of the panorama (in degrees, +- 0.5 the total angle)</param>
+                  <param index="2">Viewing angle vertical of panorama (in degrees)</param>
+                  <param index="3">Speed of the horizontal rotation (in degrees per second)</param>
+                  <param index="4">Speed of the vertical rotation (in degrees per second)</param>
+              </entry>
+
+              <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION">
+                  <description>Request VTOL transition</description>
+                  <param index="1">The target VTOL state, as defined by ENUM MAV_VTOL_STATE. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
+              </entry>
+
+              <entry value="4000" name="MAV_CMD_SET_GUIDED_SUBMODE_STANDARD">
+                  <description>This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
                   </description>
-      </entry>
-      <entry value="4001" name="MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE">
-        <description>This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
+              </entry>
+
+              <entry value="4001" name="MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE">
+                  <description>This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
                   </description>
-        <param index="1">Radius of desired circle in CIRCLE_MODE</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Unscaled target latitude of center of circle in CIRCLE_MODE</param>
-        <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
-      </entry>
-      <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT">
-        <description>Fence return point. There can only be one fence return point.
+                  <param index="1">Radius of desired circle in CIRCLE_MODE</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Unscaled target latitude of center of circle in CIRCLE_MODE</param>
+                  <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
+              </entry>
+
+      <entry value="4100" name="MAV_CMD_REQUEST_MIXER_PARAM_READ">
+        <description>Request to send mixer data in a group and a given mixer, submixer, type and parameter index.
         </description>
-        <param index="1">Reserved</param>
-        <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
+        <param index="1">Index</param>
+        <param index="2">Mixer Group</param>
+        <param index="3">Mixer Index</param>
+        <param index="4">Submixer Index</param>
+        <param index="5">Parameter Index</param>
       </entry>
-      <entry value="5001" name="MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION">
-        <description>Fence vertex for an inclusion polygon. The vehicle must stay within this area. Minimum of 3 vertices required.
+      <entry value="4101" name="MAV_CMD_REQUEST_MIXER_PARAM_LIST">
+        <description>Request to send a list of all mixer data.</description>
+        <param index="1">Mixer Group</param>
+      </entry>
+      <entry value="4102" name="MAV_CMD_SET_MIXER_PARAM">
+        <description>Request to set mixer parameter by index or by mixer and parameter address
         </description>
-        <param index="1">Polygon vertex count</param>
-        <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Reserved</param>
+        <param index="1">Index</param>
+        <param index="2">Mixer Group</param>
+        <param index="3">Mixer Index</param>
+        <param index="4">Submixer Index</param>
+        <param index="5">Parameter Index</param>
+        <param index="6">Parameter array index</param>
+        <param index="7">Parameter</param>
       </entry>
-      <entry value="5002" name="MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION">
-        <description>Fence vertex for an exclusion polygon. The vehicle must stay outside this area. Minimum of 3 vertices required.
-        </description>
-        <param index="1">Polygon vertex count</param>
-        <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Reserved</param>
+      <entry value="4103" name="MAV_CMD_SAVE_MIXER_PARAMS">
+        <description>Save mixer parameters</description>
+        <param index="1">Mixer Group</param>
       </entry>
-      <entry value="5100" name="MAV_CMD_NAV_RALLY_POINT">
-        <description>Rally point. You can have multiple rally points defined.
-        </description>
-        <param index="1">Reserved</param>
-        <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
-      </entry>
-      <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
-      <!-- BEGIN of payload range (30000 to 30999) -->
-      <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY">
-        <description>Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.</description>
-        <param index="1">Operation mode. 0: prepare single payload deploy (overwriting previous requests), but do not execute it. 1: execute payload deploy immediately (rejecting further deploy commands during execution, but allowing abort). 2: add payload deploy to existing deployment list.</param>
-        <param index="2">Desired approach vector in degrees compass heading (0..360). A negative value indicates the system can define the approach vector at will.</param>
-        <param index="3">Desired ground speed at release time. This can be overriden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.</param>
-        <param index="4">Minimum altitude clearance to the release position in meters. A negative value indicates the system can define the clearance at will.</param>
-        <param index="5">Latitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
-        <param index="6">Longitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="30002" name="MAV_CMD_PAYLOAD_CONTROL_DEPLOY">
-        <description>Control the payload deployment.</description>
-        <param index="1">Operation mode. 0: Abort deployment, continue normal mission. 1: switch to payload deploment mode. 100: delete first payload deployment request. 101: delete all payload deployment requests.</param>
-        <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Reserved</param>
-        <param index="6">Reserved</param>
-        <param index="7">Reserved</param>
-      </entry>
-      <!-- END of payload range (30000 to 30999) -->
-      <!-- BEGIN user defined range (31000 to 31999) -->
-      <entry value="31000" name="MAV_CMD_WAYPOINT_USER_1">
-        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31001" name="MAV_CMD_WAYPOINT_USER_2">
-        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31002" name="MAV_CMD_WAYPOINT_USER_3">
-        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31003" name="MAV_CMD_WAYPOINT_USER_4">
-        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31004" name="MAV_CMD_WAYPOINT_USER_5">
-        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31005" name="MAV_CMD_SPATIAL_USER_1">
-        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31006" name="MAV_CMD_SPATIAL_USER_2">
-        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31007" name="MAV_CMD_SPATIAL_USER_3">
-        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31008" name="MAV_CMD_SPATIAL_USER_4">
-        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31009" name="MAV_CMD_SPATIAL_USER_5">
-        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">Latitude unscaled</param>
-        <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude, in meters AMSL</param>
-      </entry>
-      <entry value="31010" name="MAV_CMD_USER_1">
-        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="31011" name="MAV_CMD_USER_2">
-        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="31012" name="MAV_CMD_USER_3">
-        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="31013" name="MAV_CMD_USER_4">
-        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <entry value="31014" name="MAV_CMD_USER_5">
-        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-        <param index="1">User defined</param>
-        <param index="2">User defined</param>
-        <param index="3">User defined</param>
-        <param index="4">User defined</param>
-        <param index="5">User defined</param>
-        <param index="6">User defined</param>
-        <param index="7">User defined</param>
-      </entry>
-      <!-- END of user range (31000 to 31999) -->
-    </enum>
-    <enum name="MAV_DATA_STREAM">
-      <description>THIS INTERFACE IS DEPRECATED AS OF JULY 2015. Please use MESSAGE_INTERVAL instead. A data stream is not a fixed set of messages, but rather a
+
+              <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
+
+              <!-- BEGIN of payload range (30000 to 30999) -->
+              <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY">
+                  <description>Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.</description>
+                  <param index="1">Operation mode. 0: prepare single payload deploy (overwriting previous requests), but do not execute it. 1: execute payload deploy immediately (rejecting further deploy commands during execution, but allowing abort). 2: add payload deploy to existing deployment list.</param>
+                  <param index="2">Desired approach vector in degrees compass heading (0..360). A negative value indicates the system can define the approach vector at will.</param>
+                  <param index="3">Desired ground speed at release time. This can be overriden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.</param>
+                  <param index="4">Minimum altitude clearance to the release position in meters. A negative value indicates the system can define the clearance at will.</param>
+                  <param index="5">Latitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
+                  <param index="6">Longitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="30002" name="MAV_CMD_PAYLOAD_CONTROL_DEPLOY">
+                  <description>Control the payload deployment.</description>
+                  <param index="1">Operation mode. 0: Abort deployment, continue normal mission. 1: switch to payload deploment mode. 100: delete first payload deployment request. 101: delete all payload deployment requests.</param>
+                  <param index="2">Reserved</param>
+                  <param index="3">Reserved</param>
+                  <param index="4">Reserved</param>
+                  <param index="5">Reserved</param>
+                  <param index="6">Reserved</param>
+                  <param index="7">Reserved</param>
+              </entry>
+              <!-- END of payload range (30000 to 30999) -->
+
+              <!-- BEGIN user defined range (31000 to 31999) -->
+              <entry value="31000" name="MAV_CMD_WAYPOINT_USER_1">
+                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31001" name="MAV_CMD_WAYPOINT_USER_2">
+                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31002" name="MAV_CMD_WAYPOINT_USER_3">
+                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31003" name="MAV_CMD_WAYPOINT_USER_4">
+                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31004" name="MAV_CMD_WAYPOINT_USER_5">
+                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31005" name="MAV_CMD_SPATIAL_USER_1">
+                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31006" name="MAV_CMD_SPATIAL_USER_2">
+                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31007" name="MAV_CMD_SPATIAL_USER_3">
+                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31008" name="MAV_CMD_SPATIAL_USER_4">
+                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31009" name="MAV_CMD_SPATIAL_USER_5">
+                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">Latitude unscaled</param>
+                  <param index="6">Longitude unscaled</param>
+                  <param index="7">Altitude, in meters AMSL</param>
+              </entry>
+              <entry value="31010" name="MAV_CMD_USER_1">
+                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">User defined</param>
+                  <param index="6">User defined</param>
+                  <param index="7">User defined</param>
+              </entry>
+              <entry value="31011" name="MAV_CMD_USER_2">
+                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">User defined</param>
+                  <param index="6">User defined</param>
+                  <param index="7">User defined</param>
+              </entry>
+              <entry value="31012" name="MAV_CMD_USER_3">
+                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">User defined</param>
+                  <param index="6">User defined</param>
+                  <param index="7">User defined</param>
+              </entry>
+              <entry value="31013" name="MAV_CMD_USER_4">
+                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">User defined</param>
+                  <param index="6">User defined</param>
+                  <param index="7">User defined</param>
+              </entry>
+              <entry value="31014" name="MAV_CMD_USER_5">
+                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+                  <param index="1">User defined</param>
+                  <param index="2">User defined</param>
+                  <param index="3">User defined</param>
+                  <param index="4">User defined</param>
+                  <param index="5">User defined</param>
+                  <param index="6">User defined</param>
+                  <param index="7">User defined</param>
+              </entry>
+              <!-- END of user range (31000 to 31999) -->
+          </enum>
+          <enum name="MAV_DATA_STREAM">
+               <description>THIS INTERFACE IS DEPRECATED AS OF JULY 2015. Please use MESSAGE_INTERVAL instead. A data stream is not a fixed set of messages, but rather a
      recommendation to the autopilot software. Individual autopilots may or may not obey
      the recommended messages.</description>
-      <entry value="0" name="MAV_DATA_STREAM_ALL">
-        <description>Enable all data streams</description>
-      </entry>
-      <entry value="1" name="MAV_DATA_STREAM_RAW_SENSORS">
-        <description>Enable IMU_RAW, GPS_RAW, GPS_STATUS packets.</description>
-      </entry>
-      <entry value="2" name="MAV_DATA_STREAM_EXTENDED_STATUS">
-        <description>Enable GPS_STATUS, CONTROL_STATUS, AUX_STATUS</description>
-      </entry>
-      <entry value="3" name="MAV_DATA_STREAM_RC_CHANNELS">
-        <description>Enable RC_CHANNELS_SCALED, RC_CHANNELS_RAW, SERVO_OUTPUT_RAW</description>
-      </entry>
-      <entry value="4" name="MAV_DATA_STREAM_RAW_CONTROLLER">
-        <description>Enable ATTITUDE_CONTROLLER_OUTPUT, POSITION_CONTROLLER_OUTPUT, NAV_CONTROLLER_OUTPUT.</description>
-      </entry>
-      <entry value="6" name="MAV_DATA_STREAM_POSITION">
-        <description>Enable LOCAL_POSITION, GLOBAL_POSITION/GLOBAL_POSITION_INT messages.</description>
-      </entry>
-      <entry value="10" name="MAV_DATA_STREAM_EXTRA1">
-        <description>Dependent on the autopilot</description>
-      </entry>
-      <entry value="11" name="MAV_DATA_STREAM_EXTRA2">
-        <description>Dependent on the autopilot</description>
-      </entry>
-      <entry value="12" name="MAV_DATA_STREAM_EXTRA3">
-        <description>Dependent on the autopilot</description>
-      </entry>
-    </enum>
-    <enum name="MAV_ROI">
-      <description> The ROI (region of interest) for the vehicle. This can be
+               <entry value="0" name="MAV_DATA_STREAM_ALL">
+                    <description>Enable all data streams</description>
+               </entry>
+               <entry value="1" name="MAV_DATA_STREAM_RAW_SENSORS">
+                    <description>Enable IMU_RAW, GPS_RAW, GPS_STATUS packets.</description>
+               </entry>
+               <entry value="2" name="MAV_DATA_STREAM_EXTENDED_STATUS">
+                    <description>Enable GPS_STATUS, CONTROL_STATUS, AUX_STATUS</description>
+               </entry>
+               <entry value="3" name="MAV_DATA_STREAM_RC_CHANNELS">
+                    <description>Enable RC_CHANNELS_SCALED, RC_CHANNELS_RAW, SERVO_OUTPUT_RAW</description>
+               </entry>
+               <entry value="4" name="MAV_DATA_STREAM_RAW_CONTROLLER">
+                    <description>Enable ATTITUDE_CONTROLLER_OUTPUT, POSITION_CONTROLLER_OUTPUT, NAV_CONTROLLER_OUTPUT.</description>
+               </entry>
+               <entry value="6" name="MAV_DATA_STREAM_POSITION">
+                    <description>Enable LOCAL_POSITION, GLOBAL_POSITION/GLOBAL_POSITION_INT messages.</description>
+               </entry>
+               <entry value="10" name="MAV_DATA_STREAM_EXTRA1">
+                    <description>Dependent on the autopilot</description>
+               </entry>
+               <entry value="11" name="MAV_DATA_STREAM_EXTRA2">
+                    <description>Dependent on the autopilot</description>
+               </entry>
+               <entry value="12" name="MAV_DATA_STREAM_EXTRA3">
+                    <description>Dependent on the autopilot</description>
+               </entry>
+          </enum>
+          <enum name="MAV_ROI">
+               <description> The ROI (region of interest) for the vehicle. This can be
                 be used by the vehicle for camera/vehicle attitude alignment (see
                 MAV_CMD_NAV_ROI).</description>
-      <entry value="0" name="MAV_ROI_NONE">
-        <description>No region of interest.</description>
-      </entry>
-      <entry value="1" name="MAV_ROI_WPNEXT">
-        <description>Point toward next MISSION.</description>
-      </entry>
-      <entry value="2" name="MAV_ROI_WPINDEX">
-        <description>Point toward given MISSION.</description>
-      </entry>
-      <entry value="3" name="MAV_ROI_LOCATION">
-        <description>Point toward fixed location.</description>
-      </entry>
-      <entry value="4" name="MAV_ROI_TARGET">
-        <description>Point toward of given id.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_CMD_ACK">
-      <description>ACK / NACK / ERROR values as a result of MAV_CMDs and for mission item transmission.</description>
-      <entry name="MAV_CMD_ACK_OK">
-        <description>Command / mission item is ok.</description>
-      </entry>
-      <entry name="MAV_CMD_ACK_ERR_FAIL">
-        <description>Generic error message if none of the other reasons fails or if no detailed error reporting is implemented.</description>
-      </entry>
-      <entry name="MAV_CMD_ACK_ERR_ACCESS_DENIED">
-        <description>The system is refusing to accept this command from this source / communication partner.</description>
-      </entry>
-      <entry name="MAV_CMD_ACK_ERR_NOT_SUPPORTED">
-        <description>Command or mission item is not supported, other commands would be accepted.</description>
-      </entry>
-      <entry name="MAV_CMD_ACK_ERR_COORDINATE_FRAME_NOT_SUPPORTED">
-        <description>The coordinate frame of this command / mission item is not supported.</description>
-      </entry>
-      <entry name="MAV_CMD_ACK_ERR_COORDINATES_OUT_OF_RANGE">
-        <description>The coordinate frame of this command is ok, but he coordinate values exceed the safety limits of this system. This is a generic error, please use the more specific error messages below if possible.</description>
-      </entry>
-      <entry name="MAV_CMD_ACK_ERR_X_LAT_OUT_OF_RANGE">
-        <description>The X or latitude value is out of range.</description>
-      </entry>
-      <entry name="MAV_CMD_ACK_ERR_Y_LON_OUT_OF_RANGE">
-        <description>The Y or longitude value is out of range.</description>
-      </entry>
-      <entry name="MAV_CMD_ACK_ERR_Z_ALT_OUT_OF_RANGE">
-        <description>The Z or altitude value is out of range.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_PARAM_TYPE">
-      <description>Specifies the datatype of a MAVLink parameter.</description>
-      <entry value="1" name="MAV_PARAM_TYPE_UINT8">
-        <description>8-bit unsigned integer</description>
-      </entry>
-      <entry value="2" name="MAV_PARAM_TYPE_INT8">
-        <description>8-bit signed integer</description>
-      </entry>
-      <entry value="3" name="MAV_PARAM_TYPE_UINT16">
-        <description>16-bit unsigned integer</description>
-      </entry>
-      <entry value="4" name="MAV_PARAM_TYPE_INT16">
-        <description>16-bit signed integer</description>
-      </entry>
-      <entry value="5" name="MAV_PARAM_TYPE_UINT32">
-        <description>32-bit unsigned integer</description>
-      </entry>
-      <entry value="6" name="MAV_PARAM_TYPE_INT32">
-        <description>32-bit signed integer</description>
-      </entry>
-      <entry value="7" name="MAV_PARAM_TYPE_UINT64">
-        <description>64-bit unsigned integer</description>
-      </entry>
-      <entry value="8" name="MAV_PARAM_TYPE_INT64">
-        <description>64-bit signed integer</description>
-      </entry>
-      <entry value="9" name="MAV_PARAM_TYPE_REAL32">
-        <description>32-bit floating-point</description>
-      </entry>
-      <entry value="10" name="MAV_PARAM_TYPE_REAL64">
-        <description>64-bit floating-point</description>
-      </entry>
-    </enum>
-    <enum name="MAV_RESULT">
-      <description>result from a mavlink command</description>
-      <entry value="0" name="MAV_RESULT_ACCEPTED">
-        <description>Command ACCEPTED and EXECUTED</description>
-      </entry>
-      <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
-        <description>Command TEMPORARY REJECTED/DENIED</description>
-      </entry>
-      <entry value="2" name="MAV_RESULT_DENIED">
-        <description>Command PERMANENTLY DENIED</description>
-      </entry>
-      <entry value="3" name="MAV_RESULT_UNSUPPORTED">
-        <description>Command UNKNOWN/UNSUPPORTED</description>
-      </entry>
-      <entry value="4" name="MAV_RESULT_FAILED">
-        <description>Command executed, but failed</description>
-      </entry>
-    </enum>
-    <enum name="MAV_MISSION_RESULT">
-      <description>result in a mavlink mission ack</description>
-      <entry value="0" name="MAV_MISSION_ACCEPTED">
-        <description>mission accepted OK</description>
-      </entry>
-      <entry value="1" name="MAV_MISSION_ERROR">
-        <description>generic error / not accepting mission commands at all right now</description>
-      </entry>
-      <entry value="2" name="MAV_MISSION_UNSUPPORTED_FRAME">
-        <description>coordinate frame is not supported</description>
-      </entry>
-      <entry value="3" name="MAV_MISSION_UNSUPPORTED">
-        <description>command is not supported</description>
-      </entry>
-      <entry value="4" name="MAV_MISSION_NO_SPACE">
-        <description>mission item exceeds storage space</description>
-      </entry>
-      <entry value="5" name="MAV_MISSION_INVALID">
-        <description>one of the parameters has an invalid value</description>
-      </entry>
-      <entry value="6" name="MAV_MISSION_INVALID_PARAM1">
-        <description>param1 has an invalid value</description>
-      </entry>
-      <entry value="7" name="MAV_MISSION_INVALID_PARAM2">
-        <description>param2 has an invalid value</description>
-      </entry>
-      <entry value="8" name="MAV_MISSION_INVALID_PARAM3">
-        <description>param3 has an invalid value</description>
-      </entry>
-      <entry value="9" name="MAV_MISSION_INVALID_PARAM4">
-        <description>param4 has an invalid value</description>
-      </entry>
-      <entry value="10" name="MAV_MISSION_INVALID_PARAM5_X">
-        <description>x/param5 has an invalid value</description>
-      </entry>
-      <entry value="11" name="MAV_MISSION_INVALID_PARAM6_Y">
-        <description>y/param6 has an invalid value</description>
-      </entry>
-      <entry value="12" name="MAV_MISSION_INVALID_PARAM7">
-        <description>param7 has an invalid value</description>
-      </entry>
-      <entry value="13" name="MAV_MISSION_INVALID_SEQUENCE">
-        <description>received waypoint out of sequence</description>
-      </entry>
-      <entry value="14" name="MAV_MISSION_DENIED">
-        <description>not accepting any mission commands from this communication partner</description>
-      </entry>
-    </enum>
-    <enum name="MAV_SEVERITY">
-      <description>Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.</description>
-      <entry value="0" name="MAV_SEVERITY_EMERGENCY">
-        <description>System is unusable. This is a "panic" condition.</description>
-      </entry>
-      <entry value="1" name="MAV_SEVERITY_ALERT">
-        <description>Action should be taken immediately. Indicates error in non-critical systems.</description>
-      </entry>
-      <entry value="2" name="MAV_SEVERITY_CRITICAL">
-        <description>Action must be taken immediately. Indicates failure in a primary system.</description>
-      </entry>
-      <entry value="3" name="MAV_SEVERITY_ERROR">
-        <description>Indicates an error in secondary/redundant systems.</description>
-      </entry>
-      <entry value="4" name="MAV_SEVERITY_WARNING">
-        <description>Indicates about a possible future error if this is not resolved within a given timeframe. Example would be a low battery warning.</description>
-      </entry>
-      <entry value="5" name="MAV_SEVERITY_NOTICE">
-        <description>An unusual event has occured, though not an error condition. This should be investigated for the root cause.</description>
-      </entry>
-      <entry value="6" name="MAV_SEVERITY_INFO">
-        <description>Normal operational messages. Useful for logging. No action is required for these messages.</description>
-      </entry>
-      <entry value="7" name="MAV_SEVERITY_DEBUG">
-        <description>Useful non-operational messages that can assist in debugging. These should not occur during normal operation.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_POWER_STATUS">
-      <description>Power supply status flags (bitmask)</description>
-      <entry value="1" name="MAV_POWER_STATUS_BRICK_VALID">
-        <description>main brick power supply valid</description>
-      </entry>
-      <entry value="2" name="MAV_POWER_STATUS_SERVO_VALID">
-        <description>main servo power supply valid for FMU</description>
-      </entry>
-      <entry value="4" name="MAV_POWER_STATUS_USB_CONNECTED">
-        <description>USB power is connected</description>
-      </entry>
-      <entry value="8" name="MAV_POWER_STATUS_PERIPH_OVERCURRENT">
-        <description>peripheral supply is in over-current state</description>
-      </entry>
-      <entry value="16" name="MAV_POWER_STATUS_PERIPH_HIPOWER_OVERCURRENT">
-        <description>hi-power peripheral supply is in over-current state</description>
-      </entry>
-      <entry value="32" name="MAV_POWER_STATUS_CHANGED">
-        <description>Power status has changed since boot</description>
-      </entry>
-    </enum>
-    <enum name="SERIAL_CONTROL_DEV">
-      <description>SERIAL_CONTROL device types</description>
-      <entry value="0" name="SERIAL_CONTROL_DEV_TELEM1">
-        <description>First telemetry port</description>
-      </entry>
-      <entry value="1" name="SERIAL_CONTROL_DEV_TELEM2">
-        <description>Second telemetry port</description>
-      </entry>
-      <entry value="2" name="SERIAL_CONTROL_DEV_GPS1">
-        <description>First GPS port</description>
-      </entry>
-      <entry value="3" name="SERIAL_CONTROL_DEV_GPS2">
-        <description>Second GPS port</description>
-      </entry>
-      <entry value="10" name="SERIAL_CONTROL_DEV_SHELL">
-        <description>system shell</description>
-      </entry>
-    </enum>
-    <enum name="SERIAL_CONTROL_FLAG">
-      <description>SERIAL_CONTROL flags (bitmask)</description>
-      <entry value="1" name="SERIAL_CONTROL_FLAG_REPLY">
-        <description>Set if this is a reply</description>
-      </entry>
-      <entry value="2" name="SERIAL_CONTROL_FLAG_RESPOND">
-        <description>Set if the sender wants the receiver to send a response as another SERIAL_CONTROL message</description>
-      </entry>
-      <entry value="4" name="SERIAL_CONTROL_FLAG_EXCLUSIVE">
-        <description>Set if access to the serial port should be removed from whatever driver is currently using it, giving exclusive access to the SERIAL_CONTROL protocol. The port can be handed back by sending a request without this flag set</description>
-      </entry>
-      <entry value="8" name="SERIAL_CONTROL_FLAG_BLOCKING">
-        <description>Block on writes to the serial port</description>
-      </entry>
-      <entry value="16" name="SERIAL_CONTROL_FLAG_MULTI">
-        <description>Send multiple replies until port is drained</description>
-      </entry>
-    </enum>
-    <enum name="MAV_DISTANCE_SENSOR">
-      <description>Enumeration of distance sensor types</description>
-      <entry value="0" name="MAV_DISTANCE_SENSOR_LASER">
-        <description>Laser rangefinder, e.g. LightWare SF02/F or PulsedLight units</description>
-      </entry>
-      <entry value="1" name="MAV_DISTANCE_SENSOR_ULTRASOUND">
-        <description>Ultrasound rangefinder, e.g. MaxBotix units</description>
-      </entry>
-      <entry value="2" name="MAV_DISTANCE_SENSOR_INFRARED">
-        <description>Infrared rangefinder, e.g. Sharp units</description>
-      </entry>
-    </enum>
-    <enum name="MAV_SENSOR_ORIENTATION">
-      <description>Enumeration of sensor orientation, according to its rotations</description>
-      <entry value="0" name="MAV_SENSOR_ROTATION_NONE">
-        <description>Roll: 0, Pitch: 0, Yaw: 0</description>
-      </entry>
-      <entry value="1" name="MAV_SENSOR_ROTATION_YAW_45">
-        <description>Roll: 0, Pitch: 0, Yaw: 45</description>
-      </entry>
-      <entry value="2" name="MAV_SENSOR_ROTATION_YAW_90">
-        <description>Roll: 0, Pitch: 0, Yaw: 90</description>
-      </entry>
-      <entry value="3" name="MAV_SENSOR_ROTATION_YAW_135">
-        <description>Roll: 0, Pitch: 0, Yaw: 135</description>
-      </entry>
-      <entry value="4" name="MAV_SENSOR_ROTATION_YAW_180">
-        <description>Roll: 0, Pitch: 0, Yaw: 180</description>
-      </entry>
-      <entry value="5" name="MAV_SENSOR_ROTATION_YAW_225">
-        <description>Roll: 0, Pitch: 0, Yaw: 225</description>
-      </entry>
-      <entry value="6" name="MAV_SENSOR_ROTATION_YAW_270">
-        <description>Roll: 0, Pitch: 0, Yaw: 270</description>
-      </entry>
-      <entry value="7" name="MAV_SENSOR_ROTATION_YAW_315">
-        <description>Roll: 0, Pitch: 0, Yaw: 315</description>
-      </entry>
-      <entry value="8" name="MAV_SENSOR_ROTATION_ROLL_180">
-        <description>Roll: 180, Pitch: 0, Yaw: 0</description>
-      </entry>
-      <entry value="9" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_45">
-        <description>Roll: 180, Pitch: 0, Yaw: 45</description>
-      </entry>
-      <entry value="10" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_90">
-        <description>Roll: 180, Pitch: 0, Yaw: 90</description>
-      </entry>
-      <entry value="11" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_135">
-        <description>Roll: 180, Pitch: 0, Yaw: 135</description>
-      </entry>
-      <entry value="12" name="MAV_SENSOR_ROTATION_PITCH_180">
-        <description>Roll: 0, Pitch: 180, Yaw: 0</description>
-      </entry>
-      <entry value="13" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_225">
-        <description>Roll: 180, Pitch: 0, Yaw: 225</description>
-      </entry>
-      <entry value="14" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_270">
-        <description>Roll: 180, Pitch: 0, Yaw: 270</description>
-      </entry>
-      <entry value="15" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_315">
-        <description>Roll: 180, Pitch: 0, Yaw: 315</description>
-      </entry>
-      <entry value="16" name="MAV_SENSOR_ROTATION_ROLL_90">
-        <description>Roll: 90, Pitch: 0, Yaw: 0</description>
-      </entry>
-      <entry value="17" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_45">
-        <description>Roll: 90, Pitch: 0, Yaw: 45</description>
-      </entry>
-      <entry value="18" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_90">
-        <description>Roll: 90, Pitch: 0, Yaw: 90</description>
-      </entry>
-      <entry value="19" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_135">
-        <description>Roll: 90, Pitch: 0, Yaw: 135</description>
-      </entry>
-      <entry value="20" name="MAV_SENSOR_ROTATION_ROLL_270">
-        <description>Roll: 270, Pitch: 0, Yaw: 0</description>
-      </entry>
-      <entry value="21" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_45">
-        <description>Roll: 270, Pitch: 0, Yaw: 45</description>
-      </entry>
-      <entry value="22" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_90">
-        <description>Roll: 270, Pitch: 0, Yaw: 90</description>
-      </entry>
-      <entry value="23" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_135">
-        <description>Roll: 270, Pitch: 0, Yaw: 135</description>
-      </entry>
-      <entry value="24" name="MAV_SENSOR_ROTATION_PITCH_90">
-        <description>Roll: 0, Pitch: 90, Yaw: 0</description>
-      </entry>
-      <entry value="25" name="MAV_SENSOR_ROTATION_PITCH_270">
-        <description>Roll: 0, Pitch: 270, Yaw: 0</description>
-      </entry>
-      <entry value="26" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_90">
-        <description>Roll: 0, Pitch: 180, Yaw: 90</description>
-      </entry>
-      <entry value="27" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_270">
-        <description>Roll: 0, Pitch: 180, Yaw: 270</description>
-      </entry>
-      <entry value="28" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_90">
-        <description>Roll: 90, Pitch: 90, Yaw: 0</description>
-      </entry>
-      <entry value="29" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_90">
-        <description>Roll: 180, Pitch: 90, Yaw: 0</description>
-      </entry>
-      <entry value="30" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_90">
-        <description>Roll: 270, Pitch: 90, Yaw: 0</description>
-      </entry>
-      <entry value="31" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180">
-        <description>Roll: 90, Pitch: 180, Yaw: 0</description>
-      </entry>
-      <entry value="32" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_180">
-        <description>Roll: 270, Pitch: 180, Yaw: 0</description>
-      </entry>
-      <entry value="33" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_270">
-        <description>Roll: 90, Pitch: 270, Yaw: 0</description>
-      </entry>
-      <entry value="34" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_270">
-        <description>Roll: 180, Pitch: 270, Yaw: 0</description>
-      </entry>
-      <entry value="35" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_270">
-        <description>Roll: 270, Pitch: 270, Yaw: 0</description>
-      </entry>
-      <entry value="36" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90">
-        <description>Roll: 90, Pitch: 180, Yaw: 90</description>
-      </entry>
-      <entry value="37" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_270">
-        <description>Roll: 90, Pitch: 0, Yaw: 270</description>
-      </entry>
-      <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_315_PITCH_315_YAW_315">
-        <description>Roll: 315, Pitch: 315, Yaw: 315</description>
-      </entry>
-    </enum>
-    <enum name="MAV_PROTOCOL_CAPABILITY">
-      <description>Bitmask of (optional) autopilot capabilities (64 bit). If a bit is set, the autopilot supports this capability.</description>
-      <entry value="1" name="MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT">
-        <description>Autopilot supports MISSION float message type.</description>
-      </entry>
-      <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT">
-        <description>Autopilot supports the new param float message type.</description>
-      </entry>
-      <entry value="4" name="MAV_PROTOCOL_CAPABILITY_MISSION_INT">
-        <description>Autopilot supports MISSION_INT scaled integer message type.</description>
-      </entry>
-      <entry value="8" name="MAV_PROTOCOL_CAPABILITY_COMMAND_INT">
-        <description>Autopilot supports COMMAND_INT scaled integer message type.</description>
-      </entry>
-      <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_UNION">
-        <description>Autopilot supports the new param union message type.</description>
-      </entry>
-      <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">
-        <description>Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.</description>
-      </entry>
-      <entry value="64" name="MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET">
-        <description>Autopilot supports commanding attitude offboard.</description>
-      </entry>
-      <entry value="128" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED">
-        <description>Autopilot supports commanding position and velocity targets in local NED frame.</description>
-      </entry>
-      <entry value="256" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT">
-        <description>Autopilot supports commanding position and velocity targets in global scaled integers.</description>
-      </entry>
-      <entry value="512" name="MAV_PROTOCOL_CAPABILITY_TERRAIN">
-        <description>Autopilot supports terrain protocol / data handling.</description>
-      </entry>
-      <entry value="1024" name="MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET">
-        <description>Autopilot supports direct actuator control.</description>
-      </entry>
-      <entry value="2048" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION">
-        <description>Autopilot supports the flight termination command.</description>
-      </entry>
-      <entry value="4096" name="MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION">
-        <description>Autopilot supports onboard compass calibration.</description>
-      </entry>
-      <entry value="8192" name="MAV_PROTOCOL_CAPABILITY_MAVLINK2">
-        <description>Autopilot supports mavlink version 2.</description>
-      </entry>
-      <entry value="16384" name="MAV_PROTOCOL_CAPABILITY_MISSION_FENCE">
-        <description>Autopilot supports mission fence protocol.</description>
-      </entry>
-      <entry value="32768" name="MAV_PROTOCOL_CAPABILITY_MISSION_RALLY">
-        <description>Autopilot supports mission rally point protocol.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_MISSION_TYPE">
-      <description>Type of mission items being requested/sent in mission protocol.</description>
-      <entry value="0" name="MAV_MISSION_TYPE_MISSION">
-        <description>Items are mission commands for main mission.</description>
-      </entry>
-      <entry value="1" name="MAV_MISSION_TYPE_FENCE">
-        <description>Specifies GeoFence area(s). Items are MAV_CMD_FENCE_ GeoFence items.</description>
-      </entry>
-      <entry value="2" name="MAV_MISSION_TYPE_RALLY">
-        <description>Specifies the rally points for the vehicle. Rally points are alternative RTL points. Items are MAV_CMD_RALLY_POINT rally point items.</description>
-      </entry>
-      <entry value="255" name="MAV_MISSION_TYPE_ALL">
-        <description>Only used in MISSION_CLEAR_ALL to clear all mission types.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_ESTIMATOR_TYPE">
-      <description>Enumeration of estimator types</description>
-      <entry value="1" name="MAV_ESTIMATOR_TYPE_NAIVE">
-        <description>This is a naive estimator without any real covariance feedback.</description>
-      </entry>
-      <entry value="2" name="MAV_ESTIMATOR_TYPE_VISION">
-        <description>Computer vision based estimate. Might be up to scale.</description>
-      </entry>
-      <entry value="3" name="MAV_ESTIMATOR_TYPE_VIO">
-        <description>Visual-inertial estimate.</description>
-      </entry>
-      <entry value="4" name="MAV_ESTIMATOR_TYPE_GPS">
-        <description>Plain GPS estimate.</description>
-      </entry>
-      <entry value="5" name="MAV_ESTIMATOR_TYPE_GPS_INS">
-        <description>Estimator integrating GPS and inertial sensing.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_BATTERY_TYPE">
-      <description>Enumeration of battery types</description>
-      <entry value="0" name="MAV_BATTERY_TYPE_UNKNOWN">
-        <description>Not specified.</description>
-      </entry>
-      <entry value="1" name="MAV_BATTERY_TYPE_LIPO">
-        <description>Lithium polymer battery</description>
-      </entry>
-      <entry value="2" name="MAV_BATTERY_TYPE_LIFE">
-        <description>Lithium-iron-phosphate battery</description>
-      </entry>
-      <entry value="3" name="MAV_BATTERY_TYPE_LION">
-        <description>Lithium-ION battery</description>
-      </entry>
-      <entry value="4" name="MAV_BATTERY_TYPE_NIMH">
-        <description>Nickel metal hydride battery</description>
-      </entry>
-    </enum>
-    <enum name="MAV_BATTERY_FUNCTION">
-      <description>Enumeration of battery functions</description>
-      <entry value="0" name="MAV_BATTERY_FUNCTION_UNKNOWN">
-        <description>Battery function is unknown</description>
-      </entry>
-      <entry value="1" name="MAV_BATTERY_FUNCTION_ALL">
-        <description>Battery supports all flight systems</description>
-      </entry>
-      <entry value="2" name="MAV_BATTERY_FUNCTION_PROPULSION">
-        <description>Battery for the propulsion system</description>
-      </entry>
-      <entry value="3" name="MAV_BATTERY_FUNCTION_AVIONICS">
-        <description>Avionics battery</description>
-      </entry>
-      <entry value="4" name="MAV_BATTERY_TYPE_PAYLOAD">
-        <description>Payload battery</description>
-      </entry>
-    </enum>
-    <enum name="MAV_VTOL_STATE">
-      <description>Enumeration of VTOL states</description>
-      <entry value="0" name="MAV_VTOL_STATE_UNDEFINED">
-        <description>MAV is not configured as VTOL</description>
-      </entry>
-      <entry value="1" name="MAV_VTOL_STATE_TRANSITION_TO_FW">
-        <description>VTOL is in transition from multicopter to fixed-wing</description>
-      </entry>
-      <entry value="2" name="MAV_VTOL_STATE_TRANSITION_TO_MC">
-        <description>VTOL is in transition from fixed-wing to multicopter</description>
-      </entry>
-      <entry value="3" name="MAV_VTOL_STATE_MC">
-        <description>VTOL is in multicopter state</description>
-      </entry>
-      <entry value="4" name="MAV_VTOL_STATE_FW">
-        <description>VTOL is in fixed-wing state</description>
-      </entry>
-    </enum>
-    <enum name="MAV_LANDED_STATE">
-      <description>Enumeration of landed detector states</description>
-      <entry value="0" name="MAV_LANDED_STATE_UNDEFINED">
-        <description>MAV landed state is unknown</description>
-      </entry>
-      <entry value="1" name="MAV_LANDED_STATE_ON_GROUND">
-        <description>MAV is landed (on ground)</description>
-      </entry>
-      <entry value="2" name="MAV_LANDED_STATE_IN_AIR">
-        <description>MAV is in air</description>
-      </entry>
-    </enum>
-    <enum name="ADSB_ALTITUDE_TYPE">
-      <description>Enumeration of the ADSB altimeter types</description>
-      <entry value="0" name="ADSB_ALTITUDE_TYPE_PRESSURE_QNH">
-        <description>Altitude reported from a Baro source using QNH reference</description>
-      </entry>
-      <entry value="1" name="ADSB_ALTITUDE_TYPE_GEOMETRIC">
-        <description>Altitude reported from a GNSS source</description>
-      </entry>
-    </enum>
-    <enum name="ADSB_EMITTER_TYPE">
-      <description>ADSB classification for the type of vehicle emitting the transponder signal</description>
-      <entry value="0" name="ADSB_EMITTER_TYPE_NO_INFO"/>
-      <entry value="1" name="ADSB_EMITTER_TYPE_LIGHT"/>
-      <entry value="2" name="ADSB_EMITTER_TYPE_SMALL"/>
-      <entry value="3" name="ADSB_EMITTER_TYPE_LARGE"/>
-      <entry value="4" name="ADSB_EMITTER_TYPE_HIGH_VORTEX_LARGE"/>
-      <entry value="5" name="ADSB_EMITTER_TYPE_HEAVY"/>
-      <entry value="6" name="ADSB_EMITTER_TYPE_HIGHLY_MANUV"/>
-      <entry value="7" name="ADSB_EMITTER_TYPE_ROTOCRAFT"/>
-      <entry value="8" name="ADSB_EMITTER_TYPE_UNASSIGNED"/>
-      <entry value="9" name="ADSB_EMITTER_TYPE_GLIDER"/>
-      <entry value="10" name="ADSB_EMITTER_TYPE_LIGHTER_AIR"/>
-      <entry value="11" name="ADSB_EMITTER_TYPE_PARACHUTE"/>
-      <entry value="12" name="ADSB_EMITTER_TYPE_ULTRA_LIGHT"/>
-      <entry value="13" name="ADSB_EMITTER_TYPE_UNASSIGNED2"/>
-      <entry value="14" name="ADSB_EMITTER_TYPE_UAV"/>
-      <entry value="15" name="ADSB_EMITTER_TYPE_SPACE"/>
-      <entry value="16" name="ADSB_EMITTER_TYPE_UNASSGINED3"/>
-      <entry value="17" name="ADSB_EMITTER_TYPE_EMERGENCY_SURFACE"/>
-      <entry value="18" name="ADSB_EMITTER_TYPE_SERVICE_SURFACE"/>
-      <entry value="19" name="ADSB_EMITTER_TYPE_POINT_OBSTACLE"/>
-    </enum>
-    <enum name="ADSB_FLAGS">
-      <description>These flags indicate status such as data validity of each data source. Set = data valid</description>
-      <entry value="1" name="ADSB_FLAGS_VALID_COORDS"/>
-      <entry value="2" name="ADSB_FLAGS_VALID_ALTITUDE"/>
-      <entry value="4" name="ADSB_FLAGS_VALID_HEADING"/>
-      <entry value="8" name="ADSB_FLAGS_VALID_VELOCITY"/>
-      <entry value="16" name="ADSB_FLAGS_VALID_CALLSIGN"/>
-      <entry value="32" name="ADSB_FLAGS_VALID_SQUAWK"/>
-      <entry value="64" name="ADSB_FLAGS_SIMULATED"/>
-    </enum>
-    <enum name="MAV_DO_REPOSITION_FLAGS">
-      <description>Bitmask of options for the MAV_CMD_DO_REPOSITION</description>
-      <entry value="1" name="MAV_DO_REPOSITION_FLAGS_CHANGE_MODE">
-        <description>The aircraft should immediately transition into guided. This should not be set for follow me applications</description>
-      </entry>
-    </enum>
-    <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
-    <enum name="ESTIMATOR_STATUS_FLAGS">
-      <description>Flags in EKF_STATUS message</description>
-      <entry name="ESTIMATOR_ATTITUDE" value="1">
-        <description>True if the attitude estimate is good</description>
-      </entry>
-      <entry name="ESTIMATOR_VELOCITY_HORIZ" value="2">
-        <description>True if the horizontal velocity estimate is good</description>
-      </entry>
-      <entry name="ESTIMATOR_VELOCITY_VERT" value="4">
-        <description>True if the  vertical velocity estimate is good</description>
-      </entry>
-      <entry name="ESTIMATOR_POS_HORIZ_REL" value="8">
-        <description>True if the horizontal position (relative) estimate is good</description>
-      </entry>
-      <entry name="ESTIMATOR_POS_HORIZ_ABS" value="16">
-        <description>True if the horizontal position (absolute) estimate is good</description>
-      </entry>
-      <entry name="ESTIMATOR_POS_VERT_ABS" value="32">
-        <description>True if the vertical position (absolute) estimate is good</description>
-      </entry>
-      <entry name="ESTIMATOR_POS_VERT_AGL" value="64">
-        <description>True if the vertical position (above ground) estimate is good</description>
-      </entry>
-      <entry name="ESTIMATOR_CONST_POS_MODE" value="128">
-        <description>True if the EKF is in a constant position mode and is not using external measurements (eg GPS or optical flow)</description>
-      </entry>
-      <entry name="ESTIMATOR_PRED_POS_HORIZ_REL" value="256">
-        <description>True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate</description>
-      </entry>
-      <entry name="ESTIMATOR_PRED_POS_HORIZ_ABS" value="512">
-        <description>True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate</description>
-      </entry>
-      <entry name="ESTIMATOR_GPS_GLITCH" value="1024">
-        <description>True if the EKF has detected a GPS glitch</description>
-      </entry>
-    </enum>
-    <!-- motor test type enum -->
-    <enum name="MOTOR_TEST_THROTTLE_TYPE">
-      <entry name="MOTOR_TEST_THROTTLE_PERCENT" value="0">
-        <description>throttle as a percentage from 0 ~ 100</description>
-      </entry>
-      <entry name="MOTOR_TEST_THROTTLE_PWM" value="1">
-        <description>throttle as an absolute PWM value (normally in range of 1000~2000)</description>
-      </entry>
-      <entry name="MOTOR_TEST_THROTTLE_PILOT" value="2">
-        <description>throttle pass-through from pilot's transmitter</description>
-      </entry>
-    </enum>
-    <!-- GPS_INPUT ignore flags enum -->
-    <enum name="GPS_INPUT_IGNORE_FLAGS">
-      <entry name="GPS_INPUT_IGNORE_FLAG_ALT" value="1">
-        <description>ignore altitude field</description>
-      </entry>
-      <entry name="GPS_INPUT_IGNORE_FLAG_HDOP" value="2">
-        <description>ignore hdop field</description>
-      </entry>
-      <entry name="GPS_INPUT_IGNORE_FLAG_VDOP" value="4">
-        <description>ignore vdop field</description>
-      </entry>
-      <entry name="GPS_INPUT_IGNORE_FLAG_VEL_HORIZ" value="8">
-        <description>ignore horizontal velocity field (vn and ve)</description>
-      </entry>
-      <entry name="GPS_INPUT_IGNORE_FLAG_VEL_VERT" value="16">
-        <description>ignore vertical velocity field (vd)</description>
-      </entry>
-      <entry name="GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY" value="32">
-        <description>ignore speed accuracy field</description>
-      </entry>
-      <entry name="GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY" value="64">
-        <description>ignore horizontal accuracy field</description>
-      </entry>
-      <entry name="GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY" value="128">
-        <description>ignore vertical accuracy field</description>
-      </entry>
-    </enum>
-    <enum name="MAV_COLLISION_ACTION">
-      <description>Possible actions an aircraft can take to avoid a collision.</description>
-      <entry value="0" name="MAV_COLLISION_ACTION_NONE">
-        <description>Ignore any potential collisions</description>
-      </entry>
-      <entry value="1" name="MAV_COLLISION_ACTION_REPORT">
-        <description>Report potential collision</description>
-      </entry>
-      <entry value="2" name="MAV_COLLISION_ACTION_ASCEND_OR_DESCEND">
-        <description>Ascend or Descend to avoid threat</description>
-      </entry>
-      <entry value="3" name="MAV_COLLISION_ACTION_MOVE_HORIZONTALLY">
-        <description>Move horizontally to avoid threat</description>
-      </entry>
-      <entry value="4" name="MAV_COLLISION_ACTION_MOVE_PERPENDICULAR">
-        <description>Aircraft to move perpendicular to the collision's velocity vector</description>
-      </entry>
-      <entry value="5" name="MAV_COLLISION_ACTION_RTL">
-        <description>Aircraft to fly directly back to its launch point</description>
-      </entry>
-      <entry value="6" name="MAV_COLLISION_ACTION_HOVER">
-        <description>Aircraft to stop in place</description>
-      </entry>
-    </enum>
-    <enum name="MAV_COLLISION_THREAT_LEVEL">
-      <description>Aircraft-rated danger from this threat.</description>
-      <entry value="0" name="MAV_COLLISION_THREAT_LEVEL_NONE">
-        <description>Not a threat</description>
-      </entry>
-      <entry value="1" name="MAV_COLLISION_THREAT_LEVEL_LOW">
-        <description>Craft is mildly concerned about this threat</description>
-      </entry>
-      <entry value="2" name="MAV_COLLISION_THREAT_LEVEL_HIGH">
-        <description>Craft is panicing, and may take actions to avoid threat</description>
-      </entry>
-    </enum>
-    <enum name="MAV_COLLISION_SRC">
-      <description>Source of information about this collision.</description>
-      <entry value="0" name="MAV_COLLISION_SRC_ADSB">
-        <description>ID field references ADSB_VEHICLE packets</description>
-      </entry>
-      <entry value="1" name="MAV_COLLISION_SRC_MAVLINK_GPS_GLOBAL_INT">
-        <description>ID field references MAVLink SRC ID</description>
-      </entry>
-    </enum>
-    <enum name="GPS_FIX_TYPE">
-      <description>Type of GPS fix</description>
-      <entry value="0" name="GPS_FIX_TYPE_NO_GPS">
-        <description>No GPS connected</description>
-      </entry>
-      <entry value="1" name="GPS_FIX_TYPE_NO_FIX">
-        <description>No position information, GPS is connected</description>
-      </entry>
-      <entry value="2" name="GPS_FIX_TYPE_2D_FIX">
-        <description>2D position</description>
-      </entry>
-      <entry value="3" name="GPS_FIX_TYPE_3D_FIX">
-        <description>3D position</description>
-      </entry>
-      <entry value="4" name="GPS_FIX_TYPE_DGPS">
-        <description>DGPS/SBAS aided 3D position</description>
-      </entry>
-      <entry value="5" name="GPS_FIX_TYPE_RTK_FLOAT">
-        <description>RTK float, 3D position</description>
-      </entry>
-      <entry value="6" name="GPS_FIX_TYPE_RTK_FIXED">
-        <description>RTK Fixed, 3D position</description>
-      </entry>
-      <entry value="7" name="GPS_FIX_TYPE_STATIC">
-        <description>Static fixed, typically used for base stations</description>
-      </entry>
-    </enum>
-  </enums>
-  <messages>
-    <message id="0" name="HEARTBEAT">
-      <description>The heartbeat message shows that a system is present and responding. The type of the MAV and Autopilot hardware allow the receiving system to treat further messages from this system appropriate (e.g. by laying out the user interface based on the autopilot).</description>
-      <field type="uint8_t" name="type">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
-      <field type="uint8_t" name="autopilot">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
-      <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
-      <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
-      <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
-      <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
-    </message>
-    <message id="1" name="SYS_STATUS">
-      <description>The general system state. If the system is following the MAVLink standard, the system state is mainly defined by three orthogonal states/modes: The system mode, which is either LOCKED (motors shut down and locked), MANUAL (system under RC control), GUIDED (system with autonomous position control, position setpoint controlled manually) or AUTO (system guided by path/waypoint planner). The NAV_MODE defined the current flight state: LIFTOFF (often an open-loop maneuver), LANDING, WAYPOINTS or VECTOR. This represents the internal navigation state machine. The system status shows wether the system is currently active or not and if an emergency occured. During the CRITICAL and EMERGENCY states the MAV is still considered to be active, but should start emergency procedures autonomously. After a failure occured it should first move from active to critical to allow manual intervention and then move to emergency after a certain timeout.</description>
-      <field type="uint32_t" name="onboard_control_sensors_present" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are present. Value of 0: not present. Value of 1: present. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-      <field type="uint32_t" name="onboard_control_sensors_enabled" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are enabled:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-      <field type="uint32_t" name="onboard_control_sensors_health" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are operational or have an error:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-      <field type="uint16_t" name="load">Maximum usage in percent of the mainloop time, (0%: 0, 100%: 1000) should be always below 1000</field>
-      <field type="uint16_t" name="voltage_battery">Battery voltage, in millivolts (1 = 1 millivolt)</field>
-      <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
-      <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery</field>
-      <field type="uint16_t" name="drop_rate_comm">Communication drops in percent, (0%: 0, 100%: 10'000), (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
-      <field type="uint16_t" name="errors_comm">Communication errors (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
-      <field type="uint16_t" name="errors_count1">Autopilot-specific errors</field>
-      <field type="uint16_t" name="errors_count2">Autopilot-specific errors</field>
-      <field type="uint16_t" name="errors_count3">Autopilot-specific errors</field>
-      <field type="uint16_t" name="errors_count4">Autopilot-specific errors</field>
-    </message>
-    <message id="2" name="SYSTEM_TIME">
-      <description>The system time is the time of the master clock, typically the computer clock of the main onboard computer.</description>
-      <field type="uint64_t" name="time_unix_usec">Timestamp of the master clock in microseconds since UNIX epoch.</field>
-      <field type="uint32_t" name="time_boot_ms">Timestamp of the component clock since boot time in milliseconds.</field>
-    </message>
-    <!-- FIXME to be removed / merged with SYSTEM_TIME -->
-    <message id="4" name="PING">
-      <description>A ping message either requesting or responding to a ping. This allows to measure the system latencies, including serial port, radio modem and UDP connections.</description>
-      <field type="uint64_t" name="time_usec">Unix timestamp in microseconds or since system boot if smaller than MAVLink epoch (1.1.2009)</field>
-      <field type="uint32_t" name="seq">PING sequence</field>
-      <field type="uint8_t" name="target_system">0: request ping from all receiving systems, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
-      <field type="uint8_t" name="target_component">0: request ping from all receiving components, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
-    </message>
-    <message id="5" name="CHANGE_OPERATOR_CONTROL">
-      <description>Request to control this MAV</description>
-      <field type="uint8_t" name="target_system">System the GCS requests control for</field>
-      <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
-      <field type="uint8_t" name="version">0: key as plaintext, 1-255: future, different hashing/encryption variants. The GCS should in general use the safest mode possible initially and then gradually move down the encryption level if it gets a NACK message indicating an encryption mismatch.</field>
-      <field type="char[25]" name="passkey">Password / Key, depending on version plaintext or encrypted. 25 or less characters, NULL terminated. The characters may involve A-Z, a-z, 0-9, and "!?,.-"</field>
-    </message>
-    <message id="6" name="CHANGE_OPERATOR_CONTROL_ACK">
-      <description>Accept / deny control of this MAV</description>
-      <field type="uint8_t" name="gcs_system_id">ID of the GCS this message </field>
-      <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
-      <field type="uint8_t" name="ack">0: ACK, 1: NACK: Wrong passkey, 2: NACK: Unsupported passkey encryption method, 3: NACK: Already under control</field>
-    </message>
-    <message id="7" name="AUTH_KEY">
-      <description>Emit an encrypted signature / key identifying this system. PLEASE NOTE: This protocol has been kept simple, so transmitting the key requires an encrypted channel for true safety.</description>
-      <field type="char[32]" name="key">key</field>
-    </message>
-    <message id="11" name="SET_MODE">
-      <description>THIS INTERFACE IS DEPRECATED. USE COMMAND_LONG with MAV_CMD_DO_SET_MODE INSTEAD. Set the system mode, as defined by enum MAV_MODE. There is no target component id as the mode is by definition for the overall aircraft, not only for one component.</description>
-      <field type="uint8_t" name="target_system">The system setting the mode</field>
-      <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode</field>
-      <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
-    </message>
-    <!-- reserved for PARAM_VALUE_UNION -->
-    <message id="20" name="PARAM_REQUEST_READ">
-      <description>Request to read the onboard parameter with the param_id string id. Onboard parameters are stored as key[const char*] -&gt; value[float]. This allows to send a parameter to any other component (such as the GCS) without the need of previous knowledge of possible parameter names. Thus the same GCS can store different parameters for different autopilots. See also http://qgroundcontrol.org/parameter_interface for a full documentation of QGroundControl and IMU code.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored)</field>
-    </message>
-    <message id="21" name="PARAM_REQUEST_LIST">
-      <description>Request all parameters of this component. After this request, all parameters are emitted.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-    </message>
-    <message id="22" name="PARAM_VALUE">
-      <description>Emit the value of a onboard parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows him to re-request missing parameters after a loss or timeout.</description>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="float" name="param_value">Onboard parameter value</field>
-      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-      <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
-      <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
-    </message>
-    <message id="23" name="PARAM_SET">
-      <description>Set a parameter value TEMPORARILY to RAM. It will be reset to default on system reboot. Send the ACTION MAV_ACTION_STORAGE_WRITE to PERMANENTLY write the RAM contents to EEPROM. IMPORTANT: The receiving component should acknowledge the new parameter value by sending a param_value message to all communication partners. This will also ensure that multiple GCS all have an up-to-date list of all parameters. If the sending GCS did not receive a PARAM_VALUE message within its timeout time, it should re-send the PARAM_SET message.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="float" name="param_value">Onboard parameter value</field>
-      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-    </message>
-    <message id="24" name="GPS_RAW_INT">
-      <description>The global position, as returned by the Global Positioning System (GPS). This is
+               <entry value="0" name="MAV_ROI_NONE">
+                    <description>No region of interest.</description>
+               </entry>
+               <entry value="1" name="MAV_ROI_WPNEXT">
+                    <description>Point toward next MISSION.</description>
+               </entry>
+               <entry value="2" name="MAV_ROI_WPINDEX">
+                    <description>Point toward given MISSION.</description>
+               </entry>
+               <entry value="3" name="MAV_ROI_LOCATION">
+                    <description>Point toward fixed location.</description>
+               </entry>
+               <entry value="4" name="MAV_ROI_TARGET">
+                    <description>Point toward of given id.</description>
+               </entry>
+          </enum>
+          <enum name="MAV_CMD_ACK">
+               <description>ACK / NACK / ERROR values as a result of MAV_CMDs and for mission item transmission.</description>
+               <entry name="MAV_CMD_ACK_OK">
+                    <description>Command / mission item is ok.</description>
+               </entry>
+               <entry name="MAV_CMD_ACK_ERR_FAIL">
+                    <description>Generic error message if none of the other reasons fails or if no detailed error reporting is implemented.</description>
+               </entry>
+               <entry name="MAV_CMD_ACK_ERR_ACCESS_DENIED">
+                    <description>The system is refusing to accept this command from this source / communication partner.</description>
+               </entry>
+               <entry name="MAV_CMD_ACK_ERR_NOT_SUPPORTED">
+                    <description>Command or mission item is not supported, other commands would be accepted.</description>
+               </entry>
+               <entry name="MAV_CMD_ACK_ERR_COORDINATE_FRAME_NOT_SUPPORTED">
+                    <description>The coordinate frame of this command / mission item is not supported.</description>
+               </entry>
+               <entry name="MAV_CMD_ACK_ERR_COORDINATES_OUT_OF_RANGE">
+                    <description>The coordinate frame of this command is ok, but he coordinate values exceed the safety limits of this system. This is a generic error, please use the more specific error messages below if possible.</description>
+               </entry>
+               <entry name="MAV_CMD_ACK_ERR_X_LAT_OUT_OF_RANGE">
+                    <description>The X or latitude value is out of range.</description>
+               </entry>
+               <entry name="MAV_CMD_ACK_ERR_Y_LON_OUT_OF_RANGE">
+                    <description>The Y or longitude value is out of range.</description>
+               </entry>
+               <entry name="MAV_CMD_ACK_ERR_Z_ALT_OUT_OF_RANGE">
+                    <description>The Z or altitude value is out of range.</description>
+               </entry>
+          </enum>
+          <enum name="MAV_PARAM_TYPE">
+               <description>Specifies the datatype of a MAVLink parameter.</description>
+               <entry value="1" name="MAV_PARAM_TYPE_UINT8">
+                    <description>8-bit unsigned integer</description>
+               </entry>
+               <entry value="2" name="MAV_PARAM_TYPE_INT8">
+                    <description>8-bit signed integer</description>
+               </entry>
+               <entry value="3" name="MAV_PARAM_TYPE_UINT16">
+                    <description>16-bit unsigned integer</description>
+               </entry>
+               <entry value="4" name="MAV_PARAM_TYPE_INT16">
+                    <description>16-bit signed integer</description>
+               </entry>
+               <entry value="5" name="MAV_PARAM_TYPE_UINT32">
+                    <description>32-bit unsigned integer</description>
+               </entry>
+               <entry value="6" name="MAV_PARAM_TYPE_INT32">
+                    <description>32-bit signed integer</description>
+               </entry>
+               <entry value="7" name="MAV_PARAM_TYPE_UINT64">
+                    <description>64-bit unsigned integer</description>
+               </entry>
+               <entry value="8" name="MAV_PARAM_TYPE_INT64">
+                    <description>64-bit signed integer</description>
+               </entry>
+               <entry value="9" name="MAV_PARAM_TYPE_REAL32">
+                    <description>32-bit floating-point</description>
+               </entry>
+               <entry value="10" name="MAV_PARAM_TYPE_REAL64">
+                    <description>64-bit floating-point</description>
+               </entry>
+          </enum>
+          <enum name="MAV_RESULT">
+               <description>result from a mavlink command</description>
+               <entry value="0" name="MAV_RESULT_ACCEPTED">
+                    <description>Command ACCEPTED and EXECUTED</description>
+               </entry>
+               <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
+                    <description>Command TEMPORARY REJECTED/DENIED</description>
+               </entry>
+               <entry value="2" name="MAV_RESULT_DENIED">
+                    <description>Command PERMANENTLY DENIED</description>
+               </entry>
+               <entry value="3" name="MAV_RESULT_UNSUPPORTED">
+                    <description>Command UNKNOWN/UNSUPPORTED</description>
+               </entry>
+               <entry value="4" name="MAV_RESULT_FAILED">
+                    <description>Command executed, but failed</description>
+               </entry>
+          </enum>
+          <enum name="MAV_MISSION_RESULT">
+               <description>result in a mavlink mission ack</description>
+               <entry value="0" name="MAV_MISSION_ACCEPTED">
+                    <description>mission accepted OK</description>
+               </entry>
+               <entry value="1" name="MAV_MISSION_ERROR">
+                    <description>generic error / not accepting mission commands at all right now</description>
+               </entry>
+               <entry value="2" name="MAV_MISSION_UNSUPPORTED_FRAME">
+                    <description>coordinate frame is not supported</description>
+               </entry>
+               <entry value="3" name="MAV_MISSION_UNSUPPORTED">
+                    <description>command is not supported</description>
+               </entry>
+               <entry value="4" name="MAV_MISSION_NO_SPACE">
+                    <description>mission item exceeds storage space</description>
+               </entry>
+               <entry value="5" name="MAV_MISSION_INVALID">
+                    <description>one of the parameters has an invalid value</description>
+               </entry>
+               <entry value="6" name="MAV_MISSION_INVALID_PARAM1">
+                    <description>param1 has an invalid value</description>
+               </entry>
+               <entry value="7" name="MAV_MISSION_INVALID_PARAM2">
+                    <description>param2 has an invalid value</description>
+               </entry>
+               <entry value="8" name="MAV_MISSION_INVALID_PARAM3">
+                    <description>param3 has an invalid value</description>
+               </entry>
+               <entry value="9" name="MAV_MISSION_INVALID_PARAM4">
+                    <description>param4 has an invalid value</description>
+               </entry>
+               <entry value="10" name="MAV_MISSION_INVALID_PARAM5_X">
+                    <description>x/param5 has an invalid value</description>
+               </entry>
+               <entry value="11" name="MAV_MISSION_INVALID_PARAM6_Y">
+                    <description>y/param6 has an invalid value</description>
+               </entry>
+               <entry value="12" name="MAV_MISSION_INVALID_PARAM7">
+                    <description>param7 has an invalid value</description>
+               </entry>
+               <entry value="13" name="MAV_MISSION_INVALID_SEQUENCE">
+                    <description>received waypoint out of sequence</description>
+               </entry>
+               <entry value="14" name="MAV_MISSION_DENIED">
+                    <description>not accepting any mission commands from this communication partner</description>
+               </entry>
+          </enum>
+          <enum name="MAV_SEVERITY">
+               <description>Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.</description>
+               <entry value="0" name="MAV_SEVERITY_EMERGENCY">
+                  <description>System is unusable. This is a "panic" condition.</description>
+               </entry>
+               <entry value="1" name="MAV_SEVERITY_ALERT">
+                  <description>Action should be taken immediately. Indicates error in non-critical systems.</description>
+               </entry>
+               <entry value="2" name="MAV_SEVERITY_CRITICAL">
+                  <description>Action must be taken immediately. Indicates failure in a primary system.</description>
+               </entry>
+               <entry value="3" name="MAV_SEVERITY_ERROR">
+                  <description>Indicates an error in secondary/redundant systems.</description>
+               </entry>
+               <entry value="4" name="MAV_SEVERITY_WARNING">
+                  <description>Indicates about a possible future error if this is not resolved within a given timeframe. Example would be a low battery warning.</description>
+               </entry>
+               <entry value="5" name="MAV_SEVERITY_NOTICE">
+                  <description>An unusual event has occured, though not an error condition. This should be investigated for the root cause.</description>
+               </entry>
+               <entry value="6" name="MAV_SEVERITY_INFO">
+                  <description>Normal operational messages. Useful for logging. No action is required for these messages.</description>
+               </entry>
+               <entry value="7" name="MAV_SEVERITY_DEBUG">
+                  <description>Useful non-operational messages that can assist in debugging. These should not occur during normal operation.</description>
+               </entry>
+          </enum>
+          <enum name="MAV_POWER_STATUS">
+               <description>Power supply status flags (bitmask)</description>
+               <entry value="1" name="MAV_POWER_STATUS_BRICK_VALID">
+                    <description>main brick power supply valid</description>
+               </entry>
+               <entry value="2" name="MAV_POWER_STATUS_SERVO_VALID">
+                    <description>main servo power supply valid for FMU</description>
+               </entry>
+               <entry value="4" name="MAV_POWER_STATUS_USB_CONNECTED">
+                    <description>USB power is connected</description>
+               </entry>
+               <entry value="8" name="MAV_POWER_STATUS_PERIPH_OVERCURRENT">
+                    <description>peripheral supply is in over-current state</description>
+               </entry>
+               <entry value="16" name="MAV_POWER_STATUS_PERIPH_HIPOWER_OVERCURRENT">
+                    <description>hi-power peripheral supply is in over-current state</description>
+               </entry>
+               <entry value="32" name="MAV_POWER_STATUS_CHANGED">
+                    <description>Power status has changed since boot</description>
+               </entry>
+          </enum>
+          <enum name="SERIAL_CONTROL_DEV">
+               <description>SERIAL_CONTROL device types</description>
+               <entry value="0" name="SERIAL_CONTROL_DEV_TELEM1">
+                    <description>First telemetry port</description>
+               </entry>
+               <entry value="1" name="SERIAL_CONTROL_DEV_TELEM2">
+                    <description>Second telemetry port</description>
+               </entry>
+               <entry value="2" name="SERIAL_CONTROL_DEV_GPS1">
+                    <description>First GPS port</description>
+               </entry>
+               <entry value="3" name="SERIAL_CONTROL_DEV_GPS2">
+                    <description>Second GPS port</description>
+               </entry>
+               <entry value="10" name="SERIAL_CONTROL_DEV_SHELL">
+                    <description>system shell</description>
+               </entry>
+          </enum>
+          <enum name="SERIAL_CONTROL_FLAG">
+               <description>SERIAL_CONTROL flags (bitmask)</description>
+               <entry value="1" name="SERIAL_CONTROL_FLAG_REPLY">
+                    <description>Set if this is a reply</description>
+               </entry>
+               <entry value="2" name="SERIAL_CONTROL_FLAG_RESPOND">
+                    <description>Set if the sender wants the receiver to send a response as another SERIAL_CONTROL message</description>
+               </entry>
+               <entry value="4" name="SERIAL_CONTROL_FLAG_EXCLUSIVE">
+                    <description>Set if access to the serial port should be removed from whatever driver is currently using it, giving exclusive access to the SERIAL_CONTROL protocol. The port can be handed back by sending a request without this flag set</description>
+               </entry>
+               <entry value="8" name="SERIAL_CONTROL_FLAG_BLOCKING">
+                    <description>Block on writes to the serial port</description>
+               </entry>
+               <entry value="16" name="SERIAL_CONTROL_FLAG_MULTI">
+                    <description>Send multiple replies until port is drained</description>
+               </entry>
+          </enum>
+          <enum name="MAV_DISTANCE_SENSOR">
+              <description>Enumeration of distance sensor types</description>
+              <entry value="0" name="MAV_DISTANCE_SENSOR_LASER">
+                  <description>Laser rangefinder, e.g. LightWare SF02/F or PulsedLight units</description>
+              </entry>
+              <entry value="1" name="MAV_DISTANCE_SENSOR_ULTRASOUND">
+                  <description>Ultrasound rangefinder, e.g. MaxBotix units</description>
+              </entry>
+              <entry value="2" name="MAV_DISTANCE_SENSOR_INFRARED">
+                  <description>Infrared rangefinder, e.g. Sharp units</description>
+              </entry>
+          </enum>
+          <enum name="MAV_SENSOR_ORIENTATION">
+              <description>Enumeration of sensor orientation, according to its rotations</description>
+              <entry value="0" name="MAV_SENSOR_ROTATION_NONE">
+                  <description>Roll: 0, Pitch: 0, Yaw: 0</description>
+              </entry>
+              <entry value="1" name="MAV_SENSOR_ROTATION_YAW_45">
+                  <description>Roll: 0, Pitch: 0, Yaw: 45</description>
+              </entry>
+              <entry value="2" name="MAV_SENSOR_ROTATION_YAW_90">
+                  <description>Roll: 0, Pitch: 0, Yaw: 90</description>
+              </entry>
+              <entry value="3" name="MAV_SENSOR_ROTATION_YAW_135">
+                  <description>Roll: 0, Pitch: 0, Yaw: 135</description>
+              </entry>
+              <entry value="4" name="MAV_SENSOR_ROTATION_YAW_180">
+                  <description>Roll: 0, Pitch: 0, Yaw: 180</description>
+              </entry>
+              <entry value="5" name="MAV_SENSOR_ROTATION_YAW_225">
+                  <description>Roll: 0, Pitch: 0, Yaw: 225</description>
+              </entry>
+              <entry value="6" name="MAV_SENSOR_ROTATION_YAW_270">
+                  <description>Roll: 0, Pitch: 0, Yaw: 270</description>
+              </entry>
+              <entry value="7" name="MAV_SENSOR_ROTATION_YAW_315">
+                  <description>Roll: 0, Pitch: 0, Yaw: 315</description>
+              </entry>
+              <entry value="8" name="MAV_SENSOR_ROTATION_ROLL_180">
+                  <description>Roll: 180, Pitch: 0, Yaw: 0</description>
+              </entry>
+              <entry value="9" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_45">
+                  <description>Roll: 180, Pitch: 0, Yaw: 45</description>
+              </entry>
+              <entry value="10" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_90">
+                  <description>Roll: 180, Pitch: 0, Yaw: 90</description>
+              </entry>
+              <entry value="11" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_135">
+                  <description>Roll: 180, Pitch: 0, Yaw: 135</description>
+              </entry>
+              <entry value="12" name="MAV_SENSOR_ROTATION_PITCH_180">
+                  <description>Roll: 0, Pitch: 180, Yaw: 0</description>
+              </entry>
+              <entry value="13" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_225">
+                  <description>Roll: 180, Pitch: 0, Yaw: 225</description>
+              </entry>
+              <entry value="14" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_270">
+                  <description>Roll: 180, Pitch: 0, Yaw: 270</description>
+              </entry>
+              <entry value="15" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_315">
+                  <description>Roll: 180, Pitch: 0, Yaw: 315</description>
+              </entry>
+              <entry value="16" name="MAV_SENSOR_ROTATION_ROLL_90">
+                  <description>Roll: 90, Pitch: 0, Yaw: 0</description>
+              </entry>
+              <entry value="17" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_45">
+                  <description>Roll: 90, Pitch: 0, Yaw: 45</description>
+              </entry>
+              <entry value="18" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_90">
+                  <description>Roll: 90, Pitch: 0, Yaw: 90</description>
+              </entry>
+              <entry value="19" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_135">
+                  <description>Roll: 90, Pitch: 0, Yaw: 135</description>
+              </entry>
+              <entry value="20" name="MAV_SENSOR_ROTATION_ROLL_270">
+                  <description>Roll: 270, Pitch: 0, Yaw: 0</description>
+              </entry>
+              <entry value="21" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_45">
+                  <description>Roll: 270, Pitch: 0, Yaw: 45</description>
+              </entry>
+              <entry value="22" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_90">
+                  <description>Roll: 270, Pitch: 0, Yaw: 90</description>
+              </entry>
+              <entry value="23" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_135">
+                  <description>Roll: 270, Pitch: 0, Yaw: 135</description>
+              </entry>
+              <entry value="24" name="MAV_SENSOR_ROTATION_PITCH_90">
+                  <description>Roll: 0, Pitch: 90, Yaw: 0</description>
+              </entry>
+              <entry value="25" name="MAV_SENSOR_ROTATION_PITCH_270">
+                <description>Roll: 0, Pitch: 270, Yaw: 0</description>
+              </entry>
+              <entry value="26" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_90">
+                <description>Roll: 0, Pitch: 180, Yaw: 90</description>
+              </entry>
+              <entry value="27" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_270">
+                  <description>Roll: 0, Pitch: 180, Yaw: 270</description>
+              </entry>
+              <entry value="28" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_90">
+                  <description>Roll: 90, Pitch: 90, Yaw: 0</description>
+              </entry>
+              <entry value="29" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_90">
+                  <description>Roll: 180, Pitch: 90, Yaw: 0</description>
+              </entry>
+              <entry value="30" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_90">
+                  <description>Roll: 270, Pitch: 90, Yaw: 0</description>
+              </entry>
+              <entry value="31" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180">
+                  <description>Roll: 90, Pitch: 180, Yaw: 0</description>
+              </entry>
+              <entry value="32" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_180">
+                  <description>Roll: 270, Pitch: 180, Yaw: 0</description>
+              </entry>
+              <entry value="33" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_270">
+                  <description>Roll: 90, Pitch: 270, Yaw: 0</description>
+              </entry>
+              <entry value="34" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_270">
+                  <description>Roll: 180, Pitch: 270, Yaw: 0</description>
+              </entry>
+              <entry value="35" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_270">
+                  <description>Roll: 270, Pitch: 270, Yaw: 0</description>
+              </entry>
+              <entry value="36" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90">
+                  <description>Roll: 90, Pitch: 180, Yaw: 90</description>
+              </entry>
+              <entry value="37" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_270">
+                  <description>Roll: 90, Pitch: 0, Yaw: 270</description>
+              </entry>
+              <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_315_PITCH_315_YAW_315">
+                  <description>Roll: 315, Pitch: 315, Yaw: 315</description>
+              </entry>
+          </enum>
+          <enum name="MAV_PROTOCOL_CAPABILITY">
+              <description>Bitmask of (optional) autopilot capabilities (64 bit). If a bit is set, the autopilot supports this capability.</description>
+              <entry value="1" name="MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT">
+                  <description>Autopilot supports MISSION float message type.</description>
+              </entry>
+              <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT">
+                  <description>Autopilot supports the new param float message type.</description>
+              </entry>
+              <entry value="4" name="MAV_PROTOCOL_CAPABILITY_MISSION_INT">
+                  <description>Autopilot supports MISSION_INT scaled integer message type.</description>
+              </entry>
+              <entry value="8" name="MAV_PROTOCOL_CAPABILITY_COMMAND_INT">
+                  <description>Autopilot supports COMMAND_INT scaled integer message type.</description>
+              </entry>
+              <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_UNION">
+                  <description>Autopilot supports the new param union message type.</description>
+              </entry>
+              <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">
+                  <description>Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.</description>
+              </entry>
+              <entry value="64" name="MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET">
+                  <description>Autopilot supports commanding attitude offboard.</description>
+              </entry>
+              <entry value="128" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED">
+                  <description>Autopilot supports commanding position and velocity targets in local NED frame.</description>
+              </entry>
+              <entry value="256" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT">
+                  <description>Autopilot supports commanding position and velocity targets in global scaled integers.</description>
+              </entry>
+              <entry value="512" name="MAV_PROTOCOL_CAPABILITY_TERRAIN">
+                  <description>Autopilot supports terrain protocol / data handling.</description>
+              </entry>
+              <entry value="1024" name="MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET">
+                  <description>Autopilot supports direct actuator control.</description>
+              </entry>
+              <entry value="2048" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION">
+                  <description>Autopilot supports the flight termination command.</description>
+              </entry>
+              <entry value="4096" name="MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION">
+                  <description>Autopilot supports onboard compass calibration.</description>
+              </entry>
+              <entry value="8192" name="MAV_PROTOCOL_CAPABILITY_MAVLINK2">
+                  <description>Autopilot supports mavlink version 2.</description>
+              </entry>
+          </enum>
+          <enum name="MAV_ESTIMATOR_TYPE">
+              <description>Enumeration of estimator types</description>
+              <entry value="1" name="MAV_ESTIMATOR_TYPE_NAIVE">
+                  <description>This is a naive estimator without any real covariance feedback.</description>
+              </entry>
+              <entry value="2" name="MAV_ESTIMATOR_TYPE_VISION">
+                  <description>Computer vision based estimate. Might be up to scale.</description>
+              </entry>
+              <entry value="3" name="MAV_ESTIMATOR_TYPE_VIO">
+                  <description>Visual-inertial estimate.</description>
+              </entry>
+              <entry value="4" name="MAV_ESTIMATOR_TYPE_GPS">
+                  <description>Plain GPS estimate.</description>
+              </entry>
+              <entry value="5" name="MAV_ESTIMATOR_TYPE_GPS_INS">
+                  <description>Estimator integrating GPS and inertial sensing.</description>
+              </entry>
+          </enum>
+          <enum name="MAV_BATTERY_TYPE">
+              <description>Enumeration of battery types</description>
+              <entry value="0" name="MAV_BATTERY_TYPE_UNKNOWN">
+                  <description>Not specified.</description>
+              </entry>
+              <entry value="1" name="MAV_BATTERY_TYPE_LIPO">
+                  <description>Lithium polymer battery</description>
+              </entry>
+              <entry value="2" name="MAV_BATTERY_TYPE_LIFE">
+                  <description>Lithium-iron-phosphate battery</description>
+              </entry>
+              <entry value="3" name="MAV_BATTERY_TYPE_LION">
+                  <description>Lithium-ION battery</description>
+              </entry>
+              <entry value="4" name="MAV_BATTERY_TYPE_NIMH">
+                  <description>Nickel metal hydride battery</description>
+              </entry>
+          </enum>
+          <enum name="MAV_BATTERY_FUNCTION">
+              <description>Enumeration of battery functions</description>
+              <entry value="0" name="MAV_BATTERY_FUNCTION_UNKNOWN">
+                  <description>Battery function is unknown</description>
+              </entry>
+              <entry value="1" name="MAV_BATTERY_FUNCTION_ALL">
+                  <description>Battery supports all flight systems</description>
+              </entry>
+              <entry value="2" name="MAV_BATTERY_FUNCTION_PROPULSION">
+                  <description>Battery for the propulsion system</description>
+              </entry>
+              <entry value="3" name="MAV_BATTERY_FUNCTION_AVIONICS">
+                  <description>Avionics battery</description>
+              </entry>
+              <entry value="4" name="MAV_BATTERY_TYPE_PAYLOAD">
+                  <description>Payload battery</description>
+              </entry>
+          </enum>
+          <enum name="MAV_VTOL_STATE">
+              <description>Enumeration of VTOL states</description>
+              <entry value="0" name="MAV_VTOL_STATE_UNDEFINED">
+                  <description>MAV is not configured as VTOL</description>
+              </entry>
+              <entry value="1" name="MAV_VTOL_STATE_TRANSITION_TO_FW">
+                  <description>VTOL is in transition from multicopter to fixed-wing</description>
+              </entry>
+              <entry value="2" name="MAV_VTOL_STATE_TRANSITION_TO_MC">
+                  <description>VTOL is in transition from fixed-wing to multicopter</description>
+              </entry>
+              <entry value="3" name="MAV_VTOL_STATE_MC">
+                  <description>VTOL is in multicopter state</description>
+              </entry>
+              <entry value="4" name="MAV_VTOL_STATE_FW">
+                  <description>VTOL is in fixed-wing state</description>
+              </entry>
+          </enum>
+          <enum name="MAV_LANDED_STATE">
+              <description>Enumeration of landed detector states</description>
+              <entry value="0" name="MAV_LANDED_STATE_UNDEFINED">
+                  <description>MAV landed state is unknown</description>
+              </entry>
+              <entry value="1" name="MAV_LANDED_STATE_ON_GROUND">
+                  <description>MAV is landed (on ground)</description>
+              </entry>
+              <entry value="2" name="MAV_LANDED_STATE_IN_AIR">
+                  <description>MAV is in air</description>
+              </entry>
+          </enum>
+          <enum name="ADSB_ALTITUDE_TYPE">
+              <description>Enumeration of the ADSB altimeter types</description>
+              <entry value="0" name="ADSB_ALTITUDE_TYPE_PRESSURE_QNH">
+                  <description>Altitude reported from a Baro source using QNH reference</description>
+              </entry>
+              <entry value="1" name="ADSB_ALTITUDE_TYPE_GEOMETRIC">
+                  <description>Altitude reported from a GNSS source</description>
+              </entry>
+          </enum>
+          <enum name="ADSB_EMITTER_TYPE">
+              <description>ADSB classification for the type of vehicle emitting the transponder signal</description>
+              <entry value="0" name="ADSB_EMITTER_TYPE_NO_INFO"></entry>
+              <entry value="1" name="ADSB_EMITTER_TYPE_LIGHT"></entry>
+              <entry value="2" name="ADSB_EMITTER_TYPE_SMALL"></entry>
+              <entry value="3" name="ADSB_EMITTER_TYPE_LARGE"></entry>
+              <entry value="4" name="ADSB_EMITTER_TYPE_HIGH_VORTEX_LARGE"></entry>
+              <entry value="5" name="ADSB_EMITTER_TYPE_HEAVY"></entry>
+              <entry value="6" name="ADSB_EMITTER_TYPE_HIGHLY_MANUV"></entry>
+              <entry value="7" name="ADSB_EMITTER_TYPE_ROTOCRAFT"></entry>
+              <entry value="8" name="ADSB_EMITTER_TYPE_UNASSIGNED"></entry>
+              <entry value="9" name="ADSB_EMITTER_TYPE_GLIDER"></entry>
+              <entry value="10" name="ADSB_EMITTER_TYPE_LIGHTER_AIR"></entry>
+              <entry value="11" name="ADSB_EMITTER_TYPE_PARACHUTE"></entry>
+              <entry value="12" name="ADSB_EMITTER_TYPE_ULTRA_LIGHT"></entry>
+              <entry value="13" name="ADSB_EMITTER_TYPE_UNASSIGNED2"></entry>
+              <entry value="14" name="ADSB_EMITTER_TYPE_UAV"></entry>
+              <entry value="15" name="ADSB_EMITTER_TYPE_SPACE"></entry>
+              <entry value="16" name="ADSB_EMITTER_TYPE_UNASSGINED3"></entry>
+              <entry value="17" name="ADSB_EMITTER_TYPE_EMERGENCY_SURFACE"></entry>
+              <entry value="18" name="ADSB_EMITTER_TYPE_SERVICE_SURFACE"></entry>
+              <entry value="19" name="ADSB_EMITTER_TYPE_POINT_OBSTACLE"></entry>
+          </enum>
+          <enum name="ADSB_FLAGS">
+              <description>These flags indicate status such as data validity of each data source. Set = data valid</description>
+              <entry value="1" name="ADSB_FLAGS_VALID_COORDS"></entry>
+              <entry value="2" name="ADSB_FLAGS_VALID_ALTITUDE"></entry>
+              <entry value="4" name="ADSB_FLAGS_VALID_HEADING"></entry>
+              <entry value="8" name="ADSB_FLAGS_VALID_VELOCITY"></entry>
+              <entry value="16" name="ADSB_FLAGS_VALID_CALLSIGN"></entry>
+              <entry value="32" name="ADSB_FLAGS_VALID_SQUAWK"></entry>
+              <entry value="64" name="ADSB_FLAGS_SIMULATED"></entry>
+          </enum>
+          <enum name="MAV_DO_REPOSITION_FLAGS">
+              <description>Bitmask of options for the MAV_CMD_DO_REPOSITION</description>
+              <entry value="1" name="MAV_DO_REPOSITION_FLAGS_CHANGE_MODE">
+                  <description>The aircraft should immediately transition into guided. This should not be set for follow me applications</description>
+              </entry>
+          </enum>
+          <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
+          <enum name="ESTIMATOR_STATUS_FLAGS">
+              <description>Flags in EKF_STATUS message</description>
+              <entry name="ESTIMATOR_ATTITUDE" value="1">
+                  <description>True if the attitude estimate is good</description>
+              </entry>
+
+              <entry name="ESTIMATOR_VELOCITY_HORIZ" value="2">
+                  <description>True if the horizontal velocity estimate is good</description>
+              </entry>
+
+              <entry name="ESTIMATOR_VELOCITY_VERT" value="4">
+                  <description>True if the  vertical velocity estimate is good</description>
+              </entry>
+
+              <entry name="ESTIMATOR_POS_HORIZ_REL" value="8">
+                  <description>True if the horizontal position (relative) estimate is good</description>
+              </entry>
+
+              <entry name="ESTIMATOR_POS_HORIZ_ABS" value="16">
+                  <description>True if the horizontal position (absolute) estimate is good</description>
+              </entry>
+
+              <entry name="ESTIMATOR_POS_VERT_ABS" value="32">
+                  <description>True if the vertical position (absolute) estimate is good</description>
+              </entry>
+
+              <entry name="ESTIMATOR_POS_VERT_AGL" value="64">
+                  <description>True if the vertical position (above ground) estimate is good</description>
+              </entry>
+
+              <entry name="ESTIMATOR_CONST_POS_MODE" value="128">
+                  <description>True if the EKF is in a constant position mode and is not using external measurements (eg GPS or optical flow)</description>
+              </entry>
+
+              <entry name="ESTIMATOR_PRED_POS_HORIZ_REL" value="256">
+                  <description>True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate</description>
+              </entry>
+
+              <entry name="ESTIMATOR_PRED_POS_HORIZ_ABS" value="512">
+                  <description>True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate</description>
+              </entry>
+
+              <entry name="ESTIMATOR_GPS_GLITCH" value="1024">
+                  <description>True if the EKF has detected a GPS glitch</description>
+              </entry>
+          </enum>
+
+          <!-- motor test type enum -->
+          <enum name="MOTOR_TEST_THROTTLE_TYPE">
+              <entry name="MOTOR_TEST_THROTTLE_PERCENT" value="0">
+                  <description>throttle as a percentage from 0 ~ 100</description>
+              </entry>
+
+              <entry name="MOTOR_TEST_THROTTLE_PWM" value="1">
+                  <description>throttle as an absolute PWM value (normally in range of 1000~2000)</description>
+              </entry>
+
+              <entry name="MOTOR_TEST_THROTTLE_PILOT" value="2">
+                  <description>throttle pass-through from pilot's transmitter</description>
+              </entry>
+          </enum>
+
+          <!-- GPS_INPUT ignore flags enum -->
+          <enum name="GPS_INPUT_IGNORE_FLAGS">
+              <entry name="GPS_INPUT_IGNORE_FLAG_ALT" value="1">
+                  <description>ignore altitude field</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_HDOP" value="2">
+                  <description>ignore hdop field</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_VDOP" value="4">
+                  <description>ignore vdop field</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_VEL_HORIZ" value="8">
+                  <description>ignore horizontal velocity field (vn and ve)</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_VEL_VERT" value="16">
+                  <description>ignore vertical velocity field (vd)</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY" value="32">
+                  <description>ignore speed accuracy field</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY" value="64">
+                  <description>ignore horizontal accuracy field</description>
+              </entry>
+              <entry name="GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY" value="128">
+                  <description>ignore vertical accuracy field</description>
+              </entry>
+          </enum>
+          <enum name="MAV_COLLISION_ACTION">
+              <description>Possible actions an aircraft can take to avoid a collision.</description>
+              <entry value="0" name="MAV_COLLISION_ACTION_NONE">
+                  <description>Ignore any potential collisions</description>
+              </entry>
+              <entry value="1" name="MAV_COLLISION_ACTION_REPORT">
+                  <description>Report potential collision</description>
+              </entry>
+              <entry value="2" name="MAV_COLLISION_ACTION_ASCEND_OR_DESCEND">
+                  <description>Ascend or Descend to avoid threat</description>
+              </entry>
+              <entry value="3" name="MAV_COLLISION_ACTION_MOVE_HORIZONTALLY">
+                  <description>Move horizontally to avoid threat</description>
+              </entry>
+              <entry value="4" name="MAV_COLLISION_ACTION_MOVE_PERPENDICULAR">
+                  <description>Aircraft to move perpendicular to the collision's velocity vector</description>
+              </entry>
+              <entry value="5" name="MAV_COLLISION_ACTION_RTL">
+                  <description>Aircraft to fly directly back to its launch point</description>
+              </entry>
+              <entry value="6" name="MAV_COLLISION_ACTION_HOVER">
+                  <description>Aircraft to stop in place</description>
+              </entry>
+          </enum>
+          <enum name="MAV_COLLISION_THREAT_LEVEL">
+              <description>Aircraft-rated danger from this threat.</description>
+              <entry value="0" name="MAV_COLLISION_THREAT_LEVEL_NONE">
+                  <description>Not a threat</description>
+              </entry>
+              <entry value="1" name="MAV_COLLISION_THREAT_LEVEL_LOW">
+                  <description>Craft is mildly concerned about this threat</description>
+              </entry>
+              <entry value="2" name="MAV_COLLISION_THREAT_LEVEL_HIGH">
+                  <description>Craft is panicing, and may take actions to avoid threat</description>
+              </entry>
+          </enum>
+          <enum name="MAV_COLLISION_SRC">
+              <description>Source of information about this collision.</description>
+              <entry value="0" name="MAV_COLLISION_SRC_ADSB">
+                  <description>ID field references ADSB_VEHICLE packets</description>
+              </entry>
+              <entry value="1" name="MAV_COLLISION_SRC_MAVLINK_GPS_GLOBAL_INT">
+                  <description>ID field references MAVLink SRC ID</description>
+              </entry>
+          </enum>
+          <enum name="GPS_FIX_TYPE">
+              <description>Type of GPS fix</description>
+              <entry value="0" name="GPS_FIX_TYPE_NO_GPS">
+                  <description>No GPS connected</description>
+              </entry>
+              <entry value="1" name="GPS_FIX_TYPE_NO_FIX">
+                  <description>No position information, GPS is connected</description>
+              </entry>
+              <entry value="2" name="GPS_FIX_TYPE_2D_FIX">
+                  <description>2D position</description>
+              </entry>
+              <entry value="3" name="GPS_FIX_TYPE_3D_FIX">
+                  <description>3D position</description>
+              </entry>
+              <entry value="4" name="GPS_FIX_TYPE_DGPS">
+                  <description>DGPS/SBAS aided 3D position</description>
+              </entry>
+              <entry value="5" name="GPS_FIX_TYPE_RTK_FLOAT">
+                  <description>RTK float, 3D position</description>
+              </entry>
+              <entry value="6" name="GPS_FIX_TYPE_RTK_FIXED">
+                  <description>RTK Fixed, 3D position</description>
+              </entry>
+              <entry value="7" name="GPS_FIX_TYPE_STATIC">
+                  <description>Static fixed, typically used for base stations</description>
+              </entry>
+          </enum>
+         <enum name="MIXER_DATA_TYPE">
+           <description>Mixer data type</description>
+           <entry value="0" name="MIXER_DATA_TYPE_MIXER_COUNT">
+             <description>Mixer count at a given group</description>
+           </entry>
+           <entry value="1" name="MIXER_DATA_TYPE_SUBMIXER_COUNT">
+             <description>Submixer count at a given group and mixer</description>
+           </entry>
+           <entry value="2" name="MIXER_DATA_TYPE_MIXTYPE">
+             <description>Mixer type at a given group, mixer and submixer</description>
+           </entry>
+           <entry value="3" name="MIXER_DATA_TYPE_PARAMETER">
+             <description>Parameter at a given group, mixer, submixer and parameter index</description>
+           </entry>
+           <entry value="4" name="MIXER_DATA_TYPE_CONNECTION">
+             <description>Parameter at a given group, mixer, submixer, connection type and connection index</description>
+           </entry>
+           <entry value="5" name="MIXER_DATA_TYPE_PARAMETER_COUNT">
+             <description>Parameter count at a given group, mixer and submixer</description>
+           </entry>
+           <entry value="6" name="MIXER_DATA_TYPE_CONNECTION_COUNT">
+             <description>Parameter at a given group, mixer, submixer and connection type</description>
+           </entry>
+           <entry value="7" name="MIXER_DATA_TYPE_GROUP_TYPE">
+             <description>The mixer type for a particular mixer group</description>
+           </entry>
+         </enum>
+   <enum name="MIXER_GROUP">
+      <description>Identifies a set of mixers to access</description>
+      <entry value="0" name="MIXER_GROUP_NONE">
+        <description>No specific group selected</description>
+      </entry>
+      <entry value="1" name="MIXER_GROUP_LOCAL">
+        <description>Mixers on the local processor</description>
+      </entry>
+      <entry value="2" name="MIXER_GROUP_FAILSAFE">
+        <description>Mixers on a failsafe device</description>
+      </entry>
+    </enum>    
+     </enums>
+     <messages>
+          <message id="0" name="HEARTBEAT">
+               <description>The heartbeat message shows that a system is present and responding. The type of the MAV and Autopilot hardware allow the receiving system to treat further messages from this system appropriate (e.g. by laying out the user interface based on the autopilot).</description>
+               <field type="uint8_t" name="type">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
+               <field type="uint8_t" name="autopilot">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
+               <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
+               <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
+               <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
+               <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
+          </message>
+          <message id="1" name="SYS_STATUS">
+               <description>The general system state. If the system is following the MAVLink standard, the system state is mainly defined by three orthogonal states/modes: The system mode, which is either LOCKED (motors shut down and locked), MANUAL (system under RC control), GUIDED (system with autonomous position control, position setpoint controlled manually) or AUTO (system guided by path/waypoint planner). The NAV_MODE defined the current flight state: LIFTOFF (often an open-loop maneuver), LANDING, WAYPOINTS or VECTOR. This represents the internal navigation state machine. The system status shows wether the system is currently active or not and if an emergency occured. During the CRITICAL and EMERGENCY states the MAV is still considered to be active, but should start emergency procedures autonomously. After a failure occured it should first move from active to critical to allow manual intervention and then move to emergency after a certain timeout.</description>
+               <field type="uint32_t" name="onboard_control_sensors_present" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are present. Value of 0: not present. Value of 1: present. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+               <field type="uint32_t" name="onboard_control_sensors_enabled" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are enabled:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+               <field type="uint32_t" name="onboard_control_sensors_health" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are operational or have an error:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+               <field type="uint16_t" name="load">Maximum usage in percent of the mainloop time, (0%: 0, 100%: 1000) should be always below 1000</field>
+               <field type="uint16_t" name="voltage_battery">Battery voltage, in millivolts (1 = 1 millivolt)</field>
+               <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+               <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery</field>
+               <field type="uint16_t" name="drop_rate_comm">Communication drops in percent, (0%: 0, 100%: 10'000), (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
+               <field type="uint16_t" name="errors_comm">Communication errors (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
+               <field type="uint16_t" name="errors_count1">Autopilot-specific errors</field>
+               <field type="uint16_t" name="errors_count2">Autopilot-specific errors</field>
+               <field type="uint16_t" name="errors_count3">Autopilot-specific errors</field>
+               <field type="uint16_t" name="errors_count4">Autopilot-specific errors</field>
+          </message>
+          <message id="2" name="SYSTEM_TIME">
+               <description>The system time is the time of the master clock, typically the computer clock of the main onboard computer.</description>
+               <field type="uint64_t" name="time_unix_usec">Timestamp of the master clock in microseconds since UNIX epoch.</field>
+               <field type="uint32_t" name="time_boot_ms">Timestamp of the component clock since boot time in milliseconds.</field>
+          </message>
+          <!-- FIXME to be removed / merged with SYSTEM_TIME -->
+          <message id="4" name="PING">
+               <description>A ping message either requesting or responding to a ping. This allows to measure the system latencies, including serial port, radio modem and UDP connections.</description>
+               <field type="uint64_t" name="time_usec">Unix timestamp in microseconds or since system boot if smaller than MAVLink epoch (1.1.2009)</field>
+               <field type="uint32_t" name="seq">PING sequence</field>
+               <field type="uint8_t" name="target_system">0: request ping from all receiving systems, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
+               <field type="uint8_t" name="target_component">0: request ping from all receiving components, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
+          </message>
+          <message id="5" name="CHANGE_OPERATOR_CONTROL">
+               <description>Request to control this MAV</description>
+               <field type="uint8_t" name="target_system">System the GCS requests control for</field>
+               <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
+               <field type="uint8_t" name="version">0: key as plaintext, 1-255: future, different hashing/encryption variants. The GCS should in general use the safest mode possible initially and then gradually move down the encryption level if it gets a NACK message indicating an encryption mismatch.</field>
+               <field type="char[25]" name="passkey">Password / Key, depending on version plaintext or encrypted. 25 or less characters, NULL terminated. The characters may involve A-Z, a-z, 0-9, and "!?,.-"</field>
+          </message>
+          <message id="6" name="CHANGE_OPERATOR_CONTROL_ACK">
+               <description>Accept / deny control of this MAV</description>
+               <field type="uint8_t" name="gcs_system_id">ID of the GCS this message </field>
+               <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
+               <field type="uint8_t" name="ack">0: ACK, 1: NACK: Wrong passkey, 2: NACK: Unsupported passkey encryption method, 3: NACK: Already under control</field>
+          </message>
+          <message id="7" name="AUTH_KEY">
+               <description>Emit an encrypted signature / key identifying this system. PLEASE NOTE: This protocol has been kept simple, so transmitting the key requires an encrypted channel for true safety.</description>
+               <field type="char[32]" name="key">key</field>
+          </message>
+          <message id="11" name="SET_MODE">
+               <description>THIS INTERFACE IS DEPRECATED. USE COMMAND_LONG with MAV_CMD_DO_SET_MODE INSTEAD. Set the system mode, as defined by enum MAV_MODE. There is no target component id as the mode is by definition for the overall aircraft, not only for one component.</description>
+               <field type="uint8_t" name="target_system">The system setting the mode</field>
+               <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode</field>
+               <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
+          </message>
+          <!-- reserved for PARAM_VALUE_UNION -->
+          <message id="20" name="PARAM_REQUEST_READ">
+               <description>Request to read the onboard parameter with the param_id string id. Onboard parameters are stored as key[const char*] -> value[float]. This allows to send a parameter to any other component (such as the GCS) without the need of previous knowledge of possible parameter names. Thus the same GCS can store different parameters for different autopilots. See also http://qgroundcontrol.org/parameter_interface for a full documentation of QGroundControl and IMU code.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+               <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored)</field>
+          </message>
+          <message id="21" name="PARAM_REQUEST_LIST">
+               <description>Request all parameters of this component. After this request, all parameters are emitted.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+          </message>
+          <message id="22" name="PARAM_VALUE">
+               <description>Emit the value of a onboard parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows him to re-request missing parameters after a loss or timeout.</description>
+               <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+               <field type="float" name="param_value">Onboard parameter value</field>
+               <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+               <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
+               <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
+          </message>
+          <message id="23" name="PARAM_SET">
+               <description>Set a parameter value TEMPORARILY to RAM. It will be reset to default on system reboot. Send the ACTION MAV_ACTION_STORAGE_WRITE to PERMANENTLY write the RAM contents to EEPROM. IMPORTANT: The receiving component should acknowledge the new parameter value by sending a param_value message to all communication partners. This will also ensure that multiple GCS all have an up-to-date list of all parameters. If the sending GCS did not receive a PARAM_VALUE message within its timeout time, it should re-send the PARAM_SET message.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+               <field type="float" name="param_value">Onboard parameter value</field>
+               <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+          </message>
+          <message id="24" name="GPS_RAW_INT">
+               <description>The global position, as returned by the Global Positioning System (GPS). This is
                 NOT the global position estimate of the system, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
-      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="alt">Altitude (AMSL, NOT WGS84), in meters * 1000 (positive for up). Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.</field>
-      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
-      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
-      <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
-      <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
-      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
-    </message>
-    <message id="25" name="GPS_STATUS">
-      <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION for the global position estimate. This message can contain information for up to 20 satellites.</description>
-      <field type="uint8_t" name="satellites_visible">Number of satellites visible</field>
-      <field type="uint8_t[20]" name="satellite_prn">Global satellite ID</field>
-      <field type="uint8_t[20]" name="satellite_used">0: Satellite not used, 1: used for localization</field>
-      <field type="uint8_t[20]" name="satellite_elevation">Elevation (0: right on top of receiver, 90: on the horizon) of satellite</field>
-      <field type="uint8_t[20]" name="satellite_azimuth">Direction of satellite, 0: 0 deg, 255: 360 deg.</field>
-      <field type="uint8_t[20]" name="satellite_snr">Signal to noise ratio of satellite</field>
-    </message>
-    <message id="26" name="SCALED_IMU">
-      <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="int16_t" name="xacc">X acceleration (mg)</field>
-      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-      <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-      <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-      <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-      <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-      <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-      <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
-    </message>
-    <message id="27" name="RAW_IMU">
-      <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field type="int16_t" name="xacc">X acceleration (raw)</field>
-      <field type="int16_t" name="yacc">Y acceleration (raw)</field>
-      <field type="int16_t" name="zacc">Z acceleration (raw)</field>
-      <field type="int16_t" name="xgyro">Angular speed around X axis (raw)</field>
-      <field type="int16_t" name="ygyro">Angular speed around Y axis (raw)</field>
-      <field type="int16_t" name="zgyro">Angular speed around Z axis (raw)</field>
-      <field type="int16_t" name="xmag">X Magnetic field (raw)</field>
-      <field type="int16_t" name="ymag">Y Magnetic field (raw)</field>
-      <field type="int16_t" name="zmag">Z Magnetic field (raw)</field>
-    </message>
-    <message id="28" name="RAW_PRESSURE">
-      <description>The RAW pressure readings for the typical setup of one absolute pressure and one differential pressure sensor. The sensor values should be the raw, UNSCALED ADC values.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field type="int16_t" name="press_abs">Absolute pressure (raw)</field>
-      <field type="int16_t" name="press_diff1">Differential pressure 1 (raw, 0 if nonexistant)</field>
-      <field type="int16_t" name="press_diff2">Differential pressure 2 (raw, 0 if nonexistant)</field>
-      <field type="int16_t" name="temperature">Raw Temperature measurement (raw)</field>
-    </message>
-    <message id="29" name="SCALED_PRESSURE">
-      <description>The pressure readings for the typical setup of one absolute and differential pressure sensor. The units are as specified in each field.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-      <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-      <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
-    </message>
-    <message id="30" name="ATTITUDE">
-      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right).</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="roll">Roll angle (rad, -pi..+pi)</field>
-      <field type="float" name="pitch">Pitch angle (rad, -pi..+pi)</field>
-      <field type="float" name="yaw">Yaw angle (rad, -pi..+pi)</field>
-      <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-      <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-      <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
-    </message>
-    <message id="31" name="ATTITUDE_QUATERNION">
-      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation)</field>
-      <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation)</field>
-      <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation)</field>
-      <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation)</field>
-      <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-      <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-      <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
-    </message>
-    <message id="32" name="LOCAL_POSITION_NED">
-      <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="x">X Position</field>
-      <field type="float" name="y">Y Position</field>
-      <field type="float" name="z">Z Position</field>
-      <field type="float" name="vx">X Speed</field>
-      <field type="float" name="vy">Y Speed</field>
-      <field type="float" name="vz">Z Speed</field>
-    </message>
-    <message id="33" name="GLOBAL_POSITION_INT">
-      <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It
+               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
+               <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="alt">Altitude (AMSL, NOT WGS84), in meters * 1000 (positive for up). Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.</field>
+               <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+               <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+               <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
+               <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+               <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+          </message>
+          <message id="25" name="GPS_STATUS">
+               <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION for the global position estimate. This message can contain information for up to 20 satellites.</description>
+               <field type="uint8_t" name="satellites_visible">Number of satellites visible</field>
+               <field type="uint8_t[20]" name="satellite_prn">Global satellite ID</field>
+               <field type="uint8_t[20]" name="satellite_used">0: Satellite not used, 1: used for localization</field>
+               <field type="uint8_t[20]" name="satellite_elevation">Elevation (0: right on top of receiver, 90: on the horizon) of satellite</field>
+               <field type="uint8_t[20]" name="satellite_azimuth">Direction of satellite, 0: 0 deg, 255: 360 deg.</field>
+               <field type="uint8_t[20]" name="satellite_snr">Signal to noise ratio of satellite</field>
+          </message>
+          <message id="26" name="SCALED_IMU">
+               <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="int16_t" name="xacc">X acceleration (mg)</field>
+               <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+               <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+               <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
+               <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
+               <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
+               <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
+               <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
+               <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+          </message>
+          <message id="27" name="RAW_IMU">
+               <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
+               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="int16_t" name="xacc">X acceleration (raw)</field>
+               <field type="int16_t" name="yacc">Y acceleration (raw)</field>
+               <field type="int16_t" name="zacc">Z acceleration (raw)</field>
+               <field type="int16_t" name="xgyro">Angular speed around X axis (raw)</field>
+               <field type="int16_t" name="ygyro">Angular speed around Y axis (raw)</field>
+               <field type="int16_t" name="zgyro">Angular speed around Z axis (raw)</field>
+               <field type="int16_t" name="xmag">X Magnetic field (raw)</field>
+               <field type="int16_t" name="ymag">Y Magnetic field (raw)</field>
+               <field type="int16_t" name="zmag">Z Magnetic field (raw)</field>
+          </message>
+          <message id="28" name="RAW_PRESSURE">
+               <description>The RAW pressure readings for the typical setup of one absolute pressure and one differential pressure sensor. The sensor values should be the raw, UNSCALED ADC values.</description>
+               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="int16_t" name="press_abs">Absolute pressure (raw)</field>
+               <field type="int16_t" name="press_diff1">Differential pressure 1 (raw, 0 if nonexistant)</field>
+               <field type="int16_t" name="press_diff2">Differential pressure 2 (raw, 0 if nonexistant)</field>
+               <field type="int16_t" name="temperature">Raw Temperature measurement (raw)</field>
+          </message>
+          <message id="29" name="SCALED_PRESSURE">
+               <description>The pressure readings for the typical setup of one absolute and differential pressure sensor. The units are as specified in each field.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
+               <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
+               <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+          </message>
+          <message id="30" name="ATTITUDE">
+               <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right).</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="roll">Roll angle (rad, -pi..+pi)</field>
+               <field type="float" name="pitch">Pitch angle (rad, -pi..+pi)</field>
+               <field type="float" name="yaw">Yaw angle (rad, -pi..+pi)</field>
+               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
+               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+          </message>
+          <message id="31" name="ATTITUDE_QUATERNION">
+               <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation)</field>
+               <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation)</field>
+               <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation)</field>
+               <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation)</field>
+               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
+               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+          </message>
+          <message id="32" name="LOCAL_POSITION_NED">
+               <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="x">X Position</field>
+               <field type="float" name="y">Y Position</field>
+               <field type="float" name="z">Z Position</field>
+               <field type="float" name="vx">X Speed</field>
+               <field type="float" name="vy">Y Speed</field>
+               <field type="float" name="vz">Z Speed</field>
+          </message>
+          <message id="33" name="GLOBAL_POSITION_INT">
+               <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It
                is designed as scaled integer message since the resolution of float is not sufficient.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-      <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
-      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), AMSL (not WGS84 - note that virtually all GPS modules provide the AMSL as well)</field>
-      <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
-      <field type="int16_t" name="vx">Ground X Speed (Latitude, positive north), expressed as m/s * 100</field>
-      <field type="int16_t" name="vy">Ground Y Speed (Longitude, positive east), expressed as m/s * 100</field>
-      <field type="int16_t" name="vz">Ground Z Speed (Altitude, positive down), expressed as m/s * 100</field>
-      <field type="uint16_t" name="hdg">Vehicle heading (yaw angle) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
-    </message>
-    <message id="34" name="RC_CHANNELS_SCALED">
-      <description>The scaled values of the RC channels received. (-100%) -10000, (0%) 0, (100%) 10000. Channels that are inactive should be set to UINT16_MAX.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
-      <field type="int16_t" name="chan1_scaled">RC channel 1 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-      <field type="int16_t" name="chan2_scaled">RC channel 2 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-      <field type="int16_t" name="chan3_scaled">RC channel 3 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-      <field type="int16_t" name="chan4_scaled">RC channel 4 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-      <field type="int16_t" name="chan5_scaled">RC channel 5 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-      <field type="int16_t" name="chan6_scaled">RC channel 6 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-      <field type="int16_t" name="chan7_scaled">RC channel 7 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-      <field type="int16_t" name="chan8_scaled">RC channel 8 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-      <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
-    </message>
-    <message id="35" name="RC_CHANNELS_RAW">
-      <description>The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
-      <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
-    </message>
-    <message id="36" name="SERVO_OUTPUT_RAW">
-      <description>The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.</description>
-      <field type="uint32_t" name="time_usec">Timestamp (microseconds since system boot)</field>
-      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.</field>
-      <field type="uint16_t" name="servo1_raw">Servo output 1 value, in microseconds</field>
-      <field type="uint16_t" name="servo2_raw">Servo output 2 value, in microseconds</field>
-      <field type="uint16_t" name="servo3_raw">Servo output 3 value, in microseconds</field>
-      <field type="uint16_t" name="servo4_raw">Servo output 4 value, in microseconds</field>
-      <field type="uint16_t" name="servo5_raw">Servo output 5 value, in microseconds</field>
-      <field type="uint16_t" name="servo6_raw">Servo output 6 value, in microseconds</field>
-      <field type="uint16_t" name="servo7_raw">Servo output 7 value, in microseconds</field>
-      <field type="uint16_t" name="servo8_raw">Servo output 8 value, in microseconds</field>
-      <extensions/>
-      <field type="uint16_t" name="servo9_raw">Servo output 9 value, in microseconds</field>
-      <field type="uint16_t" name="servo10_raw">Servo output 10 value, in microseconds</field>
-      <field type="uint16_t" name="servo11_raw">Servo output 11 value, in microseconds</field>
-      <field type="uint16_t" name="servo12_raw">Servo output 12 value, in microseconds</field>
-      <field type="uint16_t" name="servo13_raw">Servo output 13 value, in microseconds</field>
-      <field type="uint16_t" name="servo14_raw">Servo output 14 value, in microseconds</field>
-      <field type="uint16_t" name="servo15_raw">Servo output 15 value, in microseconds</field>
-      <field type="uint16_t" name="servo16_raw">Servo output 16 value, in microseconds</field>
-    </message>
-    <message id="37" name="MISSION_REQUEST_PARTIAL_LIST">
-      <description>Request a partial list of mission items from the system/component. http://qgroundcontrol.org/mavlink/waypoint_protocol. If start and end index are the same, just send one waypoint.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="int16_t" name="start_index">Start index, 0 by default</field>
-      <field type="int16_t" name="end_index">End index, -1 by default (-1: send list to end). Else a valid index of the list</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="38" name="MISSION_WRITE_PARTIAL_LIST">
-      <description>This message is sent to the MAV to write a partial list. If start index == end index, only one item will be transmitted / updated. If the start index is NOT 0 and above the current list size, this request should be REJECTED!</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="int16_t" name="start_index">Start index, 0 by default and smaller / equal to the largest index of the current onboard list.</field>
-      <field type="int16_t" name="end_index">End index, equal or greater than start index.</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="39" name="MISSION_ITEM">
-      <description>Message encoding a mission item. This message is emitted to announce
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
+               <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), AMSL (not WGS84 - note that virtually all GPS modules provide the AMSL as well)</field>
+               <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+               <field type="int16_t" name="vx">Ground X Speed (Latitude, positive north), expressed as m/s * 100</field>
+               <field type="int16_t" name="vy">Ground Y Speed (Longitude, positive east), expressed as m/s * 100</field>
+               <field type="int16_t" name="vz">Ground Z Speed (Altitude, positive down), expressed as m/s * 100</field>
+               <field type="uint16_t" name="hdg">Vehicle heading (yaw angle) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+          </message>
+          <message id="34" name="RC_CHANNELS_SCALED">
+               <description>The scaled values of the RC channels received. (-100%) -10000, (0%) 0, (100%) 10000. Channels that are inactive should be set to UINT16_MAX.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
+               <field type="int16_t" name="chan1_scaled">RC channel 1 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+               <field type="int16_t" name="chan2_scaled">RC channel 2 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+               <field type="int16_t" name="chan3_scaled">RC channel 3 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+               <field type="int16_t" name="chan4_scaled">RC channel 4 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+               <field type="int16_t" name="chan5_scaled">RC channel 5 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+               <field type="int16_t" name="chan6_scaled">RC channel 6 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+               <field type="int16_t" name="chan7_scaled">RC channel 7 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+               <field type="int16_t" name="chan8_scaled">RC channel 8 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+          </message>
+          <message id="35" name="RC_CHANNELS_RAW">
+               <description>The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
+               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+          </message>
+          <message id="36" name="SERVO_OUTPUT_RAW">
+               <description>The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.</description>
+               <field type="uint32_t" name="time_usec">Timestamp (microseconds since system boot)</field>
+               <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.</field>
+               <field type="uint16_t" name="servo1_raw">Servo output 1 value, in microseconds</field>
+               <field type="uint16_t" name="servo2_raw">Servo output 2 value, in microseconds</field>
+               <field type="uint16_t" name="servo3_raw">Servo output 3 value, in microseconds</field>
+               <field type="uint16_t" name="servo4_raw">Servo output 4 value, in microseconds</field>
+               <field type="uint16_t" name="servo5_raw">Servo output 5 value, in microseconds</field>
+               <field type="uint16_t" name="servo6_raw">Servo output 6 value, in microseconds</field>
+               <field type="uint16_t" name="servo7_raw">Servo output 7 value, in microseconds</field>
+               <field type="uint16_t" name="servo8_raw">Servo output 8 value, in microseconds</field>
+               <extensions/>
+               <field type="uint16_t" name="servo9_raw">Servo output 9 value, in microseconds</field>
+               <field type="uint16_t" name="servo10_raw">Servo output 10 value, in microseconds</field>
+               <field type="uint16_t" name="servo11_raw">Servo output 11 value, in microseconds</field>
+               <field type="uint16_t" name="servo12_raw">Servo output 12 value, in microseconds</field>
+               <field type="uint16_t" name="servo13_raw">Servo output 13 value, in microseconds</field>
+               <field type="uint16_t" name="servo14_raw">Servo output 14 value, in microseconds</field>
+               <field type="uint16_t" name="servo15_raw">Servo output 15 value, in microseconds</field>
+               <field type="uint16_t" name="servo16_raw">Servo output 16 value, in microseconds</field>
+          </message>
+          <message id="37" name="MISSION_REQUEST_PARTIAL_LIST">
+               <description>Request a partial list of mission items from the system/component. http://qgroundcontrol.org/mavlink/waypoint_protocol. If start and end index are the same, just send one waypoint.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="int16_t" name="start_index">Start index, 0 by default</field>
+               <field type="int16_t" name="end_index">End index, -1 by default (-1: send list to end). Else a valid index of the list</field>
+          </message>
+          <message id="38" name="MISSION_WRITE_PARTIAL_LIST">
+               <description>This message is sent to the MAV to write a partial list. If start index == end index, only one item will be transmitted / updated. If the start index is NOT 0 and above the current list size, this request should be REJECTED!</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="int16_t" name="start_index">Start index, 0 by default and smaller / equal to the largest index of the current onboard list.</field>
+               <field type="int16_t" name="end_index">End index, equal or greater than start index.</field>
+          </message>
+          <message id="39" name="MISSION_ITEM">
+               <description>Message encoding a mission item. This message is emitted to announce
                 the presence of a mission item and to set a mission item on the system. The mission item can be either in x, y, z meters (type: LOCAL) or x:lat, y:lon, z:altitude. Local frame is Z-down, right handed (NED), global frame is Z-up, right handed (ENU). See also http://qgroundcontrol.org/mavlink/waypoint_protocol.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="seq">Sequence</field>
-      <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
-      <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
-      <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
-      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
-      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
-      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
-      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
-      <field type="float" name="x">PARAM5 / local: x position, global: latitude</field>
-      <field type="float" name="y">PARAM6 / y position: global: longitude</field>
-      <field type="float" name="z">PARAM7 / z position: global: altitude (relative or absolute, depending on frame.</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="40" name="MISSION_REQUEST">
-      <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM message. http://qgroundcontrol.org/mavlink/waypoint_protocol</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="seq">Sequence</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="41" name="MISSION_SET_CURRENT">
-      <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="seq">Sequence</field>
-    </message>
-    <message id="42" name="MISSION_CURRENT">
-      <description>Message that announces the sequence number of the current active mission item. The MAV will fly towards this mission item.</description>
-      <field type="uint16_t" name="seq">Sequence</field>
-    </message>
-    <message id="43" name="MISSION_REQUEST_LIST">
-      <description>Request the overall list of mission items from the system/component.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="44" name="MISSION_COUNT">
-      <description>This message is emitted as response to MISSION_REQUEST_LIST by the MAV and to initiate a write transaction. The GCS can then request the individual mission item based on the knowledge of the total number of MISSIONs.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="count">Number of mission items in the sequence</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="45" name="MISSION_CLEAR_ALL">
-      <description>Delete all mission items at once.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="46" name="MISSION_ITEM_REACHED">
-      <description>A certain mission item has been reached. The system will either hold this position (or circle on the orbit) or (if the autocontinue on the WP was set) continue to the next MISSION.</description>
-      <field type="uint16_t" name="seq">Sequence</field>
-    </message>
-    <message id="47" name="MISSION_ACK">
-      <description>Ack message during MISSION handling. The type field states if this message is a positive ack (type=0) or if an error happened (type=non-zero).</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">See MAV_MISSION_RESULT enum</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
-      <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-      <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-    </message>
-    <message id="49" name="GPS_GLOBAL_ORIGIN">
-      <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
-      <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="longitude">Longitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-    </message>
-    <message id="50" name="PARAM_MAP_RC">
-      <description>Bind a RC channel to a parameter. The parameter should change accoding to the RC channel value.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored), send -2 to disable any existing map for this rc_channel_index.</field>
-      <field type="uint8_t" name="parameter_rc_channel_index">Index of parameter RC channel. Not equal to the RC channel id. Typically correpsonds to a potentiometer-knob on the RC.</field>
-      <field type="float" name="param_value0">Initial parameter value</field>
-      <field type="float" name="scale">Scale, maps the RC range [-1, 1] to a parameter value</field>
-      <field type="float" name="param_value_min">Minimum param value. The protocol does not define if this overwrites an onboard minimum value. (Depends on implementation)</field>
-      <field type="float" name="param_value_max">Maximum param value. The protocol does not define if this overwrites an onboard maximum value. (Depends on implementation)</field>
-    </message>
-    <message id="51" name="MISSION_REQUEST_INT">
-      <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM_INT message. http://qgroundcontrol.org/mavlink/waypoint_protocol</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="seq">Sequence</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="54" name="SAFETY_SET_ALLOWED_AREA">
-      <description>Set a safety zone (volume), which is defined by two corners of a cube. This message can be used to tell the MAV which setpoints/MISSIONs to accept and which to reject. Safety areas are often enforced by national or competition regulations.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
-      <field type="float" name="p1x">x position 1 / Latitude 1</field>
-      <field type="float" name="p1y">y position 1 / Longitude 1</field>
-      <field type="float" name="p1z">z position 1 / Altitude 1</field>
-      <field type="float" name="p2x">x position 2 / Latitude 2</field>
-      <field type="float" name="p2y">y position 2 / Longitude 2</field>
-      <field type="float" name="p2z">z position 2 / Altitude 2</field>
-    </message>
-    <message id="55" name="SAFETY_ALLOWED_AREA">
-      <description>Read out the safety zone the MAV currently assumes.</description>
-      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
-      <field type="float" name="p1x">x position 1 / Latitude 1</field>
-      <field type="float" name="p1y">y position 1 / Longitude 1</field>
-      <field type="float" name="p1z">z position 1 / Altitude 1</field>
-      <field type="float" name="p2x">x position 2 / Latitude 2</field>
-      <field type="float" name="p2y">y position 2 / Longitude 2</field>
-      <field type="float" name="p2z">z position 2 / Altitude 2</field>
-    </message>
-    <message id="61" name="ATTITUDE_QUATERNION_COV">
-      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
-      <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-      <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-      <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
-      <field type="float[9]" name="covariance">Attitude covariance</field>
-    </message>
-    <message id="62" name="NAV_CONTROLLER_OUTPUT">
-      <description>The state of the fixed wing navigation and position controller.</description>
-      <field type="float" name="nav_roll">Current desired roll in degrees</field>
-      <field type="float" name="nav_pitch">Current desired pitch in degrees</field>
-      <field type="int16_t" name="nav_bearing">Current desired heading in degrees</field>
-      <field type="int16_t" name="target_bearing">Bearing to current MISSION/target in degrees</field>
-      <field type="uint16_t" name="wp_dist">Distance to active MISSION in meters</field>
-      <field type="float" name="alt_error">Current altitude error in meters</field>
-      <field type="float" name="aspd_error">Current airspeed error in meters/second</field>
-      <field type="float" name="xtrack_error">Current crosstrack error on x-y plane in meters</field>
-    </message>
-    <message id="63" name="GLOBAL_POSITION_INT_COV">
-      <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
-      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
-      <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-      <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
-      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), above MSL</field>
-      <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
-      <field type="float" name="vx">Ground X Speed (Latitude), expressed as m/s</field>
-      <field type="float" name="vy">Ground Y Speed (Longitude), expressed as m/s</field>
-      <field type="float" name="vz">Ground Z Speed (Altitude), expressed as m/s</field>
-      <field type="float[36]" name="covariance">Covariance matrix (first six entries are the first ROW, next six entries are the second row, etc.)</field>
-    </message>
-    <message id="64" name="LOCAL_POSITION_NED_COV">
-      <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
-      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
-      <field type="float" name="x">X Position</field>
-      <field type="float" name="y">Y Position</field>
-      <field type="float" name="z">Z Position</field>
-      <field type="float" name="vx">X Speed (m/s)</field>
-      <field type="float" name="vy">Y Speed (m/s)</field>
-      <field type="float" name="vz">Z Speed (m/s)</field>
-      <field type="float" name="ax">X Acceleration (m/s^2)</field>
-      <field type="float" name="ay">Y Acceleration (m/s^2)</field>
-      <field type="float" name="az">Z Acceleration (m/s^2)</field>
-      <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first nine entries are the first ROW, next eight entries are the second row, etc.)</field>
-    </message>
-    <message id="65" name="RC_CHANNELS">
-      <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="chancount">Total number of RC channels being received. This can be larger than 18, indicating that more channels are available but not given in this message. This value should be 0 when no RC channels are available.</field>
-      <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan13_raw">RC channel 13 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan14_raw">RC channel 14 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan15_raw">RC channel 15 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan16_raw">RC channel 16 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan17_raw">RC channel 17 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint16_t" name="chan18_raw">RC channel 18 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-      <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
-    </message>
-    <message id="66" name="REQUEST_DATA_STREAM">
-      <description>THIS INTERFACE IS DEPRECATED. USE SET_MESSAGE_INTERVAL INSTEAD.</description>
-      <field type="uint8_t" name="target_system">The target requested to send the message stream.</field>
-      <field type="uint8_t" name="target_component">The target requested to send the message stream.</field>
-      <field type="uint8_t" name="req_stream_id">The ID of the requested data stream</field>
-      <field type="uint16_t" name="req_message_rate">The requested message rate</field>
-      <field type="uint8_t" name="start_stop">1 to start sending, 0 to stop sending.</field>
-    </message>
-    <message id="67" name="DATA_STREAM">
-      <description>THIS INTERFACE IS DEPRECATED. USE MESSAGE_INTERVAL INSTEAD.</description>
-      <field type="uint8_t" name="stream_id">The ID of the requested data stream</field>
-      <field type="uint16_t" name="message_rate">The message rate</field>
-      <field type="uint8_t" name="on_off">1 stream is enabled, 0 stream is stopped.</field>
-    </message>
-    <message id="69" name="MANUAL_CONTROL">
-      <description>This message provides an API for manually controlling the vehicle using standard joystick axes nomenclature, along with a joystick-like input device. Unused axes can be disabled an buttons are also transmit as boolean values of their </description>
-      <field type="uint8_t" name="target">The system to be controlled.</field>
-      <field type="int16_t" name="x">X-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to forward(1000)-backward(-1000) movement on a joystick and the pitch of a vehicle.</field>
-      <field type="int16_t" name="y">Y-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to left(-1000)-right(1000) movement on a joystick and the roll of a vehicle.</field>
-      <field type="int16_t" name="z">Z-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a separate slider movement with maximum being 1000 and minimum being -1000 on a joystick and the thrust of a vehicle. Positive values are positive thrust, negative values are negative thrust.</field>
-      <field type="int16_t" name="r">R-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a twisting of the joystick, with counter-clockwise being 1000 and clockwise being -1000, and the yaw of a vehicle.</field>
-      <field type="uint16_t" name="buttons">A bitfield corresponding to the joystick buttons' current state, 1 for pressed, 0 for released. The lowest bit corresponds to Button 1.</field>
-    </message>
-    <message id="70" name="RC_CHANNELS_OVERRIDE">
-      <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. A value of UINT16_MAX means no change to that channel. A value of 0 means control of that channel should be released back to the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-    </message>
-    <message id="73" name="MISSION_ITEM_INT">
-      <description>Message encoding a mission item. This message is emitted to announce
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint16_t" name="seq">Sequence</field>
+               <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
+               <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
+               <field type="uint8_t" name="current">false:0, true:1</field>
+               <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+               <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+               <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+               <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+               <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+               <field type="float" name="x">PARAM5 / local: x position, global: latitude</field>
+               <field type="float" name="y">PARAM6 / y position: global: longitude</field>
+               <field type="float" name="z">PARAM7 / z position: global: altitude (relative or absolute, depending on frame.</field>
+          </message>
+          <message id="40" name="MISSION_REQUEST">
+               <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM message. http://qgroundcontrol.org/mavlink/waypoint_protocol</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint16_t" name="seq">Sequence</field>
+          </message>
+          <message id="41" name="MISSION_SET_CURRENT">
+               <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint16_t" name="seq">Sequence</field>
+          </message>
+          <message id="42" name="MISSION_CURRENT">
+               <description>Message that announces the sequence number of the current active mission item. The MAV will fly towards this mission item.</description>
+               <field type="uint16_t" name="seq">Sequence</field>
+          </message>
+          <message id="43" name="MISSION_REQUEST_LIST">
+               <description>Request the overall list of mission items from the system/component.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+          </message>
+          <message id="44" name="MISSION_COUNT">
+               <description>This message is emitted as response to MISSION_REQUEST_LIST by the MAV and to initiate a write transaction. The GCS can then request the individual mission item based on the knowledge of the total number of MISSIONs.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint16_t" name="count">Number of mission items in the sequence</field>
+          </message>
+          <message id="45" name="MISSION_CLEAR_ALL">
+               <description>Delete all mission items at once.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+          </message>
+          <message id="46" name="MISSION_ITEM_REACHED">
+               <description>A certain mission item has been reached. The system will either hold this position (or circle on the orbit) or (if the autocontinue on the WP was set) continue to the next MISSION.</description>
+               <field type="uint16_t" name="seq">Sequence</field>
+          </message>
+          <message id="47" name="MISSION_ACK">
+               <description>Ack message during MISSION handling. The type field states if this message is a positive ack (type=0) or if an error happened (type=non-zero).</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">See MAV_MISSION_RESULT enum</field>
+          </message>
+          <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
+               <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
+               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+          </message>
+          <message id="49" name="GPS_GLOBAL_ORIGIN">
+               <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
+               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="longitude">Longitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+          </message>
+          <message id="50" name="PARAM_MAP_RC">
+               <description>Bind a RC channel to a parameter. The parameter should change accoding to the RC channel value.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+               <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored), send -2 to disable any existing map for this rc_channel_index.</field>
+               <field type="uint8_t" name="parameter_rc_channel_index">Index of parameter RC channel. Not equal to the RC channel id. Typically correpsonds to a potentiometer-knob on the RC.</field>
+               <field type="float" name="param_value0">Initial parameter value</field>
+               <field type="float" name="scale">Scale, maps the RC range [-1, 1] to a parameter value</field>
+               <field type="float" name="param_value_min">Minimum param value. The protocol does not define if this overwrites an onboard minimum value. (Depends on implementation)</field>
+               <field type="float" name="param_value_max">Maximum param value. The protocol does not define if this overwrites an onboard maximum value. (Depends on implementation)</field>
+          </message>
+          <message id="51" name="MISSION_REQUEST_INT">
+               <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM_INT message. http://qgroundcontrol.org/mavlink/waypoint_protocol</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint16_t" name="seq">Sequence</field>
+          </message>
+          <message id="54" name="SAFETY_SET_ALLOWED_AREA">
+               <description>Set a safety zone (volume), which is defined by two corners of a cube. This message can be used to tell the MAV which setpoints/MISSIONs to accept and which to reject. Safety areas are often enforced by national or competition regulations.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
+               <field type="float" name="p1x">x position 1 / Latitude 1</field>
+               <field type="float" name="p1y">y position 1 / Longitude 1</field>
+               <field type="float" name="p1z">z position 1 / Altitude 1</field>
+               <field type="float" name="p2x">x position 2 / Latitude 2</field>
+               <field type="float" name="p2y">y position 2 / Longitude 2</field>
+               <field type="float" name="p2z">z position 2 / Altitude 2</field>
+          </message>
+          <message id="55" name="SAFETY_ALLOWED_AREA">
+               <description>Read out the safety zone the MAV currently assumes.</description>
+               <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
+               <field type="float" name="p1x">x position 1 / Latitude 1</field>
+               <field type="float" name="p1y">y position 1 / Longitude 1</field>
+               <field type="float" name="p1z">z position 1 / Altitude 1</field>
+               <field type="float" name="p2x">x position 2 / Latitude 2</field>
+               <field type="float" name="p2y">y position 2 / Longitude 2</field>
+               <field type="float" name="p2z">z position 2 / Altitude 2</field>
+          </message>
+          <message id="61" name="ATTITUDE_QUATERNION_COV">
+               <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+               <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+               <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
+               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+               <field type="float[9]" name="covariance">Attitude covariance</field>
+          </message>
+          <message id="62" name="NAV_CONTROLLER_OUTPUT">
+               <description>The state of the fixed wing navigation and position controller.</description>
+               <field type="float" name="nav_roll">Current desired roll in degrees</field>
+               <field type="float" name="nav_pitch">Current desired pitch in degrees</field>
+               <field type="int16_t" name="nav_bearing">Current desired heading in degrees</field>
+               <field type="int16_t" name="target_bearing">Bearing to current MISSION/target in degrees</field>
+               <field type="uint16_t" name="wp_dist">Distance to active MISSION in meters</field>
+               <field type="float" name="alt_error">Current altitude error in meters</field>
+               <field type="float" name="aspd_error">Current airspeed error in meters/second</field>
+               <field type="float" name="xtrack_error">Current crosstrack error on x-y plane in meters</field>
+          </message>
+          <message id="63" name="GLOBAL_POSITION_INT_COV">
+              <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.</description>
+              <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+              <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
+              <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
+              <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
+              <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), above MSL</field>
+              <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+              <field type="float" name="vx">Ground X Speed (Latitude), expressed as m/s</field>
+              <field type="float" name="vy">Ground Y Speed (Longitude), expressed as m/s</field>
+              <field type="float" name="vz">Ground Z Speed (Altitude), expressed as m/s</field>
+              <field type="float[36]" name="covariance">Covariance matrix (first six entries are the first ROW, next six entries are the second row, etc.)</field>
+          </message>
+          <message id="64" name="LOCAL_POSITION_NED_COV">
+              <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+              <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+              <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
+              <field type="float" name="x">X Position</field>
+              <field type="float" name="y">Y Position</field>
+              <field type="float" name="z">Z Position</field>
+              <field type="float" name="vx">X Speed (m/s)</field>
+              <field type="float" name="vy">Y Speed (m/s)</field>
+              <field type="float" name="vz">Z Speed (m/s)</field>
+              <field type="float" name="ax">X Acceleration (m/s^2)</field>
+              <field type="float" name="ay">Y Acceleration (m/s^2)</field>
+              <field type="float" name="az">Z Acceleration (m/s^2)</field>
+              <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first nine entries are the first ROW, next eight entries are the second row, etc.)</field>
+          </message>
+          <message id="65" name="RC_CHANNELS">
+               <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint8_t" name="chancount">Total number of RC channels being received. This can be larger than 18, indicating that more channels are available but not given in this message. This value should be 0 when no RC channels are available.</field>
+               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan13_raw">RC channel 13 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan14_raw">RC channel 14 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan15_raw">RC channel 15 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan16_raw">RC channel 16 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan17_raw">RC channel 17 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint16_t" name="chan18_raw">RC channel 18 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+          </message>
+          <message id="66" name="REQUEST_DATA_STREAM">
+               <description>THIS INTERFACE IS DEPRECATED. USE SET_MESSAGE_INTERVAL INSTEAD.</description>
+               <field type="uint8_t" name="target_system">The target requested to send the message stream.</field>
+               <field type="uint8_t" name="target_component">The target requested to send the message stream.</field>
+               <field type="uint8_t" name="req_stream_id">The ID of the requested data stream</field>
+               <field type="uint16_t" name="req_message_rate">The requested message rate</field>
+               <field type="uint8_t" name="start_stop">1 to start sending, 0 to stop sending.</field>
+          </message>
+          <message id="67" name="DATA_STREAM">
+               <description>THIS INTERFACE IS DEPRECATED. USE MESSAGE_INTERVAL INSTEAD.</description>
+               <field type="uint8_t" name="stream_id">The ID of the requested data stream</field>
+               <field type="uint16_t" name="message_rate">The message rate</field>
+               <field type="uint8_t" name="on_off">1 stream is enabled, 0 stream is stopped.</field>
+          </message>
+          <message id="69" name="MANUAL_CONTROL">
+               <description>This message provides an API for manually controlling the vehicle using standard joystick axes nomenclature, along with a joystick-like input device. Unused axes can be disabled an buttons are also transmit as boolean values of their </description>
+               <field type="uint8_t" name="target">The system to be controlled.</field>
+               <field type="int16_t" name="x">X-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to forward(1000)-backward(-1000) movement on a joystick and the pitch of a vehicle.</field>
+               <field type="int16_t" name="y">Y-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to left(-1000)-right(1000) movement on a joystick and the roll of a vehicle.</field>
+               <field type="int16_t" name="z">Z-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a separate slider movement with maximum being 1000 and minimum being -1000 on a joystick and the thrust of a vehicle. Positive values are positive thrust, negative values are negative thrust.</field>
+               <field type="int16_t" name="r">R-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a twisting of the joystick, with counter-clockwise being 1000 and clockwise being -1000, and the yaw of a vehicle.</field>
+               <field type="uint16_t" name="buttons">A bitfield corresponding to the joystick buttons' current state, 1 for pressed, 0 for released. The lowest bit corresponds to Button 1.</field>
+          </message>
+          <message id="70" name="RC_CHANNELS_OVERRIDE">
+               <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. A value of UINT16_MAX means no change to that channel. A value of 0 means control of that channel should be released back to the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+          </message>
+          <message id="73" name="MISSION_ITEM_INT">
+              <description>Message encoding a mission item. This message is emitted to announce
                 the presence of a mission item and to set a mission item on the system. The mission item can be either in x, y, z meters (type: LOCAL) or x:lat, y:lon, z:altitude. Local frame is Z-down, right handed (NED), global frame is Z-up, right handed (ENU). See alsohttp://qgroundcontrol.org/mavlink/waypoint_protocol.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="seq">Waypoint ID (sequence number). Starts at zero. Increases monotonically for each waypoint, no gaps in the sequence (0,1,2,3,4).</field>
-      <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
-      <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
-      <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
-      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
-      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
-      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
-      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
-      <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
-      <field type="int32_t" name="y">PARAM6 / y position: local: x position in meters * 1e4, global: longitude in degrees *10^7</field>
-      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
-      <extensions/>
-      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
-    </message>
-    <message id="74" name="VFR_HUD">
-      <description>Metrics typically displayed on a HUD for fixed wing aircraft</description>
-      <field type="float" name="airspeed">Current airspeed in m/s</field>
-      <field type="float" name="groundspeed">Current ground speed in m/s</field>
-      <field type="int16_t" name="heading">Current heading in degrees, in compass units (0..360, 0=north)</field>
-      <field type="uint16_t" name="throttle">Current throttle setting in integer percent, 0 to 100</field>
-      <field type="float" name="alt">Current altitude (MSL), in meters</field>
-      <field type="float" name="climb">Current climb rate in meters/second</field>
-    </message>
-    <message id="75" name="COMMAND_INT">
-      <description>Message encoding a command with parameters as scaled integers. Scaling depends on the actual command value.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="frame">The coordinate system of the COMMAND. see MAV_FRAME in mavlink_types.h</field>
-      <field type="uint16_t" name="command">The scheduled action for the mission item. see MAV_CMD in common.xml MAVLink specs</field>
-      <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
-      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
-      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
-      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
-      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
-      <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
-      <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
-      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
-    </message>
-    <message id="76" name="COMMAND_LONG">
-      <description>Send a command with up to seven parameters to the MAV</description>
-      <field type="uint8_t" name="target_system">System which should execute the command</field>
-      <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
-      <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
-      <field type="uint8_t" name="confirmation">0: First transmission of this command. 1-255: Confirmation transmissions (e.g. for kill command)</field>
-      <field type="float" name="param1">Parameter 1, as defined by MAV_CMD enum.</field>
-      <field type="float" name="param2">Parameter 2, as defined by MAV_CMD enum.</field>
-      <field type="float" name="param3">Parameter 3, as defined by MAV_CMD enum.</field>
-      <field type="float" name="param4">Parameter 4, as defined by MAV_CMD enum.</field>
-      <field type="float" name="param5">Parameter 5, as defined by MAV_CMD enum.</field>
-      <field type="float" name="param6">Parameter 6, as defined by MAV_CMD enum.</field>
-      <field type="float" name="param7">Parameter 7, as defined by MAV_CMD enum.</field>
-    </message>
-    <message id="77" name="COMMAND_ACK">
-      <description>Report status of a command. Includes feedback wether the command was executed.</description>
-      <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
-      <field type="uint8_t" name="result">See MAV_RESULT enum</field>
-    </message>
-    <message id="81" name="MANUAL_SETPOINT">
-      <description>Setpoint in roll, pitch, yaw and thrust from the operator</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-      <field type="float" name="roll">Desired roll rate in radians per second</field>
-      <field type="float" name="pitch">Desired pitch rate in radians per second</field>
-      <field type="float" name="yaw">Desired yaw rate in radians per second</field>
-      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1</field>
-      <field type="uint8_t" name="mode_switch">Flight mode switch position, 0.. 255</field>
-      <field type="uint8_t" name="manual_override_switch">Override mode switch position, 0.. 255</field>
-    </message>
-    <message id="82" name="SET_ATTITUDE_TARGET">
-      <description>Sets a desired vehicle attitude. Used by an external controller to command the vehicle (manual controller or other system).</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 6: reserved, bit 7: throttle, bit 8: attitude</field>
-      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
-      <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
-      <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
-      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
-    </message>
-    <message id="83" name="ATTITUDE_TARGET">
-      <description>Reports the current commanded attitude of the vehicle as specified by the autopilot. This should match the commands sent in a SET_ATTITUDE_TARGET message if the vehicle is being controlled this way.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-      <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 7: reserved, bit 8: attitude</field>
-      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
-      <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
-      <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
-      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
-    </message>
-    <message id="84" name="SET_POSITION_TARGET_LOCAL_NED">
-      <description>Sets a desired vehicle position in a local north-east-down coordinate frame. Used by an external controller to command the vehicle (manual controller or other system).</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
-      <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-      <field type="float" name="x">X Position in NED frame in meters</field>
-      <field type="float" name="y">Y Position in NED frame in meters</field>
-      <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
-      <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-      <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-      <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-      <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="yaw">yaw setpoint in rad</field>
-      <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
-    </message>
-    <message id="85" name="POSITION_TARGET_LOCAL_NED">
-      <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_LOCAL_NED if the vehicle is being controlled this way.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
-      <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-      <field type="float" name="x">X Position in NED frame in meters</field>
-      <field type="float" name="y">Y Position in NED frame in meters</field>
-      <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
-      <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-      <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-      <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-      <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="yaw">yaw setpoint in rad</field>
-      <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
-    </message>
-    <message id="86" name="SET_POSITION_TARGET_GLOBAL_INT">
-      <description>Sets a desired vehicle position, velocity, and/or acceleration in a global coordinate system (WGS84). Used by an external controller to command the vehicle (manual controller or other system).</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
-      <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-      <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
-      <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
-      <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
-      <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-      <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-      <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-      <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="yaw">yaw setpoint in rad</field>
-      <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
-    </message>
-    <message id="87" name="POSITION_TARGET_GLOBAL_INT">
-      <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_GLOBAL_INT if the vehicle is being controlled this way.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
-      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
-      <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-      <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
-      <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
-      <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
-      <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-      <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-      <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-      <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-      <field type="float" name="yaw">yaw setpoint in rad</field>
-      <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
-    </message>
-    <message id="89" name="LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET">
-      <description>The offset in X, Y, Z and yaw between the LOCAL_POSITION_NED messages of MAV X and the global coordinate frame in NED coordinates. Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="x">X Position</field>
-      <field type="float" name="y">Y Position</field>
-      <field type="float" name="z">Z Position</field>
-      <field type="float" name="roll">Roll</field>
-      <field type="float" name="pitch">Pitch</field>
-      <field type="float" name="yaw">Yaw</field>
-    </message>
-    <message id="90" name="HIL_STATE">
-      <description>DEPRECATED PACKET! Suffers from missing airspeed fields and singularities due to Euler angles. Please use HIL_STATE_QUATERNION instead. Sent from simulation to autopilot. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field type="float" name="roll">Roll angle (rad)</field>
-      <field type="float" name="pitch">Pitch angle (rad)</field>
-      <field type="float" name="yaw">Yaw angle (rad)</field>
-      <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
-      <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
-      <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
-      <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
-      <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
-      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
-      <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
-      <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
-      <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
-      <field type="int16_t" name="xacc">X acceleration (mg)</field>
-      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-    </message>
-    <message id="91" name="HIL_CONTROLS">
-      <description>Sent from autopilot to simulation. Hardware in the loop control outputs</description>
-      <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field name="roll_ailerons" type="float">Control output -1 .. 1</field>
-      <field name="pitch_elevator" type="float">Control output -1 .. 1</field>
-      <field name="yaw_rudder" type="float">Control output -1 .. 1</field>
-      <field name="throttle" type="float">Throttle 0 .. 1</field>
-      <field name="aux1" type="float">Aux 1, -1 .. 1</field>
-      <field name="aux2" type="float">Aux 2, -1 .. 1</field>
-      <field name="aux3" type="float">Aux 3, -1 .. 1</field>
-      <field name="aux4" type="float">Aux 4, -1 .. 1</field>
-      <field name="mode" type="uint8_t">System mode (MAV_MODE)</field>
-      <field name="nav_mode" type="uint8_t">Navigation mode (MAV_NAV_MODE)</field>
-    </message>
-    <message id="92" name="HIL_RC_INPUTS_RAW">
-      <description>Sent from simulation to autopilot. The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds</field>
-      <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds</field>
-      <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds</field>
-      <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds</field>
-      <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds</field>
-      <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds</field>
-      <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds</field>
-      <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds</field>
-      <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds</field>
-      <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds</field>
-      <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds</field>
-      <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds</field>
-      <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 255: 100%</field>
-    </message>
-    <message id="93" name="HIL_ACTUATOR_CONTROLS">
-      <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>
-      <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field name="controls" type="float[16]">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
-      <field name="mode" type="uint8_t">System mode (MAV_MODE), includes arming state.</field>
-      <field name="flags" type="uint64_t">Flags as bitfield, reserved for future use.</field>
-    </message>
-    <message id="100" name="OPTICAL_FLOW">
-      <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
-      <field type="uint64_t" name="time_usec">Timestamp (UNIX)</field>
-      <field type="uint8_t" name="sensor_id">Sensor ID</field>
-      <field type="int16_t" name="flow_x">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
-      <field type="int16_t" name="flow_y">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
-      <field type="float" name="flow_comp_m_x">Flow in meters in x-sensor direction, angular-speed compensated</field>
-      <field type="float" name="flow_comp_m_y">Flow in meters in y-sensor direction, angular-speed compensated</field>
-      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
-      <field type="float" name="ground_distance">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
-    </message>
-    <message id="101" name="GLOBAL_VISION_POSITION_ESTIMATE">
-      <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-      <field type="float" name="x">Global X position</field>
-      <field type="float" name="y">Global Y position</field>
-      <field type="float" name="z">Global Z position</field>
-      <field type="float" name="roll">Roll angle in rad</field>
-      <field type="float" name="pitch">Pitch angle in rad</field>
-      <field type="float" name="yaw">Yaw angle in rad</field>
-    </message>
-    <message id="102" name="VISION_POSITION_ESTIMATE">
-      <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-      <field type="float" name="x">Global X position</field>
-      <field type="float" name="y">Global Y position</field>
-      <field type="float" name="z">Global Z position</field>
-      <field type="float" name="roll">Roll angle in rad</field>
-      <field type="float" name="pitch">Pitch angle in rad</field>
-      <field type="float" name="yaw">Yaw angle in rad</field>
-    </message>
-    <message id="103" name="VISION_SPEED_ESTIMATE">
-      <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-      <field type="float" name="x">Global X speed</field>
-      <field type="float" name="y">Global Y speed</field>
-      <field type="float" name="z">Global Z speed</field>
-    </message>
-    <message id="104" name="VICON_POSITION_ESTIMATE">
-      <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-      <field type="float" name="x">Global X position</field>
-      <field type="float" name="y">Global Y position</field>
-      <field type="float" name="z">Global Z position</field>
-      <field type="float" name="roll">Roll angle in rad</field>
-      <field type="float" name="pitch">Pitch angle in rad</field>
-      <field type="float" name="yaw">Yaw angle in rad</field>
-    </message>
-    <message id="105" name="HIGHRES_IMU">
-      <description>The IMU readings in SI units in NED body frame</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-      <field type="float" name="xacc">X acceleration (m/s^2)</field>
-      <field type="float" name="yacc">Y acceleration (m/s^2)</field>
-      <field type="float" name="zacc">Z acceleration (m/s^2)</field>
-      <field type="float" name="xgyro">Angular speed around X axis (rad / sec)</field>
-      <field type="float" name="ygyro">Angular speed around Y axis (rad / sec)</field>
-      <field type="float" name="zgyro">Angular speed around Z axis (rad / sec)</field>
-      <field type="float" name="xmag">X Magnetic field (Gauss)</field>
-      <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
-      <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
-      <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
-      <field type="float" name="diff_pressure">Differential pressure in millibar</field>
-      <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
-      <field type="float" name="temperature">Temperature in degrees celsius</field>
-      <field type="uint16_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature</field>
-    </message>
-    <message id="106" name="OPTICAL_FLOW_RAD">
-      <description>Optical flow from an angular rate flow sensor (e.g. PX4FLOW or mouse sensor)</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-      <field type="uint8_t" name="sensor_id">Sensor ID</field>
-      <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
-      <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
-      <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
-      <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
-      <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
-      <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
-      <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
-      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
-      <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
-      <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
-    </message>
-    <message id="107" name="HIL_SENSOR">
-      <description>The IMU readings in SI units in NED body frame</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-      <field type="float" name="xacc">X acceleration (m/s^2)</field>
-      <field type="float" name="yacc">Y acceleration (m/s^2)</field>
-      <field type="float" name="zacc">Z acceleration (m/s^2)</field>
-      <field type="float" name="xgyro">Angular speed around X axis in body frame (rad / sec)</field>
-      <field type="float" name="ygyro">Angular speed around Y axis in body frame (rad / sec)</field>
-      <field type="float" name="zgyro">Angular speed around Z axis in body frame (rad / sec)</field>
-      <field type="float" name="xmag">X Magnetic field (Gauss)</field>
-      <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
-      <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
-      <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
-      <field type="float" name="diff_pressure">Differential pressure (airspeed) in millibar</field>
-      <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
-      <field type="float" name="temperature">Temperature in degrees celsius</field>
-      <field type="uint32_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature, bit 31: full reset of attitude/position/velocities/etc was performed in sim.</field>
-    </message>
-    <message name="SIM_STATE" id="108">
-      <description>Status of simulation environment, if used</description>
-      <field type="float" name="q1">True attitude quaternion component 1, w (1 in null-rotation)</field>
-      <field type="float" name="q2">True attitude quaternion component 2, x (0 in null-rotation)</field>
-      <field type="float" name="q3">True attitude quaternion component 3, y (0 in null-rotation)</field>
-      <field type="float" name="q4">True attitude quaternion component 4, z (0 in null-rotation)</field>
-      <field type="float" name="roll">Attitude roll expressed as Euler angles, not recommended except for human-readable outputs</field>
-      <field type="float" name="pitch">Attitude pitch expressed as Euler angles, not recommended except for human-readable outputs</field>
-      <field type="float" name="yaw">Attitude yaw expressed as Euler angles, not recommended except for human-readable outputs</field>
-      <field type="float" name="xacc">X acceleration m/s/s</field>
-      <field type="float" name="yacc">Y acceleration m/s/s</field>
-      <field type="float" name="zacc">Z acceleration m/s/s</field>
-      <field type="float" name="xgyro">Angular speed around X axis rad/s</field>
-      <field type="float" name="ygyro">Angular speed around Y axis rad/s</field>
-      <field type="float" name="zgyro">Angular speed around Z axis rad/s</field>
-      <field type="float" name="lat">Latitude in degrees</field>
-      <field type="float" name="lon">Longitude in degrees</field>
-      <field type="float" name="alt">Altitude in meters</field>
-      <field type="float" name="std_dev_horz">Horizontal position standard deviation</field>
-      <field type="float" name="std_dev_vert">Vertical position standard deviation</field>
-      <field type="float" name="vn">True velocity in m/s in NORTH direction in earth-fixed NED frame</field>
-      <field type="float" name="ve">True velocity in m/s in EAST direction in earth-fixed NED frame</field>
-      <field type="float" name="vd">True velocity in m/s in DOWN direction in earth-fixed NED frame</field>
-    </message>
-    <message name="RADIO_STATUS" id="109">
-      <description>Status generated by radio and injected into MAVLink stream.</description>
-      <field type="uint8_t" name="rssi">Local signal strength</field>
-      <field type="uint8_t" name="remrssi">Remote signal strength</field>
-      <field type="uint8_t" name="txbuf">Remaining free buffer space in percent.</field>
-      <field type="uint8_t" name="noise">Background noise level</field>
-      <field type="uint8_t" name="remnoise">Remote background noise level</field>
-      <field type="uint16_t" name="rxerrors">Receive errors</field>
-      <field type="uint16_t" name="fixed">Count of error corrected packets</field>
-    </message>
-    <message id="110" name="FILE_TRANSFER_PROTOCOL">
-      <description>File transfer message</description>
-      <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
-      <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
-      <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
-      <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
-    </message>
-    <message id="111" name="TIMESYNC">
-      <description>Time synchronization message.</description>
-      <field type="int64_t" name="tc1">Time sync timestamp 1</field>
-      <field type="int64_t" name="ts1">Time sync timestamp 2</field>
-    </message>
-    <message id="112" name="CAMERA_TRIGGER">
-      <description>Camera-IMU triggering and synchronisation message.</description>
-      <field type="uint64_t" name="time_usec">Timestamp for the image frame in microseconds</field>
-      <field type="uint32_t" name="seq">Image frame sequence</field>
-    </message>
-    <message id="113" name="HIL_GPS">
-      <description>The global position, as returned by the Global Positioning System (GPS). This is
+              <field type="uint8_t" name="target_system">System ID</field>
+              <field type="uint8_t" name="target_component">Component ID</field>
+              <field type="uint16_t" name="seq">Waypoint ID (sequence number). Starts at zero. Increases monotonically for each waypoint, no gaps in the sequence (0,1,2,3,4).</field>
+              <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
+              <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
+              <field type="uint8_t" name="current">false:0, true:1</field>
+              <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+              <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+              <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+              <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+              <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+              <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
+              <field type="int32_t" name="y">PARAM6 / y position: local: x position in meters * 1e4, global: longitude in degrees *10^7</field>
+              <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
+          </message>
+          <message id="74" name="VFR_HUD">
+               <description>Metrics typically displayed on a HUD for fixed wing aircraft</description>
+               <field type="float" name="airspeed">Current airspeed in m/s</field>
+               <field type="float" name="groundspeed">Current ground speed in m/s</field>
+               <field type="int16_t" name="heading">Current heading in degrees, in compass units (0..360, 0=north)</field>
+               <field type="uint16_t" name="throttle">Current throttle setting in integer percent, 0 to 100</field>
+               <field type="float" name="alt">Current altitude (MSL), in meters</field>
+               <field type="float" name="climb">Current climb rate in meters/second</field>
+          </message>
+          <message id="75" name="COMMAND_INT">
+              <description>Message encoding a command with parameters as scaled integers. Scaling depends on the actual command value.</description>
+              <field type="uint8_t" name="target_system">System ID</field>
+              <field type="uint8_t" name="target_component">Component ID</field>
+              <field type="uint8_t" name="frame">The coordinate system of the COMMAND. see MAV_FRAME in mavlink_types.h</field>
+              <field type="uint16_t" name="command">The scheduled action for the mission item. see MAV_CMD in common.xml MAVLink specs</field>
+              <field type="uint8_t" name="current">false:0, true:1</field>
+              <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+              <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+              <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+              <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+              <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+              <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
+              <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
+              <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
+          </message>
+          <message id="76" name="COMMAND_LONG">
+               <description>Send a command with up to seven parameters to the MAV</description>
+               <field type="uint8_t" name="target_system">System which should execute the command</field>
+               <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
+               <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
+               <field type="uint8_t" name="confirmation">0: First transmission of this command. 1-255: Confirmation transmissions (e.g. for kill command)</field>
+               <field type="float" name="param1">Parameter 1, as defined by MAV_CMD enum.</field>
+               <field type="float" name="param2">Parameter 2, as defined by MAV_CMD enum.</field>
+               <field type="float" name="param3">Parameter 3, as defined by MAV_CMD enum.</field>
+               <field type="float" name="param4">Parameter 4, as defined by MAV_CMD enum.</field>
+               <field type="float" name="param5">Parameter 5, as defined by MAV_CMD enum.</field>
+               <field type="float" name="param6">Parameter 6, as defined by MAV_CMD enum.</field>
+               <field type="float" name="param7">Parameter 7, as defined by MAV_CMD enum.</field>
+          </message>
+          <message id="77" name="COMMAND_ACK">
+               <description>Report status of a command. Includes feedback wether the command was executed.</description>
+               <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
+               <field type="uint8_t" name="result">See MAV_RESULT enum</field>
+          </message>
+         <message id="81" name="MANUAL_SETPOINT">
+             <description>Setpoint in roll, pitch, yaw and thrust from the operator</description>
+             <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+             <field type="float" name="roll">Desired roll rate in radians per second</field>
+             <field type="float" name="pitch">Desired pitch rate in radians per second</field>
+             <field type="float" name="yaw">Desired yaw rate in radians per second</field>
+             <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1</field>
+             <field type="uint8_t" name="mode_switch">Flight mode switch position, 0.. 255</field>
+             <field type="uint8_t" name="manual_override_switch">Override mode switch position, 0.. 255</field>
+         </message>
+          <message id="82" name="SET_ATTITUDE_TARGET">
+               <description>Sets a desired vehicle attitude. Used by an external controller to command the vehicle (manual controller or other system).</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 6: reserved, bit 7: throttle, bit 8: attitude</field>
+               <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+               <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
+               <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
+               <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
+               <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
+          </message>
+          <message id="83" name="ATTITUDE_TARGET">
+               <description>Reports the current commanded attitude of the vehicle as specified by the autopilot. This should match the commands sent in a SET_ATTITUDE_TARGET message if the vehicle is being controlled this way.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+               <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 7: reserved, bit 8: attitude</field>
+               <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+               <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
+               <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
+               <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
+               <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
+          </message>
+          <message id="84" name="SET_POSITION_TARGET_LOCAL_NED">
+               <description>Sets a desired vehicle position in a local north-east-down coordinate frame. Used by an external controller to command the vehicle (manual controller or other system).</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
+               <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
+               <field type="float" name="x">X Position in NED frame in meters</field>
+               <field type="float" name="y">Y Position in NED frame in meters</field>
+               <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
+               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
+               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
+               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
+               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="yaw">yaw setpoint in rad</field>
+               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+          </message>
+          <message id="85" name="POSITION_TARGET_LOCAL_NED">
+               <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_LOCAL_NED if the vehicle is being controlled this way.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+               <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
+               <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
+               <field type="float" name="x">X Position in NED frame in meters</field>
+               <field type="float" name="y">Y Position in NED frame in meters</field>
+               <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
+               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
+               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
+               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
+               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="yaw">yaw setpoint in rad</field>
+               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+          </message>
+          <message id="86" name="SET_POSITION_TARGET_GLOBAL_INT">
+               <description>Sets a desired vehicle position, velocity, and/or acceleration in a global coordinate system (WGS84). Used by an external controller to command the vehicle (manual controller or other system).</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
+               <field type="uint8_t" name="target_system">System ID</field>
+               <field type="uint8_t" name="target_component">Component ID</field>
+               <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
+               <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
+               <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
+               <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
+               <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
+               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
+               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
+               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="yaw">yaw setpoint in rad</field>
+               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+          </message>
+          <message id="87" name="POSITION_TARGET_GLOBAL_INT">
+               <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_GLOBAL_INT if the vehicle is being controlled this way.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
+               <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
+               <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
+               <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
+               <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
+               <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
+               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
+               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
+               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+               <field type="float" name="yaw">yaw setpoint in rad</field>
+               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+          </message>
+          <message id="89" name="LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET">
+               <description>The offset in X, Y, Z and yaw between the LOCAL_POSITION_NED messages of MAV X and the global coordinate frame in NED coordinates. Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="x">X Position</field>
+               <field type="float" name="y">Y Position</field>
+               <field type="float" name="z">Z Position</field>
+               <field type="float" name="roll">Roll</field>
+               <field type="float" name="pitch">Pitch</field>
+               <field type="float" name="yaw">Yaw</field>
+          </message>
+          <message id="90" name="HIL_STATE">
+               <description>DEPRECATED PACKET! Suffers from missing airspeed fields and singularities due to Euler angles. Please use HIL_STATE_QUATERNION instead. Sent from simulation to autopilot. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
+               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="float" name="roll">Roll angle (rad)</field>
+               <field type="float" name="pitch">Pitch angle (rad)</field>
+               <field type="float" name="yaw">Yaw angle (rad)</field>
+               <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
+               <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
+               <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
+               <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
+               <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
+               <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
+               <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
+               <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
+               <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
+               <field type="int16_t" name="xacc">X acceleration (mg)</field>
+               <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+               <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+          </message>
+          <message id="91" name="HIL_CONTROLS">
+               <description>Sent from autopilot to simulation. Hardware in the loop control outputs</description>
+               <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field name="roll_ailerons" type="float">Control output -1 .. 1</field>
+               <field name="pitch_elevator" type="float">Control output -1 .. 1</field>
+               <field name="yaw_rudder" type="float">Control output -1 .. 1</field>
+               <field name="throttle" type="float">Throttle 0 .. 1</field>
+               <field name="aux1" type="float">Aux 1, -1 .. 1</field>
+               <field name="aux2" type="float">Aux 2, -1 .. 1</field>
+               <field name="aux3" type="float">Aux 3, -1 .. 1</field>
+               <field name="aux4" type="float">Aux 4, -1 .. 1</field>
+               <field name="mode" type="uint8_t">System mode (MAV_MODE)</field>
+               <field name="nav_mode" type="uint8_t">Navigation mode (MAV_NAV_MODE)</field>
+          </message>
+          <message id="92" name="HIL_RC_INPUTS_RAW">
+               <description>Sent from simulation to autopilot. The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds</field>
+               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds</field>
+               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds</field>
+               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds</field>
+               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds</field>
+               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds</field>
+               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds</field>
+               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds</field>
+               <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds</field>
+               <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds</field>
+               <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds</field>
+               <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds</field>
+               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 255: 100%</field>
+          </message>
+          <message id="93" name="HIL_ACTUATOR_CONTROLS">
+               <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>
+               <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+               <field name="controls" type="float[16]">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
+               <field name="mode" type="uint8_t">System mode (MAV_MODE), includes arming state.</field>
+               <field name="flags" type="uint64_t">Flags as bitfield, reserved for future use.</field>
+          </message>
+          <message id="100" name="OPTICAL_FLOW">
+               <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
+               <field type="uint64_t" name="time_usec">Timestamp (UNIX)</field>
+               <field type="uint8_t" name="sensor_id">Sensor ID</field>
+              <field type="int16_t" name="flow_x">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
+               <field type="int16_t" name="flow_y">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
+               <field type="float" name="flow_comp_m_x">Flow in meters in x-sensor direction, angular-speed compensated</field>
+               <field type="float" name="flow_comp_m_y">Flow in meters in y-sensor direction, angular-speed compensated</field>
+               <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
+               <field type="float" name="ground_distance">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
+          </message>
+          <message id="101" name="GLOBAL_VISION_POSITION_ESTIMATE">
+               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="x">Global X position</field>
+               <field type="float" name="y">Global Y position</field>
+               <field type="float" name="z">Global Z position</field>
+               <field type="float" name="roll">Roll angle in rad</field>
+               <field type="float" name="pitch">Pitch angle in rad</field>
+               <field type="float" name="yaw">Yaw angle in rad</field>
+          </message>
+          <message id="102" name="VISION_POSITION_ESTIMATE">
+               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="x">Global X position</field>
+               <field type="float" name="y">Global Y position</field>
+               <field type="float" name="z">Global Z position</field>
+               <field type="float" name="roll">Roll angle in rad</field>
+               <field type="float" name="pitch">Pitch angle in rad</field>
+               <field type="float" name="yaw">Yaw angle in rad</field>
+          </message>
+          <message id="103" name="VISION_SPEED_ESTIMATE">
+               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="x">Global X speed</field>
+               <field type="float" name="y">Global Y speed</field>
+               <field type="float" name="z">Global Z speed</field>
+          </message>
+          <message id="104" name="VICON_POSITION_ESTIMATE">
+               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+               <field type="float" name="x">Global X position</field>
+               <field type="float" name="y">Global Y position</field>
+               <field type="float" name="z">Global Z position</field>
+               <field type="float" name="roll">Roll angle in rad</field>
+               <field type="float" name="pitch">Pitch angle in rad</field>
+               <field type="float" name="yaw">Yaw angle in rad</field>
+          </message>
+          <message id="105" name="HIGHRES_IMU">
+             <description>The IMU readings in SI units in NED body frame</description>
+             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+             <field type="float" name="xacc">X acceleration (m/s^2)</field>
+             <field type="float" name="yacc">Y acceleration (m/s^2)</field>
+             <field type="float" name="zacc">Z acceleration (m/s^2)</field>
+             <field type="float" name="xgyro">Angular speed around X axis (rad / sec)</field>
+             <field type="float" name="ygyro">Angular speed around Y axis (rad / sec)</field>
+             <field type="float" name="zgyro">Angular speed around Z axis (rad / sec)</field>
+             <field type="float" name="xmag">X Magnetic field (Gauss)</field>
+             <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
+             <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
+             <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
+             <field type="float" name="diff_pressure">Differential pressure in millibar</field>
+             <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
+             <field type="float" name="temperature">Temperature in degrees celsius</field>
+             <field type="uint16_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature</field>
+         </message>
+         <message id="106" name="OPTICAL_FLOW_RAD">
+             <description>Optical flow from an angular rate flow sensor (e.g. PX4FLOW or mouse sensor)</description>
+             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+             <field type="uint8_t" name="sensor_id">Sensor ID</field>
+             <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
+             <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
+             <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
+             <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
+             <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
+             <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
+             <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
+             <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
+             <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
+             <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
+         </message>
+
+         <message id="107" name="HIL_SENSOR"> <description>The IMU readings in SI units in NED body frame</description>
+           <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+           <field type="float" name="xacc">X acceleration (m/s^2)</field>
+           <field type="float" name="yacc">Y acceleration (m/s^2)</field>
+           <field type="float" name="zacc">Z acceleration (m/s^2)</field>
+           <field type="float" name="xgyro">Angular speed around X axis in body frame (rad / sec)</field>
+           <field type="float" name="ygyro">Angular speed around Y axis in body frame (rad / sec)</field>
+           <field type="float" name="zgyro">Angular speed around Z axis in body frame (rad / sec)</field>
+           <field type="float" name="xmag">X Magnetic field (Gauss)</field>
+           <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
+           <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
+           <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
+           <field type="float" name="diff_pressure">Differential pressure (airspeed) in millibar</field>
+           <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
+           <field type="float" name="temperature">Temperature in degrees celsius</field>
+           <field type="uint32_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature, bit 31: full reset of attitude/position/velocities/etc was performed in sim.</field>
+         </message>
+
+	  <message name="SIM_STATE" id="108">
+	    <description>Status of simulation environment, if used</description>
+            <field type="float" name="q1">True attitude quaternion component 1, w (1 in null-rotation)</field>
+            <field type="float" name="q2">True attitude quaternion component 2, x (0 in null-rotation)</field>
+            <field type="float" name="q3">True attitude quaternion component 3, y (0 in null-rotation)</field>
+            <field type="float" name="q4">True attitude quaternion component 4, z (0 in null-rotation)</field>
+            <field type="float" name="roll">Attitude roll expressed as Euler angles, not recommended except for human-readable outputs</field>
+            <field type="float" name="pitch">Attitude pitch expressed as Euler angles, not recommended except for human-readable outputs</field>
+            <field type="float" name="yaw">Attitude yaw expressed as Euler angles, not recommended except for human-readable outputs</field>
+            <field type="float" name="xacc">X acceleration m/s/s</field>
+            <field type="float" name="yacc">Y acceleration m/s/s</field>
+            <field type="float" name="zacc">Z acceleration m/s/s</field>
+            <field type="float" name="xgyro">Angular speed around X axis rad/s</field>
+            <field type="float" name="ygyro">Angular speed around Y axis rad/s</field>
+            <field type="float" name="zgyro">Angular speed around Z axis rad/s</field>
+            <field type="float" name="lat">Latitude in degrees</field>
+            <field type="float" name="lon">Longitude in degrees</field>
+            <field type="float" name="alt">Altitude in meters</field>
+            <field type="float" name="std_dev_horz">Horizontal position standard deviation</field>
+            <field type="float" name="std_dev_vert">Vertical position standard deviation</field>
+            <field type="float" name="vn">True velocity in m/s in NORTH direction in earth-fixed NED frame</field>
+            <field type="float" name="ve">True velocity in m/s in EAST direction in earth-fixed NED frame</field>
+            <field type="float" name="vd">True velocity in m/s in DOWN direction in earth-fixed NED frame</field>
+	  </message>
+
+    	  <message name="RADIO_STATUS" id="109">
+    	      <description>Status generated by radio and injected into MAVLink stream.</description>
+            <field type="uint8_t" name="rssi">Local signal strength</field>
+            <field type="uint8_t" name="remrssi">Remote signal strength</field>
+            <field type="uint8_t" name="txbuf">Remaining free buffer space in percent.</field>
+            <field type="uint8_t" name="noise">Background noise level</field>
+            <field type="uint8_t" name="remnoise">Remote background noise level</field>
+            <field type="uint16_t" name="rxerrors">Receive errors</field>
+            <field type="uint16_t" name="fixed">Count of error corrected packets</field>
+    	  </message>
+        <message id="110" name="FILE_TRANSFER_PROTOCOL">
+            <description>File transfer message</description>
+            <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
+            <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
+            <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
+            <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
+        </message>
+        <message id="111" name="TIMESYNC">
+            <description>Time synchronization message.</description>
+            <field type="int64_t" name="tc1">Time sync timestamp 1</field>
+            <field type="int64_t" name="ts1">Time sync timestamp 2</field>
+        </message>
+        <message id="112" name="CAMERA_TRIGGER">
+            <description>Camera-IMU triggering and synchronisation message.</description>
+            <field type="uint64_t" name="time_usec">Timestamp for the image frame in microseconds</field>
+            <field type="uint32_t" name="seq">Image frame sequence</field>
+        </message>
+         <message id="113" name="HIL_GPS">
+             <description>The global position, as returned by the Global Positioning System (GPS). This is
                  NOT the global position estimate of the sytem, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.</field>
-      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
-      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: 65535</field>
-      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: 65535</field>
-      <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: 65535</field>
-      <field type="int16_t" name="vn">GPS velocity in cm/s in NORTH direction in earth-fixed NED frame</field>
-      <field type="int16_t" name="ve">GPS velocity in cm/s in EAST direction in earth-fixed NED frame</field>
-      <field type="int16_t" name="vd">GPS velocity in cm/s in DOWN direction in earth-fixed NED frame</field>
-      <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: 65535</field>
-      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
-    </message>
-    <message id="114" name="HIL_OPTICAL_FLOW">
-      <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-      <field type="uint8_t" name="sensor_id">Sensor ID</field>
-      <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
-      <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
-      <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
-      <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
-      <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
-      <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
-      <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
-      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
-      <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
-      <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
-    </message>
-    <message id="115" name="HIL_STATE_QUATERNION">
-      <description>Sent from simulation to autopilot, avoids in contrast to HIL_STATE singularities. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field type="float[4]" name="attitude_quaternion">Vehicle attitude expressed as normalized quaternion in w, x, y, z order (with 1 0 0 0 being the null-rotation)</field>
-      <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
-      <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
-      <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
-      <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
-      <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
-      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
-      <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
-      <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
-      <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
-      <field type="uint16_t" name="ind_airspeed">Indicated airspeed, expressed as m/s * 100</field>
-      <field type="uint16_t" name="true_airspeed">True airspeed, expressed as m/s * 100</field>
-      <field type="int16_t" name="xacc">X acceleration (mg)</field>
-      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-    </message>
-    <message id="116" name="SCALED_IMU2">
-      <description>The RAW IMU readings for secondary 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="int16_t" name="xacc">X acceleration (mg)</field>
-      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-      <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-      <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-      <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-      <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-      <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-      <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
-    </message>
-    <message id="117" name="LOG_REQUEST_LIST">
-      <description>Request a list of available logs. On some systems calling this may stop on-board logging until LOG_REQUEST_END is called.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="start">First log id (0 for first available)</field>
-      <field type="uint16_t" name="end">Last log id (0xffff for last available)</field>
-    </message>
-    <message id="118" name="LOG_ENTRY">
-      <description>Reply to LOG_REQUEST_LIST</description>
-      <field type="uint16_t" name="id">Log id</field>
-      <field type="uint16_t" name="num_logs">Total number of logs</field>
-      <field type="uint16_t" name="last_log_num">High log number</field>
-      <field type="uint32_t" name="time_utc">UTC timestamp of log in seconds since 1970, or 0 if not available</field>
-      <field type="uint32_t" name="size">Size of the log (may be approximate) in bytes</field>
-    </message>
-    <message id="119" name="LOG_REQUEST_DATA">
-      <description>Request a chunk of a log</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
-      <field type="uint32_t" name="ofs">Offset into the log</field>
-      <field type="uint32_t" name="count">Number of bytes</field>
-    </message>
-    <message id="120" name="LOG_DATA">
-      <description>Reply to LOG_REQUEST_DATA</description>
-      <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
-      <field type="uint32_t" name="ofs">Offset into the log</field>
-      <field type="uint8_t" name="count">Number of bytes (zero for end of log)</field>
-      <field type="uint8_t[90]" name="data">log data</field>
-    </message>
-    <message id="121" name="LOG_ERASE">
-      <description>Erase all logs</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-    </message>
-    <message id="122" name="LOG_REQUEST_END">
-      <description>Stop log transfer and resume normal logging</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-    </message>
-    <message name="GPS_INJECT_DATA" id="123">
-      <description>data for injecting into the onboard GPS (used for DGPS)</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="len">data length</field>
-      <field type="uint8_t[110]" name="data">raw data (110 is enough for 12 satellites of RTCMv2)</field>
-    </message>
-    <message id="124" name="GPS2_RAW">
-      <description>Second GPS data. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
-      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
-      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
-      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
-      <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
-      <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
-      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
-      <field type="uint8_t" name="dgps_numch">Number of DGPS satellites</field>
-      <field type="uint32_t" name="dgps_age">Age of DGPS info</field>
-    </message>
-    <message id="125" name="POWER_STATUS">
-      <description>Power supply status</description>
-      <field type="uint16_t" name="Vcc">5V rail voltage in millivolts</field>
-      <field type="uint16_t" name="Vservo">servo rail voltage in millivolts</field>
-      <field type="uint16_t" name="flags">power supply status flags (see MAV_POWER_STATUS enum)</field>
-    </message>
-    <message name="SERIAL_CONTROL" id="126">
-      <description>Control a serial port. This can be used for raw access to an onboard serial peripheral such as a GPS or telemetry radio. It is designed to make it possible to update the devices firmware via MAVLink messages or change the devices settings. A message with zero bytes can be used to change just the baudrate.</description>
-      <field type="uint8_t" name="device">See SERIAL_CONTROL_DEV enum</field>
-      <field type="uint8_t" name="flags">See SERIAL_CONTROL_FLAG enum</field>
-      <field type="uint16_t" name="timeout">Timeout for reply data in milliseconds</field>
-      <field type="uint32_t" name="baudrate">Baudrate of transfer. Zero means no change.</field>
-      <field type="uint8_t" name="count">how many bytes in this transfer</field>
-      <field type="uint8_t[70]" name="data">serial data</field>
-    </message>
-    <message id="127" name="GPS_RTK">
-      <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
-      <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
-      <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
-      <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
-      <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
-      <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
-      <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
-      <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
-      <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
-      <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
-      <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
-      <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
-      <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
-      <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
-    </message>
-    <message id="128" name="GPS2_RTK">
-      <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
-      <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
-      <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
-      <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
-      <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
-      <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
-      <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
-      <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
-      <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
-      <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
-      <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
-      <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
-      <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
-      <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
-    </message>
-    <message id="129" name="SCALED_IMU3">
-      <description>The RAW IMU readings for 3rd 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="int16_t" name="xacc">X acceleration (mg)</field>
-      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-      <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-      <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-      <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-      <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-      <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-      <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
-    </message>
-    <message id="130" name="DATA_TRANSMISSION_HANDSHAKE">
-      <field type="uint8_t" name="type">type of requested/acknowledged data (as defined in ENUM DATA_TYPES in mavlink/include/mavlink_types.h)</field>
-      <field type="uint32_t" name="size">total data size in bytes (set on ACK only)</field>
-      <field type="uint16_t" name="width">Width of a matrix or image</field>
-      <field type="uint16_t" name="height">Height of a matrix or image</field>
-      <field type="uint16_t" name="packets">number of packets beeing sent (set on ACK only)</field>
-      <field type="uint8_t" name="payload">payload size per packet (normally 253 byte, see DATA field size in message ENCAPSULATED_DATA) (set on ACK only)</field>
-      <field type="uint8_t" name="jpg_quality">JPEG quality out of [1,100]</field>
-    </message>
-    <message id="131" name="ENCAPSULATED_DATA">
-      <field type="uint16_t" name="seqnr">sequence number (starting with 0 on every transmission)</field>
-      <field type="uint8_t[253]" name="data">image data bytes</field>
-    </message>
-    <message id="132" name="DISTANCE_SENSOR">
-      <field type="uint32_t" name="time_boot_ms">Time since system boot</field>
-      <field type="uint16_t" name="min_distance">Minimum distance the sensor can measure in centimeters</field>
-      <field type="uint16_t" name="max_distance">Maximum distance the sensor can measure in centimeters</field>
-      <field type="uint16_t" name="current_distance">Current distance reading</field>
-      <field type="uint8_t" name="type">Type from MAV_DISTANCE_SENSOR enum.</field>
-      <field type="uint8_t" name="id">Onboard ID of the sensor</field>
-      <field type="uint8_t" name="orientation">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
-      <field type="uint8_t" name="covariance">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
-    </message>
-    <message id="133" name="TERRAIN_REQUEST">
-      <description>Request for terrain data and terrain status</description>
-      <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
-      <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
-      <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
-      <field type="uint64_t" name="mask" print_format="0x%07x">Bitmask of requested 4x4 grids (row major 8x7 array of grids, 56 bits)</field>
-    </message>
-    <message id="134" name="TERRAIN_DATA">
-      <description>Terrain data sent from GCS. The lat/lon and grid_spacing must be the same as a lat/lon from a TERRAIN_REQUEST</description>
-      <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
-      <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
-      <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
-      <field type="uint8_t" name="gridbit">bit within the terrain request mask</field>
-      <field type="int16_t[16]" name="data">Terrain data in meters AMSL</field>
-    </message>
-    <message id="135" name="TERRAIN_CHECK">
-      <description>Request that the vehicle report terrain height at the given location. Used by GCS to check if vehicle has all terrain data needed for a mission.</description>
-      <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
-      <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
-    </message>
-    <message id="136" name="TERRAIN_REPORT">
-      <description>Response from a TERRAIN_CHECK request</description>
-      <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
-      <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
-      <field type="uint16_t" name="spacing">grid spacing (zero if terrain at this location unavailable)</field>
-      <field type="float" name="terrain_height">Terrain height in meters AMSL</field>
-      <field type="float" name="current_height">Current vehicle height above lat/lon terrain height (meters)</field>
-      <field type="uint16_t" name="pending">Number of 4x4 terrain blocks waiting to be received or read from disk</field>
-      <field type="uint16_t" name="loaded">Number of 4x4 terrain blocks in memory</field>
-    </message>
-    <message id="137" name="SCALED_PRESSURE2">
-      <description>Barometer readings for 2nd barometer</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-      <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-      <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
-    </message>
-    <message id="138" name="ATT_POS_MOCAP">
-      <description>Motion capture attitude and position</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float" name="x">X position in meters (NED)</field>
-      <field type="float" name="y">Y position in meters (NED)</field>
-      <field type="float" name="z">Z position in meters (NED)</field>
-    </message>
-    <message id="139" name="SET_ACTUATOR_CONTROL_TARGET">
-      <description>Set the vehicle attitude and body angular rates.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
-    </message>
-    <message id="140" name="ACTUATOR_CONTROL_TARGET">
-      <description>Set the vehicle attitude and body angular rates.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
-      <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
-    </message>
-    <message id="141" name="ALTITUDE">
-      <description>The current system altitude.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="float" name="altitude_monotonic">This altitude measure is initialized on system boot and monotonic (it is never reset, but represents the local altitude change). The only guarantee on this field is that it will never be reset and is consistent within a flight. The recommended value for this field is the uncorrected barometric altitude at boot time. This altitude will also drift and vary between flights.</field>
-      <field type="float" name="altitude_amsl">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output AMSL by default and not the WGS84 altitude.</field>
-      <field type="float" name="altitude_local">This is the local altitude in the local coordinate frame. It is not the altitude above home, but in reference to the coordinate origin (0, 0, 0). It is up-positive.</field>
-      <field type="float" name="altitude_relative">This is the altitude above the home position. It resets on each change of the current home position.</field>
-      <field type="float" name="altitude_terrain">This is the altitude above terrain. It might be fed by a terrain database or an altimeter. Values smaller than -1000 should be interpreted as unknown.</field>
-      <field type="float" name="bottom_clearance">This is not the altitude, but the clear space below the system according to the fused clearance estimate. It generally should max out at the maximum range of e.g. the laser altimeter. It is generally a moving target. A negative value indicates no measurement available.</field>
-    </message>
-    <message id="142" name="RESOURCE_REQUEST">
-      <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
-      <field type="uint8_t" name="request_id">Request ID. This ID should be re-used when sending back URI contents</field>
-      <field type="uint8_t" name="uri_type">The type of requested URI. 0 = a file via URL. 1 = a UAVCAN binary</field>
-      <field type="uint8_t[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
-      <field type="uint8_t" name="transfer_type">The way the autopilot wants to receive the URI. 0 = MAVLink FTP. 1 = binary stream.</field>
-      <field type="uint8_t[120]" name="storage">The storage path the autopilot wants the URI to be stored in. Will only be valid if the transfer_type has a storage associated (e.g. MAVLink FTP).</field>
-    </message>
-    <message id="143" name="SCALED_PRESSURE3">
-      <description>Barometer readings for 3rd barometer</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-      <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-      <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
-    </message>
-    <message id="144" name="FOLLOW_TARGET">
-      <description>current motion information from a designated system</description>
-      <field type="uint64_t" name="timestamp">Timestamp in milliseconds since system boot</field>
-      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
-      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-      <field type="float" name="alt">AMSL, in meters</field>
-      <field type="float[3]" name="vel">target velocity (0,0,0) for unknown</field>
-      <field type="float[3]" name="acc">linear target acceleration (0,0,0) for unknown</field>
-      <field type="float[4]" name="attitude_q">(1 0 0 0 for unknown)</field>
-      <field type="float[3]" name="rates">(0 0 0 for unknown)</field>
-      <field type="float[3]" name="position_cov">eph epv</field>
-      <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
-    </message>
-    <message id="146" name="CONTROL_SYSTEM_STATE">
-      <description>The smoothed, monotonic system state used to feed the control loops of the system.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="float" name="x_acc">X acceleration in body frame</field>
-      <field type="float" name="y_acc">Y acceleration in body frame</field>
-      <field type="float" name="z_acc">Z acceleration in body frame</field>
-      <field type="float" name="x_vel">X velocity in body frame</field>
-      <field type="float" name="y_vel">Y velocity in body frame</field>
-      <field type="float" name="z_vel">Z velocity in body frame</field>
-      <field type="float" name="x_pos">X position in local frame</field>
-      <field type="float" name="y_pos">Y position in local frame</field>
-      <field type="float" name="z_pos">Z position in local frame</field>
-      <field type="float" name="airspeed">Airspeed, set to -1 if unknown</field>
-      <field type="float[3]" name="vel_variance">Variance of body velocity estimate</field>
-      <field type="float[3]" name="pos_variance">Variance in local position</field>
-      <field type="float[4]" name="q">The attitude, represented as Quaternion</field>
-      <field type="float" name="roll_rate">Angular rate in roll axis</field>
-      <field type="float" name="pitch_rate">Angular rate in pitch axis</field>
-      <field type="float" name="yaw_rate">Angular rate in yaw axis</field>
-    </message>
-    <message id="147" name="BATTERY_STATUS">
-      <description>Battery information</description>
-      <field type="uint8_t" name="id">Battery ID</field>
-      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
-      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
-      <field type="int16_t" name="temperature">Temperature of the battery in centi-degrees celsius. INT16_MAX for unknown temperature.</field>
-      <field type="uint16_t[10]" name="voltages">Battery voltage of cells, in millivolts (1 = 1 millivolt). Cells above the valid cell count for this battery should have the UINT16_MAX value.</field>
-      <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
-      <field type="int32_t" name="current_consumed">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
-      <field type="int32_t" name="energy_consumed">Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
-      <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
-    </message>
-    <message id="148" name="AUTOPILOT_VERSION">
-      <description>Version and capability of autopilot software</description>
-      <field type="uint64_t" name="capabilities">bitmask of capabilities (see MAV_PROTOCOL_CAPABILITY enum)</field>
-      <field type="uint32_t" name="flight_sw_version">Firmware version number</field>
-      <field type="uint32_t" name="middleware_sw_version">Middleware version number</field>
-      <field type="uint32_t" name="os_sw_version">Operating system version number</field>
-      <field type="uint32_t" name="board_version">HW / board version (last 8 bytes should be silicon ID, if any)</field>
-      <field type="uint8_t[8]" name="flight_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
-      <field type="uint8_t[8]" name="middleware_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
-      <field type="uint8_t[8]" name="os_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
-      <field type="uint16_t" name="vendor_id">ID of the board vendor</field>
-      <field type="uint16_t" name="product_id">ID of the product</field>
-      <field type="uint64_t" name="uid">UID if provided by hardware</field>
-    </message>
-    <message id="149" name="LANDING_TARGET">
-      <description>The location of a landing area captured from a downward facing camera</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
-      <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
-      <field type="float" name="angle_x">X-axis angular offset (in radians) of the target from the center of the image</field>
-      <field type="float" name="angle_y">Y-axis angular offset (in radians) of the target from the center of the image</field>
-      <field type="float" name="distance">Distance to the target from the vehicle in meters</field>
-      <field type="float" name="size_x">Size in radians of target along x-axis</field>
-      <field type="float" name="size_y">Size in radians of target along y-axis</field>
-    </message>
-    <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
-    <message id="230" name="ESTIMATOR_STATUS">
-      <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovaton test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovaton test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field name="flags" type="uint16_t" enum="ESTIMATOR_STATUS_FLAGS">Integer bitmask indicating which EKF outputs are valid. See definition for ESTIMATOR_STATUS_FLAGS.</field>
-      <field name="vel_ratio" type="float">Velocity innovation test ratio</field>
-      <field name="pos_horiz_ratio" type="float">Horizontal position innovation test ratio</field>
-      <field name="pos_vert_ratio" type="float">Vertical position innovation test ratio</field>
-      <field name="mag_ratio" type="float">Magnetometer innovation test ratio</field>
-      <field name="hagl_ratio" type="float">Height above terrain innovation test ratio</field>
-      <field name="tas_ratio" type="float">True airspeed innovation test ratio</field>
-      <field name="pos_horiz_accuracy" type="float">Horizontal position 1-STD accuracy relative to the EKF local origin (m)</field>
-      <field name="pos_vert_accuracy" type="float">Vertical position 1-STD accuracy relative to the EKF local origin (m)</field>
-    </message>
-    <message id="231" name="WIND_COV">
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="float" name="wind_x">Wind in X (NED) direction in m/s</field>
-      <field type="float" name="wind_y">Wind in Y (NED) direction in m/s</field>
-      <field type="float" name="wind_z">Wind in Z (NED) direction in m/s</field>
-      <field type="float" name="var_horiz">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
-      <field type="float" name="var_vert">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
-      <field type="float" name="wind_alt">AMSL altitude (m) this measurement was taken at</field>
-      <field name="horiz_accuracy" type="float">Horizontal speed 1-STD accuracy</field>
-      <field name="vert_accuracy" type="float">Vertical speed 1-STD accuracy</field>
-    </message>
-    <message id="232" name="GPS_INPUT">
-      <description>GPS sensor input message.  This is a raw sensor value sent by the GPS. This is NOT the global position estimate of the sytem.</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS inputs</field>
-      <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_INPUT_IGNORE_FLAGS enum).  All other fields must be provided.</field>
-      <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
-      <field type="uint16_t" name="time_week">GPS week number</field>
-      <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
-      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-      <field type="float" name="alt">Altitude (AMSL, not WGS84), in m (positive for up)</field>
-      <field type="float" name="hdop">GPS HDOP horizontal dilution of position in m</field>
-      <field type="float" name="vdop">GPS VDOP vertical dilution of position in m</field>
-      <field type="float" name="vn">GPS velocity in m/s in NORTH direction in earth-fixed NED frame</field>
-      <field type="float" name="ve">GPS velocity in m/s in EAST direction in earth-fixed NED frame</field>
-      <field type="float" name="vd">GPS velocity in m/s in DOWN direction in earth-fixed NED frame</field>
-      <field type="float" name="speed_accuracy">GPS speed accuracy in m/s</field>
-      <field type="float" name="horiz_accuracy">GPS horizontal accuracy in m</field>
-      <field type="float" name="vert_accuracy">GPS vertical accuracy in m</field>
-      <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
-    </message>
-    <message id="233" name="GPS_RTCM_DATA">
-      <description>WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)</description>
-      <field type="uint8_t" name="flags">LSB: 1 means message is fragmented</field>
-      <field type="uint8_t" name="len">data length</field>
-      <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>
-    </message>
-    <message id="234" name="HIGH_LATENCY">
-      <description>Message appropriate for high latency connections like Iridium</description>
-      <field name="base_mode" type="uint8_t">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
-      <field name="custom_mode" type="uint32_t">A bitfield for use for autopilot-specific flags.</field>
-      <field name="landed_state" type="uint8_t" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
-      <field name="roll" type="int16_t">roll (centidegrees)</field>
-      <field name="pitch" type="int16_t">pitch (centidegrees)</field>
-      <field name="heading" type="uint16_t">heading (centidegrees)</field>
-      <field name="throttle" type="int8_t">throttle (percentage)</field>
-      <field name="heading_sp" type="int16_t">heading setpoint (centidegrees)</field>
-      <field name="latitude" type="int32_t">Latitude, expressed as degrees * 1E7</field>
-      <field name="longitude" type="int32_t">Longitude, expressed as degrees * 1E7</field>
-      <field name="altitude_amsl" type="int16_t">Altitude above mean sea level (meters)</field>
-      <field name="altitude_sp" type="int16_t">Altitude setpoint relative to the home position (meters)</field>
-      <field name="airspeed" type="uint8_t">airspeed (m/s)</field>
-      <field name="airspeed_sp" type="uint8_t">airspeed setpoint (m/s)</field>
-      <field name="groundspeed" type="uint8_t">groundspeed (m/s)</field>
-      <field name="climb_rate" type="int8_t">climb rate (m/s)</field>
-      <field name="gps_nsat" type="uint8_t">Number of satellites visible. If unknown, set to 255</field>
-      <field name="gps_fix_type" type="uint8_t">See the GPS_FIX_TYPE enum.</field>
-      <field name="battery_remaining" type="uint8_t">Remaining battery (percentage)</field>
-      <field name="temperature" type="int8_t">Autopilot temperature (degrees C)</field>
-      <field name="temperature_air" type="int8_t">Air temperature (degrees C) from airspeed sensor</field>
-      <field name="failsafe" type="uint8_t">failsafe (each bit represents a failsafe where 0=ok, 1=failsafe active (bit0:RC, bit1:batt, bit2:GPS, bit3:GCS, bit4:fence)</field>
-      <field name="wp_num" type="uint8_t">current waypoint number</field>
-      <field name="wp_distance" type="uint16_t">distance to target (meters)</field>
-    </message>
-    <message id="241" name="VIBRATION">
-      <description>Vibration levels and accelerometer clipping</description>
-      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-      <field type="float" name="vibration_x">Vibration levels on X-axis</field>
-      <field type="float" name="vibration_y">Vibration levels on Y-axis</field>
-      <field type="float" name="vibration_z">Vibration levels on Z-axis</field>
-      <field type="uint32_t" name="clipping_0">first accelerometer clipping count</field>
-      <field type="uint32_t" name="clipping_1">second accelerometer clipping count</field>
-      <field type="uint32_t" name="clipping_2">third accelerometer clipping count</field>
-    </message>
-    <message id="242" name="HOME_POSITION">
-      <description>This message can be requested by sending the MAV_CMD_GET_HOME_POSITION command. The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The position the system will return to and land on. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
-      <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-      <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-      <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
-      <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
-      <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
-      <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
-      <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-      <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-      <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-    </message>
-    <message id="243" name="SET_HOME_POSITION">
-      <description>The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
-      <field type="uint8_t" name="target_system">System ID.</field>
-      <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-      <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-      <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-      <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
-      <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
-      <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
-      <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
-      <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-      <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-      <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-    </message>
-    <message id="244" name="MESSAGE_INTERVAL">
-      <description>This interface replaces DATA_STREAM</description>
-      <field type="uint16_t" name="message_id">The ID of the requested MAVLink message. v1.0 is limited to 254 messages.</field>
-      <field type="int32_t" name="interval_us">The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, &gt; 0 indicates the interval at which it is sent.</field>
-    </message>
-    <message id="245" name="EXTENDED_SYS_STATE">
-      <description>Provides state for additional features</description>
-      <field type="uint8_t" name="vtol_state" enum="MAV_VTOL_STATE">The VTOL state if applicable. Is set to MAV_VTOL_STATE_UNDEFINED if UAV is not in VTOL configuration.</field>
-      <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
-    </message>
-    <message id="246" name="ADSB_VEHICLE">
-      <description>The location and information of an ADSB vehicle</description>
-      <field type="uint32_t" name="ICAO_address">ICAO address</field>
-      <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-      <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
-      <field type="uint8_t" name="altitude_type" enum="ADSB_ALTITUDE_TYPE">Type from ADSB_ALTITUDE_TYPE enum</field>
-      <field type="int32_t" name="altitude">Altitude(ASL) in millimeters</field>
-      <field type="uint16_t" name="heading">Course over ground in centidegrees</field>
-      <field type="uint16_t" name="hor_velocity">The horizontal velocity in centimeters/second</field>
-      <field type="int16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
-      <field type="char[9]" name="callsign">The callsign, 8+null</field>
-      <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">Type from ADSB_EMITTER_TYPE enum</field>
-      <field type="uint8_t" name="tslc">Time since last communication in seconds</field>
-      <field type="uint16_t" name="flags" enum="ADSB_FLAGS">Flags to indicate various statuses including valid data fields</field>
-      <field type="uint16_t" name="squawk">Squawk code</field>
-    </message>
-    <message id="247" name="COLLISION">
-      <description>Information about a potential collision</description>
-      <field type="uint8_t" name="src" enum="MAV_COLLISION_SRC">Collision data source</field>
-      <field type="uint32_t" name="id">Unique identifier, domain based on src field</field>
-      <field type="uint8_t" name="action" enum="MAV_COLLISION_ACTION">Action that is being taken to avoid this collision</field>
-      <field type="uint8_t" name="threat_level" enum="MAV_COLLISION_THREAT_LEVEL">How concerned the aircraft is about this collision</field>
-      <field type="float" name="time_to_minimum_delta">Estimated time until collision occurs (seconds)</field>
-      <field type="float" name="altitude_minimum_delta">Closest vertical distance in meters between vehicle and object</field>
-      <field type="float" name="horizontal_minimum_delta">Closest horizontal distance in meteres between vehicle and object</field>
-    </message>
-    <message id="248" name="V2_EXTENSION">
-      <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
-      <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
-      <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
-      <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
-      <field type="uint16_t" name="message_type">A code that identifies the software component that understands this message (analogous to usb device classes or mime type strings).  If this code is less than 32768, it is considered a 'registered' protocol extension and the corresponding entry should be added to https://github.com/mavlink/mavlink/extension-message-ids.xml.  Software creators can register blocks of message IDs as needed (useful for GCS specific metadata, etc...). Message_types greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
-      <field type="uint8_t[249]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
-    </message>
-    <message id="249" name="MEMORY_VECT">
-      <description>Send raw controller memory. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-      <field type="uint16_t" name="address">Starting address of the debug variables</field>
-      <field type="uint8_t" name="ver">Version code of the type variable. 0=unknown, type ignored and assumed int16_t. 1=as below</field>
-      <field type="uint8_t" name="type">Type code of the memory variables. for ver = 1: 0=16 x int16_t, 1=16 x uint16_t, 2=16 x Q15, 3=16 x 1Q14</field>
-      <field type="int8_t[32]" name="value">Memory contents at specified address</field>
-    </message>
-    <message id="250" name="DEBUG_VECT">
-      <field type="char[10]" name="name">Name</field>
-      <field type="uint64_t" name="time_usec">Timestamp</field>
-      <field type="float" name="x">x</field>
-      <field type="float" name="y">y</field>
-      <field type="float" name="z">z</field>
-    </message>
-    <message id="251" name="NAMED_VALUE_FLOAT">
-      <description>Send a key-value pair as float. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="char[10]" name="name">Name of the debug variable</field>
-      <field type="float" name="value">Floating point value</field>
-    </message>
-    <message id="252" name="NAMED_VALUE_INT">
-      <description>Send a key-value pair as integer. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="char[10]" name="name">Name of the debug variable</field>
-      <field type="int32_t" name="value">Signed integer value</field>
-    </message>
-    <message id="253" name="STATUSTEXT">
-      <description>Status text message. These messages are printed in yellow in the COMM console of QGroundControl. WARNING: They consume quite some bandwidth, so use only for important status and error messages. If implemented wisely, these messages are buffered on the MCU and sent only at a limited rate (e.g. 10 Hz).</description>
-      <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424. See enum MAV_SEVERITY.</field>
-      <field type="char[50]" name="text">Status text message, without null termination character</field>
-    </message>
-    <message id="254" name="DEBUG">
-      <description>Send a debug value. The index is used to discriminate between values. These values show up in the plot of QGroundControl as DEBUG N.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="ind">index of debug variable</field>
-      <field type="float" name="value">DEBUG value</field>
-    </message>
-    <!-- messages with ID 256 and above are only available in MAVLink2 -->
-    <message id="256" name="SETUP_SIGNING">
-      <description>Setup a MAVLink2 signing key. If called with secret_key of all zero and zero initial_timestamp will disable signing</description>
-      <field type="uint8_t" name="target_system">system id of the target</field>
-      <field type="uint8_t" name="target_component">component ID of the target</field>
-      <field type="uint8_t[32]" name="secret_key">signing key</field>
-      <field type="uint64_t" name="initial_timestamp">initial timestamp</field>
-    </message>
-    <message id="257" name="BUTTON_CHANGE">
-      <description>Report button state change</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field name="last_change_ms" type="uint32_t">Time of last change of button state</field>
-      <field name="state" type="uint8_t">Bitmap state of buttons</field>
-    </message>
-    <message id="258" name="PLAY_TUNE">
-      <description>Control vehicle tone generation (buzzer)</description>
-      <field name="target_system" type="uint8_t">System ID</field>
-      <field name="target_component" type="uint8_t">Component ID</field>
-      <field name="tune" type="char[30]">tune in board specific format</field>
-    </message>
-    <message id="259" name="CAMERA_INFORMATION">
-      <description>WIP: Information about a camera</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-      <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
-      <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
-      <field type="float" name="focal_length">Focal length in mm</field>
-      <field type="float" name="sensor_size_h">Image sensor size horizontal in mm</field>
-      <field type="float" name="sensor_size_v">Image sensor size vertical in mm</field>
-      <field type="uint16_t" name="resolution_h">Image resolution in pixels horizontal</field>
-      <field type="uint16_t" name="resolution_v">Image resolution in pixels vertical</field>
-      <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
-    </message>
-    <message id="260" name="CAMERA_SETTINGS">
-      <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-      <field type="float" name="aperture">Aperture is 1/value</field>
-      <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
-      <field type="float" name="shutter_speed">Shutter speed in s</field>
-      <field type="uint8_t" name="shutter_speed_locked">Shutter speed locked (0: auto, 1: locked)</field>
-      <field type="float" name="iso_sensitivity">ISO sensitivity</field>
-      <field type="uint8_t" name="iso_sensitivity_locked">ISO sensitivity locked (0: auto, 1: locked)</field>
-      <field type="float" name="white_balance">Color temperature in K</field>
-      <field type="uint8_t" name="white_balance_locked">Color temperature locked (0: auto, 1: locked)</field>
-      <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
-      <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
-      <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
-    </message>
-    <message id="261" name="STORAGE_INFORMATION">
-      <description>WIP: Information about a storage medium</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
-      <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
-      <field type="float" name="total_capacity">Total capacity in MiB</field>
-      <field type="float" name="used_capacity">Used capacity in MiB</field>
-      <field type="float" name="available_capacity">Available capacity in MiB</field>
-      <field type="float" name="read_speed">Read speed in MiB/s</field>
-      <field type="float" name="write_speed">Write speed in MiB/s</field>
-    </message>
-    <message id="262" name="CAMERA_CAPTURE_STATUS">
-      <description>WIP: Information about the status of a capture</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-      <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
-      <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
-      <field type="float" name="image_interval">Image capture interval in seconds</field>
-      <field type="float" name="video_framerate">Video frame rate in Hz</field>
-      <field type="uint16_t" name="image_resolution_h">Image resolution in pixels horizontal</field>
-      <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
-      <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
-      <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
-      <field type="uint32_t" name="recording_time_ms">Time in milliseconds since recording started</field>
-      <field type="float" name="available_capacity">Available storage capacity in MiB</field>
-    </message>
-    <message id="263" name="CAMERA_IMAGE_CAPTURED">
-      <description>WIP: Information about a captured image</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
-      <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-      <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7 where image was taken</field>
-      <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7 where capture was taken</field>
-      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
-      <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
-      <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
-      <field type="int32_t" name="image_index">Zero based index of this image (image count since armed -1)</field>
-      <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
-      <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
-    </message>
-    <message id="264" name="FLIGHT_INFORMATION">
-      <description>WIP: Information about flight since last arming</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint64_t" name="arming_time_utc">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
-      <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
-      <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
-    </message>
-    <message id="265" name="MOUNT_ORIENTATION">
-      <description>WIP: Orientation of a mount</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="roll">Roll in degrees</field>
-      <field type="float" name="pitch">Pitch in degrees</field>
-      <field type="float" name="yaw">Yaw in degrees</field>
-    </message>
-    <message id="266" name="LOGGING_DATA">
-      <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>
-      <field type="uint8_t" name="target_system">system ID of the target</field>
-      <field type="uint8_t" name="target_component">component ID of the target</field>
-      <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
-      <field type="uint8_t" name="length">data length</field>
-      <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
-      <field type="uint8_t[249]" name="data">logged data</field>
-    </message>
-    <message id="267" name="LOGGING_DATA_ACKED">
-      <description>A message containing logged data which requires a LOGGING_ACK to be sent back</description>
-      <field type="uint8_t" name="target_system">system ID of the target</field>
-      <field type="uint8_t" name="target_component">component ID of the target</field>
-      <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
-      <field type="uint8_t" name="length">data length</field>
-      <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
-      <field type="uint8_t[249]" name="data">logged data</field>
-    </message>
-    <message id="268" name="LOGGING_ACK">
-      <description>An ack for a LOGGING_DATA_ACKED message</description>
-      <field type="uint8_t" name="target_system">system ID of the target</field>
-      <field type="uint8_t" name="target_component">component ID of the target</field>
-      <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
-    </message>
-  </messages>
+             <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+             <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.</field>
+             <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+             <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+             <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
+             <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: 65535</field>
+             <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: 65535</field>
+             <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: 65535</field>
+             <field type="int16_t" name="vn">GPS velocity in cm/s in NORTH direction in earth-fixed NED frame</field>
+             <field type="int16_t" name="ve">GPS velocity in cm/s in EAST direction in earth-fixed NED frame</field>
+             <field type="int16_t" name="vd">GPS velocity in cm/s in DOWN direction in earth-fixed NED frame</field>
+             <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: 65535</field>
+             <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+         </message>
+         <message id="114" name="HIL_OPTICAL_FLOW">
+             <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>
+             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+             <field type="uint8_t" name="sensor_id">Sensor ID</field>
+             <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
+             <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
+             <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
+             <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
+             <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
+             <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
+             <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
+             <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
+             <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
+             <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
+         </message>
+         <message id="115" name="HIL_STATE_QUATERNION">
+             <description>Sent from simulation to autopilot, avoids in contrast to HIL_STATE singularities. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
+             <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+             <field type="float[4]" name="attitude_quaternion">Vehicle attitude expressed as normalized quaternion in w, x, y, z order (with 1 0 0 0 being the null-rotation)</field>
+             <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
+             <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
+             <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
+             <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
+             <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
+             <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
+             <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
+             <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
+             <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
+             <field type="uint16_t" name="ind_airspeed">Indicated airspeed, expressed as m/s * 100</field>
+             <field type="uint16_t" name="true_airspeed">True airspeed, expressed as m/s * 100</field>
+             <field type="int16_t" name="xacc">X acceleration (mg)</field>
+             <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+             <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+         </message>
+         <message id="116" name="SCALED_IMU2">
+           <description>The RAW IMU readings for secondary 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+           <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+           <field type="int16_t" name="xacc">X acceleration (mg)</field>
+           <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+           <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+           <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
+           <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
+           <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
+           <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
+           <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
+           <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+         </message>
+         <message id="117" name="LOG_REQUEST_LIST">
+          <description>Request a list of available logs. On some systems calling this may stop on-board logging until LOG_REQUEST_END is called.</description>
+          <field type="uint8_t" name="target_system">System ID</field>
+          <field type="uint8_t" name="target_component">Component ID</field>
+          <field type="uint16_t" name="start">First log id (0 for first available)</field>
+          <field type="uint16_t" name="end">Last log id (0xffff for last available)</field>
+         </message>
+         <message id="118" name="LOG_ENTRY">
+           <description>Reply to LOG_REQUEST_LIST</description>
+           <field type="uint16_t" name="id">Log id</field>
+           <field type="uint16_t" name="num_logs">Total number of logs</field>
+           <field type="uint16_t" name="last_log_num">High log number</field>
+           <field type="uint32_t" name="time_utc">UTC timestamp of log in seconds since 1970, or 0 if not available</field>
+           <field type="uint32_t" name="size">Size of the log (may be approximate) in bytes</field>
+         </message>
+         <message id="119" name="LOG_REQUEST_DATA">
+           <description>Request a chunk of a log</description>
+           <field type="uint8_t" name="target_system">System ID</field>
+           <field type="uint8_t" name="target_component">Component ID</field>
+           <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
+           <field type="uint32_t" name="ofs">Offset into the log</field>
+           <field type="uint32_t" name="count">Number of bytes</field>
+         </message>
+         <message id="120" name="LOG_DATA">
+           <description>Reply to LOG_REQUEST_DATA</description>
+           <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
+           <field type="uint32_t" name="ofs">Offset into the log</field>
+           <field type="uint8_t" name="count">Number of bytes (zero for end of log)</field>
+           <field type="uint8_t[90]" name="data">log data</field>
+         </message>
+         <message id="121" name="LOG_ERASE">
+           <description>Erase all logs</description>
+           <field type="uint8_t" name="target_system">System ID</field>
+           <field type="uint8_t" name="target_component">Component ID</field>
+         </message>
+         <message id="122" name="LOG_REQUEST_END">
+           <description>Stop log transfer and resume normal logging</description>
+           <field type="uint8_t" name="target_system">System ID</field>
+           <field type="uint8_t" name="target_component">Component ID</field>
+         </message>
+	       <message name="GPS_INJECT_DATA" id="123">
+           <description>data for injecting into the onboard GPS (used for DGPS)</description>
+           <field type="uint8_t" name="target_system">System ID</field>
+           <field type="uint8_t" name="target_component">Component ID</field>
+           <field type="uint8_t" name="len">data length</field>
+           <field type="uint8_t[110]" name="data">raw data (110 is enough for 12 satellites of RTCMv2)</field>
+         </message>
+         <message id="124" name="GPS2_RAW">
+           <description>Second GPS data. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
+           <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+           <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
+           <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+           <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+           <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
+           <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
+           <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
+           <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
+           <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+           <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+           <field type="uint8_t" name="dgps_numch">Number of DGPS satellites</field>
+           <field type="uint32_t" name="dgps_age">Age of DGPS info</field>
+         </message>
+         <message id="125" name="POWER_STATUS">
+               <description>Power supply status</description>
+               <field type="uint16_t" name="Vcc">5V rail voltage in millivolts</field>
+               <field type="uint16_t" name="Vservo">servo rail voltage in millivolts</field>
+               <field type="uint16_t" name="flags">power supply status flags (see MAV_POWER_STATUS enum)</field>
+         </message>
+         <message name="SERIAL_CONTROL" id="126">
+           <description>Control a serial port. This can be used for raw access to an onboard serial peripheral such as a GPS or telemetry radio. It is designed to make it possible to update the devices firmware via MAVLink messages or change the devices settings. A message with zero bytes can be used to change just the baudrate.</description>
+           <field type="uint8_t" name="device">See SERIAL_CONTROL_DEV enum</field>
+           <field type="uint8_t" name="flags">See SERIAL_CONTROL_FLAG enum</field>
+           <field type="uint16_t" name="timeout">Timeout for reply data in milliseconds</field>
+           <field type="uint32_t" name="baudrate">Baudrate of transfer. Zero means no change.</field>
+           <field type="uint8_t" name="count">how many bytes in this transfer</field>
+           <field type="uint8_t[70]" name="data">serial data</field>
+         </message>
+         <message id="127" name="GPS_RTK">
+            <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
+            <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
+            <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
+            <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
+            <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
+            <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
+            <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
+            <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
+            <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
+            <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
+            <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
+            <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
+            <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
+            <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
+         </message>
+         <message id="128" name="GPS2_RTK">
+            <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
+            <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
+            <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
+            <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
+            <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
+            <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
+            <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
+            <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
+            <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
+            <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
+            <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
+            <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
+            <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
+            <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
+        </message>
+        <message id="129" name="SCALED_IMU3">
+          <description>The RAW IMU readings for 3rd 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+          <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+          <field type="int16_t" name="xacc">X acceleration (mg)</field>
+          <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+          <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+          <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
+          <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
+          <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
+          <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
+          <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
+          <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+        </message>
+        <message id="130" name="DATA_TRANSMISSION_HANDSHAKE">
+            <field type="uint8_t" name="type">type of requested/acknowledged data (as defined in ENUM DATA_TYPES in mavlink/include/mavlink_types.h)</field>
+            <field type="uint32_t" name="size">total data size in bytes (set on ACK only)</field>
+            <field type="uint16_t" name="width">Width of a matrix or image</field>
+            <field type="uint16_t" name="height">Height of a matrix or image</field>
+            <field type="uint16_t" name="packets">number of packets beeing sent (set on ACK only)</field>
+            <field type="uint8_t" name="payload">payload size per packet (normally 253 byte, see DATA field size in message ENCAPSULATED_DATA) (set on ACK only)</field>
+            <field type="uint8_t" name="jpg_quality">JPEG quality out of [1,100]</field>
+        </message>
+        <message id="131" name="ENCAPSULATED_DATA">
+            <field type="uint16_t" name="seqnr">sequence number (starting with 0 on every transmission)</field>
+            <field type="uint8_t[253]" name="data">image data bytes</field>
+        </message>
+        <message id="132" name="DISTANCE_SENSOR">
+            <field type="uint32_t" name="time_boot_ms">Time since system boot</field>
+            <field type="uint16_t" name="min_distance">Minimum distance the sensor can measure in centimeters</field>
+            <field type="uint16_t" name="max_distance">Maximum distance the sensor can measure in centimeters</field>
+            <field type="uint16_t" name="current_distance">Current distance reading</field>
+            <field type="uint8_t" name="type">Type from MAV_DISTANCE_SENSOR enum.</field>
+            <field type="uint8_t" name="id">Onboard ID of the sensor</field>
+            <field type="uint8_t" name="orientation">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
+            <field type="uint8_t" name="covariance">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
+         </message>
+         <message id="133" name="TERRAIN_REQUEST">
+            <description>Request for terrain data and terrain status</description>
+            <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
+            <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
+            <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
+            <field type="uint64_t" name="mask" print_format="0x%07x">Bitmask of requested 4x4 grids (row major 8x7 array of grids, 56 bits)</field>
+         </message>
+         <message id="134" name="TERRAIN_DATA">
+            <description>Terrain data sent from GCS. The lat/lon and grid_spacing must be the same as a lat/lon from a TERRAIN_REQUEST</description>
+            <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
+            <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
+            <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
+            <field type="uint8_t" name="gridbit">bit within the terrain request mask</field>
+            <field type="int16_t[16]" name="data">Terrain data in meters AMSL</field>
+         </message>
+         <message id="135" name="TERRAIN_CHECK">
+            <description>Request that the vehicle report terrain height at the given location. Used by GCS to check if vehicle has all terrain data needed for a mission.</description>
+            <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
+            <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
+         </message>
+         <message id="136" name="TERRAIN_REPORT">
+            <description>Response from a TERRAIN_CHECK request</description>
+            <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
+            <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
+            <field type="uint16_t" name="spacing">grid spacing (zero if terrain at this location unavailable)</field>
+            <field type="float" name="terrain_height">Terrain height in meters AMSL</field>
+            <field type="float" name="current_height">Current vehicle height above lat/lon terrain height (meters)</field>
+            <field type="uint16_t" name="pending">Number of 4x4 terrain blocks waiting to be received or read from disk</field>
+            <field type="uint16_t" name="loaded">Number of 4x4 terrain blocks in memory</field>
+         </message>
+         <message id="137" name="SCALED_PRESSURE2">
+           <description>Barometer readings for 2nd barometer</description>
+           <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+           <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
+           <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
+           <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+         </message>
+        <message id="138" name="ATT_POS_MOCAP">
+          <description>Motion capture attitude and position</description>
+          <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+          <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+          <field type="float" name="x">X position in meters (NED)</field>
+          <field type="float" name="y">Y position in meters (NED)</field>
+          <field type="float" name="z">Z position in meters (NED)</field>
+        </message>
+        <message id="139" name="SET_ACTUATOR_CONTROL_TARGET">
+            <description>Set the vehicle attitude and body angular rates.</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
+            <field type="uint8_t" name="target_system">System ID</field>
+            <field type="uint8_t" name="target_component">Component ID</field>
+            <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
+        </message>
+        <message id="140" name="ACTUATOR_CONTROL_TARGET">
+            <description>Set the vehicle attitude and body angular rates.</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
+            <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
+        </message>
+        <message id="141" name="ALTITUDE">
+            <description>The current system altitude.</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field type="float" name="altitude_monotonic">This altitude measure is initialized on system boot and monotonic (it is never reset, but represents the local altitude change). The only guarantee on this field is that it will never be reset and is consistent within a flight. The recommended value for this field is the uncorrected barometric altitude at boot time. This altitude will also drift and vary between flights.</field>
+            <field type="float" name="altitude_amsl">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output AMSL by default and not the WGS84 altitude.</field>
+            <field type="float" name="altitude_local">This is the local altitude in the local coordinate frame. It is not the altitude above home, but in reference to the coordinate origin (0, 0, 0). It is up-positive.</field>
+            <field type="float" name="altitude_relative">This is the altitude above the home position. It resets on each change of the current home position.</field>
+            <field type="float" name="altitude_terrain">This is the altitude above terrain. It might be fed by a terrain database or an altimeter. Values smaller than -1000 should be interpreted as unknown.</field>
+            <field type="float" name="bottom_clearance">This is not the altitude, but the clear space below the system according to the fused clearance estimate. It generally should max out at the maximum range of e.g. the laser altimeter. It is generally a moving target. A negative value indicates no measurement available.</field>
+        </message>
+        <message id="142" name="RESOURCE_REQUEST">
+            <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
+            <field type="uint8_t" name="request_id">Request ID. This ID should be re-used when sending back URI contents</field>
+            <field type="uint8_t" name="uri_type">The type of requested URI. 0 = a file via URL. 1 = a UAVCAN binary</field>
+            <field type="uint8_t[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
+            <field type="uint8_t" name="transfer_type">The way the autopilot wants to receive the URI. 0 = MAVLink FTP. 1 = binary stream.</field>
+            <field type="uint8_t[120]" name="storage">The storage path the autopilot wants the URI to be stored in. Will only be valid if the transfer_type has a storage associated (e.g. MAVLink FTP).</field>
+        </message>
+        <message id="143" name="SCALED_PRESSURE3">
+          <description>Barometer readings for 3rd barometer</description>
+          <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+          <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
+          <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
+           <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+        </message>
+        <message id="144" name="FOLLOW_TARGET">
+              <description>current motion information from a designated system</description>
+              <field type="uint64_t" name="timestamp">Timestamp in milliseconds since system boot</field>
+              <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
+              <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+              <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+              <field type="float" name="alt">AMSL, in meters</field>
+              <field type="float[3]" name="vel">target velocity (0,0,0) for unknown</field>
+              <field type="float[3]" name="acc">linear target acceleration (0,0,0) for unknown</field>
+              <field type="float[4]" name="attitude_q">(1 0 0 0 for unknown)</field>
+              <field type="float[3]" name="rates">(0 0 0 for unknown)</field>
+              <field type="float[3]" name="position_cov">eph epv</field>
+              <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
+        </message>
+        <message id="146" name="CONTROL_SYSTEM_STATE">
+            <description>The smoothed, monotonic system state used to feed the control loops of the system.</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field type="float" name="x_acc">X acceleration in body frame</field>
+            <field type="float" name="y_acc">Y acceleration in body frame</field>
+            <field type="float" name="z_acc">Z acceleration in body frame</field>
+            <field type="float" name="x_vel">X velocity in body frame</field>
+            <field type="float" name="y_vel">Y velocity in body frame</field>
+            <field type="float" name="z_vel">Z velocity in body frame</field>
+            <field type="float" name="x_pos">X position in local frame</field>
+            <field type="float" name="y_pos">Y position in local frame</field>
+            <field type="float" name="z_pos">Z position in local frame</field>
+            <field type="float" name="airspeed">Airspeed, set to -1 if unknown</field>
+            <field type="float[3]" name="vel_variance">Variance of body velocity estimate</field>
+            <field type="float[3]" name="pos_variance">Variance in local position</field>
+            <field type="float[4]" name="q">The attitude, represented as Quaternion</field>
+            <field type="float" name="roll_rate">Angular rate in roll axis</field>
+            <field type="float" name="pitch_rate">Angular rate in pitch axis</field>
+            <field type="float" name="yaw_rate">Angular rate in yaw axis</field>
+        </message>
+        <message id="147" name="BATTERY_STATUS">
+            <description>Battery information</description>
+            <field type="uint8_t" name="id">Battery ID</field>
+            <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
+            <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
+            <field type="int16_t" name="temperature">Temperature of the battery in centi-degrees celsius. INT16_MAX for unknown temperature.</field>
+            <field type="uint16_t[10]" name="voltages">Battery voltage of cells, in millivolts (1 = 1 millivolt). Cells above the valid cell count for this battery should have the UINT16_MAX value.</field>
+            <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+            <field type="int32_t" name="current_consumed">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
+            <field type="int32_t" name="energy_consumed">Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
+            <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
+        </message>
+        <message id="148" name="AUTOPILOT_VERSION">
+            <description>Version and capability of autopilot software</description>
+            <field type="uint64_t" name="capabilities">bitmask of capabilities (see MAV_PROTOCOL_CAPABILITY enum)</field>
+            <field type="uint32_t" name="flight_sw_version">Firmware version number</field>
+            <field type="uint32_t" name="middleware_sw_version">Middleware version number</field>
+            <field type="uint32_t" name="os_sw_version">Operating system version number</field>
+            <field type="uint32_t" name="board_version">HW / board version (last 8 bytes should be silicon ID, if any)</field>
+            <field type="uint8_t[8]" name="flight_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+            <field type="uint8_t[8]" name="middleware_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+            <field type="uint8_t[8]" name="os_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+            <field type="uint16_t" name="vendor_id">ID of the board vendor</field>
+            <field type="uint16_t" name="product_id">ID of the product</field>
+            <field type="uint64_t" name="uid">UID if provided by hardware</field>
+        </message>
+        <message id="149" name="LANDING_TARGET">
+            <description>The location of a landing area captured from a downward facing camera</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
+            <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
+            <field type="float" name="angle_x">X-axis angular offset (in radians) of the target from the center of the image</field>
+            <field type="float" name="angle_y">Y-axis angular offset (in radians) of the target from the center of the image</field>
+            <field type="float" name="distance">Distance to the target from the vehicle in meters</field>
+            <field type="float" name="size_x">Size in radians of target along x-axis</field>
+            <field type="float" name="size_y">Size in radians of target along y-axis</field>
+        </message>
+
+        <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
+        <message id="230" name="ESTIMATOR_STATUS">
+            <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovaton test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovaton test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field name="flags" type="uint16_t" enum="ESTIMATOR_STATUS_FLAGS">Integer bitmask indicating which EKF outputs are valid. See definition for ESTIMATOR_STATUS_FLAGS.</field>
+            <field name="vel_ratio" type="float">Velocity innovation test ratio</field>
+            <field name="pos_horiz_ratio" type="float">Horizontal position innovation test ratio</field>
+            <field name="pos_vert_ratio" type="float">Vertical position innovation test ratio</field>
+            <field name="mag_ratio" type="float">Magnetometer innovation test ratio</field>
+            <field name="hagl_ratio" type="float">Height above terrain innovation test ratio</field>
+            <field name="tas_ratio" type="float">True airspeed innovation test ratio</field>
+            <field name="pos_horiz_accuracy" type="float">Horizontal position 1-STD accuracy relative to the EKF local origin (m)</field>
+            <field name="pos_vert_accuracy" type="float">Vertical position 1-STD accuracy relative to the EKF local origin (m)</field>
+        </message>
+        <message id="231" name="WIND_COV">
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field type="float" name="wind_x">Wind in X (NED) direction in m/s</field>
+            <field type="float" name="wind_y">Wind in Y (NED) direction in m/s</field>
+            <field type="float" name="wind_z">Wind in Z (NED) direction in m/s</field>
+            <field type="float" name="var_horiz">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
+            <field type="float" name="var_vert">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
+            <field type="float" name="wind_alt">AMSL altitude (m) this measurement was taken at</field>
+            <field name="horiz_accuracy" type="float">Horizontal speed 1-STD accuracy</field>
+            <field name="vert_accuracy" type="float">Vertical speed 1-STD accuracy</field>
+        </message>
+        <message id="232" name="GPS_INPUT">
+            <description>GPS sensor input message.  This is a raw sensor value sent by the GPS. This is NOT the global position estimate of the sytem.</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS inputs</field>
+            <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_INPUT_IGNORE_FLAGS enum).  All other fields must be provided.</field>
+            <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
+            <field type="uint16_t" name="time_week">GPS week number</field>
+            <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
+            <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+            <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+            <field type="float" name="alt">Altitude (AMSL, not WGS84), in m (positive for up)</field>
+            <field type="float" name="hdop">GPS HDOP horizontal dilution of position in m</field>
+            <field type="float" name="vdop">GPS VDOP vertical dilution of position in m</field>
+            <field type="float" name="vn">GPS velocity in m/s in NORTH direction in earth-fixed NED frame</field>
+            <field type="float" name="ve">GPS velocity in m/s in EAST direction in earth-fixed NED frame</field>
+            <field type="float" name="vd">GPS velocity in m/s in DOWN direction in earth-fixed NED frame</field>
+            <field type="float" name="speed_accuracy">GPS speed accuracy in m/s</field>
+            <field type="float" name="horiz_accuracy">GPS horizontal accuracy in m</field>
+            <field type="float" name="vert_accuracy">GPS vertical accuracy in m</field>
+            <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
+        </message>
+        <message id="233" name="GPS_RTCM_DATA">
+           <description>WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)</description>
+           <field type="uint8_t" name="flags">LSB: 1 means message is fragmented</field>
+           <field type="uint8_t" name="len">data length</field>
+           <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>
+        </message>
+        <message id="234" name="HIGH_LATENCY">
+            <description>Message appropriate for high latency connections like Iridium</description>
+            <field name="base_mode" type="uint8_t">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
+            <field name="custom_mode" type="uint32_t">A bitfield for use for autopilot-specific flags.</field>
+            <field name="landed_state" type="uint8_t" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+            <field name="roll" type="int16_t">roll (centidegrees)</field>
+            <field name="pitch" type="int16_t">pitch (centidegrees)</field>
+            <field name="heading" type="uint16_t">heading (centidegrees)</field>
+            <field name="throttle" type="int8_t">throttle (percentage)</field>
+            <field name="heading_sp" type="int16_t">heading setpoint (centidegrees)</field>
+            <field name="latitude" type="int32_t">Latitude, expressed as degrees * 1E7</field>
+            <field name="longitude" type="int32_t">Longitude, expressed as degrees * 1E7</field>
+            <field name="altitude_amsl" type="int16_t">Altitude above mean sea level (meters)</field>
+            <field name="altitude_sp" type="int16_t">Altitude setpoint relative to the home position (meters)</field>
+            <field name="airspeed" type="uint8_t">airspeed (m/s)</field>
+            <field name="airspeed_sp" type="uint8_t">airspeed setpoint (m/s)</field>
+            <field name="groundspeed" type="uint8_t">groundspeed (m/s)</field>
+            <field name="climb_rate" type="int8_t">climb rate (m/s)</field>
+            <field name="gps_nsat" type="uint8_t">Number of satellites visible. If unknown, set to 255</field>
+            <field name="gps_fix_type" type="uint8_t">See the GPS_FIX_TYPE enum.</field>
+            <field name="battery_remaining" type="uint8_t">Remaining battery (percentage)</field>
+            <field name="temperature" type="int8_t">Autopilot temperature (degrees C)</field>
+            <field name="temperature_air" type="int8_t">Air temperature (degrees C) from airspeed sensor</field>
+            <field name="failsafe" type="uint8_t">failsafe (each bit represents a failsafe where 0=ok, 1=failsafe active (bit0:RC, bit1:batt, bit2:GPS, bit3:GCS, bit4:fence)</field>
+            <field name="wp_num" type="uint8_t">current waypoint number</field>
+            <field name="wp_distance" type="uint16_t">distance to target (meters)</field>
+        </message>
+    <message id="235" name="MIXER_PARAMETER">
+      <description>Mixer paraemter emitted after a read or set request</description>
+      <field type="uint16_t" name="count">Total number of onboard parameters</field>
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>      
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
+      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
+      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>      
+      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="uint8_t" name="param_array_size">Size of the array for this parameter</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float[8]" name="param_values">Array of parameter values</field>
+    </message>    
+
+        <message id="241" name="VIBRATION">
+            <description>Vibration levels and accelerometer clipping</description>
+            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+            <field type="float" name="vibration_x">Vibration levels on X-axis</field>
+            <field type="float" name="vibration_y">Vibration levels on Y-axis</field>
+            <field type="float" name="vibration_z">Vibration levels on Z-axis</field>
+            <field type="uint32_t" name="clipping_0">first accelerometer clipping count</field>
+            <field type="uint32_t" name="clipping_1">second accelerometer clipping count</field>
+            <field type="uint32_t" name="clipping_2">third accelerometer clipping count</field>
+        </message>
+        <message id="242" name="HOME_POSITION">
+               <description>This message can be requested by sending the MAV_CMD_GET_HOME_POSITION command. The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The position the system will return to and land on. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
+               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
+               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+               <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
+               <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
+               <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
+               <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
+               <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+        </message>
+        <message id="243" name="SET_HOME_POSITION">
+               <description>The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
+               <field type="uint8_t" name="target_system">System ID.</field>
+               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
+               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
+               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+               <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
+               <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
+               <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
+               <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
+               <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+               <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+        </message>
+        <message id="244" name="MESSAGE_INTERVAL">
+            <description>This interface replaces DATA_STREAM</description>
+            <field type="uint16_t" name="message_id">The ID of the requested MAVLink message. v1.0 is limited to 254 messages.</field>
+            <field type="int32_t" name="interval_us">The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, > 0 indicates the interval at which it is sent.</field>
+        </message>
+        <message id="245" name="EXTENDED_SYS_STATE">
+            <description>Provides state for additional features</description>
+            <field type="uint8_t" name="vtol_state" enum="MAV_VTOL_STATE">The VTOL state if applicable. Is set to MAV_VTOL_STATE_UNDEFINED if UAV is not in VTOL configuration.</field>
+            <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+        </message>
+        <message id="246" name="ADSB_VEHICLE">
+          <description>The location and information of an ADSB vehicle</description>
+          <field type="uint32_t" name="ICAO_address">ICAO address</field>
+          <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
+          <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
+          <field type="uint8_t" name="altitude_type" enum="ADSB_ALTITUDE_TYPE">Type from ADSB_ALTITUDE_TYPE enum</field>
+          <field type="int32_t" name="altitude">Altitude(ASL) in millimeters</field>
+          <field type="uint16_t" name="heading">Course over ground in centidegrees</field>
+          <field type="uint16_t" name="hor_velocity">The horizontal velocity in centimeters/second</field>
+          <field type="int16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
+          <field type="char[9]" name="callsign">The callsign, 8+null</field>
+          <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">Type from ADSB_EMITTER_TYPE enum</field>
+          <field type="uint8_t" name="tslc">Time since last communication in seconds</field>
+          <field type="uint16_t" name="flags" enum="ADSB_FLAGS">Flags to indicate various statuses including valid data fields</field>
+          <field type="uint16_t" name="squawk">Squawk code</field>
+        </message>
+        <message id="247" name="COLLISION">
+          <description>Information about a potential collision</description>
+          <field type="uint8_t" name="src" enum="MAV_COLLISION_SRC">Collision data source</field>
+          <field type="uint32_t" name="id">Unique identifier, domain based on src field</field>
+          <field type="uint8_t" name="action" enum="MAV_COLLISION_ACTION">Action that is being taken to avoid this collision</field>
+          <field type="uint8_t" name="threat_level" enum="MAV_COLLISION_THREAT_LEVEL">How concerned the aircraft is about this collision</field>
+          <field type="float" name="time_to_minimum_delta">Estimated time until collision occurs (seconds)</field>
+          <field type="float" name="altitude_minimum_delta">Closest vertical distance in meters between vehicle and object</field>
+          <field type="float" name="horizontal_minimum_delta">Closest horizontal distance in meteres between vehicle and object</field>
+        </message>
+        <message id="248" name="V2_EXTENSION">
+            <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
+            <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
+            <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
+            <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
+            <field type="uint16_t" name="message_type">A code that identifies the software component that understands this message (analogous to usb device classes or mime type strings).  If this code is less than 32768, it is considered a 'registered' protocol extension and the corresponding entry should be added to https://github.com/mavlink/mavlink/extension-message-ids.xml.  Software creators can register blocks of message IDs as needed (useful for GCS specific metadata, etc...). Message_types greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
+            <field type="uint8_t[249]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
+        </message>
+          <message id="249" name="MEMORY_VECT">
+               <description>Send raw controller memory. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+               <field type="uint16_t" name="address">Starting address of the debug variables</field>
+               <field type="uint8_t" name="ver">Version code of the type variable. 0=unknown, type ignored and assumed int16_t. 1=as below</field>
+               <field type="uint8_t" name="type">Type code of the memory variables. for ver = 1: 0=16 x int16_t, 1=16 x uint16_t, 2=16 x Q15, 3=16 x 1Q14</field>
+               <field type="int8_t[32]" name="value">Memory contents at specified address</field>
+          </message>
+          <message id="250" name="DEBUG_VECT">
+               <field type="char[10]" name="name">Name</field>
+               <field type="uint64_t" name="time_usec">Timestamp</field>
+               <field type="float" name="x">x</field>
+               <field type="float" name="y">y</field>
+               <field type="float" name="z">z</field>
+          </message>
+          <message id="251" name="NAMED_VALUE_FLOAT">
+               <description>Send a key-value pair as float. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="char[10]" name="name">Name of the debug variable</field>
+               <field type="float" name="value">Floating point value</field>
+          </message>
+          <message id="252" name="NAMED_VALUE_INT">
+               <description>Send a key-value pair as integer. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="char[10]" name="name">Name of the debug variable</field>
+               <field type="int32_t" name="value">Signed integer value</field>
+          </message>
+          <message id="253" name="STATUSTEXT">
+               <description>Status text message. These messages are printed in yellow in the COMM console of QGroundControl. WARNING: They consume quite some bandwidth, so use only for important status and error messages. If implemented wisely, these messages are buffered on the MCU and sent only at a limited rate (e.g. 10 Hz).</description>
+               <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424. See enum MAV_SEVERITY.</field>
+               <field type="char[50]" name="text">Status text message, without null termination character</field>
+          </message>
+          <message id="254" name="DEBUG">
+               <description>Send a debug value. The index is used to discriminate between values. These values show up in the plot of QGroundControl as DEBUG N.</description>
+               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint8_t" name="ind">index of debug variable</field>
+               <field type="float" name="value">DEBUG value</field>
+          </message>
+
+          <!-- messages with ID 256 and above are only available in MAVLink2 -->
+          <message id="256" name="SETUP_SIGNING">
+               <description>Setup a MAVLink2 signing key. If called with secret_key of all zero and zero initial_timestamp will disable signing</description>
+               <field type="uint8_t" name="target_system">system id of the target</field>
+               <field type="uint8_t" name="target_component">component ID of the target</field>
+               <field type="uint8_t[32]" name="secret_key">signing key</field>
+               <field type="uint64_t" name="initial_timestamp">initial timestamp</field>
+          </message>
+
+	  <message id="257" name="BUTTON_CHANGE">
+            <description>Report button state change</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field name="last_change_ms" type="uint32_t">Time of last change of button state</field>
+            <field name="state" type="uint8_t">Bitmap state of buttons</field>
+          </message>
+
+          <message id="258" name="PLAY_TUNE">
+            <description>Control vehicle tone generation (buzzer)</description>
+            <field name="target_system" type="uint8_t">System ID</field>
+            <field name="target_component" type="uint8_t">Component ID</field>
+            <field name="tune" type="char[30]">tune in board specific format</field>
+          </message>
+
+        <message id="259" name="CAMERA_INFORMATION">
+            <description>WIP: Information about a camera</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+            <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
+            <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
+            <field type="float" name="focal_length">Focal length in mm</field>
+            <field type="float" name="sensor_size_h">Image sensor size horizontal in mm</field>
+            <field type="float" name="sensor_size_v">Image sensor size vertical in mm</field>
+            <field type="uint16_t" name="resolution_h">Image resolution in pixels horizontal</field>
+            <field type="uint16_t" name="resolution_v">Image resolution in pixels vertical</field>
+            <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
+        </message>
+        <message id="260" name="CAMERA_SETTINGS">
+            <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+            <field type="float" name="aperture">Aperture is 1/value</field>
+            <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
+            <field type="float" name="shutter_speed">Shutter speed in s</field>
+            <field type="uint8_t" name="shutter_speed_locked">Shutter speed locked (0: auto, 1: locked)</field>
+            <field type="float" name="iso_sensitivity">ISO sensitivity</field>
+            <field type="uint8_t" name="iso_sensitivity_locked">ISO sensitivity locked (0: auto, 1: locked)</field>
+            <field type="float" name="white_balance">Color temperature in K</field>
+            <field type="uint8_t" name="white_balance_locked">Color temperature locked (0: auto, 1: locked)</field>
+            <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
+            <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
+            <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
+        </message>
+        <message id="261" name="STORAGE_INFORMATION">
+            <description>WIP: Information about a storage medium</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
+            <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
+            <field type="float" name="total_capacity">Total capacity in MiB</field>
+            <field type="float" name="used_capacity">Used capacity in MiB</field>
+            <field type="float" name="available_capacity">Available capacity in MiB</field>
+            <field type="float" name="read_speed">Read speed in MiB/s</field>
+            <field type="float" name="write_speed">Write speed in MiB/s</field>
+        </message>
+        <message id="262" name="CAMERA_CAPTURE_STATUS">
+            <description>WIP: Information about the status of a capture</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+            <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
+            <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
+            <field type="float" name="image_interval">Image capture interval in seconds</field>
+            <field type="float" name="video_framerate">Video frame rate in Hz</field>
+            <field type="uint16_t" name="image_resolution_h">Image resolution in pixels horizontal</field>
+            <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
+            <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
+            <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
+        </message>
+        <message id="263" name="CAMERA_IMAGE_CAPTURED">
+            <description>WIP: Information about a captured image</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+            <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7 where image was taken</field>
+            <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7 where capture was taken</field>
+            <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
+            <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
+            <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
+            <field type="char[210]" name="file_path">File path of image taken.</field>
+        </message>
+
+        <message id="264" name="FLIGHT_INFORMATION">
+            <description>WIP: Information about flight since last arming</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint64_t" name="arming_time_utc">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+            <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+            <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
+        </message>
+
+        <message id="265" name="MOUNT_ORIENTATION">
+            <description>WIP: Orientation of a mount</description>
+                <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="float" name="roll">Roll in degrees</field>
+               <field type="float" name="pitch">Pitch in degrees</field>
+               <field type="float" name="yaw">Yaw in degrees</field>
+        </message>
+
+        <message id="266" name="LOGGING_DATA">
+               <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>
+               <field type="uint8_t" name="target_system">system ID of the target</field>
+               <field type="uint8_t" name="target_component">component ID of the target</field>
+               <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
+               <field type="uint8_t" name="length">data length</field>
+               <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
+               <field type="uint8_t[249]" name="data">logged data</field>
+          </message>
+          <message id="267" name="LOGGING_DATA_ACKED">
+               <description>A message containing logged data which requires a LOGGING_ACK to be sent back</description>
+               <field type="uint8_t" name="target_system">system ID of the target</field>
+               <field type="uint8_t" name="target_component">component ID of the target</field>
+               <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
+               <field type="uint8_t" name="length">data length</field>
+               <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
+               <field type="uint8_t[249]" name="data">logged data</field>
+          </message>
+          <message id="268" name="LOGGING_ACK">
+               <description>An ack for a LOGGING_DATA_ACKED message</description>
+               <field type="uint8_t" name="target_system">system ID of the target</field>
+               <field type="uint8_t" name="target_component">component ID of the target</field>
+               <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
+          </message>
+    </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1,1471 +1,1450 @@
-<?xml version='1.0'?>
+<?xml version="1.0"?>
 <mavlink>
-     <version>3</version>
-     <dialect>0</dialect>
-     <enums>
-          <enum name="MAV_AUTOPILOT">
-               <description>Micro air vehicle / autopilot classes. This identifies the individual model.</description>
-               <entry value="0" name="MAV_AUTOPILOT_GENERIC">
-                    <description>Generic autopilot, full support for everything</description>
-               </entry>
-               <entry value="1" name="MAV_AUTOPILOT_RESERVED">
-                    <description>Reserved for future use.</description>
-               </entry>
-               <entry value="2" name="MAV_AUTOPILOT_SLUGS">
-                    <description>SLUGS autopilot, http://slugsuav.soe.ucsc.edu</description>
-               </entry>
-               <entry value="3" name="MAV_AUTOPILOT_ARDUPILOTMEGA">
-                    <description>ArduPilotMega / ArduCopter, http://diydrones.com</description>
-               </entry>
-               <entry value="4" name="MAV_AUTOPILOT_OPENPILOT">
-                    <description>OpenPilot, http://openpilot.org</description>
-               </entry>
-               <entry value="5" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_ONLY">
-                    <description>Generic autopilot only supporting simple waypoints</description>
-               </entry>
-               <entry value="6" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_AND_SIMPLE_NAVIGATION_ONLY">
-                    <description>Generic autopilot supporting waypoints and other simple navigation commands</description>
-               </entry>
-               <entry value="7" name="MAV_AUTOPILOT_GENERIC_MISSION_FULL">
-                    <description>Generic autopilot supporting the full mission command set</description>
-               </entry>
-               <entry value="8" name="MAV_AUTOPILOT_INVALID">
-                    <description>No valid autopilot, e.g. a GCS or other MAVLink component</description>
-               </entry>
-               <entry value="9" name="MAV_AUTOPILOT_PPZ">
-                    <description>PPZ UAV - http://nongnu.org/paparazzi</description>
-               </entry>
-               <entry value="10" name="MAV_AUTOPILOT_UDB">
-                    <description>UAV Dev Board</description>
-               </entry>
-               <entry value="11" name="MAV_AUTOPILOT_FP">
-                    <description>FlexiPilot</description>
-               </entry>
-               <entry value="12" name="MAV_AUTOPILOT_PX4">
-                   <description>PX4 Autopilot - http://pixhawk.ethz.ch/px4/</description>
-               </entry>
-               <entry value="13" name="MAV_AUTOPILOT_SMACCMPILOT">
-                   <description>SMACCMPilot - http://smaccmpilot.org</description>
-               </entry>
-               <entry value="14" name="MAV_AUTOPILOT_AUTOQUAD">
-                    <description>AutoQuad -- http://autoquad.org</description>
-               </entry>
-               <entry value="15" name="MAV_AUTOPILOT_ARMAZILA">
-                    <description>Armazila -- http://armazila.com</description>
-               </entry>
-               <entry value="16" name="MAV_AUTOPILOT_AEROB">
-                    <description>Aerob -- http://aerob.ru</description>
-               </entry>
-               <entry value="17" name="MAV_AUTOPILOT_ASLUAV">
-                    <description>ASLUAV autopilot -- http://www.asl.ethz.ch</description>
-               </entry>
-          </enum>
-          <enum name="MAV_TYPE">
-               <entry value="0" name="MAV_TYPE_GENERIC">
-                    <description>Generic micro air vehicle.</description>
-               </entry>
-               <entry value="1" name="MAV_TYPE_FIXED_WING">
-                    <description>Fixed wing aircraft.</description>
-               </entry>
-               <entry value="2" name="MAV_TYPE_QUADROTOR">
-                    <description>Quadrotor</description>
-               </entry>
-               <entry value="3" name="MAV_TYPE_COAXIAL">
-                    <description>Coaxial helicopter</description>
-               </entry>
-               <entry value="4" name="MAV_TYPE_HELICOPTER">
-                    <description>Normal helicopter with tail rotor.</description>
-               </entry>
-               <entry value="5" name="MAV_TYPE_ANTENNA_TRACKER">
-                    <description>Ground installation</description>
-               </entry>
-               <entry value="6" name="MAV_TYPE_GCS">
-                    <description>Operator control unit / ground control station</description>
-               </entry>
-               <entry value="7" name="MAV_TYPE_AIRSHIP">
-                    <description>Airship, controlled</description>
-               </entry>
-               <entry value="8" name="MAV_TYPE_FREE_BALLOON">
-                    <description>Free balloon, uncontrolled</description>
-               </entry>
-               <entry value="9" name="MAV_TYPE_ROCKET">
-                    <description>Rocket</description>
-               </entry>
-               <entry value="10" name="MAV_TYPE_GROUND_ROVER">
-                    <description>Ground rover</description>
-               </entry>
-               <entry value="11" name="MAV_TYPE_SURFACE_BOAT">
-                    <description>Surface vessel, boat, ship</description>
-               </entry>
-               <entry value="12" name="MAV_TYPE_SUBMARINE">
-                    <description>Submarine</description>
-               </entry>
-               <entry value="13" name="MAV_TYPE_HEXAROTOR">
-                    <description>Hexarotor</description>
-               </entry>
-               <entry value="14" name="MAV_TYPE_OCTOROTOR">
-                    <description>Octorotor</description>
-               </entry>
-               <entry value="15" name="MAV_TYPE_TRICOPTER">
-                    <description>Tricopter</description>
-               </entry>
-               <entry value="16" name="MAV_TYPE_FLAPPING_WING">
-                    <description>Flapping wing</description>
-               </entry>
-               <entry value="17" name="MAV_TYPE_KITE">
-                    <description>Kite</description>
-               </entry>
-               <entry value="18" name="MAV_TYPE_ONBOARD_CONTROLLER">
-                    <description>Onboard companion controller</description>
-               </entry>
-               <entry value="19" name="MAV_TYPE_VTOL_DUOROTOR">
-                    <description>Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter.</description>
-               </entry>
-               <entry value="20" name="MAV_TYPE_VTOL_QUADROTOR">
-                    <description>Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter.</description>
-               </entry>
-               <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
-                    <description>Tiltrotor VTOL</description>
-               </entry>
-               <!-- Entries up to 25 reserved for other VTOL airframes -->
-               <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
-                    <description>VTOL reserved 2</description>
-               </entry>
-               <entry value="23" name="MAV_TYPE_VTOL_RESERVED3">
-                    <description>VTOL reserved 3</description>
-               </entry>
-               <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
-                    <description>VTOL reserved 4</description>
-               </entry>
-               <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
-                    <description>VTOL reserved 5</description>
-               </entry>
-               <entry value="26" name="MAV_TYPE_GIMBAL">
-                    <description>Onboard gimbal</description>
-               </entry>
-               <entry value="27" name="MAV_TYPE_ADSB">
-                    <description>Onboard ADSB peripheral</description>
-               </entry>
-          </enum>
-          <enum name="FIRMWARE_VERSION_TYPE">
-              <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>
-              <entry value="0" name="FIRMWARE_VERSION_TYPE_DEV">
-                  <description>development release</description>
-              </entry>
-              <entry value="64" name="FIRMWARE_VERSION_TYPE_ALPHA">
-                  <description>alpha release</description>
-              </entry>
-              <entry value="128" name="FIRMWARE_VERSION_TYPE_BETA">
-                  <description>beta release</description>
-              </entry>
-              <entry value="192" name="FIRMWARE_VERSION_TYPE_RC">
-                  <description>release candidate</description>
-              </entry>
-              <entry value="255" name="FIRMWARE_VERSION_TYPE_OFFICIAL">
-                  <description>official stable release</description>
-              </entry>
-          </enum>
-          <!-- WARNING: MAV_ACTION Enum is no longer supported - has been removed. Please use MAV_CMD -->
-          <enum name="MAV_MODE_FLAG">
-                <description>These flags encode the MAV mode.</description>
-                <entry value="128" name="MAV_MODE_FLAG_SAFETY_ARMED">
-                     <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignore when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
-                </entry>
-                <entry value="64" name="MAV_MODE_FLAG_MANUAL_INPUT_ENABLED">
-                     <description>0b01000000 remote control input is enabled.</description>
-                </entry>
-                <entry value="32" name="MAV_MODE_FLAG_HIL_ENABLED">
-                      <description>0b00100000 hardware in the loop simulation. All motors / actuators are blocked, but internal software is full operational.</description>
-                </entry>
-                <entry value="16" name="MAV_MODE_FLAG_STABILIZE_ENABLED">
-                     <description>0b00010000 system stabilizes electronically its attitude (and optionally position). It needs however further control inputs to move around.</description>
-                </entry>
-                <entry value="8" name="MAV_MODE_FLAG_GUIDED_ENABLED">
-                     <description>0b00001000 guided mode enabled, system flies MISSIONs / mission items.</description>
-                </entry>
-                <entry value="4" name="MAV_MODE_FLAG_AUTO_ENABLED">
-                     <description>0b00000100 autonomous mode enabled, system finds its own goal positions. Guided flag can be set or not, depends on the actual implementation.</description>
-                </entry>
-                <entry value="2" name="MAV_MODE_FLAG_TEST_ENABLED">
-                     <description>0b00000010 system has a test mode enabled. This flag is intended for temporary system tests and should not be used for stable implementations.</description>
-                </entry>
-                <entry value="1" name="MAV_MODE_FLAG_CUSTOM_MODE_ENABLED">
-                     <description>0b00000001 Reserved for future use.</description>
-                </entry>
-          </enum>
-          <enum name="MAV_MODE_FLAG_DECODE_POSITION">
-               <description>These values encode the bit positions of the decode position. These values can be used to read the value of a flag bit by combining the base_mode variable with AND with the flag position value. The result will be either 0 or 1, depending on if the flag is set or not.</description>
-                <entry value="128" name="MAV_MODE_FLAG_DECODE_POSITION_SAFETY">
-                     <description>First bit:  10000000</description>
-                </entry>
-                <entry value="64" name="MAV_MODE_FLAG_DECODE_POSITION_MANUAL">
-                     <description>Second bit: 01000000</description>
-                </entry>
-                <entry value="32" name="MAV_MODE_FLAG_DECODE_POSITION_HIL">
-                     <description>Third bit:  00100000</description>
-                </entry>
-                <entry value="16" name="MAV_MODE_FLAG_DECODE_POSITION_STABILIZE">
-                     <description>Fourth bit: 00010000</description>
-                </entry>
-                <entry value="8" name="MAV_MODE_FLAG_DECODE_POSITION_GUIDED">
-                     <description>Fifth bit:  00001000</description>
-                </entry>
-                <entry value="4" name="MAV_MODE_FLAG_DECODE_POSITION_AUTO">
-                     <description>Sixt bit:   00000100</description>
-                </entry>
-                <entry value="2" name="MAV_MODE_FLAG_DECODE_POSITION_TEST">
-                     <description>Seventh bit: 00000010</description>
-                </entry>
-                <entry value="1" name="MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE">
-                     <description>Eighth bit: 00000001</description>
-                </entry>
-          </enum>
-          <enum name="MAV_GOTO">
-               <description>Override command, pauses current mission execution and moves immediately to a position</description>
-               <entry value="0" name="MAV_GOTO_DO_HOLD">
-                    <description>Hold at the current position.</description>
-               </entry>
-               <entry value="1" name="MAV_GOTO_DO_CONTINUE">
-                    <description>Continue with the next item in mission execution.</description>
-               </entry>
-               <entry value="2" name="MAV_GOTO_HOLD_AT_CURRENT_POSITION">
-                    <description>Hold at the current position of the system</description>
-               </entry>
-               <entry value="3" name="MAV_GOTO_HOLD_AT_SPECIFIED_POSITION">
-                    <description>Hold at the position specified in the parameters of the DO_HOLD action</description>
-               </entry>
-          </enum>
-          <enum name="MAV_MODE">
-               <description>These defines are predefined OR-combined mode flags. There is no need to use values from this enum, but it
+  <version>3</version>
+  <dialect>0</dialect>
+  <enums>
+    <enum name="MAV_AUTOPILOT">
+      <description>Micro air vehicle / autopilot classes. This identifies the individual model.</description>
+      <entry value="0" name="MAV_AUTOPILOT_GENERIC">
+        <description>Generic autopilot, full support for everything</description>
+      </entry>
+      <entry value="1" name="MAV_AUTOPILOT_RESERVED">
+        <description>Reserved for future use.</description>
+      </entry>
+      <entry value="2" name="MAV_AUTOPILOT_SLUGS">
+        <description>SLUGS autopilot, http://slugsuav.soe.ucsc.edu</description>
+      </entry>
+      <entry value="3" name="MAV_AUTOPILOT_ARDUPILOTMEGA">
+        <description>ArduPilotMega / ArduCopter, http://diydrones.com</description>
+      </entry>
+      <entry value="4" name="MAV_AUTOPILOT_OPENPILOT">
+        <description>OpenPilot, http://openpilot.org</description>
+      </entry>
+      <entry value="5" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_ONLY">
+        <description>Generic autopilot only supporting simple waypoints</description>
+      </entry>
+      <entry value="6" name="MAV_AUTOPILOT_GENERIC_WAYPOINTS_AND_SIMPLE_NAVIGATION_ONLY">
+        <description>Generic autopilot supporting waypoints and other simple navigation commands</description>
+      </entry>
+      <entry value="7" name="MAV_AUTOPILOT_GENERIC_MISSION_FULL">
+        <description>Generic autopilot supporting the full mission command set</description>
+      </entry>
+      <entry value="8" name="MAV_AUTOPILOT_INVALID">
+        <description>No valid autopilot, e.g. a GCS or other MAVLink component</description>
+      </entry>
+      <entry value="9" name="MAV_AUTOPILOT_PPZ">
+        <description>PPZ UAV - http://nongnu.org/paparazzi</description>
+      </entry>
+      <entry value="10" name="MAV_AUTOPILOT_UDB">
+        <description>UAV Dev Board</description>
+      </entry>
+      <entry value="11" name="MAV_AUTOPILOT_FP">
+        <description>FlexiPilot</description>
+      </entry>
+      <entry value="12" name="MAV_AUTOPILOT_PX4">
+        <description>PX4 Autopilot - http://pixhawk.ethz.ch/px4/</description>
+      </entry>
+      <entry value="13" name="MAV_AUTOPILOT_SMACCMPILOT">
+        <description>SMACCMPilot - http://smaccmpilot.org</description>
+      </entry>
+      <entry value="14" name="MAV_AUTOPILOT_AUTOQUAD">
+        <description>AutoQuad -- http://autoquad.org</description>
+      </entry>
+      <entry value="15" name="MAV_AUTOPILOT_ARMAZILA">
+        <description>Armazila -- http://armazila.com</description>
+      </entry>
+      <entry value="16" name="MAV_AUTOPILOT_AEROB">
+        <description>Aerob -- http://aerob.ru</description>
+      </entry>
+      <entry value="17" name="MAV_AUTOPILOT_ASLUAV">
+        <description>ASLUAV autopilot -- http://www.asl.ethz.ch</description>
+      </entry>
+    </enum>
+    <enum name="MAV_TYPE">
+      <entry value="0" name="MAV_TYPE_GENERIC">
+        <description>Generic micro air vehicle.</description>
+      </entry>
+      <entry value="1" name="MAV_TYPE_FIXED_WING">
+        <description>Fixed wing aircraft.</description>
+      </entry>
+      <entry value="2" name="MAV_TYPE_QUADROTOR">
+        <description>Quadrotor</description>
+      </entry>
+      <entry value="3" name="MAV_TYPE_COAXIAL">
+        <description>Coaxial helicopter</description>
+      </entry>
+      <entry value="4" name="MAV_TYPE_HELICOPTER">
+        <description>Normal helicopter with tail rotor.</description>
+      </entry>
+      <entry value="5" name="MAV_TYPE_ANTENNA_TRACKER">
+        <description>Ground installation</description>
+      </entry>
+      <entry value="6" name="MAV_TYPE_GCS">
+        <description>Operator control unit / ground control station</description>
+      </entry>
+      <entry value="7" name="MAV_TYPE_AIRSHIP">
+        <description>Airship, controlled</description>
+      </entry>
+      <entry value="8" name="MAV_TYPE_FREE_BALLOON">
+        <description>Free balloon, uncontrolled</description>
+      </entry>
+      <entry value="9" name="MAV_TYPE_ROCKET">
+        <description>Rocket</description>
+      </entry>
+      <entry value="10" name="MAV_TYPE_GROUND_ROVER">
+        <description>Ground rover</description>
+      </entry>
+      <entry value="11" name="MAV_TYPE_SURFACE_BOAT">
+        <description>Surface vessel, boat, ship</description>
+      </entry>
+      <entry value="12" name="MAV_TYPE_SUBMARINE">
+        <description>Submarine</description>
+      </entry>
+      <entry value="13" name="MAV_TYPE_HEXAROTOR">
+        <description>Hexarotor</description>
+      </entry>
+      <entry value="14" name="MAV_TYPE_OCTOROTOR">
+        <description>Octorotor</description>
+      </entry>
+      <entry value="15" name="MAV_TYPE_TRICOPTER">
+        <description>Tricopter</description>
+      </entry>
+      <entry value="16" name="MAV_TYPE_FLAPPING_WING">
+        <description>Flapping wing</description>
+      </entry>
+      <entry value="17" name="MAV_TYPE_KITE">
+        <description>Kite</description>
+      </entry>
+      <entry value="18" name="MAV_TYPE_ONBOARD_CONTROLLER">
+        <description>Onboard companion controller</description>
+      </entry>
+      <entry value="19" name="MAV_TYPE_VTOL_DUOROTOR">
+        <description>Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter.</description>
+      </entry>
+      <entry value="20" name="MAV_TYPE_VTOL_QUADROTOR">
+        <description>Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter.</description>
+      </entry>
+      <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
+        <description>Tiltrotor VTOL</description>
+      </entry>
+      <!-- Entries up to 25 reserved for other VTOL airframes -->
+      <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
+        <description>VTOL reserved 2</description>
+      </entry>
+      <entry value="23" name="MAV_TYPE_VTOL_RESERVED3">
+        <description>VTOL reserved 3</description>
+      </entry>
+      <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
+        <description>VTOL reserved 4</description>
+      </entry>
+      <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
+        <description>VTOL reserved 5</description>
+      </entry>
+      <entry value="26" name="MAV_TYPE_GIMBAL">
+        <description>Onboard gimbal</description>
+      </entry>
+      <entry value="27" name="MAV_TYPE_ADSB">
+        <description>Onboard ADSB peripheral</description>
+      </entry>
+    </enum>
+    <enum name="FIRMWARE_VERSION_TYPE">
+      <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>
+      <entry value="0" name="FIRMWARE_VERSION_TYPE_DEV">
+        <description>development release</description>
+      </entry>
+      <entry value="64" name="FIRMWARE_VERSION_TYPE_ALPHA">
+        <description>alpha release</description>
+      </entry>
+      <entry value="128" name="FIRMWARE_VERSION_TYPE_BETA">
+        <description>beta release</description>
+      </entry>
+      <entry value="192" name="FIRMWARE_VERSION_TYPE_RC">
+        <description>release candidate</description>
+      </entry>
+      <entry value="255" name="FIRMWARE_VERSION_TYPE_OFFICIAL">
+        <description>official stable release</description>
+      </entry>
+    </enum>
+    <!-- WARNING: MAV_ACTION Enum is no longer supported - has been removed. Please use MAV_CMD -->
+    <enum name="MAV_MODE_FLAG">
+      <description>These flags encode the MAV mode.</description>
+      <entry value="128" name="MAV_MODE_FLAG_SAFETY_ARMED">
+        <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignore when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
+      </entry>
+      <entry value="64" name="MAV_MODE_FLAG_MANUAL_INPUT_ENABLED">
+        <description>0b01000000 remote control input is enabled.</description>
+      </entry>
+      <entry value="32" name="MAV_MODE_FLAG_HIL_ENABLED">
+        <description>0b00100000 hardware in the loop simulation. All motors / actuators are blocked, but internal software is full operational.</description>
+      </entry>
+      <entry value="16" name="MAV_MODE_FLAG_STABILIZE_ENABLED">
+        <description>0b00010000 system stabilizes electronically its attitude (and optionally position). It needs however further control inputs to move around.</description>
+      </entry>
+      <entry value="8" name="MAV_MODE_FLAG_GUIDED_ENABLED">
+        <description>0b00001000 guided mode enabled, system flies MISSIONs / mission items.</description>
+      </entry>
+      <entry value="4" name="MAV_MODE_FLAG_AUTO_ENABLED">
+        <description>0b00000100 autonomous mode enabled, system finds its own goal positions. Guided flag can be set or not, depends on the actual implementation.</description>
+      </entry>
+      <entry value="2" name="MAV_MODE_FLAG_TEST_ENABLED">
+        <description>0b00000010 system has a test mode enabled. This flag is intended for temporary system tests and should not be used for stable implementations.</description>
+      </entry>
+      <entry value="1" name="MAV_MODE_FLAG_CUSTOM_MODE_ENABLED">
+        <description>0b00000001 Reserved for future use.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MODE_FLAG_DECODE_POSITION">
+      <description>These values encode the bit positions of the decode position. These values can be used to read the value of a flag bit by combining the base_mode variable with AND with the flag position value. The result will be either 0 or 1, depending on if the flag is set or not.</description>
+      <entry value="128" name="MAV_MODE_FLAG_DECODE_POSITION_SAFETY">
+        <description>First bit:  10000000</description>
+      </entry>
+      <entry value="64" name="MAV_MODE_FLAG_DECODE_POSITION_MANUAL">
+        <description>Second bit: 01000000</description>
+      </entry>
+      <entry value="32" name="MAV_MODE_FLAG_DECODE_POSITION_HIL">
+        <description>Third bit:  00100000</description>
+      </entry>
+      <entry value="16" name="MAV_MODE_FLAG_DECODE_POSITION_STABILIZE">
+        <description>Fourth bit: 00010000</description>
+      </entry>
+      <entry value="8" name="MAV_MODE_FLAG_DECODE_POSITION_GUIDED">
+        <description>Fifth bit:  00001000</description>
+      </entry>
+      <entry value="4" name="MAV_MODE_FLAG_DECODE_POSITION_AUTO">
+        <description>Sixt bit:   00000100</description>
+      </entry>
+      <entry value="2" name="MAV_MODE_FLAG_DECODE_POSITION_TEST">
+        <description>Seventh bit: 00000010</description>
+      </entry>
+      <entry value="1" name="MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE">
+        <description>Eighth bit: 00000001</description>
+      </entry>
+    </enum>
+    <enum name="MAV_GOTO">
+      <description>Override command, pauses current mission execution and moves immediately to a position</description>
+      <entry value="0" name="MAV_GOTO_DO_HOLD">
+        <description>Hold at the current position.</description>
+      </entry>
+      <entry value="1" name="MAV_GOTO_DO_CONTINUE">
+        <description>Continue with the next item in mission execution.</description>
+      </entry>
+      <entry value="2" name="MAV_GOTO_HOLD_AT_CURRENT_POSITION">
+        <description>Hold at the current position of the system</description>
+      </entry>
+      <entry value="3" name="MAV_GOTO_HOLD_AT_SPECIFIED_POSITION">
+        <description>Hold at the position specified in the parameters of the DO_HOLD action</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MODE">
+      <description>These defines are predefined OR-combined mode flags. There is no need to use values from this enum, but it
                simplifies the use of the mode flags. Note that manual input is enabled in all modes as a safety override.</description>
-               <entry value="0" name="MAV_MODE_PREFLIGHT">
-                    <description>System is not ready to fly, booting, calibrating, etc. No flag is set.</description>
-               </entry>
-               <entry value="80" name="MAV_MODE_STABILIZE_DISARMED">
-                    <description>System is allowed to be active, under assisted RC control.</description>
-               </entry>
-               <entry value="208" name="MAV_MODE_STABILIZE_ARMED">
-                    <description>System is allowed to be active, under assisted RC control.</description>
-               </entry>
-               <entry value="64" name="MAV_MODE_MANUAL_DISARMED">
-                    <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
-               </entry>
-               <entry value="192" name="MAV_MODE_MANUAL_ARMED">
-                    <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
-               </entry>
-               <entry value="88" name="MAV_MODE_GUIDED_DISARMED">
-                    <description>System is allowed to be active, under autonomous control, manual setpoint</description>
-               </entry>
-               <entry value="216" name="MAV_MODE_GUIDED_ARMED">
-                    <description>System is allowed to be active, under autonomous control, manual setpoint</description>
-               </entry>
-               <entry value="92" name="MAV_MODE_AUTO_DISARMED">
-                    <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by MISSIONs)</description>
-               </entry>
-               <entry value="220" name="MAV_MODE_AUTO_ARMED">
-                    <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by MISSIONs)</description>
-               </entry>
-               <entry value="66" name="MAV_MODE_TEST_DISARMED">
-                    <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
-               </entry>
-               <entry value="194" name="MAV_MODE_TEST_ARMED">
-                    <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
-               </entry>
-          </enum>
-          <enum name="MAV_STATE">
-               <entry value="0" name="MAV_STATE_UNINIT">
-                    <description>Uninitialized system, state is unknown.</description>
-               </entry>
-               <entry name="MAV_STATE_BOOT">
-                    <description>System is booting up.</description>
-               </entry>
-               <entry name="MAV_STATE_CALIBRATING">
-                    <description>System is calibrating and not flight-ready.</description>
-               </entry>
-               <entry name="MAV_STATE_STANDBY">
-                    <description>System is grounded and on standby. It can be launched any time.</description>
-               </entry>
-               <entry name="MAV_STATE_ACTIVE">
-                    <description>System is active and might be already airborne. Motors are engaged.</description>
-               </entry>
-               <entry name="MAV_STATE_CRITICAL">
-                    <description>System is in a non-normal flight mode. It can however still navigate.</description>
-               </entry>
-               <entry name="MAV_STATE_EMERGENCY">
-                    <description>System is in a non-normal flight mode. It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
-               </entry>
-               <entry name="MAV_STATE_POWEROFF">
-                    <description>System just initialized its power-down sequence, will shut down now.</description>
-               </entry>
-          </enum>
-          <enum name="MAV_COMPONENT">
-               <entry value="0" name="MAV_COMP_ID_ALL">
-                    <description/>
-               </entry>
-               <entry value="220" name="MAV_COMP_ID_GPS">
-                    <description/>
-               </entry>
-               <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
-                    <description/>
-               </entry>
-               <entry value="195" name="MAV_COMP_ID_PATHPLANNER">
-                    <description/>
-               </entry>
-               <entry value="180" name="MAV_COMP_ID_MAPPER">
-                    <description/>
-               </entry>
-               <entry value="100" name="MAV_COMP_ID_CAMERA">
-                    <description/>
-               </entry>
-               <entry value="200" name="MAV_COMP_ID_IMU">
-                    <description/>
-               </entry>
-               <entry value="201" name="MAV_COMP_ID_IMU_2">
-                    <description/>
-               </entry>
-               <entry value="202" name="MAV_COMP_ID_IMU_3">
-                    <description/>
-               </entry>
-               <entry value="240" name="MAV_COMP_ID_UDP_BRIDGE">
-                    <description/>
-               </entry>
-               <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
-                    <description/>
-               </entry>
-               <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
-                    <description/>
-               </entry>
-               <entry value="140" name="MAV_COMP_ID_SERVO1">
-                    <description/>
-               </entry>
-               <entry value="141" name="MAV_COMP_ID_SERVO2">
-                    <description/>
-               </entry>
-               <entry value="142" name="MAV_COMP_ID_SERVO3">
-                    <description/>
-               </entry>
-               <entry value="143" name="MAV_COMP_ID_SERVO4">
-                    <description/>
-               </entry>
-               <entry value="144" name="MAV_COMP_ID_SERVO5">
-                    <description/>
-               </entry>
-               <entry value="145" name="MAV_COMP_ID_SERVO6">
-                    <description/>
-               </entry>
-               <entry value="146" name="MAV_COMP_ID_SERVO7">
-                    <description/>
-               </entry>
-               <entry value="147" name="MAV_COMP_ID_SERVO8">
-                    <description/>
-               </entry>
-               <entry value="148" name="MAV_COMP_ID_SERVO9">
-                    <description/>
-               </entry>
-               <entry value="149" name="MAV_COMP_ID_SERVO10">
-                    <description/>
-               </entry>
-               <entry value="150" name="MAV_COMP_ID_SERVO11">
-                    <description/>
-               </entry>
-               <entry value="151" name="MAV_COMP_ID_SERVO12">
-                    <description/>
-               </entry>
-               <entry value="152" name="MAV_COMP_ID_SERVO13">
-                    <description/>
-               </entry>
-               <entry value="153" name="MAV_COMP_ID_SERVO14">
-                    <description/>
-               </entry>
-               <entry value="154" name="MAV_COMP_ID_GIMBAL">
-                    <description/>
-               </entry>
-               <entry value="155" name="MAV_COMP_ID_LOG">
-                    <description/>
-               </entry>
-               <entry value="156" name="MAV_COMP_ID_ADSB">
-                    <description/>
-               </entry>
-               <entry value="157" name="MAV_COMP_ID_OSD">
-                    <description>On Screen Display (OSD) devices for video links</description>
-               </entry>
-               <entry value="158" name="MAV_COMP_ID_PERIPHERAL">
-                    <description>Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter sub-protocol</description>
-               </entry>
-               <entry value="159" name="MAV_COMP_ID_QX1_GIMBAL">
-                    <description/>
-               </entry>
-          </enum>
-          <enum name="MAV_SYS_STATUS_SENSOR">
-               <description>These encode the sensors whose status is sent as part of the SYS_STATUS message.</description>
-               <entry value="1" name="MAV_SYS_STATUS_SENSOR_3D_GYRO">
-                    <description>0x01 3D gyro</description>
-               </entry>
-               <entry value="2" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL">
-                    <description>0x02 3D accelerometer</description>
-               </entry>
-               <entry value="4" name="MAV_SYS_STATUS_SENSOR_3D_MAG">
-                    <description>0x04 3D magnetometer</description>
-               </entry>
-               <entry value="8" name="MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE">
-                    <description>0x08 absolute pressure</description>
-               </entry>
-               <entry value="16" name="MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE">
-                    <description>0x10 differential pressure</description>
-               </entry>
-               <entry value="32" name="MAV_SYS_STATUS_SENSOR_GPS">
-                    <description>0x20 GPS</description>
-               </entry>
-               <entry value="64" name="MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW">
-                    <description>0x40 optical flow</description>
-               </entry>
-               <entry value="128" name="MAV_SYS_STATUS_SENSOR_VISION_POSITION">
-                    <description>0x80 computer vision position</description>
-               </entry>
-               <entry value="256" name="MAV_SYS_STATUS_SENSOR_LASER_POSITION">
-                    <description>0x100 laser based position</description>
-               </entry>
-               <entry value="512" name="MAV_SYS_STATUS_SENSOR_EXTERNAL_GROUND_TRUTH">
-                    <description>0x200 external ground truth (Vicon or Leica)</description>
-               </entry>
-               <entry value="1024" name="MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL">
-                    <description>0x400 3D angular rate control</description>
-               </entry>
-               <entry value="2048" name="MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION">
-                    <description>0x800 attitude stabilization</description>
-               </entry>
-               <entry value="4096" name="MAV_SYS_STATUS_SENSOR_YAW_POSITION">
-                    <description>0x1000 yaw position</description>
-               </entry>
-               <entry value="8192" name="MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL">
-                    <description>0x2000 z/altitude control</description>
-               </entry>
-               <entry value="16384" name="MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL">
-                    <description>0x4000 x/y position control</description>
-               </entry>
-               <entry value="32768" name="MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS">
-                    <description>0x8000 motor outputs / control</description>
-               </entry>
-               <entry value="65536" name="MAV_SYS_STATUS_SENSOR_RC_RECEIVER">
-                    <description>0x10000 rc receiver</description>
-               </entry>
-               <entry value="131072" name="MAV_SYS_STATUS_SENSOR_3D_GYRO2">
-                    <description>0x20000 2nd 3D gyro</description>
-               </entry>
-               <entry value="262144" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL2">
-                    <description>0x40000 2nd 3D accelerometer</description>
-               </entry>
-               <entry value="524288" name="MAV_SYS_STATUS_SENSOR_3D_MAG2">
-                    <description>0x80000 2nd 3D magnetometer</description>
-               </entry>
-               <entry value="1048576" name="MAV_SYS_STATUS_GEOFENCE">
-                    <description>0x100000 geofence</description>
-               </entry>
-               <entry value="2097152" name="MAV_SYS_STATUS_AHRS">
-                    <description>0x200000 AHRS subsystem health</description>
-               </entry>
-               <entry value="4194304" name="MAV_SYS_STATUS_TERRAIN">
-                    <description>0x400000 Terrain subsystem health</description>
-               </entry>
-               <entry value="8388608" name="MAV_SYS_STATUS_REVERSE_MOTOR">
-                    <description>0x800000 Motors are reversed</description>
-               </entry>
-               <entry value="16777216" name="MAV_SYS_STATUS_LOGGING">
-                    <description>0x1000000 Logging</description>
-               </entry>
-          </enum>
-          <enum name="MAV_FRAME">
-               <entry value="0" name="MAV_FRAME_GLOBAL">
-                    <description>Global coordinate frame, WGS84 coordinate system. First value / x: latitude, second value / y: longitude, third value / z: positive altitude over mean sea level (MSL)</description>
-               </entry>
-               <entry value="1" name="MAV_FRAME_LOCAL_NED">
-                    <description>Local coordinate frame, Z-up (x: north, y: east, z: down).</description>
-               </entry>
-               <entry value="2" name="MAV_FRAME_MISSION">
-                    <description>NOT a coordinate frame, indicates a mission command.</description>
-               </entry>
-               <entry value="3" name="MAV_FRAME_GLOBAL_RELATIVE_ALT">
-                    <description>Global coordinate frame, WGS84 coordinate system, relative altitude over ground with respect to the home position. First value / x: latitude, second value / y: longitude, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
-               </entry>
-               <entry value="4" name="MAV_FRAME_LOCAL_ENU">
-                    <description>Local coordinate frame, Z-down (x: east, y: north, z: up)</description>
-               </entry>
-               <entry value="5" name="MAV_FRAME_GLOBAL_INT">
-                   <description>Global coordinate frame, WGS84 coordinate system. First value / x: latitude in degrees*1.0e-7, second value / y: longitude in degrees*1.0e-7, third value / z: positive altitude over mean sea level (MSL)</description>
-               </entry>
-               <entry value="6" name="MAV_FRAME_GLOBAL_RELATIVE_ALT_INT">
-                   <description>Global coordinate frame, WGS84 coordinate system, relative altitude over ground with respect to the home position. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
-               </entry>
-               <entry value="7" name="MAV_FRAME_LOCAL_OFFSET_NED">
-                   <description>Offset to the current local frame. Anything expressed in this frame should be added to the current local frame position.</description>
-               </entry>
-               <entry value="8" name="MAV_FRAME_BODY_NED">
-                   <description>Setpoint in body NED frame. This makes sense if all position control is externalized - e.g. useful to command 2 m/s^2 acceleration to the right.</description>
-               </entry>
-               <entry value="9" name="MAV_FRAME_BODY_OFFSET_NED">
-                   <description>Offset in body NED frame. This makes sense if adding setpoints to the current flight path, to avoid an obstacle - e.g. useful to command 2 m/s^2 acceleration to the east.</description>
-               </entry>
-               <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">
-                   <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
-               </entry>
-               <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
-                   <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
-               </entry>
-          </enum>
-          <enum name="MAVLINK_DATA_STREAM_TYPE">
-               <entry name="MAVLINK_DATA_STREAM_IMG_JPEG">
-                    <description/>
-               </entry>
-               <entry name="MAVLINK_DATA_STREAM_IMG_BMP">
-                    <description/>
-               </entry>
-               <entry name="MAVLINK_DATA_STREAM_IMG_RAW8U">
-                    <description/>
-               </entry>
-               <entry name="MAVLINK_DATA_STREAM_IMG_RAW32U">
-                    <description/>
-               </entry>
-               <entry name="MAVLINK_DATA_STREAM_IMG_PGM">
-                    <description/>
-               </entry>
-               <entry name="MAVLINK_DATA_STREAM_IMG_PNG">
-                    <description/>
-               </entry>
-          </enum>
-          <!-- fenced mode enums -->
-          <enum name="FENCE_ACTION">
-              <entry name="FENCE_ACTION_NONE" value="0">
-                  <description>Disable fenced mode</description>
-              </entry>
-              <entry name="FENCE_ACTION_GUIDED" value="1">
-                  <description>Switched to guided mode to return point (fence point 0)</description>
-              </entry>
-              <entry name="FENCE_ACTION_REPORT" value="2">
-                  <description>Report fence breach, but don't take action</description>
-              </entry>
-              <entry name="FENCE_ACTION_GUIDED_THR_PASS" value="3">
-                  <description>Switched to guided mode to return point (fence point 0) with manual throttle control</description>
-              </entry>
-              <entry name="FENCE_ACTION_RTL" value="4">
-                  <description>Switch to RTL (return to launch) mode and head for the return point.</description>
-              </entry>
-          </enum>
-
-          <enum name="FENCE_BREACH">
-              <entry name="FENCE_BREACH_NONE" value="0">
-                  <description>No last fence breach</description>
-              </entry>
-              <entry name="FENCE_BREACH_MINALT" value="1">
-                  <description>Breached minimum altitude</description>
-              </entry>
-              <entry name="FENCE_BREACH_MAXALT" value="2">
-                  <description>Breached maximum altitude</description>
-              </entry>
-              <entry name="FENCE_BREACH_BOUNDARY" value="3">
-                  <description>Breached fence boundary</description>
-              </entry>
-          </enum>
-          <!-- Camera Mount mode Enumeration -->
-          <enum name="MAV_MOUNT_MODE">
-              <description>Enumeration of possible mount operation modes</description>
-              <entry name="MAV_MOUNT_MODE_RETRACT" value="0"><description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description></entry>
-              <entry name="MAV_MOUNT_MODE_NEUTRAL" value="1"><description>Load and keep neutral position (Roll,Pitch,Yaw) from permanent memory.</description></entry>
-              <entry name="MAV_MOUNT_MODE_MAVLINK_TARGETING" value="2"><description>Load neutral position and start MAVLink Roll,Pitch,Yaw control with stabilization</description></entry>
-              <entry name="MAV_MOUNT_MODE_RC_TARGETING" value="3"><description>Load neutral position and start RC Roll,Pitch,Yaw control with stabilization</description></entry>
-              <entry name="MAV_MOUNT_MODE_GPS_POINT" value="4"><description>Load neutral position and start to point to Lat,Lon,Alt</description></entry>
-          </enum>
-          <enum name="MAV_CMD">
-               <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data.</description>
-               <entry value="16" name="MAV_CMD_NAV_WAYPOINT">
-                    <description>Navigate to MISSION.</description>
-                    <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
-                    <param index="2">Acceptance radius in meters (if the sphere with this radius is hit, the MISSION counts as reached)</param>
-                    <param index="3">0 to pass through the WP, if > 0 radius in meters to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
-                    <param index="4">Desired yaw angle at MISSION (rotary wing)</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="17" name="MAV_CMD_NAV_LOITER_UNLIM">
-                    <description>Loiter around this MISSION an unlimited amount of time</description>
-                    <param index="1">Empty</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-                    <param index="4">Desired yaw angle.</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="18" name="MAV_CMD_NAV_LOITER_TURNS">
-                    <description>Loiter around this MISSION for X turns</description>
-                    <param index="1">Turns</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="19" name="MAV_CMD_NAV_LOITER_TIME">
-                    <description>Loiter around this MISSION for X seconds</description>
-                    <param index="1">Seconds (decimal)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="20" name="MAV_CMD_NAV_RETURN_TO_LAUNCH">
-                    <description>Return to launch location</description>
-                    <param index="1">Empty</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="21" name="MAV_CMD_NAV_LAND">
-                    <description>Land at location</description>
-                    <param index="1">Abort Alt</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Desired yaw angle</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="22" name="MAV_CMD_NAV_TAKEOFF">
-                    <description>Takeoff from ground / hand</description>
-                    <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Yaw angle (if magnetometer present), ignored without magnetometer</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="23" name="MAV_CMD_NAV_LAND_LOCAL">
-                    <description>Land at local position (local frame only)</description>
-                    <param index="1">Landing target number (if available)</param>
-                    <param index="2">Maximum accepted offset from desired landing position [m] - computed magnitude from spherical coordinates: d = sqrt(x^2 + y^2 + z^2), which gives the maximum accepted distance between the desired landing position and the position where the vehicle is about to land</param>
-                    <param index="3">Landing descend rate [ms^-1]</param>
-                    <param index="4">Desired yaw angle [rad]</param>
-                    <param index="5">Y-axis position [m]</param>
-                    <param index="6">X-axis position [m]</param>
-                    <param index="7">Z-axis / ground level position [m]</param>
-               </entry>
-               <entry value="24" name="MAV_CMD_NAV_TAKEOFF_LOCAL">
-                    <description>Takeoff from local position (local frame only)</description>
-                    <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor [rad]</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Takeoff ascend rate [ms^-1]</param>
-                    <param index="4">Yaw angle [rad] (if magnetometer or another yaw estimation source present), ignored without one of these</param>
-                    <param index="5">Y-axis position [m]</param>
-                    <param index="6">X-axis position [m]</param>
-                    <param index="7">Z-axis position [m]</param>
-               </entry>
-               <entry value="25" name="MAV_CMD_NAV_FOLLOW">
-                    <description>Vehicle following, i.e. this waypoint represents the position of a moving vehicle</description>
-                    <param index="1">Following logic to use (e.g. loitering or sinusoidal following) - depends on specific autopilot implementation</param>
-                    <param index="2">Ground speed of vehicle to be followed</param>
-                    <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
-                    <param index="4">Desired yaw angle.</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT">
-                   <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
-                   <param index="1">Climb or Descend (0 = Neutral, command completes when within 5m of this command's altitude, 1 = Climbing, command completes when at or above this command's altitude, 2 = Descending, command completes when at or below this command's altitude. </param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Desired altitude in meters</param>
-               </entry>
-                <entry value="31" name="MAV_CMD_NAV_LOITER_TO_ALT">
-                    <description>Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint. </description>
-                    <param index="1">Heading Required (0 = False)</param>
-                    <param index="2">Radius in meters. If positive loiter clockwise, negative counter-clockwise, 0 means no change to standard loiter.</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="32" name="MAV_CMD_DO_FOLLOW">
-                    <description>Being following a target</description>
-                    <param index="1">System ID (the system ID of the FOLLOW_TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode</param>
-                    <param index="2">RESERVED</param>
-                    <param index="3">RESERVED</param>
-                    <param index="4">altitude flag: 0: Keep current altitude, 1: keep altitude difference to target, 2: go to a fixed altitude above home</param>
-                    <param index="5">altitude</param>
-                    <param index="6">RESERVED</param>
-                    <param index="7">TTL in seconds in which the MAV should go to the default position hold mode after a message rx timeout</param>
-               </entry>
-               <entry value="33" name="MAV_CMD_DO_FOLLOW_REPOSITION">
-                    <description>Reposition the MAV after a follow target command has been sent</description>
-                    <param index="1">Camera q1 (where 0 is on the ray from the camera to the tracking device)</param>
-                    <param index="2">Camera q2</param>
-                    <param index="3">Camera q3</param>
-                    <param index="4">Camera q4</param>
-                    <param index="5">altitude offset from target (m)</param>
-                    <param index="6">X offset from target (m)</param>
-                    <param index="7">Y offset from target (m)</param>
-               </entry>
-               <entry value="80" name="MAV_CMD_NAV_ROI">
-                    <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
-                    <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
-                    <param index="2">MISSION index/ target ID. (see MAV_ROI enum)</param>
-                    <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
-                    <param index="4">Empty</param>
-                    <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
-                    <param index="6">y</param>
-                    <param index="7">z</param>
-               </entry>
-               <entry value="81" name="MAV_CMD_NAV_PATHPLANNING">
-                    <description>Control autonomous path planning on the MAV.</description>
-                    <param index="1">0: Disable local obstacle avoidance / local path planning (without resetting map), 1: Enable local path planning, 2: Enable and reset local path planning</param>
-                    <param index="2">0: Disable full path planning (without resetting map), 1: Enable, 2: Enable and reset map/occupancy grid, 3: Enable and reset planned route, but not occupancy grid</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Yaw angle at goal, in compass degrees, [0..360]</param>
-                    <param index="5">Latitude/X of goal</param>
-                    <param index="6">Longitude/Y of goal</param>
-                    <param index="7">Altitude/Z of goal</param>
-               </entry>
-               <entry value="82" name="MAV_CMD_NAV_SPLINE_WAYPOINT">
-                    <description>Navigate to MISSION using a spline path.</description>
-                    <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Latitude/X of goal</param>
-                    <param index="6">Longitude/Y of goal</param>
-                    <param index="7">Altitude/Z of goal</param>
-               </entry>
-               <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
-                    <description>Takeoff from ground using VTOL mode</description>
-                    <param index="1">Empty</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Yaw angle in degrees</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="85" name="MAV_CMD_NAV_VTOL_LAND">
-                    <description>Land using VTOL mode</description>
-                    <param index="1">Empty</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Yaw angle in degrees</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-
-               <!-- IDs 90 and 91 are reserved until the end of 2014,
+      <entry value="0" name="MAV_MODE_PREFLIGHT">
+        <description>System is not ready to fly, booting, calibrating, etc. No flag is set.</description>
+      </entry>
+      <entry value="80" name="MAV_MODE_STABILIZE_DISARMED">
+        <description>System is allowed to be active, under assisted RC control.</description>
+      </entry>
+      <entry value="208" name="MAV_MODE_STABILIZE_ARMED">
+        <description>System is allowed to be active, under assisted RC control.</description>
+      </entry>
+      <entry value="64" name="MAV_MODE_MANUAL_DISARMED">
+        <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
+      </entry>
+      <entry value="192" name="MAV_MODE_MANUAL_ARMED">
+        <description>System is allowed to be active, under manual (RC) control, no stabilization</description>
+      </entry>
+      <entry value="88" name="MAV_MODE_GUIDED_DISARMED">
+        <description>System is allowed to be active, under autonomous control, manual setpoint</description>
+      </entry>
+      <entry value="216" name="MAV_MODE_GUIDED_ARMED">
+        <description>System is allowed to be active, under autonomous control, manual setpoint</description>
+      </entry>
+      <entry value="92" name="MAV_MODE_AUTO_DISARMED">
+        <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by MISSIONs)</description>
+      </entry>
+      <entry value="220" name="MAV_MODE_AUTO_ARMED">
+        <description>System is allowed to be active, under autonomous control and navigation (the trajectory is decided onboard and not pre-programmed by MISSIONs)</description>
+      </entry>
+      <entry value="66" name="MAV_MODE_TEST_DISARMED">
+        <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
+      </entry>
+      <entry value="194" name="MAV_MODE_TEST_ARMED">
+        <description>UNDEFINED mode. This solely depends on the autopilot - use with caution, intended for developers only.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_STATE">
+      <entry value="0" name="MAV_STATE_UNINIT">
+        <description>Uninitialized system, state is unknown.</description>
+      </entry>
+      <entry name="MAV_STATE_BOOT">
+        <description>System is booting up.</description>
+      </entry>
+      <entry name="MAV_STATE_CALIBRATING">
+        <description>System is calibrating and not flight-ready.</description>
+      </entry>
+      <entry name="MAV_STATE_STANDBY">
+        <description>System is grounded and on standby. It can be launched any time.</description>
+      </entry>
+      <entry name="MAV_STATE_ACTIVE">
+        <description>System is active and might be already airborne. Motors are engaged.</description>
+      </entry>
+      <entry name="MAV_STATE_CRITICAL">
+        <description>System is in a non-normal flight mode. It can however still navigate.</description>
+      </entry>
+      <entry name="MAV_STATE_EMERGENCY">
+        <description>System is in a non-normal flight mode. It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
+      </entry>
+      <entry name="MAV_STATE_POWEROFF">
+        <description>System just initialized its power-down sequence, will shut down now.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_COMPONENT">
+      <entry value="0" name="MAV_COMP_ID_ALL">
+        <description/>
+      </entry>
+      <entry value="220" name="MAV_COMP_ID_GPS">
+        <description/>
+      </entry>
+      <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
+        <description/>
+      </entry>
+      <entry value="195" name="MAV_COMP_ID_PATHPLANNER">
+        <description/>
+      </entry>
+      <entry value="180" name="MAV_COMP_ID_MAPPER">
+        <description/>
+      </entry>
+      <entry value="100" name="MAV_COMP_ID_CAMERA">
+        <description/>
+      </entry>
+      <entry value="200" name="MAV_COMP_ID_IMU">
+        <description/>
+      </entry>
+      <entry value="201" name="MAV_COMP_ID_IMU_2">
+        <description/>
+      </entry>
+      <entry value="202" name="MAV_COMP_ID_IMU_3">
+        <description/>
+      </entry>
+      <entry value="240" name="MAV_COMP_ID_UDP_BRIDGE">
+        <description/>
+      </entry>
+      <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
+        <description/>
+      </entry>
+      <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
+        <description/>
+      </entry>
+      <entry value="140" name="MAV_COMP_ID_SERVO1">
+        <description/>
+      </entry>
+      <entry value="141" name="MAV_COMP_ID_SERVO2">
+        <description/>
+      </entry>
+      <entry value="142" name="MAV_COMP_ID_SERVO3">
+        <description/>
+      </entry>
+      <entry value="143" name="MAV_COMP_ID_SERVO4">
+        <description/>
+      </entry>
+      <entry value="144" name="MAV_COMP_ID_SERVO5">
+        <description/>
+      </entry>
+      <entry value="145" name="MAV_COMP_ID_SERVO6">
+        <description/>
+      </entry>
+      <entry value="146" name="MAV_COMP_ID_SERVO7">
+        <description/>
+      </entry>
+      <entry value="147" name="MAV_COMP_ID_SERVO8">
+        <description/>
+      </entry>
+      <entry value="148" name="MAV_COMP_ID_SERVO9">
+        <description/>
+      </entry>
+      <entry value="149" name="MAV_COMP_ID_SERVO10">
+        <description/>
+      </entry>
+      <entry value="150" name="MAV_COMP_ID_SERVO11">
+        <description/>
+      </entry>
+      <entry value="151" name="MAV_COMP_ID_SERVO12">
+        <description/>
+      </entry>
+      <entry value="152" name="MAV_COMP_ID_SERVO13">
+        <description/>
+      </entry>
+      <entry value="153" name="MAV_COMP_ID_SERVO14">
+        <description/>
+      </entry>
+      <entry value="154" name="MAV_COMP_ID_GIMBAL">
+        <description/>
+      </entry>
+      <entry value="155" name="MAV_COMP_ID_LOG">
+        <description/>
+      </entry>
+      <entry value="156" name="MAV_COMP_ID_ADSB">
+        <description/>
+      </entry>
+      <entry value="157" name="MAV_COMP_ID_OSD">
+        <description>On Screen Display (OSD) devices for video links</description>
+      </entry>
+      <entry value="158" name="MAV_COMP_ID_PERIPHERAL">
+        <description>Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter sub-protocol</description>
+      </entry>
+      <entry value="159" name="MAV_COMP_ID_QX1_GIMBAL">
+        <description/>
+      </entry>
+    </enum>
+    <enum name="MAV_SYS_STATUS_SENSOR">
+      <description>These encode the sensors whose status is sent as part of the SYS_STATUS message.</description>
+      <entry value="1" name="MAV_SYS_STATUS_SENSOR_3D_GYRO">
+        <description>0x01 3D gyro</description>
+      </entry>
+      <entry value="2" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL">
+        <description>0x02 3D accelerometer</description>
+      </entry>
+      <entry value="4" name="MAV_SYS_STATUS_SENSOR_3D_MAG">
+        <description>0x04 3D magnetometer</description>
+      </entry>
+      <entry value="8" name="MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE">
+        <description>0x08 absolute pressure</description>
+      </entry>
+      <entry value="16" name="MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE">
+        <description>0x10 differential pressure</description>
+      </entry>
+      <entry value="32" name="MAV_SYS_STATUS_SENSOR_GPS">
+        <description>0x20 GPS</description>
+      </entry>
+      <entry value="64" name="MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW">
+        <description>0x40 optical flow</description>
+      </entry>
+      <entry value="128" name="MAV_SYS_STATUS_SENSOR_VISION_POSITION">
+        <description>0x80 computer vision position</description>
+      </entry>
+      <entry value="256" name="MAV_SYS_STATUS_SENSOR_LASER_POSITION">
+        <description>0x100 laser based position</description>
+      </entry>
+      <entry value="512" name="MAV_SYS_STATUS_SENSOR_EXTERNAL_GROUND_TRUTH">
+        <description>0x200 external ground truth (Vicon or Leica)</description>
+      </entry>
+      <entry value="1024" name="MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL">
+        <description>0x400 3D angular rate control</description>
+      </entry>
+      <entry value="2048" name="MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION">
+        <description>0x800 attitude stabilization</description>
+      </entry>
+      <entry value="4096" name="MAV_SYS_STATUS_SENSOR_YAW_POSITION">
+        <description>0x1000 yaw position</description>
+      </entry>
+      <entry value="8192" name="MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL">
+        <description>0x2000 z/altitude control</description>
+      </entry>
+      <entry value="16384" name="MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL">
+        <description>0x4000 x/y position control</description>
+      </entry>
+      <entry value="32768" name="MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS">
+        <description>0x8000 motor outputs / control</description>
+      </entry>
+      <entry value="65536" name="MAV_SYS_STATUS_SENSOR_RC_RECEIVER">
+        <description>0x10000 rc receiver</description>
+      </entry>
+      <entry value="131072" name="MAV_SYS_STATUS_SENSOR_3D_GYRO2">
+        <description>0x20000 2nd 3D gyro</description>
+      </entry>
+      <entry value="262144" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL2">
+        <description>0x40000 2nd 3D accelerometer</description>
+      </entry>
+      <entry value="524288" name="MAV_SYS_STATUS_SENSOR_3D_MAG2">
+        <description>0x80000 2nd 3D magnetometer</description>
+      </entry>
+      <entry value="1048576" name="MAV_SYS_STATUS_GEOFENCE">
+        <description>0x100000 geofence</description>
+      </entry>
+      <entry value="2097152" name="MAV_SYS_STATUS_AHRS">
+        <description>0x200000 AHRS subsystem health</description>
+      </entry>
+      <entry value="4194304" name="MAV_SYS_STATUS_TERRAIN">
+        <description>0x400000 Terrain subsystem health</description>
+      </entry>
+      <entry value="8388608" name="MAV_SYS_STATUS_REVERSE_MOTOR">
+        <description>0x800000 Motors are reversed</description>
+      </entry>
+      <entry value="16777216" name="MAV_SYS_STATUS_LOGGING">
+        <description>0x1000000 Logging</description>
+      </entry>
+    </enum>
+    <enum name="MAV_FRAME">
+      <entry value="0" name="MAV_FRAME_GLOBAL">
+        <description>Global coordinate frame, WGS84 coordinate system. First value / x: latitude, second value / y: longitude, third value / z: positive altitude over mean sea level (MSL)</description>
+      </entry>
+      <entry value="1" name="MAV_FRAME_LOCAL_NED">
+        <description>Local coordinate frame, Z-up (x: north, y: east, z: down).</description>
+      </entry>
+      <entry value="2" name="MAV_FRAME_MISSION">
+        <description>NOT a coordinate frame, indicates a mission command.</description>
+      </entry>
+      <entry value="3" name="MAV_FRAME_GLOBAL_RELATIVE_ALT">
+        <description>Global coordinate frame, WGS84 coordinate system, relative altitude over ground with respect to the home position. First value / x: latitude, second value / y: longitude, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
+      </entry>
+      <entry value="4" name="MAV_FRAME_LOCAL_ENU">
+        <description>Local coordinate frame, Z-down (x: east, y: north, z: up)</description>
+      </entry>
+      <entry value="5" name="MAV_FRAME_GLOBAL_INT">
+        <description>Global coordinate frame, WGS84 coordinate system. First value / x: latitude in degrees*1.0e-7, second value / y: longitude in degrees*1.0e-7, third value / z: positive altitude over mean sea level (MSL)</description>
+      </entry>
+      <entry value="6" name="MAV_FRAME_GLOBAL_RELATIVE_ALT_INT">
+        <description>Global coordinate frame, WGS84 coordinate system, relative altitude over ground with respect to the home position. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude with 0 being at the altitude of the home location.</description>
+      </entry>
+      <entry value="7" name="MAV_FRAME_LOCAL_OFFSET_NED">
+        <description>Offset to the current local frame. Anything expressed in this frame should be added to the current local frame position.</description>
+      </entry>
+      <entry value="8" name="MAV_FRAME_BODY_NED">
+        <description>Setpoint in body NED frame. This makes sense if all position control is externalized - e.g. useful to command 2 m/s^2 acceleration to the right.</description>
+      </entry>
+      <entry value="9" name="MAV_FRAME_BODY_OFFSET_NED">
+        <description>Offset in body NED frame. This makes sense if adding setpoints to the current flight path, to avoid an obstacle - e.g. useful to command 2 m/s^2 acceleration to the east.</description>
+      </entry>
+      <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">
+        <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+      </entry>
+      <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
+        <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+      </entry>
+    </enum>
+    <enum name="MAVLINK_DATA_STREAM_TYPE">
+      <entry name="MAVLINK_DATA_STREAM_IMG_JPEG">
+        <description/>
+      </entry>
+      <entry name="MAVLINK_DATA_STREAM_IMG_BMP">
+        <description/>
+      </entry>
+      <entry name="MAVLINK_DATA_STREAM_IMG_RAW8U">
+        <description/>
+      </entry>
+      <entry name="MAVLINK_DATA_STREAM_IMG_RAW32U">
+        <description/>
+      </entry>
+      <entry name="MAVLINK_DATA_STREAM_IMG_PGM">
+        <description/>
+      </entry>
+      <entry name="MAVLINK_DATA_STREAM_IMG_PNG">
+        <description/>
+      </entry>
+    </enum>
+    <!-- fenced mode enums -->
+    <enum name="FENCE_ACTION">
+      <entry name="FENCE_ACTION_NONE" value="0">
+        <description>Disable fenced mode</description>
+      </entry>
+      <entry name="FENCE_ACTION_GUIDED" value="1">
+        <description>Switched to guided mode to return point (fence point 0)</description>
+      </entry>
+      <entry name="FENCE_ACTION_REPORT" value="2">
+        <description>Report fence breach, but don't take action</description>
+      </entry>
+      <entry name="FENCE_ACTION_GUIDED_THR_PASS" value="3">
+        <description>Switched to guided mode to return point (fence point 0) with manual throttle control</description>
+      </entry>
+      <entry name="FENCE_ACTION_RTL" value="4">
+        <description>Switch to RTL (return to launch) mode and head for the return point.</description>
+      </entry>
+    </enum>
+    <enum name="FENCE_BREACH">
+      <entry name="FENCE_BREACH_NONE" value="0">
+        <description>No last fence breach</description>
+      </entry>
+      <entry name="FENCE_BREACH_MINALT" value="1">
+        <description>Breached minimum altitude</description>
+      </entry>
+      <entry name="FENCE_BREACH_MAXALT" value="2">
+        <description>Breached maximum altitude</description>
+      </entry>
+      <entry name="FENCE_BREACH_BOUNDARY" value="3">
+        <description>Breached fence boundary</description>
+      </entry>
+    </enum>
+    <!-- Camera Mount mode Enumeration -->
+    <enum name="MAV_MOUNT_MODE">
+      <description>Enumeration of possible mount operation modes</description>
+      <entry name="MAV_MOUNT_MODE_RETRACT" value="0">
+        <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
+      </entry>
+      <entry name="MAV_MOUNT_MODE_NEUTRAL" value="1">
+        <description>Load and keep neutral position (Roll,Pitch,Yaw) from permanent memory.</description>
+      </entry>
+      <entry name="MAV_MOUNT_MODE_MAVLINK_TARGETING" value="2">
+        <description>Load neutral position and start MAVLink Roll,Pitch,Yaw control with stabilization</description>
+      </entry>
+      <entry name="MAV_MOUNT_MODE_RC_TARGETING" value="3">
+        <description>Load neutral position and start RC Roll,Pitch,Yaw control with stabilization</description>
+      </entry>
+      <entry name="MAV_MOUNT_MODE_GPS_POINT" value="4">
+        <description>Load neutral position and start to point to Lat,Lon,Alt</description>
+      </entry>
+    </enum>
+    <enum name="MAV_CMD">
+      <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data.</description>
+      <entry value="16" name="MAV_CMD_NAV_WAYPOINT">
+        <description>Navigate to MISSION.</description>
+        <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
+        <param index="2">Acceptance radius in meters (if the sphere with this radius is hit, the MISSION counts as reached)</param>
+        <param index="3">0 to pass through the WP, if &gt; 0 radius in meters to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
+        <param index="4">Desired yaw angle at MISSION (rotary wing)</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="17" name="MAV_CMD_NAV_LOITER_UNLIM">
+        <description>Loiter around this MISSION an unlimited amount of time</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
+        <param index="4">Desired yaw angle.</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="18" name="MAV_CMD_NAV_LOITER_TURNS">
+        <description>Loiter around this MISSION for X turns</description>
+        <param index="1">Turns</param>
+        <param index="2">Empty</param>
+        <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
+        <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="19" name="MAV_CMD_NAV_LOITER_TIME">
+        <description>Loiter around this MISSION for X seconds</description>
+        <param index="1">Seconds (decimal)</param>
+        <param index="2">Empty</param>
+        <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
+        <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location. Else, this is desired yaw angle</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="20" name="MAV_CMD_NAV_RETURN_TO_LAUNCH">
+        <description>Return to launch location</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="21" name="MAV_CMD_NAV_LAND">
+        <description>Land at location</description>
+        <param index="1">Abort Alt</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Desired yaw angle</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="22" name="MAV_CMD_NAV_TAKEOFF">
+        <description>Takeoff from ground / hand</description>
+        <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Yaw angle (if magnetometer present), ignored without magnetometer</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="23" name="MAV_CMD_NAV_LAND_LOCAL">
+        <description>Land at local position (local frame only)</description>
+        <param index="1">Landing target number (if available)</param>
+        <param index="2">Maximum accepted offset from desired landing position [m] - computed magnitude from spherical coordinates: d = sqrt(x^2 + y^2 + z^2), which gives the maximum accepted distance between the desired landing position and the position where the vehicle is about to land</param>
+        <param index="3">Landing descend rate [ms^-1]</param>
+        <param index="4">Desired yaw angle [rad]</param>
+        <param index="5">Y-axis position [m]</param>
+        <param index="6">X-axis position [m]</param>
+        <param index="7">Z-axis / ground level position [m]</param>
+      </entry>
+      <entry value="24" name="MAV_CMD_NAV_TAKEOFF_LOCAL">
+        <description>Takeoff from local position (local frame only)</description>
+        <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor [rad]</param>
+        <param index="2">Empty</param>
+        <param index="3">Takeoff ascend rate [ms^-1]</param>
+        <param index="4">Yaw angle [rad] (if magnetometer or another yaw estimation source present), ignored without one of these</param>
+        <param index="5">Y-axis position [m]</param>
+        <param index="6">X-axis position [m]</param>
+        <param index="7">Z-axis position [m]</param>
+      </entry>
+      <entry value="25" name="MAV_CMD_NAV_FOLLOW">
+        <description>Vehicle following, i.e. this waypoint represents the position of a moving vehicle</description>
+        <param index="1">Following logic to use (e.g. loitering or sinusoidal following) - depends on specific autopilot implementation</param>
+        <param index="2">Ground speed of vehicle to be followed</param>
+        <param index="3">Radius around MISSION, in meters. If positive loiter clockwise, else counter-clockwise</param>
+        <param index="4">Desired yaw angle.</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT">
+        <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
+        <param index="1">Climb or Descend (0 = Neutral, command completes when within 5m of this command's altitude, 1 = Climbing, command completes when at or above this command's altitude, 2 = Descending, command completes when at or below this command's altitude. </param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Desired altitude in meters</param>
+      </entry>
+      <entry value="31" name="MAV_CMD_NAV_LOITER_TO_ALT">
+        <description>Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint. </description>
+        <param index="1">Heading Required (0 = False)</param>
+        <param index="2">Radius in meters. If positive loiter clockwise, negative counter-clockwise, 0 means no change to standard loiter.</param>
+        <param index="3">Empty</param>
+        <param index="4">Forward moving aircraft this sets exit xtrack location: 0 for center of loiter wp, 1 for exit location</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="32" name="MAV_CMD_DO_FOLLOW">
+        <description>Being following a target</description>
+        <param index="1">System ID (the system ID of the FOLLOW_TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode</param>
+        <param index="2">RESERVED</param>
+        <param index="3">RESERVED</param>
+        <param index="4">altitude flag: 0: Keep current altitude, 1: keep altitude difference to target, 2: go to a fixed altitude above home</param>
+        <param index="5">altitude</param>
+        <param index="6">RESERVED</param>
+        <param index="7">TTL in seconds in which the MAV should go to the default position hold mode after a message rx timeout</param>
+      </entry>
+      <entry value="33" name="MAV_CMD_DO_FOLLOW_REPOSITION">
+        <description>Reposition the MAV after a follow target command has been sent</description>
+        <param index="1">Camera q1 (where 0 is on the ray from the camera to the tracking device)</param>
+        <param index="2">Camera q2</param>
+        <param index="3">Camera q3</param>
+        <param index="4">Camera q4</param>
+        <param index="5">altitude offset from target (m)</param>
+        <param index="6">X offset from target (m)</param>
+        <param index="7">Y offset from target (m)</param>
+      </entry>
+      <entry value="80" name="MAV_CMD_NAV_ROI">
+        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
+        <param index="2">MISSION index/ target ID. (see MAV_ROI enum)</param>
+        <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
+        <param index="4">Empty</param>
+        <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
+        <param index="6">y</param>
+        <param index="7">z</param>
+      </entry>
+      <entry value="81" name="MAV_CMD_NAV_PATHPLANNING">
+        <description>Control autonomous path planning on the MAV.</description>
+        <param index="1">0: Disable local obstacle avoidance / local path planning (without resetting map), 1: Enable local path planning, 2: Enable and reset local path planning</param>
+        <param index="2">0: Disable full path planning (without resetting map), 1: Enable, 2: Enable and reset map/occupancy grid, 3: Enable and reset planned route, but not occupancy grid</param>
+        <param index="3">Empty</param>
+        <param index="4">Yaw angle at goal, in compass degrees, [0..360]</param>
+        <param index="5">Latitude/X of goal</param>
+        <param index="6">Longitude/Y of goal</param>
+        <param index="7">Altitude/Z of goal</param>
+      </entry>
+      <entry value="82" name="MAV_CMD_NAV_SPLINE_WAYPOINT">
+        <description>Navigate to MISSION using a spline path.</description>
+        <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Latitude/X of goal</param>
+        <param index="6">Longitude/Y of goal</param>
+        <param index="7">Altitude/Z of goal</param>
+      </entry>
+      <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
+        <description>Takeoff from ground using VTOL mode</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Yaw angle in degrees</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="85" name="MAV_CMD_NAV_VTOL_LAND">
+        <description>Land using VTOL mode</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Yaw angle in degrees</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <!-- IDs 90 and 91 are reserved until the end of 2014,
                     as they were used in some conflicting proposals
                     between PX4 and ardupilot and need to be kept
                     unused to prevent errors -->
-
-               <entry value="92" name="MAV_CMD_NAV_GUIDED_ENABLE">
-                    <description>hand control over to an external controller</description>
-                    <param index="1">On / Off (> 0.5f on)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="93" name="MAV_CMD_NAV_DELAY">
-                    <description>Delay the next navigation command a number of seconds or until a specified time</description>
-                    <param index="1">Delay in seconds (decimal, -1 to enable time-of-day fields)</param>
-                    <param index="2">hour (24h format, UTC, -1 to ignore)</param>
-                    <param index="3">minute (24h format, UTC, -1 to ignore)</param>
-                    <param index="4">second (24h format, UTC)</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="95" name="MAV_CMD_NAV_LAST">
-                    <description>NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration</description>
-                    <param index="1">Empty</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="112" name="MAV_CMD_CONDITION_DELAY">
-                    <description>Delay mission state machine.</description>
-                    <param index="1">Delay in seconds (decimal)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="113" name="MAV_CMD_CONDITION_CHANGE_ALT">
-                    <description>Ascend/descend at rate.  Delay mission state machine until desired altitude reached.</description>
-                    <param index="1">Descent / Ascend rate (m/s)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Finish Altitude</param>
-               </entry>
-               <entry value="114" name="MAV_CMD_CONDITION_DISTANCE">
-                    <description>Delay mission state machine until within desired distance of next NAV point.</description>
-                    <param index="1">Distance (meters)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="115" name="MAV_CMD_CONDITION_YAW">
-                    <description>Reach a certain target angle.</description>
-                    <param index="1">target angle: [0-360], 0 is north</param>
-                    <param index="2">speed during yaw change:[deg per second]</param>
-                    <param index="3">direction: negative: counter clockwise, positive: clockwise [-1,1]</param>
-                    <param index="4">relative offset or absolute angle: [ 1,0]</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="159" name="MAV_CMD_CONDITION_LAST">
-                    <description>NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration</description>
-                    <param index="1">Empty</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="176" name="MAV_CMD_DO_SET_MODE">
-                    <description>Set system mode.</description>
-                    <param index="1">Mode, as defined by ENUM MAV_MODE</param>
-                    <param index="2">Custom mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
-                    <param index="3">Custom sub mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="177" name="MAV_CMD_DO_JUMP">
-                    <description>Jump to the desired command in the mission list.  Repeat this action only the specified number of times</description>
-                    <param index="1">Sequence number</param>
-                    <param index="2">Repeat count</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="178" name="MAV_CMD_DO_CHANGE_SPEED">
-                    <description>Change speed and/or throttle set points.</description>
-                    <param index="1">Speed type (0=Airspeed, 1=Ground Speed)</param>
-                    <param index="2">Speed  (m/s, -1 indicates no change)</param>
-                    <param index="3">Throttle  ( Percent, -1 indicates no change)</param>
-                    <param index="4">absolute or relative [0,1]</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="179" name="MAV_CMD_DO_SET_HOME">
-                    <description>Changes the home location either to the current location or a specified location.</description>
-                    <param index="1">Use current (1=use current location, 0=use specified location)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Altitude</param>
-               </entry>
-               <entry value="180" name="MAV_CMD_DO_SET_PARAMETER">
-                    <description>Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.</description>
-                    <param index="1">Parameter number</param>
-                    <param index="2">Parameter value</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="181" name="MAV_CMD_DO_SET_RELAY">
-                    <description>Set a relay to a condition.</description>
-                    <param index="1">Relay number</param>
-                    <param index="2">Setting (1=on, 0=off, others possible depending on system hardware)</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="182" name="MAV_CMD_DO_REPEAT_RELAY">
-                    <description>Cycle a relay on and off for a desired number of cyles with a desired period.</description>
-                    <param index="1">Relay number</param>
-                    <param index="2">Cycle count</param>
-                    <param index="3">Cycle time (seconds, decimal)</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="183" name="MAV_CMD_DO_SET_SERVO">
-                    <description>Set a servo to a desired PWM value.</description>
-                    <param index="1">Servo number</param>
-                    <param index="2">PWM (microseconds, 1000 to 2000 typical)</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="184" name="MAV_CMD_DO_REPEAT_SERVO">
-                    <description>Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.</description>
-                    <param index="1">Servo number</param>
-                    <param index="2">PWM (microseconds, 1000 to 2000 typical)</param>
-                    <param index="3">Cycle count</param>
-                    <param index="4">Cycle time (seconds)</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="185" name="MAV_CMD_DO_FLIGHTTERMINATION">
-                    <description>Terminate flight immediately</description>
-                    <param index="1">Flight termination activated if > 0.5</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-                </entry>
-                <entry value="186" name="MAV_CMD_DO_CHANGE_ALTITUDE">
-                    <description>Change altitude set point.</description>
-                    <param index="1">Altitude in meters</param>
-                    <param index="2">Mav frame of new altitude (see MAV_FRAME)</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-                </entry>
-                <entry value="189" name="MAV_CMD_DO_LAND_START">
-                    <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0/0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>
-                    <param index="1">Empty</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Latitude</param>
-                    <param index="6">Longitude</param>
-                    <param index="7">Empty</param>
-                </entry>
-                <entry value="190" name="MAV_CMD_DO_RALLY_LAND">
-                    <description>Mission command to perform a landing from a rally point.</description>
-                    <param index="1">Break altitude (meters)</param>
-                    <param index="2">Landing speed (m/s)</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-                </entry>
-                <entry value="191" name="MAV_CMD_DO_GO_AROUND">
-                    <description>Mission command to safely abort an autonmous landing.</description>
-                    <param index="1">Altitude (meters)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-                </entry>
-
-               <entry value="192" name="MAV_CMD_DO_REPOSITION">
-                    <description>Reposition the vehicle to a specific WGS84 global position.</description>
-                    <param index="1">Ground speed, less than 0 (-1) for default</param>
-                    <param index="2">Bitmask of option flags, see the MAV_DO_REPOSITION_FLAGS enum.</param>
-                    <param index="3">Reserved</param>
-                    <param index="4">Yaw heading, NaN for unchanged. For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
-                    <param index="5">Latitude (deg * 1E7)</param>
-                    <param index="6">Longitude (deg * 1E7)</param>
-                    <param index="7">Altitude (meters)</param>
-               </entry>
-               <entry value="193" name="MAV_CMD_DO_PAUSE_CONTINUE">
-                    <description>If in a GPS controlled position mode, hold the current position or continue.</description>
-                    <param index="1">0: Pause current mission or reposition command, hold current position. 1: Continue mission. A VTOL capable vehicle should enter hover mode (multicopter and VTOL planes). A plane should loiter with the default loiter radius.</param>
-                    <param index="2">Reserved</param>
-                    <param index="3">Reserved</param>
-                    <param index="4">Reserved</param>
-                    <param index="5">Reserved</param>
-                    <param index="6">Reserved</param>
-                    <param index="7">Reserved</param>
-               </entry>
-               <entry value="194" name="MAV_CMD_DO_SET_REVERSE">
-                    <description>Set moving direction to forward or reverse.</description>
-                    <param index="1">Direction (0=Forward, 1=Reverse)</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="200" name="MAV_CMD_DO_CONTROL_VIDEO">
-                    <description>Control onboard camera system.</description>
-                    <param index="1">Camera ID (-1 for all)</param>
-                    <param index="2">Transmission: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
-                    <param index="3">Transmission mode: 0: video stream, >0: single images every n seconds (decimal)</param>
-                    <param index="4">Recording: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="201" name="MAV_CMD_DO_SET_ROI">
-                    <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
-                    <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
-                    <param index="2">MISSION index/ target ID. (see MAV_ROI enum)</param>
-                    <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
-                    <param index="4">Empty</param>
-                    <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
-                    <param index="6">y</param>
-                    <param index="7">z</param>
-               </entry>
-
-               <!-- Camera Controller Mission Commands Enumeration -->
-               <!-- MAV_CMD_DO_DIGICAM_CONFIGURE should be deprecated and replaced with CAMERA_SETTINGS -->
-               <entry name="MAV_CMD_DO_DIGICAM_CONFIGURE" value="202">
-                   <description>Mission command to configure an on-board camera controller system.</description>
-                   <param index="1">Modes: P, TV, AV, M, Etc</param>
-                   <param index="2">Shutter speed: Divisor number for one second</param>
-                   <param index="3">Aperture: F stop number</param>
-                   <param index="4">ISO number e.g. 80, 100, 200, Etc</param>
-                   <param index="5">Exposure type enumerator</param>
-                   <param index="6">Command Identity</param>
-                   <param index="7">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</param>
-               </entry>
-
-               <entry name="MAV_CMD_DO_DIGICAM_CONTROL" value="203">
-                   <description>Mission command to control an on-board camera controller system.</description>
-                   <param index="1">Session control e.g. show/hide lens</param>
-                   <param index="2">Zoom's absolute position</param>
-                   <param index="3">Zooming step value to offset zoom from the current position</param>
-                   <param index="4">Focus Locking, Unlocking or Re-locking</param>
-                   <param index="5">Shooting Command</param>
-                   <param index="6">Command Identity</param>
-                   <param index="7">Empty</param>
-               </entry>
-
-               <!-- Camera Mount Mission Commands Enumeration -->
-               <entry name="MAV_CMD_DO_MOUNT_CONFIGURE" value="204">
-                   <description>Mission command to configure a camera or antenna mount</description>
-                   <param index="1">Mount operation mode (see MAV_MOUNT_MODE enum)</param>
-                   <param index="2">stabilize roll? (1 = yes, 0 = no)</param>
-                   <param index="3">stabilize pitch? (1 = yes, 0 = no)</param>
-                   <param index="4">stabilize yaw? (1 = yes, 0 = no)</param>
-                   <param index="5">Empty</param>
-                   <param index="6">Empty</param>
-                   <param index="7">Empty</param>
-               </entry>
-
-               <entry name="MAV_CMD_DO_MOUNT_CONTROL" value="205">
-                   <description>Mission command to control a camera or antenna mount</description>
-                   <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode.</param>
-                   <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode.</param>
-                   <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode.</param>
-                   <param index="4">WIP: alt in meters depending on mount mode.</param>
-                   <param index="5">WIP: latitude in degrees * 1E7, set if appropriate mount mode.</param>
-                   <param index="6">WIP: longitude in degrees * 1E7, set if appropriate mount mode.</param>
-                   <param index="7">MAV_MOUNT_MODE enum value</param>
-               </entry>
-
-               <entry name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" value="206">
-                   <description>Mission command to set CAM_TRIGG_DIST for this flight</description>
-                   <param index="1">Camera trigger distance (meters)</param>
-                   <param index="2">Empty</param>
-                   <param index="3">Empty</param>
-                   <param index="4">Empty</param>
-                   <param index="5">Empty</param>
-                   <param index="6">Empty</param>
-                   <param index="7">Empty</param>
-               </entry>
-
-               <entry name="MAV_CMD_DO_FENCE_ENABLE" value="207">
-                   <description>Mission command to enable the geofence</description>
-                   <param index="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
-                   <param index="2">Empty</param>
-                   <param index="3">Empty</param>
-                   <param index="4">Empty</param>
-                   <param index="5">Empty</param>
-                   <param index="6">Empty</param>
-                   <param index="7">Empty</param>
-               </entry>
-
-               <entry name="MAV_CMD_DO_PARACHUTE" value="208">
-                   <description>Mission command to trigger a parachute</description>
-                   <param index="1">action (0=disable, 1=enable, 2=release, for some systems see PARACHUTE_ACTION enum, not in general message set.)</param>
-                   <param index="2">Empty</param>
-                   <param index="3">Empty</param>
-                   <param index="4">Empty</param>
-                   <param index="5">Empty</param>
-                   <param index="6">Empty</param>
-                   <param index="7">Empty</param>
-               </entry>
-
-               <entry name="MAV_CMD_DO_MOTOR_TEST" value="209">
-                   <description>Mission command to perform motor test</description>
-                   <param index="1">motor sequence number (a number from 1 to max number of motors on the vehicle)</param>
-                   <param index="2">throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)</param>
-                   <param index="3">throttle</param>
-                   <param index="4">timeout (in seconds)</param>
-                   <param index="5">Empty</param>
-                   <param index="6">Empty</param>
-                   <param index="7">Empty</param>
-               </entry>
-
-               <entry name="MAV_CMD_DO_INVERTED_FLIGHT" value="210">
-                   <description>Change to/from inverted flight</description>
-                   <param index="1">inverted (0=normal, 1=inverted)</param>
-                   <param index="2">Empty</param>
-                   <param index="3">Empty</param>
-                   <param index="4">Empty</param>
-                   <param index="5">Empty</param>
-                   <param index="6">Empty</param>
-                   <param index="7">Empty</param>
-               </entry>
-
-               <entry name="MAV_CMD_NAV_SET_YAW_SPEED" value="213">
-                    <description>Sets a desired vehicle turn angle and speed change</description>
-                    <param index="1">yaw angle to adjust steering by in centidegress</param>
-                    <param index="2">speed - normalized to 0 .. 1</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-
-
-              <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT">
-                <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
-                <param index="1">q1 - quaternion param #1, w (1 in null-rotation)</param>
-                <param index="2">q2 - quaternion param #2, x (0 in null-rotation)</param>
-                <param index="3">q3 - quaternion param #3, y (0 in null-rotation)</param>
-                <param index="4">q4 - quaternion param #4, z (0 in null-rotation)</param>
-                <param index="5">Empty</param>
-                <param index="6">Empty</param>
-                <param index="7">Empty</param>
-              </entry>
-
-               <entry value="221" name="MAV_CMD_DO_GUIDED_MASTER">
-                    <description>set id of master controller</description>
-                    <param index="1">System ID</param>
-                    <param index="2">Component ID</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-
-               <entry value="222" name="MAV_CMD_DO_GUIDED_LIMITS">
-                 <description>set limits for external control</description>
-                 <param index="1">timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout</param>
-                 <param index="2">absolute altitude min (in meters, AMSL) - if vehicle moves below this alt, the command will be aborted and the mission will continue.  0 means no lower altitude limit</param>
-                 <param index="3">absolute altitude max (in meters)- if vehicle moves above this alt, the command will be aborted and the mission will continue.  0 means no upper altitude limit</param>
-                 <param index="4">horizontal move limit (in meters, AMSL) - if vehicle moves more than this distance from it's location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal altitude limit</param>
-                 <param index="5">Empty</param>
-                 <param index="6">Empty</param>
-                 <param index="7">Empty</param>
-               </entry>
-
-               <entry value="223" name="MAV_CMD_DO_ENGINE_CONTROL">
-                 <description>Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines</description>
-                 <param index="1">0: Stop engine, 1:Start Engine</param>
-                 <param index="2">0: Warm start, 1:Cold start. Controls use of choke where applicable</param>
-                 <param index="3">Height delay (meters). This is for commanding engine start only after the vehicle has gained the specified height. Used in VTOL vehicles during takeoff to start engine after the aircraft is off the ground. Zero for no delay.</param>
-                 <param index="4">Empty</param>
-                 <param index="5">Empty</param>
-                 <param index="5">Empty</param>
-                 <param index="6">Empty</param>
-                 <param index="7">Empty</param>
-               </entry>
-
-               <entry value="240" name="MAV_CMD_DO_LAST">
-                    <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
-                    <param index="1">Empty</param>
-                    <param index="2">Empty</param>
-                    <param index="3">Empty</param>
-                    <param index="4">Empty</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="241" name="MAV_CMD_PREFLIGHT_CALIBRATION">
-                    <description>Trigger calibration. This command will be only accepted if in pre-flight mode.</description>
-                    <param index="1">Gyro calibration: 0: no, 1: yes</param>
-                    <param index="2">Magnetometer calibration: 0: no, 1: yes</param>
-                    <param index="3">Ground pressure: 0: no, 1: yes</param>
-                    <param index="4">Radio calibration: 0: no, 1: yes</param>
-                    <param index="5">Accelerometer calibration: 0: no, 1: yes</param>
-                    <param index="6">Compass/Motor interference calibration: 0: no, 1: yes</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="242" name="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS">
-                    <description>Set sensor offsets. This command will be only accepted if in pre-flight mode.</description>
-                    <param index="1">Sensor to adjust the offsets for: 0: gyros, 1: accelerometer, 2: magnetometer, 3: barometer, 4: optical flow, 5: second magnetometer, 6: third magnetometer</param>
-                    <param index="2">X axis offset (or generic dimension 1), in the sensor's raw units</param>
-                    <param index="3">Y axis offset (or generic dimension 2), in the sensor's raw units</param>
-                    <param index="4">Z axis offset (or generic dimension 3), in the sensor's raw units</param>
-                    <param index="5">Generic dimension 4, in the sensor's raw units</param>
-                    <param index="6">Generic dimension 5, in the sensor's raw units</param>
-                    <param index="7">Generic dimension 6, in the sensor's raw units</param>
-               </entry>
-               <entry value="243" name="MAV_CMD_PREFLIGHT_UAVCAN">
-                    <description>Trigger UAVCAN config. This command will be only accepted if in pre-flight mode.</description>
-                    <param index="1">1: Trigger actuator ID assignment and direction mapping.</param>
-                    <param index="2">Reserved</param>
-                    <param index="3">Reserved</param>
-                    <param index="4">Reserved</param>
-                    <param index="5">Reserved</param>
-                    <param index="6">Reserved</param>
-                    <param index="7">Reserved</param>
-               </entry>
-               <entry value="245" name="MAV_CMD_PREFLIGHT_STORAGE">
-                    <description>Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.</description>
-                    <param index="1">Parameter storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
-                    <param index="2">Mission storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
-                    <param index="3">Onboard logging: 0: Ignore, 1: Start default rate logging, -1: Stop logging, > 1: start logging with rate of param 3 in Hz (e.g. set to 1000 for 1000 Hz logging)</param>
-                    <param index="4">Reserved</param>
-                    <param index="5">Empty</param>
-                    <param index="6">Empty</param>
-                    <param index="7">Empty</param>
-               </entry>
-               <entry value="246" name="MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN">
-                    <description>Request the reboot or shutdown of system components.</description>
-                    <param index="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
-                    <param index="2">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
-                    <param index="3">WIP: 0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
-                    <param index="4">WIP: 0: Do nothing for mount (e.g. gimbal), 1: Reboot mount, 2: Shutdown mount, 3: Reboot mount and keep it in the bootloader until upgraded</param>
-                    <param index="5">Reserved, send 0</param>
-                    <param index="6">Reserved, send 0</param>
-                    <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
-               </entry>
-               <entry value="252" name="MAV_CMD_OVERRIDE_GOTO">
-                    <description>Hold / continue the current action</description>
-                    <param index="1">MAV_GOTO_DO_HOLD: hold MAV_GOTO_DO_CONTINUE: continue with next item in mission plan</param>
-                    <param index="2">MAV_GOTO_HOLD_AT_CURRENT_POSITION: Hold at current position MAV_GOTO_HOLD_AT_SPECIFIED_POSITION: hold at specified position</param>
-                    <param index="3">MAV_FRAME coordinate frame of hold point</param>
-                    <param index="4">Desired yaw angle in degrees</param>
-                    <param index="5">Latitude / X position</param>
-                    <param index="6">Longitude / Y position</param>
-                    <param index="7">Altitude / Z position</param>
-               </entry>
-               <entry value="300" name="MAV_CMD_MISSION_START">
-                    <description>start running a mission</description>
-                    <param index="1">first_item: the first mission item to run</param>
-                    <param index="2">last_item:  the last mission item to run (after this item is run, the mission ends)</param>
-               </entry>
-               <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM">
-                    <description>Arms / Disarms a component</description>
-                    <param index="1">1 to arm, 0 to disarm</param>
-               </entry>
-               <entry value="410" name="MAV_CMD_GET_HOME_POSITION">
-                    <description>Request the home position from the vehicle.</description>
-                    <param index="1">Reserved</param>
-                    <param index="2">Reserved</param>
-                    <param index="3">Reserved</param>
-                    <param index="4">Reserved</param>
-                    <param index="5">Reserved</param>
-                    <param index="6">Reserved</param>
-                    <param index="7">Reserved</param>
-               </entry>
-               <entry value="500" name="MAV_CMD_START_RX_PAIR">
-                    <description>Starts receiver pairing</description>
-                    <param index="1">0:Spektrum</param>
-                    <param index="2">0:Spektrum DSM2, 1:Spektrum DSMX</param>
-               </entry>
-               <entry value="510" name="MAV_CMD_GET_MESSAGE_INTERVAL">
-                    <description>Request the interval between messages for a particular MAVLink message ID</description>
-                    <param index="1">The MAVLink message ID</param>
-               </entry>
-               <entry value="511" name="MAV_CMD_SET_MESSAGE_INTERVAL">
-                    <description>Request the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM</description>
-                    <param index="1">The MAVLink message ID</param>
-                    <param index="2">The interval between two messages, in microseconds. Set to -1 to disable and 0 to request default rate.</param>
-               </entry>
-               <entry value="520" name="MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES">
-                 <description>Request autopilot capabilities</description>
-                 <param index="1">1: Request autopilot version</param>
-                 <param index="2">Reserved (all remaining params)</param>
-               </entry>
-               <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
-                 <description>WIP: Request camera information (CAMERA_INFORMATION)</description>
-                 <param index="1">1: Request camera capabilities</param>
-                 <param index="2">Camera ID</param>
-                 <param index="3">Reserved (all remaining params)</param>
-               </entry>
-               <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
-                 <description>WIP: Request camera settings (CAMERA_SETTINGS)</description>
-                 <param index="1">1: Request camera settings</param>
-                 <param index="2">Camera ID</param>
-                 <param index="3">Reserved (all remaining params)</param>
-               </entry>
-               <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS_1">
-                 <description>WIP: Set the camera settings part 1 (CAMERA_SETTINGS)</description>
-                 <param index="1">Camera ID</param>
-                 <param index="2">Aperture (1/value)</param>
-                 <param index="3">Aperture locked (0: auto, 1: locked)</param>
-                 <param index="4">Shutter speed in s</param>
-                 <param index="5">Shutter speed locked (0: auto, 1: locked)</param>
-                 <param index="6">ISO sensitivity</param>
-                 <param index="7">ISO sensitivity locked (0: auto, 1: locked)</param>
-               </entry>
-               <entry value="524" name="MAV_CMD_SET_CAMERA_SETTINGS_2">
-                 <description>WIP: Set the camera settings part 2 (CAMERA_SETTINGS)</description>
-                 <param index="1">Camera ID</param>
-                 <param index="2">White balance locked (0: auto, 1: locked)</param>
-                 <param index="3">White balance (color temperature in K)</param>
-                 <param index="4">Reserved for camera mode ID</param>
-                 <param index="5">Reserved for color mode ID</param>
-                 <param index="6">Reserved for image format ID</param>
-                 <param index="7">Reserved</param>
-               </entry>
-               <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
-                 <description>WIP: Request storage information (STORAGE_INFORMATION)</description>
-                 <param index="1">1: Request storage information</param>
-                 <param index="2">Storage ID</param>
-                 <param index="3">Reserved (all remaining params)</param>
-               </entry>
-               <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
-                 <description>WIP: Format a storage medium</description>
-                 <param index="1">1: Format storage</param>
-                 <param index="2">Storage ID</param>
-                 <param index="3">Reserved (all remaining params)</param>
-               </entry>
-               <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
-                 <description>WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
-                 <param index="1">1: Request camera capture status</param>
-                 <param index="2">Camera ID</param>
-                 <param index="3">Reserved (all remaining params)</param>
-               </entry>
-               <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
-                 <description>WIP: Request flight information (FLIGHT_INFORMATION)</description>
-                 <param index="1">1: Request flight information</param>
-                 <param index="2">Reserved (all remaining params)</param>
-               </entry>
-
-              <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
-                  <description>Start image capture sequence</description>
-                  <param index="1">Duration between two consecutive pictures (in seconds)</param>
-                  <param index="2">Number of images to capture total - 0 for unlimited capture</param>
-                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
-                  <param index="4">WIP: Resolution horizontal in pixels</param>
-                  <param index="5">WIP: Resolution horizontal in pixels</param>
-                  <param index="6">WIP: Camera ID</param>
-              </entry>
-
-              <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
-                  <description>Stop image capture sequence</description>
-                  <param index="1">Camera ID</param>
-                  <param index="2">Reserved</param>
-              </entry>
-
-              <entry name="MAV_CMD_DO_TRIGGER_CONTROL" value="2003">
-                   <description>Enable or disable on-board camera triggering system.</description>
-                   <param index="1">Trigger enable/disable (0 for disable, 1 for start)</param>
-                   <param index="2">Shutter integration time (in ms)</param>
-                   <param index="3">Reserved</param>
-              </entry>
-
-              <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
-                  <description>Starts video capture</description>
-                  <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
-                  <param index="2">Frames per second</param>
-                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
-                  <param index="4">WIP: Resolution horizontal in pixels</param>
-                  <param index="5">WIP: Resolution horizontal in pixels</param>
-              </entry>
-
-              <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
-                  <description>Stop the current video capture</description>
-                  <param index="1">WIP: Camera ID</param>
-                  <param index="2">Reserved</param>
-              </entry>
-
-              <entry value="2510" name="MAV_CMD_LOGGING_START">
-                   <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
-                   <param index="1">Format: 0: ULog</param>
-                   <param index="2">Reserved (set to 0)</param>
-                   <param index="3">Reserved (set to 0)</param>
-                   <param index="4">Reserved (set to 0)</param>
-                   <param index="5">Reserved (set to 0)</param>
-                   <param index="6">Reserved (set to 0)</param>
-                   <param index="7">Reserved (set to 0)</param>
-              </entry>
-              <entry value="2511" name="MAV_CMD_LOGGING_STOP">
-                   <description>Request to stop streaming log data over MAVLink</description>
-                   <param index="1">Reserved (set to 0)</param>
-                   <param index="2">Reserved (set to 0)</param>
-                   <param index="3">Reserved (set to 0)</param>
-                   <param index="4">Reserved (set to 0)</param>
-                   <param index="5">Reserved (set to 0)</param>
-                   <param index="6">Reserved (set to 0)</param>
-                   <param index="7">Reserved (set to 0)</param>
-              </entry>
-
-              <entry value="2520" name="MAV_CMD_AIRFRAME_CONFIGURATION">
-                  <description></description>
-                  <param index="1">Landing gear ID (default: 0, -1 for all)</param>
-                  <param index="2">Landing gear position (Down: 0, Up: 1, NAN for no change)</param>
-                  <param index="3">Reserved, set to NAN</param>
-                  <param index="4">Reserved, set to NAN</param>
-                  <param index="5">Reserved, set to NAN</param>
-                  <param index="6">Reserved, set to NAN</param>
-                  <param index="7">Reserved, set to NAN</param>
-              </entry>
-
-              <entry value="2800" name="MAV_CMD_PANORAMA_CREATE">
-                  <description>Create a panorama at the current position</description>
-                  <param index="1">Viewing angle horizontal of the panorama (in degrees, +- 0.5 the total angle)</param>
-                  <param index="2">Viewing angle vertical of panorama (in degrees)</param>
-                  <param index="3">Speed of the horizontal rotation (in degrees per second)</param>
-                  <param index="4">Speed of the vertical rotation (in degrees per second)</param>
-              </entry>
-
-              <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION">
-                  <description>Request VTOL transition</description>
-                  <param index="1">The target VTOL state, as defined by ENUM MAV_VTOL_STATE. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
-              </entry>
-
-              <entry value="4000" name="MAV_CMD_SET_GUIDED_SUBMODE_STANDARD">
-                  <description>This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
+      <entry value="92" name="MAV_CMD_NAV_GUIDED_ENABLE">
+        <description>hand control over to an external controller</description>
+        <param index="1">On / Off (&gt; 0.5f on)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="93" name="MAV_CMD_NAV_DELAY">
+        <description>Delay the next navigation command a number of seconds or until a specified time</description>
+        <param index="1">Delay in seconds (decimal, -1 to enable time-of-day fields)</param>
+        <param index="2">hour (24h format, UTC, -1 to ignore)</param>
+        <param index="3">minute (24h format, UTC, -1 to ignore)</param>
+        <param index="4">second (24h format, UTC)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="95" name="MAV_CMD_NAV_LAST">
+        <description>NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="112" name="MAV_CMD_CONDITION_DELAY">
+        <description>Delay mission state machine.</description>
+        <param index="1">Delay in seconds (decimal)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="113" name="MAV_CMD_CONDITION_CHANGE_ALT">
+        <description>Ascend/descend at rate.  Delay mission state machine until desired altitude reached.</description>
+        <param index="1">Descent / Ascend rate (m/s)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Finish Altitude</param>
+      </entry>
+      <entry value="114" name="MAV_CMD_CONDITION_DISTANCE">
+        <description>Delay mission state machine until within desired distance of next NAV point.</description>
+        <param index="1">Distance (meters)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="115" name="MAV_CMD_CONDITION_YAW">
+        <description>Reach a certain target angle.</description>
+        <param index="1">target angle: [0-360], 0 is north</param>
+        <param index="2">speed during yaw change:[deg per second]</param>
+        <param index="3">direction: negative: counter clockwise, positive: clockwise [-1,1]</param>
+        <param index="4">relative offset or absolute angle: [ 1,0]</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="159" name="MAV_CMD_CONDITION_LAST">
+        <description>NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="176" name="MAV_CMD_DO_SET_MODE">
+        <description>Set system mode.</description>
+        <param index="1">Mode, as defined by ENUM MAV_MODE</param>
+        <param index="2">Custom mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
+        <param index="3">Custom sub mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="177" name="MAV_CMD_DO_JUMP">
+        <description>Jump to the desired command in the mission list.  Repeat this action only the specified number of times</description>
+        <param index="1">Sequence number</param>
+        <param index="2">Repeat count</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="178" name="MAV_CMD_DO_CHANGE_SPEED">
+        <description>Change speed and/or throttle set points.</description>
+        <param index="1">Speed type (0=Airspeed, 1=Ground Speed)</param>
+        <param index="2">Speed  (m/s, -1 indicates no change)</param>
+        <param index="3">Throttle  ( Percent, -1 indicates no change)</param>
+        <param index="4">absolute or relative [0,1]</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="179" name="MAV_CMD_DO_SET_HOME">
+        <description>Changes the home location either to the current location or a specified location.</description>
+        <param index="1">Use current (1=use current location, 0=use specified location)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="180" name="MAV_CMD_DO_SET_PARAMETER">
+        <description>Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.</description>
+        <param index="1">Parameter number</param>
+        <param index="2">Parameter value</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="181" name="MAV_CMD_DO_SET_RELAY">
+        <description>Set a relay to a condition.</description>
+        <param index="1">Relay number</param>
+        <param index="2">Setting (1=on, 0=off, others possible depending on system hardware)</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="182" name="MAV_CMD_DO_REPEAT_RELAY">
+        <description>Cycle a relay on and off for a desired number of cyles with a desired period.</description>
+        <param index="1">Relay number</param>
+        <param index="2">Cycle count</param>
+        <param index="3">Cycle time (seconds, decimal)</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="183" name="MAV_CMD_DO_SET_SERVO">
+        <description>Set a servo to a desired PWM value.</description>
+        <param index="1">Servo number</param>
+        <param index="2">PWM (microseconds, 1000 to 2000 typical)</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="184" name="MAV_CMD_DO_REPEAT_SERVO">
+        <description>Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.</description>
+        <param index="1">Servo number</param>
+        <param index="2">PWM (microseconds, 1000 to 2000 typical)</param>
+        <param index="3">Cycle count</param>
+        <param index="4">Cycle time (seconds)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="185" name="MAV_CMD_DO_FLIGHTTERMINATION">
+        <description>Terminate flight immediately</description>
+        <param index="1">Flight termination activated if &gt; 0.5</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="186" name="MAV_CMD_DO_CHANGE_ALTITUDE">
+        <description>Change altitude set point.</description>
+        <param index="1">Altitude in meters</param>
+        <param index="2">Mav frame of new altitude (see MAV_FRAME)</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="189" name="MAV_CMD_DO_LAND_START">
+        <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0/0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="190" name="MAV_CMD_DO_RALLY_LAND">
+        <description>Mission command to perform a landing from a rally point.</description>
+        <param index="1">Break altitude (meters)</param>
+        <param index="2">Landing speed (m/s)</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="191" name="MAV_CMD_DO_GO_AROUND">
+        <description>Mission command to safely abort an autonmous landing.</description>
+        <param index="1">Altitude (meters)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="192" name="MAV_CMD_DO_REPOSITION">
+        <description>Reposition the vehicle to a specific WGS84 global position.</description>
+        <param index="1">Ground speed, less than 0 (-1) for default</param>
+        <param index="2">Bitmask of option flags, see the MAV_DO_REPOSITION_FLAGS enum.</param>
+        <param index="3">Reserved</param>
+        <param index="4">Yaw heading, NaN for unchanged. For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
+        <param index="5">Latitude (deg * 1E7)</param>
+        <param index="6">Longitude (deg * 1E7)</param>
+        <param index="7">Altitude (meters)</param>
+      </entry>
+      <entry value="193" name="MAV_CMD_DO_PAUSE_CONTINUE">
+        <description>If in a GPS controlled position mode, hold the current position or continue.</description>
+        <param index="1">0: Pause current mission or reposition command, hold current position. 1: Continue mission. A VTOL capable vehicle should enter hover mode (multicopter and VTOL planes). A plane should loiter with the default loiter radius.</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="194" name="MAV_CMD_DO_SET_REVERSE">
+        <description>Set moving direction to forward or reverse.</description>
+        <param index="1">Direction (0=Forward, 1=Reverse)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="200" name="MAV_CMD_DO_CONTROL_VIDEO">
+        <description>Control onboard camera system.</description>
+        <param index="1">Camera ID (-1 for all)</param>
+        <param index="2">Transmission: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
+        <param index="3">Transmission mode: 0: video stream, &gt;0: single images every n seconds (decimal)</param>
+        <param index="4">Recording: 0: disabled, 1: enabled compressed, 2: enabled raw</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="201" name="MAV_CMD_DO_SET_ROI">
+        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
+        <param index="2">MISSION index/ target ID. (see MAV_ROI enum)</param>
+        <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
+        <param index="4">Empty</param>
+        <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
+        <param index="6">y</param>
+        <param index="7">z</param>
+      </entry>
+      <!-- Camera Controller Mission Commands Enumeration -->
+      <!-- MAV_CMD_DO_DIGICAM_CONFIGURE should be deprecated and replaced with CAMERA_SETTINGS -->
+      <entry name="MAV_CMD_DO_DIGICAM_CONFIGURE" value="202">
+        <description>Mission command to configure an on-board camera controller system.</description>
+        <param index="1">Modes: P, TV, AV, M, Etc</param>
+        <param index="2">Shutter speed: Divisor number for one second</param>
+        <param index="3">Aperture: F stop number</param>
+        <param index="4">ISO number e.g. 80, 100, 200, Etc</param>
+        <param index="5">Exposure type enumerator</param>
+        <param index="6">Command Identity</param>
+        <param index="7">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</param>
+      </entry>
+      <entry name="MAV_CMD_DO_DIGICAM_CONTROL" value="203">
+        <description>Mission command to control an on-board camera controller system.</description>
+        <param index="1">Session control e.g. show/hide lens</param>
+        <param index="2">Zoom's absolute position</param>
+        <param index="3">Zooming step value to offset zoom from the current position</param>
+        <param index="4">Focus Locking, Unlocking or Re-locking</param>
+        <param index="5">Shooting Command</param>
+        <param index="6">Command Identity</param>
+        <param index="7">Empty</param>
+      </entry>
+      <!-- Camera Mount Mission Commands Enumeration -->
+      <entry name="MAV_CMD_DO_MOUNT_CONFIGURE" value="204">
+        <description>Mission command to configure a camera or antenna mount</description>
+        <param index="1">Mount operation mode (see MAV_MOUNT_MODE enum)</param>
+        <param index="2">stabilize roll? (1 = yes, 0 = no)</param>
+        <param index="3">stabilize pitch? (1 = yes, 0 = no)</param>
+        <param index="4">stabilize yaw? (1 = yes, 0 = no)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry name="MAV_CMD_DO_MOUNT_CONTROL" value="205">
+        <description>Mission command to control a camera or antenna mount</description>
+        <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode.</param>
+        <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode.</param>
+        <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode.</param>
+        <param index="4">WIP: alt in meters depending on mount mode.</param>
+        <param index="5">WIP: latitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="6">WIP: longitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="7">MAV_MOUNT_MODE enum value</param>
+      </entry>
+      <entry name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" value="206">
+        <description>Mission command to set CAM_TRIGG_DIST for this flight</description>
+        <param index="1">Camera trigger distance (meters)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry name="MAV_CMD_DO_FENCE_ENABLE" value="207">
+        <description>Mission command to enable the geofence</description>
+        <param index="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry name="MAV_CMD_DO_PARACHUTE" value="208">
+        <description>Mission command to trigger a parachute</description>
+        <param index="1">action (0=disable, 1=enable, 2=release, for some systems see PARACHUTE_ACTION enum, not in general message set.)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry name="MAV_CMD_DO_MOTOR_TEST" value="209">
+        <description>Mission command to perform motor test</description>
+        <param index="1">motor sequence number (a number from 1 to max number of motors on the vehicle)</param>
+        <param index="2">throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)</param>
+        <param index="3">throttle</param>
+        <param index="4">timeout (in seconds)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry name="MAV_CMD_DO_INVERTED_FLIGHT" value="210">
+        <description>Change to/from inverted flight</description>
+        <param index="1">inverted (0=normal, 1=inverted)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry name="MAV_CMD_NAV_SET_YAW_SPEED" value="213">
+        <description>Sets a desired vehicle turn angle and speed change</description>
+        <param index="1">yaw angle to adjust steering by in centidegress</param>
+        <param index="2">speed - normalized to 0 .. 1</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT">
+        <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
+        <param index="1">q1 - quaternion param #1, w (1 in null-rotation)</param>
+        <param index="2">q2 - quaternion param #2, x (0 in null-rotation)</param>
+        <param index="3">q3 - quaternion param #3, y (0 in null-rotation)</param>
+        <param index="4">q4 - quaternion param #4, z (0 in null-rotation)</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="221" name="MAV_CMD_DO_GUIDED_MASTER">
+        <description>set id of master controller</description>
+        <param index="1">System ID</param>
+        <param index="2">Component ID</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="222" name="MAV_CMD_DO_GUIDED_LIMITS">
+        <description>set limits for external control</description>
+        <param index="1">timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout</param>
+        <param index="2">absolute altitude min (in meters, AMSL) - if vehicle moves below this alt, the command will be aborted and the mission will continue.  0 means no lower altitude limit</param>
+        <param index="3">absolute altitude max (in meters)- if vehicle moves above this alt, the command will be aborted and the mission will continue.  0 means no upper altitude limit</param>
+        <param index="4">horizontal move limit (in meters, AMSL) - if vehicle moves more than this distance from it's location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal altitude limit</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="223" name="MAV_CMD_DO_ENGINE_CONTROL">
+        <description>Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines</description>
+        <param index="1">0: Stop engine, 1:Start Engine</param>
+        <param index="2">0: Warm start, 1:Cold start. Controls use of choke where applicable</param>
+        <param index="3">Height delay (meters). This is for commanding engine start only after the vehicle has gained the specified height. Used in VTOL vehicles during takeoff to start engine after the aircraft is off the ground. Zero for no delay.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="240" name="MAV_CMD_DO_LAST">
+        <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
+        <param index="1">Empty</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="241" name="MAV_CMD_PREFLIGHT_CALIBRATION">
+        <description>Trigger calibration. This command will be only accepted if in pre-flight mode. Except for Temperature Calibration, only one sensor should be set in a single message and all others should be zero.</description>
+        <param index="1">1: gyro calibration, 3: gyro temperature calibration</param>
+        <param index="2">1: magnetometer calibration</param>
+        <param index="3">1: ground pressure calibration</param>
+        <param index="4">1: radio RC calibration, 2: RC trim calibration</param>
+        <param index="5">1: accelerometer calibration, 2: board level calibration, 3: accelerometer temperature calibration</param>
+        <param index="6">1: APM: compass/motor interference calibration / PX4: airspeed calibration</param>
+        <param index="7">1: ESC calibration, 3: barometer temperature calibration</param>
+      </entry>
+      <entry value="242" name="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS">
+        <description>Set sensor offsets. This command will be only accepted if in pre-flight mode.</description>
+        <param index="1">Sensor to adjust the offsets for: 0: gyros, 1: accelerometer, 2: magnetometer, 3: barometer, 4: optical flow, 5: second magnetometer, 6: third magnetometer</param>
+        <param index="2">X axis offset (or generic dimension 1), in the sensor's raw units</param>
+        <param index="3">Y axis offset (or generic dimension 2), in the sensor's raw units</param>
+        <param index="4">Z axis offset (or generic dimension 3), in the sensor's raw units</param>
+        <param index="5">Generic dimension 4, in the sensor's raw units</param>
+        <param index="6">Generic dimension 5, in the sensor's raw units</param>
+        <param index="7">Generic dimension 6, in the sensor's raw units</param>
+      </entry>
+      <entry value="243" name="MAV_CMD_PREFLIGHT_UAVCAN">
+        <description>Trigger UAVCAN config. This command will be only accepted if in pre-flight mode.</description>
+        <param index="1">1: Trigger actuator ID assignment and direction mapping.</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="245" name="MAV_CMD_PREFLIGHT_STORAGE">
+        <description>Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.</description>
+        <param index="1">Parameter storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
+        <param index="2">Mission storage: 0: READ FROM FLASH/EEPROM, 1: WRITE CURRENT TO FLASH/EEPROM, 2: Reset to defaults</param>
+        <param index="3">Onboard logging: 0: Ignore, 1: Start default rate logging, -1: Stop logging, &gt; 1: start logging with rate of param 3 in Hz (e.g. set to 1000 for 1000 Hz logging)</param>
+        <param index="4">Reserved</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="246" name="MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN">
+        <description>Request the reboot or shutdown of system components.</description>
+        <param index="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
+        <param index="2">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
+        <param index="3">WIP: 0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
+        <param index="4">WIP: 0: Do nothing for mount (e.g. gimbal), 1: Reboot mount, 2: Shutdown mount, 3: Reboot mount and keep it in the bootloader until upgraded</param>
+        <param index="5">Reserved, send 0</param>
+        <param index="6">Reserved, send 0</param>
+        <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
+      </entry>
+      <entry value="252" name="MAV_CMD_OVERRIDE_GOTO">
+        <description>Hold / continue the current action</description>
+        <param index="1">MAV_GOTO_DO_HOLD: hold MAV_GOTO_DO_CONTINUE: continue with next item in mission plan</param>
+        <param index="2">MAV_GOTO_HOLD_AT_CURRENT_POSITION: Hold at current position MAV_GOTO_HOLD_AT_SPECIFIED_POSITION: hold at specified position</param>
+        <param index="3">MAV_FRAME coordinate frame of hold point</param>
+        <param index="4">Desired yaw angle in degrees</param>
+        <param index="5">Latitude / X position</param>
+        <param index="6">Longitude / Y position</param>
+        <param index="7">Altitude / Z position</param>
+      </entry>
+      <entry value="300" name="MAV_CMD_MISSION_START">
+        <description>start running a mission</description>
+        <param index="1">first_item: the first mission item to run</param>
+        <param index="2">last_item:  the last mission item to run (after this item is run, the mission ends)</param>
+      </entry>
+      <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM">
+        <description>Arms / Disarms a component</description>
+        <param index="1">1 to arm, 0 to disarm</param>
+      </entry>
+      <entry value="410" name="MAV_CMD_GET_HOME_POSITION">
+        <description>Request the home position from the vehicle.</description>
+        <param index="1">Reserved</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="500" name="MAV_CMD_START_RX_PAIR">
+        <description>Starts receiver pairing</description>
+        <param index="1">0:Spektrum</param>
+        <param index="2">0:Spektrum DSM2, 1:Spektrum DSMX</param>
+      </entry>
+      <entry value="510" name="MAV_CMD_GET_MESSAGE_INTERVAL">
+        <description>Request the interval between messages for a particular MAVLink message ID</description>
+        <param index="1">The MAVLink message ID</param>
+      </entry>
+      <entry value="511" name="MAV_CMD_SET_MESSAGE_INTERVAL">
+        <description>Request the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM</description>
+        <param index="1">The MAVLink message ID</param>
+        <param index="2">The interval between two messages, in microseconds. Set to -1 to disable and 0 to request default rate.</param>
+      </entry>
+      <entry value="520" name="MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES">
+        <description>Request autopilot capabilities</description>
+        <param index="1">1: Request autopilot version</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
+        <description>WIP: Request camera information (CAMERA_INFORMATION)</description>
+        <param index="1">1: Request camera capabilities</param>
+        <param index="2">Camera ID</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
+        <description>WIP: Request camera settings (CAMERA_SETTINGS)</description>
+        <param index="1">1: Request camera settings</param>
+        <param index="2">Camera ID</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS_1">
+        <description>WIP: Set the camera settings part 1 (CAMERA_SETTINGS)</description>
+        <param index="1">Camera ID</param>
+        <param index="2">Aperture (1/value)</param>
+        <param index="3">Aperture locked (0: auto, 1: locked)</param>
+        <param index="4">Shutter speed in s</param>
+        <param index="5">Shutter speed locked (0: auto, 1: locked)</param>
+        <param index="6">ISO sensitivity</param>
+        <param index="7">ISO sensitivity locked (0: auto, 1: locked)</param>
+      </entry>
+      <entry value="524" name="MAV_CMD_SET_CAMERA_SETTINGS_2">
+        <description>WIP: Set the camera settings part 2 (CAMERA_SETTINGS)</description>
+        <param index="1">Camera ID</param>
+        <param index="2">White balance locked (0: auto, 1: locked)</param>
+        <param index="3">White balance (color temperature in K)</param>
+        <param index="4">Reserved for camera mode ID</param>
+        <param index="5">Reserved for color mode ID</param>
+        <param index="6">Reserved for image format ID</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
+        <description>WIP: Request storage information (STORAGE_INFORMATION)</description>
+        <param index="1">1: Request storage information</param>
+        <param index="2">Storage ID</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
+        <description>WIP: Format a storage medium</description>
+        <param index="1">1: Format storage</param>
+        <param index="2">Storage ID</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
+        <description>WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
+        <param index="1">1: Request camera capture status</param>
+        <param index="2">Camera ID</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
+        <description>WIP: Request flight information (FLIGHT_INFORMATION)</description>
+        <param index="1">1: Request flight information</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
+        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture.</description>
+        <param index="1">Duration between two consecutive pictures (in seconds)</param>
+        <param index="2">Number of images to capture total - 0 for unlimited capture</param>
+        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
+        <param index="4">WIP: Resolution horizontal in pixels</param>
+        <param index="5">WIP: Resolution horizontal in pixels</param>
+        <param index="6">WIP: Camera ID</param>
+      </entry>
+      <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
+        <description>Stop image capture sequence</description>
+        <param index="1">Camera ID</param>
+        <param index="2">Reserved</param>
+      </entry>
+      <entry name="MAV_CMD_DO_TRIGGER_CONTROL" value="2003">
+        <description>Enable or disable on-board camera triggering system.</description>
+        <param index="1">Trigger enable/disable (0 for disable, 1 for start)</param>
+        <param index="2">Shutter integration time (in ms)</param>
+        <param index="3">Reserved</param>
+      </entry>
+      <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
+        <description>Starts video capture (recording)</description>
+        <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
+        <param index="2">Frames per second, set to -1 for highest framerate possible.</param>
+        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
+        <param index="4">WIP: Resolution horizontal in pixels</param>
+        <param index="5">WIP: Resolution horizontal in pixels</param>
+        <param index="6">WIP: Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise time in Hz)</param>
+      </entry>
+      <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
+        <description>Stop the current video capture (recording)</description>
+        <param index="1">WIP: Camera ID</param>
+        <param index="2">Reserved</param>
+      </entry>
+      <entry value="2510" name="MAV_CMD_LOGGING_START">
+        <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
+        <param index="1">Format: 0: ULog</param>
+        <param index="2">Reserved (set to 0)</param>
+        <param index="3">Reserved (set to 0)</param>
+        <param index="4">Reserved (set to 0)</param>
+        <param index="5">Reserved (set to 0)</param>
+        <param index="6">Reserved (set to 0)</param>
+        <param index="7">Reserved (set to 0)</param>
+      </entry>
+      <entry value="2511" name="MAV_CMD_LOGGING_STOP">
+        <description>Request to stop streaming log data over MAVLink</description>
+        <param index="1">Reserved (set to 0)</param>
+        <param index="2">Reserved (set to 0)</param>
+        <param index="3">Reserved (set to 0)</param>
+        <param index="4">Reserved (set to 0)</param>
+        <param index="5">Reserved (set to 0)</param>
+        <param index="6">Reserved (set to 0)</param>
+        <param index="7">Reserved (set to 0)</param>
+      </entry>
+      <entry value="2520" name="MAV_CMD_AIRFRAME_CONFIGURATION">
+        <description/>
+        <param index="1">Landing gear ID (default: 0, -1 for all)</param>
+        <param index="2">Landing gear position (Down: 0, Up: 1, NAN for no change)</param>
+        <param index="3">Reserved, set to NAN</param>
+        <param index="4">Reserved, set to NAN</param>
+        <param index="5">Reserved, set to NAN</param>
+        <param index="6">Reserved, set to NAN</param>
+        <param index="7">Reserved, set to NAN</param>
+      </entry>
+      <entry value="2800" name="MAV_CMD_PANORAMA_CREATE">
+        <description>Create a panorama at the current position</description>
+        <param index="1">Viewing angle horizontal of the panorama (in degrees, +- 0.5 the total angle)</param>
+        <param index="2">Viewing angle vertical of panorama (in degrees)</param>
+        <param index="3">Speed of the horizontal rotation (in degrees per second)</param>
+        <param index="4">Speed of the vertical rotation (in degrees per second)</param>
+      </entry>
+      <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION">
+        <description>Request VTOL transition</description>
+        <param index="1">The target VTOL state, as defined by ENUM MAV_VTOL_STATE. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
+      </entry>
+      <entry value="4000" name="MAV_CMD_SET_GUIDED_SUBMODE_STANDARD">
+        <description>This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
                   </description>
-              </entry>
-
-              <entry value="4001" name="MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE">
-                  <description>This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
+      </entry>
+      <entry value="4001" name="MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE">
+        <description>This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
                   </description>
-                  <param index="1">Radius of desired circle in CIRCLE_MODE</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Unscaled target latitude of center of circle in CIRCLE_MODE</param>
-                  <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
-              </entry>
-
+        <param index="1">Radius of desired circle in CIRCLE_MODE</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Unscaled target latitude of center of circle in CIRCLE_MODE</param>
+        <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
+      </entry>
       <entry value="4101" name="MAV_CMD_REQUEST_MIXER_PARAM_LIST">
         <description>Request to send a list of all mixer data.</description>
         <param index="1">Mixer Group</param>
@@ -1474,922 +1453,970 @@
         <description>Save mixer parameters</description>
         <param index="1">Mixer Group</param>
       </entry>
-
-              <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
-
-              <!-- BEGIN of payload range (30000 to 30999) -->
-              <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY">
-                  <description>Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.</description>
-                  <param index="1">Operation mode. 0: prepare single payload deploy (overwriting previous requests), but do not execute it. 1: execute payload deploy immediately (rejecting further deploy commands during execution, but allowing abort). 2: add payload deploy to existing deployment list.</param>
-                  <param index="2">Desired approach vector in degrees compass heading (0..360). A negative value indicates the system can define the approach vector at will.</param>
-                  <param index="3">Desired ground speed at release time. This can be overriden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.</param>
-                  <param index="4">Minimum altitude clearance to the release position in meters. A negative value indicates the system can define the clearance at will.</param>
-                  <param index="5">Latitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
-                  <param index="6">Longitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="30002" name="MAV_CMD_PAYLOAD_CONTROL_DEPLOY">
-                  <description>Control the payload deployment.</description>
-                  <param index="1">Operation mode. 0: Abort deployment, continue normal mission. 1: switch to payload deploment mode. 100: delete first payload deployment request. 101: delete all payload deployment requests.</param>
-                  <param index="2">Reserved</param>
-                  <param index="3">Reserved</param>
-                  <param index="4">Reserved</param>
-                  <param index="5">Reserved</param>
-                  <param index="6">Reserved</param>
-                  <param index="7">Reserved</param>
-              </entry>
-              <!-- END of payload range (30000 to 30999) -->
-
-              <!-- BEGIN user defined range (31000 to 31999) -->
-              <entry value="31000" name="MAV_CMD_WAYPOINT_USER_1">
-                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31001" name="MAV_CMD_WAYPOINT_USER_2">
-                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31002" name="MAV_CMD_WAYPOINT_USER_3">
-                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31003" name="MAV_CMD_WAYPOINT_USER_4">
-                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31004" name="MAV_CMD_WAYPOINT_USER_5">
-                  <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31005" name="MAV_CMD_SPATIAL_USER_1">
-                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31006" name="MAV_CMD_SPATIAL_USER_2">
-                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31007" name="MAV_CMD_SPATIAL_USER_3">
-                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31008" name="MAV_CMD_SPATIAL_USER_4">
-                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31009" name="MAV_CMD_SPATIAL_USER_5">
-                  <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">Latitude unscaled</param>
-                  <param index="6">Longitude unscaled</param>
-                  <param index="7">Altitude, in meters AMSL</param>
-              </entry>
-              <entry value="31010" name="MAV_CMD_USER_1">
-                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">User defined</param>
-                  <param index="6">User defined</param>
-                  <param index="7">User defined</param>
-              </entry>
-              <entry value="31011" name="MAV_CMD_USER_2">
-                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">User defined</param>
-                  <param index="6">User defined</param>
-                  <param index="7">User defined</param>
-              </entry>
-              <entry value="31012" name="MAV_CMD_USER_3">
-                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">User defined</param>
-                  <param index="6">User defined</param>
-                  <param index="7">User defined</param>
-              </entry>
-              <entry value="31013" name="MAV_CMD_USER_4">
-                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">User defined</param>
-                  <param index="6">User defined</param>
-                  <param index="7">User defined</param>
-              </entry>
-              <entry value="31014" name="MAV_CMD_USER_5">
-                  <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
-                  <param index="1">User defined</param>
-                  <param index="2">User defined</param>
-                  <param index="3">User defined</param>
-                  <param index="4">User defined</param>
-                  <param index="5">User defined</param>
-                  <param index="6">User defined</param>
-                  <param index="7">User defined</param>
-              </entry>
-              <!-- END of user range (31000 to 31999) -->
-          </enum>
-          <enum name="MAV_DATA_STREAM">
-               <description>THIS INTERFACE IS DEPRECATED AS OF JULY 2015. Please use MESSAGE_INTERVAL instead. A data stream is not a fixed set of messages, but rather a
+      <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT">
+        <description>Fence return point. There can only be one fence return point.
+        </description>
+        <param index="1">Reserved</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <entry value="5001" name="MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION">
+        <description>Fence vertex for an inclusion polygon. The vehicle must stay within this area. Minimum of 3 vertices required.
+        </description>
+        <param index="1">Polygon vertex count</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="5002" name="MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION">
+        <description>Fence vertex for an exclusion polygon. The vehicle must stay outside this area. Minimum of 3 vertices required.
+        </description>
+        <param index="1">Polygon vertex count</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <entry value="5100" name="MAV_CMD_NAV_RALLY_POINT">
+        <description>Rally point. You can have multiple rally points defined.
+        </description>
+        <param index="1">Reserved</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
+      <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
+      <!-- BEGIN of payload range (30000 to 30999) -->
+      <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY">
+        <description>Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.</description>
+        <param index="1">Operation mode. 0: prepare single payload deploy (overwriting previous requests), but do not execute it. 1: execute payload deploy immediately (rejecting further deploy commands during execution, but allowing abort). 2: add payload deploy to existing deployment list.</param>
+        <param index="2">Desired approach vector in degrees compass heading (0..360). A negative value indicates the system can define the approach vector at will.</param>
+        <param index="3">Desired ground speed at release time. This can be overriden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.</param>
+        <param index="4">Minimum altitude clearance to the release position in meters. A negative value indicates the system can define the clearance at will.</param>
+        <param index="5">Latitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
+        <param index="6">Longitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="30002" name="MAV_CMD_PAYLOAD_CONTROL_DEPLOY">
+        <description>Control the payload deployment.</description>
+        <param index="1">Operation mode. 0: Abort deployment, continue normal mission. 1: switch to payload deploment mode. 100: delete first payload deployment request. 101: delete all payload deployment requests.</param>
+        <param index="2">Reserved</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
+      <!-- END of payload range (30000 to 30999) -->
+      <!-- BEGIN user defined range (31000 to 31999) -->
+      <entry value="31000" name="MAV_CMD_WAYPOINT_USER_1">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31001" name="MAV_CMD_WAYPOINT_USER_2">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31002" name="MAV_CMD_WAYPOINT_USER_3">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31003" name="MAV_CMD_WAYPOINT_USER_4">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31004" name="MAV_CMD_WAYPOINT_USER_5">
+        <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31005" name="MAV_CMD_SPATIAL_USER_1">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31006" name="MAV_CMD_SPATIAL_USER_2">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31007" name="MAV_CMD_SPATIAL_USER_3">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31008" name="MAV_CMD_SPATIAL_USER_4">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31009" name="MAV_CMD_SPATIAL_USER_5">
+        <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">Latitude unscaled</param>
+        <param index="6">Longitude unscaled</param>
+        <param index="7">Altitude, in meters AMSL</param>
+      </entry>
+      <entry value="31010" name="MAV_CMD_USER_1">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry value="31011" name="MAV_CMD_USER_2">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry value="31012" name="MAV_CMD_USER_3">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry value="31013" name="MAV_CMD_USER_4">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <entry value="31014" name="MAV_CMD_USER_5">
+        <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
+        <param index="1">User defined</param>
+        <param index="2">User defined</param>
+        <param index="3">User defined</param>
+        <param index="4">User defined</param>
+        <param index="5">User defined</param>
+        <param index="6">User defined</param>
+        <param index="7">User defined</param>
+      </entry>
+      <!-- END of user range (31000 to 31999) -->
+    </enum>
+    <enum name="MAV_DATA_STREAM">
+      <description>THIS INTERFACE IS DEPRECATED AS OF JULY 2015. Please use MESSAGE_INTERVAL instead. A data stream is not a fixed set of messages, but rather a
      recommendation to the autopilot software. Individual autopilots may or may not obey
      the recommended messages.</description>
-               <entry value="0" name="MAV_DATA_STREAM_ALL">
-                    <description>Enable all data streams</description>
-               </entry>
-               <entry value="1" name="MAV_DATA_STREAM_RAW_SENSORS">
-                    <description>Enable IMU_RAW, GPS_RAW, GPS_STATUS packets.</description>
-               </entry>
-               <entry value="2" name="MAV_DATA_STREAM_EXTENDED_STATUS">
-                    <description>Enable GPS_STATUS, CONTROL_STATUS, AUX_STATUS</description>
-               </entry>
-               <entry value="3" name="MAV_DATA_STREAM_RC_CHANNELS">
-                    <description>Enable RC_CHANNELS_SCALED, RC_CHANNELS_RAW, SERVO_OUTPUT_RAW</description>
-               </entry>
-               <entry value="4" name="MAV_DATA_STREAM_RAW_CONTROLLER">
-                    <description>Enable ATTITUDE_CONTROLLER_OUTPUT, POSITION_CONTROLLER_OUTPUT, NAV_CONTROLLER_OUTPUT.</description>
-               </entry>
-               <entry value="6" name="MAV_DATA_STREAM_POSITION">
-                    <description>Enable LOCAL_POSITION, GLOBAL_POSITION/GLOBAL_POSITION_INT messages.</description>
-               </entry>
-               <entry value="10" name="MAV_DATA_STREAM_EXTRA1">
-                    <description>Dependent on the autopilot</description>
-               </entry>
-               <entry value="11" name="MAV_DATA_STREAM_EXTRA2">
-                    <description>Dependent on the autopilot</description>
-               </entry>
-               <entry value="12" name="MAV_DATA_STREAM_EXTRA3">
-                    <description>Dependent on the autopilot</description>
-               </entry>
-          </enum>
-          <enum name="MAV_ROI">
-               <description> The ROI (region of interest) for the vehicle. This can be
+      <entry value="0" name="MAV_DATA_STREAM_ALL">
+        <description>Enable all data streams</description>
+      </entry>
+      <entry value="1" name="MAV_DATA_STREAM_RAW_SENSORS">
+        <description>Enable IMU_RAW, GPS_RAW, GPS_STATUS packets.</description>
+      </entry>
+      <entry value="2" name="MAV_DATA_STREAM_EXTENDED_STATUS">
+        <description>Enable GPS_STATUS, CONTROL_STATUS, AUX_STATUS</description>
+      </entry>
+      <entry value="3" name="MAV_DATA_STREAM_RC_CHANNELS">
+        <description>Enable RC_CHANNELS_SCALED, RC_CHANNELS_RAW, SERVO_OUTPUT_RAW</description>
+      </entry>
+      <entry value="4" name="MAV_DATA_STREAM_RAW_CONTROLLER">
+        <description>Enable ATTITUDE_CONTROLLER_OUTPUT, POSITION_CONTROLLER_OUTPUT, NAV_CONTROLLER_OUTPUT.</description>
+      </entry>
+      <entry value="6" name="MAV_DATA_STREAM_POSITION">
+        <description>Enable LOCAL_POSITION, GLOBAL_POSITION/GLOBAL_POSITION_INT messages.</description>
+      </entry>
+      <entry value="10" name="MAV_DATA_STREAM_EXTRA1">
+        <description>Dependent on the autopilot</description>
+      </entry>
+      <entry value="11" name="MAV_DATA_STREAM_EXTRA2">
+        <description>Dependent on the autopilot</description>
+      </entry>
+      <entry value="12" name="MAV_DATA_STREAM_EXTRA3">
+        <description>Dependent on the autopilot</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ROI">
+      <description> The ROI (region of interest) for the vehicle. This can be
                 be used by the vehicle for camera/vehicle attitude alignment (see
                 MAV_CMD_NAV_ROI).</description>
-               <entry value="0" name="MAV_ROI_NONE">
-                    <description>No region of interest.</description>
-               </entry>
-               <entry value="1" name="MAV_ROI_WPNEXT">
-                    <description>Point toward next MISSION.</description>
-               </entry>
-               <entry value="2" name="MAV_ROI_WPINDEX">
-                    <description>Point toward given MISSION.</description>
-               </entry>
-               <entry value="3" name="MAV_ROI_LOCATION">
-                    <description>Point toward fixed location.</description>
-               </entry>
-               <entry value="4" name="MAV_ROI_TARGET">
-                    <description>Point toward of given id.</description>
-               </entry>
-          </enum>
-          <enum name="MAV_CMD_ACK">
-               <description>ACK / NACK / ERROR values as a result of MAV_CMDs and for mission item transmission.</description>
-               <entry name="MAV_CMD_ACK_OK">
-                    <description>Command / mission item is ok.</description>
-               </entry>
-               <entry name="MAV_CMD_ACK_ERR_FAIL">
-                    <description>Generic error message if none of the other reasons fails or if no detailed error reporting is implemented.</description>
-               </entry>
-               <entry name="MAV_CMD_ACK_ERR_ACCESS_DENIED">
-                    <description>The system is refusing to accept this command from this source / communication partner.</description>
-               </entry>
-               <entry name="MAV_CMD_ACK_ERR_NOT_SUPPORTED">
-                    <description>Command or mission item is not supported, other commands would be accepted.</description>
-               </entry>
-               <entry name="MAV_CMD_ACK_ERR_COORDINATE_FRAME_NOT_SUPPORTED">
-                    <description>The coordinate frame of this command / mission item is not supported.</description>
-               </entry>
-               <entry name="MAV_CMD_ACK_ERR_COORDINATES_OUT_OF_RANGE">
-                    <description>The coordinate frame of this command is ok, but he coordinate values exceed the safety limits of this system. This is a generic error, please use the more specific error messages below if possible.</description>
-               </entry>
-               <entry name="MAV_CMD_ACK_ERR_X_LAT_OUT_OF_RANGE">
-                    <description>The X or latitude value is out of range.</description>
-               </entry>
-               <entry name="MAV_CMD_ACK_ERR_Y_LON_OUT_OF_RANGE">
-                    <description>The Y or longitude value is out of range.</description>
-               </entry>
-               <entry name="MAV_CMD_ACK_ERR_Z_ALT_OUT_OF_RANGE">
-                    <description>The Z or altitude value is out of range.</description>
-               </entry>
-          </enum>
-          <enum name="MAV_PARAM_TYPE">
-               <description>Specifies the datatype of a MAVLink parameter.</description>
-               <entry value="1" name="MAV_PARAM_TYPE_UINT8">
-                    <description>8-bit unsigned integer</description>
-               </entry>
-               <entry value="2" name="MAV_PARAM_TYPE_INT8">
-                    <description>8-bit signed integer</description>
-               </entry>
-               <entry value="3" name="MAV_PARAM_TYPE_UINT16">
-                    <description>16-bit unsigned integer</description>
-               </entry>
-               <entry value="4" name="MAV_PARAM_TYPE_INT16">
-                    <description>16-bit signed integer</description>
-               </entry>
-               <entry value="5" name="MAV_PARAM_TYPE_UINT32">
-                    <description>32-bit unsigned integer</description>
-               </entry>
-               <entry value="6" name="MAV_PARAM_TYPE_INT32">
-                    <description>32-bit signed integer</description>
-               </entry>
-               <entry value="7" name="MAV_PARAM_TYPE_UINT64">
-                    <description>64-bit unsigned integer</description>
-               </entry>
-               <entry value="8" name="MAV_PARAM_TYPE_INT64">
-                    <description>64-bit signed integer</description>
-               </entry>
-               <entry value="9" name="MAV_PARAM_TYPE_REAL32">
-                    <description>32-bit floating-point</description>
-               </entry>
-               <entry value="10" name="MAV_PARAM_TYPE_REAL64">
-                    <description>64-bit floating-point</description>
-               </entry>
-          </enum>
-          <enum name="MAV_RESULT">
-               <description>result from a mavlink command</description>
-               <entry value="0" name="MAV_RESULT_ACCEPTED">
-                    <description>Command ACCEPTED and EXECUTED</description>
-               </entry>
-               <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
-                    <description>Command TEMPORARY REJECTED/DENIED</description>
-               </entry>
-               <entry value="2" name="MAV_RESULT_DENIED">
-                    <description>Command PERMANENTLY DENIED</description>
-               </entry>
-               <entry value="3" name="MAV_RESULT_UNSUPPORTED">
-                    <description>Command UNKNOWN/UNSUPPORTED</description>
-               </entry>
-               <entry value="4" name="MAV_RESULT_FAILED">
-                    <description>Command executed, but failed</description>
-               </entry>
-          </enum>
-          <enum name="MAV_MISSION_RESULT">
-               <description>result in a mavlink mission ack</description>
-               <entry value="0" name="MAV_MISSION_ACCEPTED">
-                    <description>mission accepted OK</description>
-               </entry>
-               <entry value="1" name="MAV_MISSION_ERROR">
-                    <description>generic error / not accepting mission commands at all right now</description>
-               </entry>
-               <entry value="2" name="MAV_MISSION_UNSUPPORTED_FRAME">
-                    <description>coordinate frame is not supported</description>
-               </entry>
-               <entry value="3" name="MAV_MISSION_UNSUPPORTED">
-                    <description>command is not supported</description>
-               </entry>
-               <entry value="4" name="MAV_MISSION_NO_SPACE">
-                    <description>mission item exceeds storage space</description>
-               </entry>
-               <entry value="5" name="MAV_MISSION_INVALID">
-                    <description>one of the parameters has an invalid value</description>
-               </entry>
-               <entry value="6" name="MAV_MISSION_INVALID_PARAM1">
-                    <description>param1 has an invalid value</description>
-               </entry>
-               <entry value="7" name="MAV_MISSION_INVALID_PARAM2">
-                    <description>param2 has an invalid value</description>
-               </entry>
-               <entry value="8" name="MAV_MISSION_INVALID_PARAM3">
-                    <description>param3 has an invalid value</description>
-               </entry>
-               <entry value="9" name="MAV_MISSION_INVALID_PARAM4">
-                    <description>param4 has an invalid value</description>
-               </entry>
-               <entry value="10" name="MAV_MISSION_INVALID_PARAM5_X">
-                    <description>x/param5 has an invalid value</description>
-               </entry>
-               <entry value="11" name="MAV_MISSION_INVALID_PARAM6_Y">
-                    <description>y/param6 has an invalid value</description>
-               </entry>
-               <entry value="12" name="MAV_MISSION_INVALID_PARAM7">
-                    <description>param7 has an invalid value</description>
-               </entry>
-               <entry value="13" name="MAV_MISSION_INVALID_SEQUENCE">
-                    <description>received waypoint out of sequence</description>
-               </entry>
-               <entry value="14" name="MAV_MISSION_DENIED">
-                    <description>not accepting any mission commands from this communication partner</description>
-               </entry>
-          </enum>
-          <enum name="MAV_SEVERITY">
-               <description>Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.</description>
-               <entry value="0" name="MAV_SEVERITY_EMERGENCY">
-                  <description>System is unusable. This is a "panic" condition.</description>
-               </entry>
-               <entry value="1" name="MAV_SEVERITY_ALERT">
-                  <description>Action should be taken immediately. Indicates error in non-critical systems.</description>
-               </entry>
-               <entry value="2" name="MAV_SEVERITY_CRITICAL">
-                  <description>Action must be taken immediately. Indicates failure in a primary system.</description>
-               </entry>
-               <entry value="3" name="MAV_SEVERITY_ERROR">
-                  <description>Indicates an error in secondary/redundant systems.</description>
-               </entry>
-               <entry value="4" name="MAV_SEVERITY_WARNING">
-                  <description>Indicates about a possible future error if this is not resolved within a given timeframe. Example would be a low battery warning.</description>
-               </entry>
-               <entry value="5" name="MAV_SEVERITY_NOTICE">
-                  <description>An unusual event has occured, though not an error condition. This should be investigated for the root cause.</description>
-               </entry>
-               <entry value="6" name="MAV_SEVERITY_INFO">
-                  <description>Normal operational messages. Useful for logging. No action is required for these messages.</description>
-               </entry>
-               <entry value="7" name="MAV_SEVERITY_DEBUG">
-                  <description>Useful non-operational messages that can assist in debugging. These should not occur during normal operation.</description>
-               </entry>
-          </enum>
-          <enum name="MAV_POWER_STATUS">
-               <description>Power supply status flags (bitmask)</description>
-               <entry value="1" name="MAV_POWER_STATUS_BRICK_VALID">
-                    <description>main brick power supply valid</description>
-               </entry>
-               <entry value="2" name="MAV_POWER_STATUS_SERVO_VALID">
-                    <description>main servo power supply valid for FMU</description>
-               </entry>
-               <entry value="4" name="MAV_POWER_STATUS_USB_CONNECTED">
-                    <description>USB power is connected</description>
-               </entry>
-               <entry value="8" name="MAV_POWER_STATUS_PERIPH_OVERCURRENT">
-                    <description>peripheral supply is in over-current state</description>
-               </entry>
-               <entry value="16" name="MAV_POWER_STATUS_PERIPH_HIPOWER_OVERCURRENT">
-                    <description>hi-power peripheral supply is in over-current state</description>
-               </entry>
-               <entry value="32" name="MAV_POWER_STATUS_CHANGED">
-                    <description>Power status has changed since boot</description>
-               </entry>
-          </enum>
-          <enum name="SERIAL_CONTROL_DEV">
-               <description>SERIAL_CONTROL device types</description>
-               <entry value="0" name="SERIAL_CONTROL_DEV_TELEM1">
-                    <description>First telemetry port</description>
-               </entry>
-               <entry value="1" name="SERIAL_CONTROL_DEV_TELEM2">
-                    <description>Second telemetry port</description>
-               </entry>
-               <entry value="2" name="SERIAL_CONTROL_DEV_GPS1">
-                    <description>First GPS port</description>
-               </entry>
-               <entry value="3" name="SERIAL_CONTROL_DEV_GPS2">
-                    <description>Second GPS port</description>
-               </entry>
-               <entry value="10" name="SERIAL_CONTROL_DEV_SHELL">
-                    <description>system shell</description>
-               </entry>
-          </enum>
-          <enum name="SERIAL_CONTROL_FLAG">
-               <description>SERIAL_CONTROL flags (bitmask)</description>
-               <entry value="1" name="SERIAL_CONTROL_FLAG_REPLY">
-                    <description>Set if this is a reply</description>
-               </entry>
-               <entry value="2" name="SERIAL_CONTROL_FLAG_RESPOND">
-                    <description>Set if the sender wants the receiver to send a response as another SERIAL_CONTROL message</description>
-               </entry>
-               <entry value="4" name="SERIAL_CONTROL_FLAG_EXCLUSIVE">
-                    <description>Set if access to the serial port should be removed from whatever driver is currently using it, giving exclusive access to the SERIAL_CONTROL protocol. The port can be handed back by sending a request without this flag set</description>
-               </entry>
-               <entry value="8" name="SERIAL_CONTROL_FLAG_BLOCKING">
-                    <description>Block on writes to the serial port</description>
-               </entry>
-               <entry value="16" name="SERIAL_CONTROL_FLAG_MULTI">
-                    <description>Send multiple replies until port is drained</description>
-               </entry>
-          </enum>
-          <enum name="MAV_DISTANCE_SENSOR">
-              <description>Enumeration of distance sensor types</description>
-              <entry value="0" name="MAV_DISTANCE_SENSOR_LASER">
-                  <description>Laser rangefinder, e.g. LightWare SF02/F or PulsedLight units</description>
-              </entry>
-              <entry value="1" name="MAV_DISTANCE_SENSOR_ULTRASOUND">
-                  <description>Ultrasound rangefinder, e.g. MaxBotix units</description>
-              </entry>
-              <entry value="2" name="MAV_DISTANCE_SENSOR_INFRARED">
-                  <description>Infrared rangefinder, e.g. Sharp units</description>
-              </entry>
-          </enum>
-          <enum name="MAV_SENSOR_ORIENTATION">
-              <description>Enumeration of sensor orientation, according to its rotations</description>
-              <entry value="0" name="MAV_SENSOR_ROTATION_NONE">
-                  <description>Roll: 0, Pitch: 0, Yaw: 0</description>
-              </entry>
-              <entry value="1" name="MAV_SENSOR_ROTATION_YAW_45">
-                  <description>Roll: 0, Pitch: 0, Yaw: 45</description>
-              </entry>
-              <entry value="2" name="MAV_SENSOR_ROTATION_YAW_90">
-                  <description>Roll: 0, Pitch: 0, Yaw: 90</description>
-              </entry>
-              <entry value="3" name="MAV_SENSOR_ROTATION_YAW_135">
-                  <description>Roll: 0, Pitch: 0, Yaw: 135</description>
-              </entry>
-              <entry value="4" name="MAV_SENSOR_ROTATION_YAW_180">
-                  <description>Roll: 0, Pitch: 0, Yaw: 180</description>
-              </entry>
-              <entry value="5" name="MAV_SENSOR_ROTATION_YAW_225">
-                  <description>Roll: 0, Pitch: 0, Yaw: 225</description>
-              </entry>
-              <entry value="6" name="MAV_SENSOR_ROTATION_YAW_270">
-                  <description>Roll: 0, Pitch: 0, Yaw: 270</description>
-              </entry>
-              <entry value="7" name="MAV_SENSOR_ROTATION_YAW_315">
-                  <description>Roll: 0, Pitch: 0, Yaw: 315</description>
-              </entry>
-              <entry value="8" name="MAV_SENSOR_ROTATION_ROLL_180">
-                  <description>Roll: 180, Pitch: 0, Yaw: 0</description>
-              </entry>
-              <entry value="9" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_45">
-                  <description>Roll: 180, Pitch: 0, Yaw: 45</description>
-              </entry>
-              <entry value="10" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_90">
-                  <description>Roll: 180, Pitch: 0, Yaw: 90</description>
-              </entry>
-              <entry value="11" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_135">
-                  <description>Roll: 180, Pitch: 0, Yaw: 135</description>
-              </entry>
-              <entry value="12" name="MAV_SENSOR_ROTATION_PITCH_180">
-                  <description>Roll: 0, Pitch: 180, Yaw: 0</description>
-              </entry>
-              <entry value="13" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_225">
-                  <description>Roll: 180, Pitch: 0, Yaw: 225</description>
-              </entry>
-              <entry value="14" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_270">
-                  <description>Roll: 180, Pitch: 0, Yaw: 270</description>
-              </entry>
-              <entry value="15" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_315">
-                  <description>Roll: 180, Pitch: 0, Yaw: 315</description>
-              </entry>
-              <entry value="16" name="MAV_SENSOR_ROTATION_ROLL_90">
-                  <description>Roll: 90, Pitch: 0, Yaw: 0</description>
-              </entry>
-              <entry value="17" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_45">
-                  <description>Roll: 90, Pitch: 0, Yaw: 45</description>
-              </entry>
-              <entry value="18" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_90">
-                  <description>Roll: 90, Pitch: 0, Yaw: 90</description>
-              </entry>
-              <entry value="19" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_135">
-                  <description>Roll: 90, Pitch: 0, Yaw: 135</description>
-              </entry>
-              <entry value="20" name="MAV_SENSOR_ROTATION_ROLL_270">
-                  <description>Roll: 270, Pitch: 0, Yaw: 0</description>
-              </entry>
-              <entry value="21" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_45">
-                  <description>Roll: 270, Pitch: 0, Yaw: 45</description>
-              </entry>
-              <entry value="22" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_90">
-                  <description>Roll: 270, Pitch: 0, Yaw: 90</description>
-              </entry>
-              <entry value="23" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_135">
-                  <description>Roll: 270, Pitch: 0, Yaw: 135</description>
-              </entry>
-              <entry value="24" name="MAV_SENSOR_ROTATION_PITCH_90">
-                  <description>Roll: 0, Pitch: 90, Yaw: 0</description>
-              </entry>
-              <entry value="25" name="MAV_SENSOR_ROTATION_PITCH_270">
-                <description>Roll: 0, Pitch: 270, Yaw: 0</description>
-              </entry>
-              <entry value="26" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_90">
-                <description>Roll: 0, Pitch: 180, Yaw: 90</description>
-              </entry>
-              <entry value="27" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_270">
-                  <description>Roll: 0, Pitch: 180, Yaw: 270</description>
-              </entry>
-              <entry value="28" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_90">
-                  <description>Roll: 90, Pitch: 90, Yaw: 0</description>
-              </entry>
-              <entry value="29" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_90">
-                  <description>Roll: 180, Pitch: 90, Yaw: 0</description>
-              </entry>
-              <entry value="30" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_90">
-                  <description>Roll: 270, Pitch: 90, Yaw: 0</description>
-              </entry>
-              <entry value="31" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180">
-                  <description>Roll: 90, Pitch: 180, Yaw: 0</description>
-              </entry>
-              <entry value="32" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_180">
-                  <description>Roll: 270, Pitch: 180, Yaw: 0</description>
-              </entry>
-              <entry value="33" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_270">
-                  <description>Roll: 90, Pitch: 270, Yaw: 0</description>
-              </entry>
-              <entry value="34" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_270">
-                  <description>Roll: 180, Pitch: 270, Yaw: 0</description>
-              </entry>
-              <entry value="35" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_270">
-                  <description>Roll: 270, Pitch: 270, Yaw: 0</description>
-              </entry>
-              <entry value="36" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90">
-                  <description>Roll: 90, Pitch: 180, Yaw: 90</description>
-              </entry>
-              <entry value="37" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_270">
-                  <description>Roll: 90, Pitch: 0, Yaw: 270</description>
-              </entry>
-              <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_315_PITCH_315_YAW_315">
-                  <description>Roll: 315, Pitch: 315, Yaw: 315</description>
-              </entry>
-          </enum>
-          <enum name="MAV_PROTOCOL_CAPABILITY">
-              <description>Bitmask of (optional) autopilot capabilities (64 bit). If a bit is set, the autopilot supports this capability.</description>
-              <entry value="1" name="MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT">
-                  <description>Autopilot supports MISSION float message type.</description>
-              </entry>
-              <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT">
-                  <description>Autopilot supports the new param float message type.</description>
-              </entry>
-              <entry value="4" name="MAV_PROTOCOL_CAPABILITY_MISSION_INT">
-                  <description>Autopilot supports MISSION_INT scaled integer message type.</description>
-              </entry>
-              <entry value="8" name="MAV_PROTOCOL_CAPABILITY_COMMAND_INT">
-                  <description>Autopilot supports COMMAND_INT scaled integer message type.</description>
-              </entry>
-              <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_UNION">
-                  <description>Autopilot supports the new param union message type.</description>
-              </entry>
-              <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">
-                  <description>Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.</description>
-              </entry>
-              <entry value="64" name="MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET">
-                  <description>Autopilot supports commanding attitude offboard.</description>
-              </entry>
-              <entry value="128" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED">
-                  <description>Autopilot supports commanding position and velocity targets in local NED frame.</description>
-              </entry>
-              <entry value="256" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT">
-                  <description>Autopilot supports commanding position and velocity targets in global scaled integers.</description>
-              </entry>
-              <entry value="512" name="MAV_PROTOCOL_CAPABILITY_TERRAIN">
-                  <description>Autopilot supports terrain protocol / data handling.</description>
-              </entry>
-              <entry value="1024" name="MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET">
-                  <description>Autopilot supports direct actuator control.</description>
-              </entry>
-              <entry value="2048" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION">
-                  <description>Autopilot supports the flight termination command.</description>
-              </entry>
-              <entry value="4096" name="MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION">
-                  <description>Autopilot supports onboard compass calibration.</description>
-              </entry>
-              <entry value="8192" name="MAV_PROTOCOL_CAPABILITY_MAVLINK2">
-                  <description>Autopilot supports mavlink version 2.</description>
-              </entry>
-          </enum>
-          <enum name="MAV_ESTIMATOR_TYPE">
-              <description>Enumeration of estimator types</description>
-              <entry value="1" name="MAV_ESTIMATOR_TYPE_NAIVE">
-                  <description>This is a naive estimator without any real covariance feedback.</description>
-              </entry>
-              <entry value="2" name="MAV_ESTIMATOR_TYPE_VISION">
-                  <description>Computer vision based estimate. Might be up to scale.</description>
-              </entry>
-              <entry value="3" name="MAV_ESTIMATOR_TYPE_VIO">
-                  <description>Visual-inertial estimate.</description>
-              </entry>
-              <entry value="4" name="MAV_ESTIMATOR_TYPE_GPS">
-                  <description>Plain GPS estimate.</description>
-              </entry>
-              <entry value="5" name="MAV_ESTIMATOR_TYPE_GPS_INS">
-                  <description>Estimator integrating GPS and inertial sensing.</description>
-              </entry>
-          </enum>
-          <enum name="MAV_BATTERY_TYPE">
-              <description>Enumeration of battery types</description>
-              <entry value="0" name="MAV_BATTERY_TYPE_UNKNOWN">
-                  <description>Not specified.</description>
-              </entry>
-              <entry value="1" name="MAV_BATTERY_TYPE_LIPO">
-                  <description>Lithium polymer battery</description>
-              </entry>
-              <entry value="2" name="MAV_BATTERY_TYPE_LIFE">
-                  <description>Lithium-iron-phosphate battery</description>
-              </entry>
-              <entry value="3" name="MAV_BATTERY_TYPE_LION">
-                  <description>Lithium-ION battery</description>
-              </entry>
-              <entry value="4" name="MAV_BATTERY_TYPE_NIMH">
-                  <description>Nickel metal hydride battery</description>
-              </entry>
-          </enum>
-          <enum name="MAV_BATTERY_FUNCTION">
-              <description>Enumeration of battery functions</description>
-              <entry value="0" name="MAV_BATTERY_FUNCTION_UNKNOWN">
-                  <description>Battery function is unknown</description>
-              </entry>
-              <entry value="1" name="MAV_BATTERY_FUNCTION_ALL">
-                  <description>Battery supports all flight systems</description>
-              </entry>
-              <entry value="2" name="MAV_BATTERY_FUNCTION_PROPULSION">
-                  <description>Battery for the propulsion system</description>
-              </entry>
-              <entry value="3" name="MAV_BATTERY_FUNCTION_AVIONICS">
-                  <description>Avionics battery</description>
-              </entry>
-              <entry value="4" name="MAV_BATTERY_TYPE_PAYLOAD">
-                  <description>Payload battery</description>
-              </entry>
-          </enum>
-          <enum name="MAV_VTOL_STATE">
-              <description>Enumeration of VTOL states</description>
-              <entry value="0" name="MAV_VTOL_STATE_UNDEFINED">
-                  <description>MAV is not configured as VTOL</description>
-              </entry>
-              <entry value="1" name="MAV_VTOL_STATE_TRANSITION_TO_FW">
-                  <description>VTOL is in transition from multicopter to fixed-wing</description>
-              </entry>
-              <entry value="2" name="MAV_VTOL_STATE_TRANSITION_TO_MC">
-                  <description>VTOL is in transition from fixed-wing to multicopter</description>
-              </entry>
-              <entry value="3" name="MAV_VTOL_STATE_MC">
-                  <description>VTOL is in multicopter state</description>
-              </entry>
-              <entry value="4" name="MAV_VTOL_STATE_FW">
-                  <description>VTOL is in fixed-wing state</description>
-              </entry>
-          </enum>
-          <enum name="MAV_LANDED_STATE">
-              <description>Enumeration of landed detector states</description>
-              <entry value="0" name="MAV_LANDED_STATE_UNDEFINED">
-                  <description>MAV landed state is unknown</description>
-              </entry>
-              <entry value="1" name="MAV_LANDED_STATE_ON_GROUND">
-                  <description>MAV is landed (on ground)</description>
-              </entry>
-              <entry value="2" name="MAV_LANDED_STATE_IN_AIR">
-                  <description>MAV is in air</description>
-              </entry>
-          </enum>
-          <enum name="ADSB_ALTITUDE_TYPE">
-              <description>Enumeration of the ADSB altimeter types</description>
-              <entry value="0" name="ADSB_ALTITUDE_TYPE_PRESSURE_QNH">
-                  <description>Altitude reported from a Baro source using QNH reference</description>
-              </entry>
-              <entry value="1" name="ADSB_ALTITUDE_TYPE_GEOMETRIC">
-                  <description>Altitude reported from a GNSS source</description>
-              </entry>
-          </enum>
-          <enum name="ADSB_EMITTER_TYPE">
-              <description>ADSB classification for the type of vehicle emitting the transponder signal</description>
-              <entry value="0" name="ADSB_EMITTER_TYPE_NO_INFO"></entry>
-              <entry value="1" name="ADSB_EMITTER_TYPE_LIGHT"></entry>
-              <entry value="2" name="ADSB_EMITTER_TYPE_SMALL"></entry>
-              <entry value="3" name="ADSB_EMITTER_TYPE_LARGE"></entry>
-              <entry value="4" name="ADSB_EMITTER_TYPE_HIGH_VORTEX_LARGE"></entry>
-              <entry value="5" name="ADSB_EMITTER_TYPE_HEAVY"></entry>
-              <entry value="6" name="ADSB_EMITTER_TYPE_HIGHLY_MANUV"></entry>
-              <entry value="7" name="ADSB_EMITTER_TYPE_ROTOCRAFT"></entry>
-              <entry value="8" name="ADSB_EMITTER_TYPE_UNASSIGNED"></entry>
-              <entry value="9" name="ADSB_EMITTER_TYPE_GLIDER"></entry>
-              <entry value="10" name="ADSB_EMITTER_TYPE_LIGHTER_AIR"></entry>
-              <entry value="11" name="ADSB_EMITTER_TYPE_PARACHUTE"></entry>
-              <entry value="12" name="ADSB_EMITTER_TYPE_ULTRA_LIGHT"></entry>
-              <entry value="13" name="ADSB_EMITTER_TYPE_UNASSIGNED2"></entry>
-              <entry value="14" name="ADSB_EMITTER_TYPE_UAV"></entry>
-              <entry value="15" name="ADSB_EMITTER_TYPE_SPACE"></entry>
-              <entry value="16" name="ADSB_EMITTER_TYPE_UNASSGINED3"></entry>
-              <entry value="17" name="ADSB_EMITTER_TYPE_EMERGENCY_SURFACE"></entry>
-              <entry value="18" name="ADSB_EMITTER_TYPE_SERVICE_SURFACE"></entry>
-              <entry value="19" name="ADSB_EMITTER_TYPE_POINT_OBSTACLE"></entry>
-          </enum>
-          <enum name="ADSB_FLAGS">
-              <description>These flags indicate status such as data validity of each data source. Set = data valid</description>
-              <entry value="1" name="ADSB_FLAGS_VALID_COORDS"></entry>
-              <entry value="2" name="ADSB_FLAGS_VALID_ALTITUDE"></entry>
-              <entry value="4" name="ADSB_FLAGS_VALID_HEADING"></entry>
-              <entry value="8" name="ADSB_FLAGS_VALID_VELOCITY"></entry>
-              <entry value="16" name="ADSB_FLAGS_VALID_CALLSIGN"></entry>
-              <entry value="32" name="ADSB_FLAGS_VALID_SQUAWK"></entry>
-              <entry value="64" name="ADSB_FLAGS_SIMULATED"></entry>
-          </enum>
-          <enum name="MAV_DO_REPOSITION_FLAGS">
-              <description>Bitmask of options for the MAV_CMD_DO_REPOSITION</description>
-              <entry value="1" name="MAV_DO_REPOSITION_FLAGS_CHANGE_MODE">
-                  <description>The aircraft should immediately transition into guided. This should not be set for follow me applications</description>
-              </entry>
-          </enum>
-          <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
-          <enum name="ESTIMATOR_STATUS_FLAGS">
-              <description>Flags in EKF_STATUS message</description>
-              <entry name="ESTIMATOR_ATTITUDE" value="1">
-                  <description>True if the attitude estimate is good</description>
-              </entry>
-
-              <entry name="ESTIMATOR_VELOCITY_HORIZ" value="2">
-                  <description>True if the horizontal velocity estimate is good</description>
-              </entry>
-
-              <entry name="ESTIMATOR_VELOCITY_VERT" value="4">
-                  <description>True if the  vertical velocity estimate is good</description>
-              </entry>
-
-              <entry name="ESTIMATOR_POS_HORIZ_REL" value="8">
-                  <description>True if the horizontal position (relative) estimate is good</description>
-              </entry>
-
-              <entry name="ESTIMATOR_POS_HORIZ_ABS" value="16">
-                  <description>True if the horizontal position (absolute) estimate is good</description>
-              </entry>
-
-              <entry name="ESTIMATOR_POS_VERT_ABS" value="32">
-                  <description>True if the vertical position (absolute) estimate is good</description>
-              </entry>
-
-              <entry name="ESTIMATOR_POS_VERT_AGL" value="64">
-                  <description>True if the vertical position (above ground) estimate is good</description>
-              </entry>
-
-              <entry name="ESTIMATOR_CONST_POS_MODE" value="128">
-                  <description>True if the EKF is in a constant position mode and is not using external measurements (eg GPS or optical flow)</description>
-              </entry>
-
-              <entry name="ESTIMATOR_PRED_POS_HORIZ_REL" value="256">
-                  <description>True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate</description>
-              </entry>
-
-              <entry name="ESTIMATOR_PRED_POS_HORIZ_ABS" value="512">
-                  <description>True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate</description>
-              </entry>
-
-              <entry name="ESTIMATOR_GPS_GLITCH" value="1024">
-                  <description>True if the EKF has detected a GPS glitch</description>
-              </entry>
-          </enum>
-
-          <!-- motor test type enum -->
-          <enum name="MOTOR_TEST_THROTTLE_TYPE">
-              <entry name="MOTOR_TEST_THROTTLE_PERCENT" value="0">
-                  <description>throttle as a percentage from 0 ~ 100</description>
-              </entry>
-
-              <entry name="MOTOR_TEST_THROTTLE_PWM" value="1">
-                  <description>throttle as an absolute PWM value (normally in range of 1000~2000)</description>
-              </entry>
-
-              <entry name="MOTOR_TEST_THROTTLE_PILOT" value="2">
-                  <description>throttle pass-through from pilot's transmitter</description>
-              </entry>
-          </enum>
-
-          <!-- GPS_INPUT ignore flags enum -->
-          <enum name="GPS_INPUT_IGNORE_FLAGS">
-              <entry name="GPS_INPUT_IGNORE_FLAG_ALT" value="1">
-                  <description>ignore altitude field</description>
-              </entry>
-              <entry name="GPS_INPUT_IGNORE_FLAG_HDOP" value="2">
-                  <description>ignore hdop field</description>
-              </entry>
-              <entry name="GPS_INPUT_IGNORE_FLAG_VDOP" value="4">
-                  <description>ignore vdop field</description>
-              </entry>
-              <entry name="GPS_INPUT_IGNORE_FLAG_VEL_HORIZ" value="8">
-                  <description>ignore horizontal velocity field (vn and ve)</description>
-              </entry>
-              <entry name="GPS_INPUT_IGNORE_FLAG_VEL_VERT" value="16">
-                  <description>ignore vertical velocity field (vd)</description>
-              </entry>
-              <entry name="GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY" value="32">
-                  <description>ignore speed accuracy field</description>
-              </entry>
-              <entry name="GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY" value="64">
-                  <description>ignore horizontal accuracy field</description>
-              </entry>
-              <entry name="GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY" value="128">
-                  <description>ignore vertical accuracy field</description>
-              </entry>
-          </enum>
-          <enum name="MAV_COLLISION_ACTION">
-              <description>Possible actions an aircraft can take to avoid a collision.</description>
-              <entry value="0" name="MAV_COLLISION_ACTION_NONE">
-                  <description>Ignore any potential collisions</description>
-              </entry>
-              <entry value="1" name="MAV_COLLISION_ACTION_REPORT">
-                  <description>Report potential collision</description>
-              </entry>
-              <entry value="2" name="MAV_COLLISION_ACTION_ASCEND_OR_DESCEND">
-                  <description>Ascend or Descend to avoid threat</description>
-              </entry>
-              <entry value="3" name="MAV_COLLISION_ACTION_MOVE_HORIZONTALLY">
-                  <description>Move horizontally to avoid threat</description>
-              </entry>
-              <entry value="4" name="MAV_COLLISION_ACTION_MOVE_PERPENDICULAR">
-                  <description>Aircraft to move perpendicular to the collision's velocity vector</description>
-              </entry>
-              <entry value="5" name="MAV_COLLISION_ACTION_RTL">
-                  <description>Aircraft to fly directly back to its launch point</description>
-              </entry>
-              <entry value="6" name="MAV_COLLISION_ACTION_HOVER">
-                  <description>Aircraft to stop in place</description>
-              </entry>
-          </enum>
-          <enum name="MAV_COLLISION_THREAT_LEVEL">
-              <description>Aircraft-rated danger from this threat.</description>
-              <entry value="0" name="MAV_COLLISION_THREAT_LEVEL_NONE">
-                  <description>Not a threat</description>
-              </entry>
-              <entry value="1" name="MAV_COLLISION_THREAT_LEVEL_LOW">
-                  <description>Craft is mildly concerned about this threat</description>
-              </entry>
-              <entry value="2" name="MAV_COLLISION_THREAT_LEVEL_HIGH">
-                  <description>Craft is panicing, and may take actions to avoid threat</description>
-              </entry>
-          </enum>
-          <enum name="MAV_COLLISION_SRC">
-              <description>Source of information about this collision.</description>
-              <entry value="0" name="MAV_COLLISION_SRC_ADSB">
-                  <description>ID field references ADSB_VEHICLE packets</description>
-              </entry>
-              <entry value="1" name="MAV_COLLISION_SRC_MAVLINK_GPS_GLOBAL_INT">
-                  <description>ID field references MAVLink SRC ID</description>
-              </entry>
-          </enum>
-          <enum name="GPS_FIX_TYPE">
-              <description>Type of GPS fix</description>
-              <entry value="0" name="GPS_FIX_TYPE_NO_GPS">
-                  <description>No GPS connected</description>
-              </entry>
-              <entry value="1" name="GPS_FIX_TYPE_NO_FIX">
-                  <description>No position information, GPS is connected</description>
-              </entry>
-              <entry value="2" name="GPS_FIX_TYPE_2D_FIX">
-                  <description>2D position</description>
-              </entry>
-              <entry value="3" name="GPS_FIX_TYPE_3D_FIX">
-                  <description>3D position</description>
-              </entry>
-              <entry value="4" name="GPS_FIX_TYPE_DGPS">
-                  <description>DGPS/SBAS aided 3D position</description>
-              </entry>
-              <entry value="5" name="GPS_FIX_TYPE_RTK_FLOAT">
-                  <description>RTK float, 3D position</description>
-              </entry>
-              <entry value="6" name="GPS_FIX_TYPE_RTK_FIXED">
-                  <description>RTK Fixed, 3D position</description>
-              </entry>
-              <entry value="7" name="GPS_FIX_TYPE_STATIC">
-                  <description>Static fixed, typically used for base stations</description>
-              </entry>
-          </enum>
-   <enum name="MIXER_GROUP">
+      <entry value="0" name="MAV_ROI_NONE">
+        <description>No region of interest.</description>
+      </entry>
+      <entry value="1" name="MAV_ROI_WPNEXT">
+        <description>Point toward next MISSION.</description>
+      </entry>
+      <entry value="2" name="MAV_ROI_WPINDEX">
+        <description>Point toward given MISSION.</description>
+      </entry>
+      <entry value="3" name="MAV_ROI_LOCATION">
+        <description>Point toward fixed location.</description>
+      </entry>
+      <entry value="4" name="MAV_ROI_TARGET">
+        <description>Point toward of given id.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_CMD_ACK">
+      <description>ACK / NACK / ERROR values as a result of MAV_CMDs and for mission item transmission.</description>
+      <entry name="MAV_CMD_ACK_OK">
+        <description>Command / mission item is ok.</description>
+      </entry>
+      <entry name="MAV_CMD_ACK_ERR_FAIL">
+        <description>Generic error message if none of the other reasons fails or if no detailed error reporting is implemented.</description>
+      </entry>
+      <entry name="MAV_CMD_ACK_ERR_ACCESS_DENIED">
+        <description>The system is refusing to accept this command from this source / communication partner.</description>
+      </entry>
+      <entry name="MAV_CMD_ACK_ERR_NOT_SUPPORTED">
+        <description>Command or mission item is not supported, other commands would be accepted.</description>
+      </entry>
+      <entry name="MAV_CMD_ACK_ERR_COORDINATE_FRAME_NOT_SUPPORTED">
+        <description>The coordinate frame of this command / mission item is not supported.</description>
+      </entry>
+      <entry name="MAV_CMD_ACK_ERR_COORDINATES_OUT_OF_RANGE">
+        <description>The coordinate frame of this command is ok, but he coordinate values exceed the safety limits of this system. This is a generic error, please use the more specific error messages below if possible.</description>
+      </entry>
+      <entry name="MAV_CMD_ACK_ERR_X_LAT_OUT_OF_RANGE">
+        <description>The X or latitude value is out of range.</description>
+      </entry>
+      <entry name="MAV_CMD_ACK_ERR_Y_LON_OUT_OF_RANGE">
+        <description>The Y or longitude value is out of range.</description>
+      </entry>
+      <entry name="MAV_CMD_ACK_ERR_Z_ALT_OUT_OF_RANGE">
+        <description>The Z or altitude value is out of range.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_PARAM_TYPE">
+      <description>Specifies the datatype of a MAVLink parameter.</description>
+      <entry value="1" name="MAV_PARAM_TYPE_UINT8">
+        <description>8-bit unsigned integer</description>
+      </entry>
+      <entry value="2" name="MAV_PARAM_TYPE_INT8">
+        <description>8-bit signed integer</description>
+      </entry>
+      <entry value="3" name="MAV_PARAM_TYPE_UINT16">
+        <description>16-bit unsigned integer</description>
+      </entry>
+      <entry value="4" name="MAV_PARAM_TYPE_INT16">
+        <description>16-bit signed integer</description>
+      </entry>
+      <entry value="5" name="MAV_PARAM_TYPE_UINT32">
+        <description>32-bit unsigned integer</description>
+      </entry>
+      <entry value="6" name="MAV_PARAM_TYPE_INT32">
+        <description>32-bit signed integer</description>
+      </entry>
+      <entry value="7" name="MAV_PARAM_TYPE_UINT64">
+        <description>64-bit unsigned integer</description>
+      </entry>
+      <entry value="8" name="MAV_PARAM_TYPE_INT64">
+        <description>64-bit signed integer</description>
+      </entry>
+      <entry value="9" name="MAV_PARAM_TYPE_REAL32">
+        <description>32-bit floating-point</description>
+      </entry>
+      <entry value="10" name="MAV_PARAM_TYPE_REAL64">
+        <description>64-bit floating-point</description>
+      </entry>
+    </enum>
+    <enum name="MAV_RESULT">
+      <description>result from a mavlink command</description>
+      <entry value="0" name="MAV_RESULT_ACCEPTED">
+        <description>Command ACCEPTED and EXECUTED</description>
+      </entry>
+      <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
+        <description>Command TEMPORARY REJECTED/DENIED</description>
+      </entry>
+      <entry value="2" name="MAV_RESULT_DENIED">
+        <description>Command PERMANENTLY DENIED</description>
+      </entry>
+      <entry value="3" name="MAV_RESULT_UNSUPPORTED">
+        <description>Command UNKNOWN/UNSUPPORTED</description>
+      </entry>
+      <entry value="4" name="MAV_RESULT_FAILED">
+        <description>Command executed, but failed</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MISSION_RESULT">
+      <description>result in a mavlink mission ack</description>
+      <entry value="0" name="MAV_MISSION_ACCEPTED">
+        <description>mission accepted OK</description>
+      </entry>
+      <entry value="1" name="MAV_MISSION_ERROR">
+        <description>generic error / not accepting mission commands at all right now</description>
+      </entry>
+      <entry value="2" name="MAV_MISSION_UNSUPPORTED_FRAME">
+        <description>coordinate frame is not supported</description>
+      </entry>
+      <entry value="3" name="MAV_MISSION_UNSUPPORTED">
+        <description>command is not supported</description>
+      </entry>
+      <entry value="4" name="MAV_MISSION_NO_SPACE">
+        <description>mission item exceeds storage space</description>
+      </entry>
+      <entry value="5" name="MAV_MISSION_INVALID">
+        <description>one of the parameters has an invalid value</description>
+      </entry>
+      <entry value="6" name="MAV_MISSION_INVALID_PARAM1">
+        <description>param1 has an invalid value</description>
+      </entry>
+      <entry value="7" name="MAV_MISSION_INVALID_PARAM2">
+        <description>param2 has an invalid value</description>
+      </entry>
+      <entry value="8" name="MAV_MISSION_INVALID_PARAM3">
+        <description>param3 has an invalid value</description>
+      </entry>
+      <entry value="9" name="MAV_MISSION_INVALID_PARAM4">
+        <description>param4 has an invalid value</description>
+      </entry>
+      <entry value="10" name="MAV_MISSION_INVALID_PARAM5_X">
+        <description>x/param5 has an invalid value</description>
+      </entry>
+      <entry value="11" name="MAV_MISSION_INVALID_PARAM6_Y">
+        <description>y/param6 has an invalid value</description>
+      </entry>
+      <entry value="12" name="MAV_MISSION_INVALID_PARAM7">
+        <description>param7 has an invalid value</description>
+      </entry>
+      <entry value="13" name="MAV_MISSION_INVALID_SEQUENCE">
+        <description>received waypoint out of sequence</description>
+      </entry>
+      <entry value="14" name="MAV_MISSION_DENIED">
+        <description>not accepting any mission commands from this communication partner</description>
+      </entry>
+    </enum>
+    <enum name="MAV_SEVERITY">
+      <description>Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.</description>
+      <entry value="0" name="MAV_SEVERITY_EMERGENCY">
+        <description>System is unusable. This is a "panic" condition.</description>
+      </entry>
+      <entry value="1" name="MAV_SEVERITY_ALERT">
+        <description>Action should be taken immediately. Indicates error in non-critical systems.</description>
+      </entry>
+      <entry value="2" name="MAV_SEVERITY_CRITICAL">
+        <description>Action must be taken immediately. Indicates failure in a primary system.</description>
+      </entry>
+      <entry value="3" name="MAV_SEVERITY_ERROR">
+        <description>Indicates an error in secondary/redundant systems.</description>
+      </entry>
+      <entry value="4" name="MAV_SEVERITY_WARNING">
+        <description>Indicates about a possible future error if this is not resolved within a given timeframe. Example would be a low battery warning.</description>
+      </entry>
+      <entry value="5" name="MAV_SEVERITY_NOTICE">
+        <description>An unusual event has occured, though not an error condition. This should be investigated for the root cause.</description>
+      </entry>
+      <entry value="6" name="MAV_SEVERITY_INFO">
+        <description>Normal operational messages. Useful for logging. No action is required for these messages.</description>
+      </entry>
+      <entry value="7" name="MAV_SEVERITY_DEBUG">
+        <description>Useful non-operational messages that can assist in debugging. These should not occur during normal operation.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_POWER_STATUS">
+      <description>Power supply status flags (bitmask)</description>
+      <entry value="1" name="MAV_POWER_STATUS_BRICK_VALID">
+        <description>main brick power supply valid</description>
+      </entry>
+      <entry value="2" name="MAV_POWER_STATUS_SERVO_VALID">
+        <description>main servo power supply valid for FMU</description>
+      </entry>
+      <entry value="4" name="MAV_POWER_STATUS_USB_CONNECTED">
+        <description>USB power is connected</description>
+      </entry>
+      <entry value="8" name="MAV_POWER_STATUS_PERIPH_OVERCURRENT">
+        <description>peripheral supply is in over-current state</description>
+      </entry>
+      <entry value="16" name="MAV_POWER_STATUS_PERIPH_HIPOWER_OVERCURRENT">
+        <description>hi-power peripheral supply is in over-current state</description>
+      </entry>
+      <entry value="32" name="MAV_POWER_STATUS_CHANGED">
+        <description>Power status has changed since boot</description>
+      </entry>
+    </enum>
+    <enum name="SERIAL_CONTROL_DEV">
+      <description>SERIAL_CONTROL device types</description>
+      <entry value="0" name="SERIAL_CONTROL_DEV_TELEM1">
+        <description>First telemetry port</description>
+      </entry>
+      <entry value="1" name="SERIAL_CONTROL_DEV_TELEM2">
+        <description>Second telemetry port</description>
+      </entry>
+      <entry value="2" name="SERIAL_CONTROL_DEV_GPS1">
+        <description>First GPS port</description>
+      </entry>
+      <entry value="3" name="SERIAL_CONTROL_DEV_GPS2">
+        <description>Second GPS port</description>
+      </entry>
+      <entry value="10" name="SERIAL_CONTROL_DEV_SHELL">
+        <description>system shell</description>
+      </entry>
+    </enum>
+    <enum name="SERIAL_CONTROL_FLAG">
+      <description>SERIAL_CONTROL flags (bitmask)</description>
+      <entry value="1" name="SERIAL_CONTROL_FLAG_REPLY">
+        <description>Set if this is a reply</description>
+      </entry>
+      <entry value="2" name="SERIAL_CONTROL_FLAG_RESPOND">
+        <description>Set if the sender wants the receiver to send a response as another SERIAL_CONTROL message</description>
+      </entry>
+      <entry value="4" name="SERIAL_CONTROL_FLAG_EXCLUSIVE">
+        <description>Set if access to the serial port should be removed from whatever driver is currently using it, giving exclusive access to the SERIAL_CONTROL protocol. The port can be handed back by sending a request without this flag set</description>
+      </entry>
+      <entry value="8" name="SERIAL_CONTROL_FLAG_BLOCKING">
+        <description>Block on writes to the serial port</description>
+      </entry>
+      <entry value="16" name="SERIAL_CONTROL_FLAG_MULTI">
+        <description>Send multiple replies until port is drained</description>
+      </entry>
+    </enum>
+    <enum name="MAV_DISTANCE_SENSOR">
+      <description>Enumeration of distance sensor types</description>
+      <entry value="0" name="MAV_DISTANCE_SENSOR_LASER">
+        <description>Laser rangefinder, e.g. LightWare SF02/F or PulsedLight units</description>
+      </entry>
+      <entry value="1" name="MAV_DISTANCE_SENSOR_ULTRASOUND">
+        <description>Ultrasound rangefinder, e.g. MaxBotix units</description>
+      </entry>
+      <entry value="2" name="MAV_DISTANCE_SENSOR_INFRARED">
+        <description>Infrared rangefinder, e.g. Sharp units</description>
+      </entry>
+    </enum>
+    <enum name="MAV_SENSOR_ORIENTATION">
+      <description>Enumeration of sensor orientation, according to its rotations</description>
+      <entry value="0" name="MAV_SENSOR_ROTATION_NONE">
+        <description>Roll: 0, Pitch: 0, Yaw: 0</description>
+      </entry>
+      <entry value="1" name="MAV_SENSOR_ROTATION_YAW_45">
+        <description>Roll: 0, Pitch: 0, Yaw: 45</description>
+      </entry>
+      <entry value="2" name="MAV_SENSOR_ROTATION_YAW_90">
+        <description>Roll: 0, Pitch: 0, Yaw: 90</description>
+      </entry>
+      <entry value="3" name="MAV_SENSOR_ROTATION_YAW_135">
+        <description>Roll: 0, Pitch: 0, Yaw: 135</description>
+      </entry>
+      <entry value="4" name="MAV_SENSOR_ROTATION_YAW_180">
+        <description>Roll: 0, Pitch: 0, Yaw: 180</description>
+      </entry>
+      <entry value="5" name="MAV_SENSOR_ROTATION_YAW_225">
+        <description>Roll: 0, Pitch: 0, Yaw: 225</description>
+      </entry>
+      <entry value="6" name="MAV_SENSOR_ROTATION_YAW_270">
+        <description>Roll: 0, Pitch: 0, Yaw: 270</description>
+      </entry>
+      <entry value="7" name="MAV_SENSOR_ROTATION_YAW_315">
+        <description>Roll: 0, Pitch: 0, Yaw: 315</description>
+      </entry>
+      <entry value="8" name="MAV_SENSOR_ROTATION_ROLL_180">
+        <description>Roll: 180, Pitch: 0, Yaw: 0</description>
+      </entry>
+      <entry value="9" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_45">
+        <description>Roll: 180, Pitch: 0, Yaw: 45</description>
+      </entry>
+      <entry value="10" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_90">
+        <description>Roll: 180, Pitch: 0, Yaw: 90</description>
+      </entry>
+      <entry value="11" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_135">
+        <description>Roll: 180, Pitch: 0, Yaw: 135</description>
+      </entry>
+      <entry value="12" name="MAV_SENSOR_ROTATION_PITCH_180">
+        <description>Roll: 0, Pitch: 180, Yaw: 0</description>
+      </entry>
+      <entry value="13" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_225">
+        <description>Roll: 180, Pitch: 0, Yaw: 225</description>
+      </entry>
+      <entry value="14" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_270">
+        <description>Roll: 180, Pitch: 0, Yaw: 270</description>
+      </entry>
+      <entry value="15" name="MAV_SENSOR_ROTATION_ROLL_180_YAW_315">
+        <description>Roll: 180, Pitch: 0, Yaw: 315</description>
+      </entry>
+      <entry value="16" name="MAV_SENSOR_ROTATION_ROLL_90">
+        <description>Roll: 90, Pitch: 0, Yaw: 0</description>
+      </entry>
+      <entry value="17" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_45">
+        <description>Roll: 90, Pitch: 0, Yaw: 45</description>
+      </entry>
+      <entry value="18" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_90">
+        <description>Roll: 90, Pitch: 0, Yaw: 90</description>
+      </entry>
+      <entry value="19" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_135">
+        <description>Roll: 90, Pitch: 0, Yaw: 135</description>
+      </entry>
+      <entry value="20" name="MAV_SENSOR_ROTATION_ROLL_270">
+        <description>Roll: 270, Pitch: 0, Yaw: 0</description>
+      </entry>
+      <entry value="21" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_45">
+        <description>Roll: 270, Pitch: 0, Yaw: 45</description>
+      </entry>
+      <entry value="22" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_90">
+        <description>Roll: 270, Pitch: 0, Yaw: 90</description>
+      </entry>
+      <entry value="23" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_135">
+        <description>Roll: 270, Pitch: 0, Yaw: 135</description>
+      </entry>
+      <entry value="24" name="MAV_SENSOR_ROTATION_PITCH_90">
+        <description>Roll: 0, Pitch: 90, Yaw: 0</description>
+      </entry>
+      <entry value="25" name="MAV_SENSOR_ROTATION_PITCH_270">
+        <description>Roll: 0, Pitch: 270, Yaw: 0</description>
+      </entry>
+      <entry value="26" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_90">
+        <description>Roll: 0, Pitch: 180, Yaw: 90</description>
+      </entry>
+      <entry value="27" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_270">
+        <description>Roll: 0, Pitch: 180, Yaw: 270</description>
+      </entry>
+      <entry value="28" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_90">
+        <description>Roll: 90, Pitch: 90, Yaw: 0</description>
+      </entry>
+      <entry value="29" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_90">
+        <description>Roll: 180, Pitch: 90, Yaw: 0</description>
+      </entry>
+      <entry value="30" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_90">
+        <description>Roll: 270, Pitch: 90, Yaw: 0</description>
+      </entry>
+      <entry value="31" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180">
+        <description>Roll: 90, Pitch: 180, Yaw: 0</description>
+      </entry>
+      <entry value="32" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_180">
+        <description>Roll: 270, Pitch: 180, Yaw: 0</description>
+      </entry>
+      <entry value="33" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_270">
+        <description>Roll: 90, Pitch: 270, Yaw: 0</description>
+      </entry>
+      <entry value="34" name="MAV_SENSOR_ROTATION_ROLL_180_PITCH_270">
+        <description>Roll: 180, Pitch: 270, Yaw: 0</description>
+      </entry>
+      <entry value="35" name="MAV_SENSOR_ROTATION_ROLL_270_PITCH_270">
+        <description>Roll: 270, Pitch: 270, Yaw: 0</description>
+      </entry>
+      <entry value="36" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90">
+        <description>Roll: 90, Pitch: 180, Yaw: 90</description>
+      </entry>
+      <entry value="37" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_270">
+        <description>Roll: 90, Pitch: 0, Yaw: 270</description>
+      </entry>
+      <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_315_PITCH_315_YAW_315">
+        <description>Roll: 315, Pitch: 315, Yaw: 315</description>
+      </entry>
+    </enum>
+    <enum name="MAV_PROTOCOL_CAPABILITY">
+      <description>Bitmask of (optional) autopilot capabilities (64 bit). If a bit is set, the autopilot supports this capability.</description>
+      <entry value="1" name="MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT">
+        <description>Autopilot supports MISSION float message type.</description>
+      </entry>
+      <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT">
+        <description>Autopilot supports the new param float message type.</description>
+      </entry>
+      <entry value="4" name="MAV_PROTOCOL_CAPABILITY_MISSION_INT">
+        <description>Autopilot supports MISSION_INT scaled integer message type.</description>
+      </entry>
+      <entry value="8" name="MAV_PROTOCOL_CAPABILITY_COMMAND_INT">
+        <description>Autopilot supports COMMAND_INT scaled integer message type.</description>
+      </entry>
+      <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_UNION">
+        <description>Autopilot supports the new param union message type.</description>
+      </entry>
+      <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">
+        <description>Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.</description>
+      </entry>
+      <entry value="64" name="MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET">
+        <description>Autopilot supports commanding attitude offboard.</description>
+      </entry>
+      <entry value="128" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED">
+        <description>Autopilot supports commanding position and velocity targets in local NED frame.</description>
+      </entry>
+      <entry value="256" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT">
+        <description>Autopilot supports commanding position and velocity targets in global scaled integers.</description>
+      </entry>
+      <entry value="512" name="MAV_PROTOCOL_CAPABILITY_TERRAIN">
+        <description>Autopilot supports terrain protocol / data handling.</description>
+      </entry>
+      <entry value="1024" name="MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET">
+        <description>Autopilot supports direct actuator control.</description>
+      </entry>
+      <entry value="2048" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION">
+        <description>Autopilot supports the flight termination command.</description>
+      </entry>
+      <entry value="4096" name="MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION">
+        <description>Autopilot supports onboard compass calibration.</description>
+      </entry>
+      <entry value="8192" name="MAV_PROTOCOL_CAPABILITY_MAVLINK2">
+        <description>Autopilot supports mavlink version 2.</description>
+      </entry>
+      <entry value="16384" name="MAV_PROTOCOL_CAPABILITY_MISSION_FENCE">
+        <description>Autopilot supports mission fence protocol.</description>
+      </entry>
+      <entry value="32768" name="MAV_PROTOCOL_CAPABILITY_MISSION_RALLY">
+        <description>Autopilot supports mission rally point protocol.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_MISSION_TYPE">
+      <description>Type of mission items being requested/sent in mission protocol.</description>
+      <entry value="0" name="MAV_MISSION_TYPE_MISSION">
+        <description>Items are mission commands for main mission.</description>
+      </entry>
+      <entry value="1" name="MAV_MISSION_TYPE_FENCE">
+        <description>Specifies GeoFence area(s). Items are MAV_CMD_FENCE_ GeoFence items.</description>
+      </entry>
+      <entry value="2" name="MAV_MISSION_TYPE_RALLY">
+        <description>Specifies the rally points for the vehicle. Rally points are alternative RTL points. Items are MAV_CMD_RALLY_POINT rally point items.</description>
+      </entry>
+      <entry value="255" name="MAV_MISSION_TYPE_ALL">
+        <description>Only used in MISSION_CLEAR_ALL to clear all mission types.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ESTIMATOR_TYPE">
+      <description>Enumeration of estimator types</description>
+      <entry value="1" name="MAV_ESTIMATOR_TYPE_NAIVE">
+        <description>This is a naive estimator without any real covariance feedback.</description>
+      </entry>
+      <entry value="2" name="MAV_ESTIMATOR_TYPE_VISION">
+        <description>Computer vision based estimate. Might be up to scale.</description>
+      </entry>
+      <entry value="3" name="MAV_ESTIMATOR_TYPE_VIO">
+        <description>Visual-inertial estimate.</description>
+      </entry>
+      <entry value="4" name="MAV_ESTIMATOR_TYPE_GPS">
+        <description>Plain GPS estimate.</description>
+      </entry>
+      <entry value="5" name="MAV_ESTIMATOR_TYPE_GPS_INS">
+        <description>Estimator integrating GPS and inertial sensing.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_BATTERY_TYPE">
+      <description>Enumeration of battery types</description>
+      <entry value="0" name="MAV_BATTERY_TYPE_UNKNOWN">
+        <description>Not specified.</description>
+      </entry>
+      <entry value="1" name="MAV_BATTERY_TYPE_LIPO">
+        <description>Lithium polymer battery</description>
+      </entry>
+      <entry value="2" name="MAV_BATTERY_TYPE_LIFE">
+        <description>Lithium-iron-phosphate battery</description>
+      </entry>
+      <entry value="3" name="MAV_BATTERY_TYPE_LION">
+        <description>Lithium-ION battery</description>
+      </entry>
+      <entry value="4" name="MAV_BATTERY_TYPE_NIMH">
+        <description>Nickel metal hydride battery</description>
+      </entry>
+    </enum>
+    <enum name="MAV_BATTERY_FUNCTION">
+      <description>Enumeration of battery functions</description>
+      <entry value="0" name="MAV_BATTERY_FUNCTION_UNKNOWN">
+        <description>Battery function is unknown</description>
+      </entry>
+      <entry value="1" name="MAV_BATTERY_FUNCTION_ALL">
+        <description>Battery supports all flight systems</description>
+      </entry>
+      <entry value="2" name="MAV_BATTERY_FUNCTION_PROPULSION">
+        <description>Battery for the propulsion system</description>
+      </entry>
+      <entry value="3" name="MAV_BATTERY_FUNCTION_AVIONICS">
+        <description>Avionics battery</description>
+      </entry>
+      <entry value="4" name="MAV_BATTERY_TYPE_PAYLOAD">
+        <description>Payload battery</description>
+      </entry>
+    </enum>
+    <enum name="MAV_VTOL_STATE">
+      <description>Enumeration of VTOL states</description>
+      <entry value="0" name="MAV_VTOL_STATE_UNDEFINED">
+        <description>MAV is not configured as VTOL</description>
+      </entry>
+      <entry value="1" name="MAV_VTOL_STATE_TRANSITION_TO_FW">
+        <description>VTOL is in transition from multicopter to fixed-wing</description>
+      </entry>
+      <entry value="2" name="MAV_VTOL_STATE_TRANSITION_TO_MC">
+        <description>VTOL is in transition from fixed-wing to multicopter</description>
+      </entry>
+      <entry value="3" name="MAV_VTOL_STATE_MC">
+        <description>VTOL is in multicopter state</description>
+      </entry>
+      <entry value="4" name="MAV_VTOL_STATE_FW">
+        <description>VTOL is in fixed-wing state</description>
+      </entry>
+    </enum>
+    <enum name="MAV_LANDED_STATE">
+      <description>Enumeration of landed detector states</description>
+      <entry value="0" name="MAV_LANDED_STATE_UNDEFINED">
+        <description>MAV landed state is unknown</description>
+      </entry>
+      <entry value="1" name="MAV_LANDED_STATE_ON_GROUND">
+        <description>MAV is landed (on ground)</description>
+      </entry>
+      <entry value="2" name="MAV_LANDED_STATE_IN_AIR">
+        <description>MAV is in air</description>
+      </entry>
+    </enum>
+    <enum name="ADSB_ALTITUDE_TYPE">
+      <description>Enumeration of the ADSB altimeter types</description>
+      <entry value="0" name="ADSB_ALTITUDE_TYPE_PRESSURE_QNH">
+        <description>Altitude reported from a Baro source using QNH reference</description>
+      </entry>
+      <entry value="1" name="ADSB_ALTITUDE_TYPE_GEOMETRIC">
+        <description>Altitude reported from a GNSS source</description>
+      </entry>
+    </enum>
+    <enum name="ADSB_EMITTER_TYPE">
+      <description>ADSB classification for the type of vehicle emitting the transponder signal</description>
+      <entry value="0" name="ADSB_EMITTER_TYPE_NO_INFO"/>
+      <entry value="1" name="ADSB_EMITTER_TYPE_LIGHT"/>
+      <entry value="2" name="ADSB_EMITTER_TYPE_SMALL"/>
+      <entry value="3" name="ADSB_EMITTER_TYPE_LARGE"/>
+      <entry value="4" name="ADSB_EMITTER_TYPE_HIGH_VORTEX_LARGE"/>
+      <entry value="5" name="ADSB_EMITTER_TYPE_HEAVY"/>
+      <entry value="6" name="ADSB_EMITTER_TYPE_HIGHLY_MANUV"/>
+      <entry value="7" name="ADSB_EMITTER_TYPE_ROTOCRAFT"/>
+      <entry value="8" name="ADSB_EMITTER_TYPE_UNASSIGNED"/>
+      <entry value="9" name="ADSB_EMITTER_TYPE_GLIDER"/>
+      <entry value="10" name="ADSB_EMITTER_TYPE_LIGHTER_AIR"/>
+      <entry value="11" name="ADSB_EMITTER_TYPE_PARACHUTE"/>
+      <entry value="12" name="ADSB_EMITTER_TYPE_ULTRA_LIGHT"/>
+      <entry value="13" name="ADSB_EMITTER_TYPE_UNASSIGNED2"/>
+      <entry value="14" name="ADSB_EMITTER_TYPE_UAV"/>
+      <entry value="15" name="ADSB_EMITTER_TYPE_SPACE"/>
+      <entry value="16" name="ADSB_EMITTER_TYPE_UNASSGINED3"/>
+      <entry value="17" name="ADSB_EMITTER_TYPE_EMERGENCY_SURFACE"/>
+      <entry value="18" name="ADSB_EMITTER_TYPE_SERVICE_SURFACE"/>
+      <entry value="19" name="ADSB_EMITTER_TYPE_POINT_OBSTACLE"/>
+    </enum>
+    <enum name="ADSB_FLAGS">
+      <description>These flags indicate status such as data validity of each data source. Set = data valid</description>
+      <entry value="1" name="ADSB_FLAGS_VALID_COORDS"/>
+      <entry value="2" name="ADSB_FLAGS_VALID_ALTITUDE"/>
+      <entry value="4" name="ADSB_FLAGS_VALID_HEADING"/>
+      <entry value="8" name="ADSB_FLAGS_VALID_VELOCITY"/>
+      <entry value="16" name="ADSB_FLAGS_VALID_CALLSIGN"/>
+      <entry value="32" name="ADSB_FLAGS_VALID_SQUAWK"/>
+      <entry value="64" name="ADSB_FLAGS_SIMULATED"/>
+    </enum>
+    <enum name="MAV_DO_REPOSITION_FLAGS">
+      <description>Bitmask of options for the MAV_CMD_DO_REPOSITION</description>
+      <entry value="1" name="MAV_DO_REPOSITION_FLAGS_CHANGE_MODE">
+        <description>The aircraft should immediately transition into guided. This should not be set for follow me applications</description>
+      </entry>
+    </enum>
+    <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
+    <enum name="ESTIMATOR_STATUS_FLAGS">
+      <description>Flags in EKF_STATUS message</description>
+      <entry name="ESTIMATOR_ATTITUDE" value="1">
+        <description>True if the attitude estimate is good</description>
+      </entry>
+      <entry name="ESTIMATOR_VELOCITY_HORIZ" value="2">
+        <description>True if the horizontal velocity estimate is good</description>
+      </entry>
+      <entry name="ESTIMATOR_VELOCITY_VERT" value="4">
+        <description>True if the  vertical velocity estimate is good</description>
+      </entry>
+      <entry name="ESTIMATOR_POS_HORIZ_REL" value="8">
+        <description>True if the horizontal position (relative) estimate is good</description>
+      </entry>
+      <entry name="ESTIMATOR_POS_HORIZ_ABS" value="16">
+        <description>True if the horizontal position (absolute) estimate is good</description>
+      </entry>
+      <entry name="ESTIMATOR_POS_VERT_ABS" value="32">
+        <description>True if the vertical position (absolute) estimate is good</description>
+      </entry>
+      <entry name="ESTIMATOR_POS_VERT_AGL" value="64">
+        <description>True if the vertical position (above ground) estimate is good</description>
+      </entry>
+      <entry name="ESTIMATOR_CONST_POS_MODE" value="128">
+        <description>True if the EKF is in a constant position mode and is not using external measurements (eg GPS or optical flow)</description>
+      </entry>
+      <entry name="ESTIMATOR_PRED_POS_HORIZ_REL" value="256">
+        <description>True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate</description>
+      </entry>
+      <entry name="ESTIMATOR_PRED_POS_HORIZ_ABS" value="512">
+        <description>True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate</description>
+      </entry>
+      <entry name="ESTIMATOR_GPS_GLITCH" value="1024">
+        <description>True if the EKF has detected a GPS glitch</description>
+      </entry>
+    </enum>
+    <!-- motor test type enum -->
+    <enum name="MOTOR_TEST_THROTTLE_TYPE">
+      <entry name="MOTOR_TEST_THROTTLE_PERCENT" value="0">
+        <description>throttle as a percentage from 0 ~ 100</description>
+      </entry>
+      <entry name="MOTOR_TEST_THROTTLE_PWM" value="1">
+        <description>throttle as an absolute PWM value (normally in range of 1000~2000)</description>
+      </entry>
+      <entry name="MOTOR_TEST_THROTTLE_PILOT" value="2">
+        <description>throttle pass-through from pilot's transmitter</description>
+      </entry>
+    </enum>
+    <!-- GPS_INPUT ignore flags enum -->
+    <enum name="GPS_INPUT_IGNORE_FLAGS">
+      <entry name="GPS_INPUT_IGNORE_FLAG_ALT" value="1">
+        <description>ignore altitude field</description>
+      </entry>
+      <entry name="GPS_INPUT_IGNORE_FLAG_HDOP" value="2">
+        <description>ignore hdop field</description>
+      </entry>
+      <entry name="GPS_INPUT_IGNORE_FLAG_VDOP" value="4">
+        <description>ignore vdop field</description>
+      </entry>
+      <entry name="GPS_INPUT_IGNORE_FLAG_VEL_HORIZ" value="8">
+        <description>ignore horizontal velocity field (vn and ve)</description>
+      </entry>
+      <entry name="GPS_INPUT_IGNORE_FLAG_VEL_VERT" value="16">
+        <description>ignore vertical velocity field (vd)</description>
+      </entry>
+      <entry name="GPS_INPUT_IGNORE_FLAG_SPEED_ACCURACY" value="32">
+        <description>ignore speed accuracy field</description>
+      </entry>
+      <entry name="GPS_INPUT_IGNORE_FLAG_HORIZONTAL_ACCURACY" value="64">
+        <description>ignore horizontal accuracy field</description>
+      </entry>
+      <entry name="GPS_INPUT_IGNORE_FLAG_VERTICAL_ACCURACY" value="128">
+        <description>ignore vertical accuracy field</description>
+      </entry>
+    </enum>
+    <enum name="MAV_COLLISION_ACTION">
+      <description>Possible actions an aircraft can take to avoid a collision.</description>
+      <entry value="0" name="MAV_COLLISION_ACTION_NONE">
+        <description>Ignore any potential collisions</description>
+      </entry>
+      <entry value="1" name="MAV_COLLISION_ACTION_REPORT">
+        <description>Report potential collision</description>
+      </entry>
+      <entry value="2" name="MAV_COLLISION_ACTION_ASCEND_OR_DESCEND">
+        <description>Ascend or Descend to avoid threat</description>
+      </entry>
+      <entry value="3" name="MAV_COLLISION_ACTION_MOVE_HORIZONTALLY">
+        <description>Move horizontally to avoid threat</description>
+      </entry>
+      <entry value="4" name="MAV_COLLISION_ACTION_MOVE_PERPENDICULAR">
+        <description>Aircraft to move perpendicular to the collision's velocity vector</description>
+      </entry>
+      <entry value="5" name="MAV_COLLISION_ACTION_RTL">
+        <description>Aircraft to fly directly back to its launch point</description>
+      </entry>
+      <entry value="6" name="MAV_COLLISION_ACTION_HOVER">
+        <description>Aircraft to stop in place</description>
+      </entry>
+    </enum>
+    <enum name="MAV_COLLISION_THREAT_LEVEL">
+      <description>Aircraft-rated danger from this threat.</description>
+      <entry value="0" name="MAV_COLLISION_THREAT_LEVEL_NONE">
+        <description>Not a threat</description>
+      </entry>
+      <entry value="1" name="MAV_COLLISION_THREAT_LEVEL_LOW">
+        <description>Craft is mildly concerned about this threat</description>
+      </entry>
+      <entry value="2" name="MAV_COLLISION_THREAT_LEVEL_HIGH">
+        <description>Craft is panicing, and may take actions to avoid threat</description>
+      </entry>
+    </enum>
+    <enum name="MAV_COLLISION_SRC">
+      <description>Source of information about this collision.</description>
+      <entry value="0" name="MAV_COLLISION_SRC_ADSB">
+        <description>ID field references ADSB_VEHICLE packets</description>
+      </entry>
+      <entry value="1" name="MAV_COLLISION_SRC_MAVLINK_GPS_GLOBAL_INT">
+        <description>ID field references MAVLink SRC ID</description>
+      </entry>
+    </enum>
+    <enum name="GPS_FIX_TYPE">
+      <description>Type of GPS fix</description>
+      <entry value="0" name="GPS_FIX_TYPE_NO_GPS">
+        <description>No GPS connected</description>
+      </entry>
+      <entry value="1" name="GPS_FIX_TYPE_NO_FIX">
+        <description>No position information, GPS is connected</description>
+      </entry>
+      <entry value="2" name="GPS_FIX_TYPE_2D_FIX">
+        <description>2D position</description>
+      </entry>
+      <entry value="3" name="GPS_FIX_TYPE_3D_FIX">
+        <description>3D position</description>
+      </entry>
+      <entry value="4" name="GPS_FIX_TYPE_DGPS">
+        <description>DGPS/SBAS aided 3D position</description>
+      </entry>
+      <entry value="5" name="GPS_FIX_TYPE_RTK_FLOAT">
+        <description>RTK float, 3D position</description>
+      </entry>
+      <entry value="6" name="GPS_FIX_TYPE_RTK_FIXED">
+        <description>RTK Fixed, 3D position</description>
+      </entry>
+      <entry value="7" name="GPS_FIX_TYPE_STATIC">
+        <description>Static fixed, typically used for base stations</description>
+      </entry>
+    </enum>
+    <enum name="MIXER_GROUP">
       <description>Identifies a set of mixers to access</description>
       <entry value="0" name="MIXER_GROUP_NONE">
         <description>No specific group selected</description>
@@ -2400,1335 +2427,1349 @@
       <entry value="2" name="MIXER_GROUP_FAILSAFE">
         <description>Mixers on a failsafe device</description>
       </entry>
-    </enum>    
-   <enum name="MIXER_PARAM_FLAGS">
+    </enum>
+    <enum name="MIXER_PARAM_FLAGS">
       <description>Flags for different parameter qualities and states</description>
       <entry value="1" name="MIXER_PARAM_READ_ONLY">
         <description>Parameter is read only</description>
       </entry>
-    </enum>    
-    
-    
-    
-     </enums>
-     <messages>
-          <message id="0" name="HEARTBEAT">
-               <description>The heartbeat message shows that a system is present and responding. The type of the MAV and Autopilot hardware allow the receiving system to treat further messages from this system appropriate (e.g. by laying out the user interface based on the autopilot).</description>
-               <field type="uint8_t" name="type">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
-               <field type="uint8_t" name="autopilot">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
-               <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
-               <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
-               <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
-               <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
-          </message>
-          <message id="1" name="SYS_STATUS">
-               <description>The general system state. If the system is following the MAVLink standard, the system state is mainly defined by three orthogonal states/modes: The system mode, which is either LOCKED (motors shut down and locked), MANUAL (system under RC control), GUIDED (system with autonomous position control, position setpoint controlled manually) or AUTO (system guided by path/waypoint planner). The NAV_MODE defined the current flight state: LIFTOFF (often an open-loop maneuver), LANDING, WAYPOINTS or VECTOR. This represents the internal navigation state machine. The system status shows wether the system is currently active or not and if an emergency occured. During the CRITICAL and EMERGENCY states the MAV is still considered to be active, but should start emergency procedures autonomously. After a failure occured it should first move from active to critical to allow manual intervention and then move to emergency after a certain timeout.</description>
-               <field type="uint32_t" name="onboard_control_sensors_present" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are present. Value of 0: not present. Value of 1: present. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-               <field type="uint32_t" name="onboard_control_sensors_enabled" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are enabled:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-               <field type="uint32_t" name="onboard_control_sensors_health" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are operational or have an error:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
-               <field type="uint16_t" name="load">Maximum usage in percent of the mainloop time, (0%: 0, 100%: 1000) should be always below 1000</field>
-               <field type="uint16_t" name="voltage_battery">Battery voltage, in millivolts (1 = 1 millivolt)</field>
-               <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
-               <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery</field>
-               <field type="uint16_t" name="drop_rate_comm">Communication drops in percent, (0%: 0, 100%: 10'000), (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
-               <field type="uint16_t" name="errors_comm">Communication errors (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
-               <field type="uint16_t" name="errors_count1">Autopilot-specific errors</field>
-               <field type="uint16_t" name="errors_count2">Autopilot-specific errors</field>
-               <field type="uint16_t" name="errors_count3">Autopilot-specific errors</field>
-               <field type="uint16_t" name="errors_count4">Autopilot-specific errors</field>
-          </message>
-          <message id="2" name="SYSTEM_TIME">
-               <description>The system time is the time of the master clock, typically the computer clock of the main onboard computer.</description>
-               <field type="uint64_t" name="time_unix_usec">Timestamp of the master clock in microseconds since UNIX epoch.</field>
-               <field type="uint32_t" name="time_boot_ms">Timestamp of the component clock since boot time in milliseconds.</field>
-          </message>
-          <!-- FIXME to be removed / merged with SYSTEM_TIME -->
-          <message id="4" name="PING">
-               <description>A ping message either requesting or responding to a ping. This allows to measure the system latencies, including serial port, radio modem and UDP connections.</description>
-               <field type="uint64_t" name="time_usec">Unix timestamp in microseconds or since system boot if smaller than MAVLink epoch (1.1.2009)</field>
-               <field type="uint32_t" name="seq">PING sequence</field>
-               <field type="uint8_t" name="target_system">0: request ping from all receiving systems, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
-               <field type="uint8_t" name="target_component">0: request ping from all receiving components, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
-          </message>
-          <message id="5" name="CHANGE_OPERATOR_CONTROL">
-               <description>Request to control this MAV</description>
-               <field type="uint8_t" name="target_system">System the GCS requests control for</field>
-               <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
-               <field type="uint8_t" name="version">0: key as plaintext, 1-255: future, different hashing/encryption variants. The GCS should in general use the safest mode possible initially and then gradually move down the encryption level if it gets a NACK message indicating an encryption mismatch.</field>
-               <field type="char[25]" name="passkey">Password / Key, depending on version plaintext or encrypted. 25 or less characters, NULL terminated. The characters may involve A-Z, a-z, 0-9, and "!?,.-"</field>
-          </message>
-          <message id="6" name="CHANGE_OPERATOR_CONTROL_ACK">
-               <description>Accept / deny control of this MAV</description>
-               <field type="uint8_t" name="gcs_system_id">ID of the GCS this message </field>
-               <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
-               <field type="uint8_t" name="ack">0: ACK, 1: NACK: Wrong passkey, 2: NACK: Unsupported passkey encryption method, 3: NACK: Already under control</field>
-          </message>
-          <message id="7" name="AUTH_KEY">
-               <description>Emit an encrypted signature / key identifying this system. PLEASE NOTE: This protocol has been kept simple, so transmitting the key requires an encrypted channel for true safety.</description>
-               <field type="char[32]" name="key">key</field>
-          </message>
-          <message id="11" name="SET_MODE">
-               <description>THIS INTERFACE IS DEPRECATED. USE COMMAND_LONG with MAV_CMD_DO_SET_MODE INSTEAD. Set the system mode, as defined by enum MAV_MODE. There is no target component id as the mode is by definition for the overall aircraft, not only for one component.</description>
-               <field type="uint8_t" name="target_system">The system setting the mode</field>
-               <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode</field>
-               <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
-          </message>
-          <!-- reserved for PARAM_VALUE_UNION -->
-          <message id="20" name="PARAM_REQUEST_READ">
-               <description>Request to read the onboard parameter with the param_id string id. Onboard parameters are stored as key[const char*] -> value[float]. This allows to send a parameter to any other component (such as the GCS) without the need of previous knowledge of possible parameter names. Thus the same GCS can store different parameters for different autopilots. See also http://qgroundcontrol.org/parameter_interface for a full documentation of QGroundControl and IMU code.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-               <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored)</field>
-          </message>
-          <message id="21" name="PARAM_REQUEST_LIST">
-               <description>Request all parameters of this component. After this request, all parameters are emitted.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-          </message>
-          <message id="22" name="PARAM_VALUE">
-               <description>Emit the value of a onboard parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows him to re-request missing parameters after a loss or timeout.</description>
-               <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-               <field type="float" name="param_value">Onboard parameter value</field>
-               <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-               <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
-               <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
-          </message>
-          <message id="23" name="PARAM_SET">
-               <description>Set a parameter value TEMPORARILY to RAM. It will be reset to default on system reboot. Send the ACTION MAV_ACTION_STORAGE_WRITE to PERMANENTLY write the RAM contents to EEPROM. IMPORTANT: The receiving component should acknowledge the new parameter value by sending a param_value message to all communication partners. This will also ensure that multiple GCS all have an up-to-date list of all parameters. If the sending GCS did not receive a PARAM_VALUE message within its timeout time, it should re-send the PARAM_SET message.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-               <field type="float" name="param_value">Onboard parameter value</field>
-               <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-          </message>
-          <message id="24" name="GPS_RAW_INT">
-               <description>The global position, as returned by the Global Positioning System (GPS). This is
+    </enum>
+  </enums>
+  <messages>
+    <message id="0" name="HEARTBEAT">
+      <description>The heartbeat message shows that a system is present and responding. The type of the MAV and Autopilot hardware allow the receiving system to treat further messages from this system appropriate (e.g. by laying out the user interface based on the autopilot).</description>
+      <field type="uint8_t" name="type">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
+      <field type="uint8_t" name="autopilot">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
+      <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
+      <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
+      <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
+      <field type="uint8_t_mavlink_version" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
+    </message>
+    <message id="1" name="SYS_STATUS">
+      <description>The general system state. If the system is following the MAVLink standard, the system state is mainly defined by three orthogonal states/modes: The system mode, which is either LOCKED (motors shut down and locked), MANUAL (system under RC control), GUIDED (system with autonomous position control, position setpoint controlled manually) or AUTO (system guided by path/waypoint planner). The NAV_MODE defined the current flight state: LIFTOFF (often an open-loop maneuver), LANDING, WAYPOINTS or VECTOR. This represents the internal navigation state machine. The system status shows wether the system is currently active or not and if an emergency occured. During the CRITICAL and EMERGENCY states the MAV is still considered to be active, but should start emergency procedures autonomously. After a failure occured it should first move from active to critical to allow manual intervention and then move to emergency after a certain timeout.</description>
+      <field type="uint32_t" name="onboard_control_sensors_present" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are present. Value of 0: not present. Value of 1: present. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+      <field type="uint32_t" name="onboard_control_sensors_enabled" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are enabled:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+      <field type="uint32_t" name="onboard_control_sensors_health" print_format="0x%04x">Bitmask showing which onboard controllers and sensors are operational or have an error:  Value of 0: not enabled. Value of 1: enabled. Indices defined by ENUM MAV_SYS_STATUS_SENSOR</field>
+      <field type="uint16_t" name="load">Maximum usage in percent of the mainloop time, (0%: 0, 100%: 1000) should be always below 1000</field>
+      <field type="uint16_t" name="voltage_battery">Battery voltage, in millivolts (1 = 1 millivolt)</field>
+      <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+      <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery</field>
+      <field type="uint16_t" name="drop_rate_comm">Communication drops in percent, (0%: 0, 100%: 10'000), (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
+      <field type="uint16_t" name="errors_comm">Communication errors (UART, I2C, SPI, CAN), dropped packets on all links (packets that were corrupted on reception on the MAV)</field>
+      <field type="uint16_t" name="errors_count1">Autopilot-specific errors</field>
+      <field type="uint16_t" name="errors_count2">Autopilot-specific errors</field>
+      <field type="uint16_t" name="errors_count3">Autopilot-specific errors</field>
+      <field type="uint16_t" name="errors_count4">Autopilot-specific errors</field>
+    </message>
+    <message id="2" name="SYSTEM_TIME">
+      <description>The system time is the time of the master clock, typically the computer clock of the main onboard computer.</description>
+      <field type="uint64_t" name="time_unix_usec">Timestamp of the master clock in microseconds since UNIX epoch.</field>
+      <field type="uint32_t" name="time_boot_ms">Timestamp of the component clock since boot time in milliseconds.</field>
+    </message>
+    <!-- FIXME to be removed / merged with SYSTEM_TIME -->
+    <message id="4" name="PING">
+      <description>A ping message either requesting or responding to a ping. This allows to measure the system latencies, including serial port, radio modem and UDP connections.</description>
+      <field type="uint64_t" name="time_usec">Unix timestamp in microseconds or since system boot if smaller than MAVLink epoch (1.1.2009)</field>
+      <field type="uint32_t" name="seq">PING sequence</field>
+      <field type="uint8_t" name="target_system">0: request ping from all receiving systems, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
+      <field type="uint8_t" name="target_component">0: request ping from all receiving components, if greater than 0: message is a ping response and number is the system id of the requesting system</field>
+    </message>
+    <message id="5" name="CHANGE_OPERATOR_CONTROL">
+      <description>Request to control this MAV</description>
+      <field type="uint8_t" name="target_system">System the GCS requests control for</field>
+      <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
+      <field type="uint8_t" name="version">0: key as plaintext, 1-255: future, different hashing/encryption variants. The GCS should in general use the safest mode possible initially and then gradually move down the encryption level if it gets a NACK message indicating an encryption mismatch.</field>
+      <field type="char[25]" name="passkey">Password / Key, depending on version plaintext or encrypted. 25 or less characters, NULL terminated. The characters may involve A-Z, a-z, 0-9, and "!?,.-"</field>
+    </message>
+    <message id="6" name="CHANGE_OPERATOR_CONTROL_ACK">
+      <description>Accept / deny control of this MAV</description>
+      <field type="uint8_t" name="gcs_system_id">ID of the GCS this message </field>
+      <field type="uint8_t" name="control_request">0: request control of this MAV, 1: Release control of this MAV</field>
+      <field type="uint8_t" name="ack">0: ACK, 1: NACK: Wrong passkey, 2: NACK: Unsupported passkey encryption method, 3: NACK: Already under control</field>
+    </message>
+    <message id="7" name="AUTH_KEY">
+      <description>Emit an encrypted signature / key identifying this system. PLEASE NOTE: This protocol has been kept simple, so transmitting the key requires an encrypted channel for true safety.</description>
+      <field type="char[32]" name="key">key</field>
+    </message>
+    <message id="11" name="SET_MODE">
+      <description>THIS INTERFACE IS DEPRECATED. USE COMMAND_LONG with MAV_CMD_DO_SET_MODE INSTEAD. Set the system mode, as defined by enum MAV_MODE. There is no target component id as the mode is by definition for the overall aircraft, not only for one component.</description>
+      <field type="uint8_t" name="target_system">The system setting the mode</field>
+      <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode</field>
+      <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
+    </message>
+    <!-- reserved for PARAM_VALUE_UNION -->
+    <message id="20" name="PARAM_REQUEST_READ">
+      <description>Request to read the onboard parameter with the param_id string id. Onboard parameters are stored as key[const char*] -&gt; value[float]. This allows to send a parameter to any other component (such as the GCS) without the need of previous knowledge of possible parameter names. Thus the same GCS can store different parameters for different autopilots. See also http://qgroundcontrol.org/parameter_interface for a full documentation of QGroundControl and IMU code.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored)</field>
+    </message>
+    <message id="21" name="PARAM_REQUEST_LIST">
+      <description>Request all parameters of this component. After this request, all parameters are emitted.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="22" name="PARAM_VALUE">
+      <description>Emit the value of a onboard parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows him to re-request missing parameters after a loss or timeout.</description>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float" name="param_value">Onboard parameter value</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
+      <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
+    </message>
+    <message id="23" name="PARAM_SET">
+      <description>Set a parameter value TEMPORARILY to RAM. It will be reset to default on system reboot. Send the ACTION MAV_ACTION_STORAGE_WRITE to PERMANENTLY write the RAM contents to EEPROM. IMPORTANT: The receiving component should acknowledge the new parameter value by sending a param_value message to all communication partners. This will also ensure that multiple GCS all have an up-to-date list of all parameters. If the sending GCS did not receive a PARAM_VALUE message within its timeout time, it should re-send the PARAM_SET message.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float" name="param_value">Onboard parameter value</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+    </message>
+    <message id="24" name="GPS_RAW_INT">
+      <description>The global position, as returned by the Global Positioning System (GPS). This is
                 NOT the global position estimate of the system, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
-               <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="alt">Altitude (AMSL, NOT WGS84), in meters * 1000 (positive for up). Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.</field>
-               <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
-               <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
-               <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
-               <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
-               <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
-          </message>
-          <message id="25" name="GPS_STATUS">
-               <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION for the global position estimate. This message can contain information for up to 20 satellites.</description>
-               <field type="uint8_t" name="satellites_visible">Number of satellites visible</field>
-               <field type="uint8_t[20]" name="satellite_prn">Global satellite ID</field>
-               <field type="uint8_t[20]" name="satellite_used">0: Satellite not used, 1: used for localization</field>
-               <field type="uint8_t[20]" name="satellite_elevation">Elevation (0: right on top of receiver, 90: on the horizon) of satellite</field>
-               <field type="uint8_t[20]" name="satellite_azimuth">Direction of satellite, 0: 0 deg, 255: 360 deg.</field>
-               <field type="uint8_t[20]" name="satellite_snr">Signal to noise ratio of satellite</field>
-          </message>
-          <message id="26" name="SCALED_IMU">
-               <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="int16_t" name="xacc">X acceleration (mg)</field>
-               <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-               <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-               <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-               <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-               <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-               <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-               <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-               <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
-          </message>
-          <message id="27" name="RAW_IMU">
-               <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field type="int16_t" name="xacc">X acceleration (raw)</field>
-               <field type="int16_t" name="yacc">Y acceleration (raw)</field>
-               <field type="int16_t" name="zacc">Z acceleration (raw)</field>
-               <field type="int16_t" name="xgyro">Angular speed around X axis (raw)</field>
-               <field type="int16_t" name="ygyro">Angular speed around Y axis (raw)</field>
-               <field type="int16_t" name="zgyro">Angular speed around Z axis (raw)</field>
-               <field type="int16_t" name="xmag">X Magnetic field (raw)</field>
-               <field type="int16_t" name="ymag">Y Magnetic field (raw)</field>
-               <field type="int16_t" name="zmag">Z Magnetic field (raw)</field>
-          </message>
-          <message id="28" name="RAW_PRESSURE">
-               <description>The RAW pressure readings for the typical setup of one absolute pressure and one differential pressure sensor. The sensor values should be the raw, UNSCALED ADC values.</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field type="int16_t" name="press_abs">Absolute pressure (raw)</field>
-               <field type="int16_t" name="press_diff1">Differential pressure 1 (raw, 0 if nonexistant)</field>
-               <field type="int16_t" name="press_diff2">Differential pressure 2 (raw, 0 if nonexistant)</field>
-               <field type="int16_t" name="temperature">Raw Temperature measurement (raw)</field>
-          </message>
-          <message id="29" name="SCALED_PRESSURE">
-               <description>The pressure readings for the typical setup of one absolute and differential pressure sensor. The units are as specified in each field.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-               <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-               <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
-          </message>
-          <message id="30" name="ATTITUDE">
-               <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="roll">Roll angle (rad, -pi..+pi)</field>
-               <field type="float" name="pitch">Pitch angle (rad, -pi..+pi)</field>
-               <field type="float" name="yaw">Yaw angle (rad, -pi..+pi)</field>
-               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
-          </message>
-          <message id="31" name="ATTITUDE_QUATERNION">
-               <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation)</field>
-               <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation)</field>
-               <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation)</field>
-               <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation)</field>
-               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
-          </message>
-          <message id="32" name="LOCAL_POSITION_NED">
-               <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="x">X Position</field>
-               <field type="float" name="y">Y Position</field>
-               <field type="float" name="z">Z Position</field>
-               <field type="float" name="vx">X Speed</field>
-               <field type="float" name="vy">Y Speed</field>
-               <field type="float" name="vz">Z Speed</field>
-          </message>
-          <message id="33" name="GLOBAL_POSITION_INT">
-               <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
+      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="alt">Altitude (AMSL, NOT WGS84), in meters * 1000 (positive for up). Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.</field>
+      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+    </message>
+    <message id="25" name="GPS_STATUS">
+      <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION for the global position estimate. This message can contain information for up to 20 satellites.</description>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible</field>
+      <field type="uint8_t[20]" name="satellite_prn">Global satellite ID</field>
+      <field type="uint8_t[20]" name="satellite_used">0: Satellite not used, 1: used for localization</field>
+      <field type="uint8_t[20]" name="satellite_elevation">Elevation (0: right on top of receiver, 90: on the horizon) of satellite</field>
+      <field type="uint8_t[20]" name="satellite_azimuth">Direction of satellite, 0: 0 deg, 255: 360 deg.</field>
+      <field type="uint8_t[20]" name="satellite_snr">Signal to noise ratio of satellite</field>
+    </message>
+    <message id="26" name="SCALED_IMU">
+      <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="int16_t" name="xacc">X acceleration (mg)</field>
+      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+      <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
+      <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
+      <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
+      <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
+      <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
+      <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+    </message>
+    <message id="27" name="RAW_IMU">
+      <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field type="int16_t" name="xacc">X acceleration (raw)</field>
+      <field type="int16_t" name="yacc">Y acceleration (raw)</field>
+      <field type="int16_t" name="zacc">Z acceleration (raw)</field>
+      <field type="int16_t" name="xgyro">Angular speed around X axis (raw)</field>
+      <field type="int16_t" name="ygyro">Angular speed around Y axis (raw)</field>
+      <field type="int16_t" name="zgyro">Angular speed around Z axis (raw)</field>
+      <field type="int16_t" name="xmag">X Magnetic field (raw)</field>
+      <field type="int16_t" name="ymag">Y Magnetic field (raw)</field>
+      <field type="int16_t" name="zmag">Z Magnetic field (raw)</field>
+    </message>
+    <message id="28" name="RAW_PRESSURE">
+      <description>The RAW pressure readings for the typical setup of one absolute pressure and one differential pressure sensor. The sensor values should be the raw, UNSCALED ADC values.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field type="int16_t" name="press_abs">Absolute pressure (raw)</field>
+      <field type="int16_t" name="press_diff1">Differential pressure 1 (raw, 0 if nonexistant)</field>
+      <field type="int16_t" name="press_diff2">Differential pressure 2 (raw, 0 if nonexistant)</field>
+      <field type="int16_t" name="temperature">Raw Temperature measurement (raw)</field>
+    </message>
+    <message id="29" name="SCALED_PRESSURE">
+      <description>The pressure readings for the typical setup of one absolute and differential pressure sensor. The units are as specified in each field.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
+      <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
+      <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+    </message>
+    <message id="30" name="ATTITUDE">
+      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right).</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float" name="roll">Roll angle (rad, -pi..+pi)</field>
+      <field type="float" name="pitch">Pitch angle (rad, -pi..+pi)</field>
+      <field type="float" name="yaw">Yaw angle (rad, -pi..+pi)</field>
+      <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
+      <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
+      <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+    </message>
+    <message id="31" name="ATTITUDE_QUATERNION">
+      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation)</field>
+      <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation)</field>
+      <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation)</field>
+      <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation)</field>
+      <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
+      <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
+      <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+    </message>
+    <message id="32" name="LOCAL_POSITION_NED">
+      <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float" name="x">X Position</field>
+      <field type="float" name="y">Y Position</field>
+      <field type="float" name="z">Z Position</field>
+      <field type="float" name="vx">X Speed</field>
+      <field type="float" name="vy">Y Speed</field>
+      <field type="float" name="vz">Z Speed</field>
+    </message>
+    <message id="33" name="GLOBAL_POSITION_INT">
+      <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It
                is designed as scaled integer message since the resolution of float is not sufficient.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-               <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
-               <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), AMSL (not WGS84 - note that virtually all GPS modules provide the AMSL as well)</field>
-               <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
-               <field type="int16_t" name="vx">Ground X Speed (Latitude, positive north), expressed as m/s * 100</field>
-               <field type="int16_t" name="vy">Ground Y Speed (Longitude, positive east), expressed as m/s * 100</field>
-               <field type="int16_t" name="vz">Ground Z Speed (Altitude, positive down), expressed as m/s * 100</field>
-               <field type="uint16_t" name="hdg">Vehicle heading (yaw angle) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
-          </message>
-          <message id="34" name="RC_CHANNELS_SCALED">
-               <description>The scaled values of the RC channels received. (-100%) -10000, (0%) 0, (100%) 10000. Channels that are inactive should be set to UINT16_MAX.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
-               <field type="int16_t" name="chan1_scaled">RC channel 1 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="int16_t" name="chan2_scaled">RC channel 2 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="int16_t" name="chan3_scaled">RC channel 3 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="int16_t" name="chan4_scaled">RC channel 4 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="int16_t" name="chan5_scaled">RC channel 5 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="int16_t" name="chan6_scaled">RC channel 6 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="int16_t" name="chan7_scaled">RC channel 7 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="int16_t" name="chan8_scaled">RC channel 8 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
-               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
-          </message>
-          <message id="35" name="RC_CHANNELS_RAW">
-               <description>The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
-               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
-          </message>
-          <message id="36" name="SERVO_OUTPUT_RAW">
-               <description>The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.</description>
-               <field type="uint32_t" name="time_usec">Timestamp (microseconds since system boot)</field>
-               <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.</field>
-               <field type="uint16_t" name="servo1_raw">Servo output 1 value, in microseconds</field>
-               <field type="uint16_t" name="servo2_raw">Servo output 2 value, in microseconds</field>
-               <field type="uint16_t" name="servo3_raw">Servo output 3 value, in microseconds</field>
-               <field type="uint16_t" name="servo4_raw">Servo output 4 value, in microseconds</field>
-               <field type="uint16_t" name="servo5_raw">Servo output 5 value, in microseconds</field>
-               <field type="uint16_t" name="servo6_raw">Servo output 6 value, in microseconds</field>
-               <field type="uint16_t" name="servo7_raw">Servo output 7 value, in microseconds</field>
-               <field type="uint16_t" name="servo8_raw">Servo output 8 value, in microseconds</field>
-               <extensions/>
-               <field type="uint16_t" name="servo9_raw">Servo output 9 value, in microseconds</field>
-               <field type="uint16_t" name="servo10_raw">Servo output 10 value, in microseconds</field>
-               <field type="uint16_t" name="servo11_raw">Servo output 11 value, in microseconds</field>
-               <field type="uint16_t" name="servo12_raw">Servo output 12 value, in microseconds</field>
-               <field type="uint16_t" name="servo13_raw">Servo output 13 value, in microseconds</field>
-               <field type="uint16_t" name="servo14_raw">Servo output 14 value, in microseconds</field>
-               <field type="uint16_t" name="servo15_raw">Servo output 15 value, in microseconds</field>
-               <field type="uint16_t" name="servo16_raw">Servo output 16 value, in microseconds</field>
-          </message>
-          <message id="37" name="MISSION_REQUEST_PARTIAL_LIST">
-               <description>Request a partial list of mission items from the system/component. http://qgroundcontrol.org/mavlink/waypoint_protocol. If start and end index are the same, just send one waypoint.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="int16_t" name="start_index">Start index, 0 by default</field>
-               <field type="int16_t" name="end_index">End index, -1 by default (-1: send list to end). Else a valid index of the list</field>
-          </message>
-          <message id="38" name="MISSION_WRITE_PARTIAL_LIST">
-               <description>This message is sent to the MAV to write a partial list. If start index == end index, only one item will be transmitted / updated. If the start index is NOT 0 and above the current list size, this request should be REJECTED!</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="int16_t" name="start_index">Start index, 0 by default and smaller / equal to the largest index of the current onboard list.</field>
-               <field type="int16_t" name="end_index">End index, equal or greater than start index.</field>
-          </message>
-          <message id="39" name="MISSION_ITEM">
-               <description>Message encoding a mission item. This message is emitted to announce
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
+      <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
+      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), AMSL (not WGS84 - note that virtually all GPS modules provide the AMSL as well)</field>
+      <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+      <field type="int16_t" name="vx">Ground X Speed (Latitude, positive north), expressed as m/s * 100</field>
+      <field type="int16_t" name="vy">Ground Y Speed (Longitude, positive east), expressed as m/s * 100</field>
+      <field type="int16_t" name="vz">Ground Z Speed (Altitude, positive down), expressed as m/s * 100</field>
+      <field type="uint16_t" name="hdg">Vehicle heading (yaw angle) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+    </message>
+    <message id="34" name="RC_CHANNELS_SCALED">
+      <description>The scaled values of the RC channels received. (-100%) -10000, (0%) 0, (100%) 10000. Channels that are inactive should be set to UINT16_MAX.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
+      <field type="int16_t" name="chan1_scaled">RC channel 1 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+      <field type="int16_t" name="chan2_scaled">RC channel 2 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+      <field type="int16_t" name="chan3_scaled">RC channel 3 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+      <field type="int16_t" name="chan4_scaled">RC channel 4 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+      <field type="int16_t" name="chan5_scaled">RC channel 5 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+      <field type="int16_t" name="chan6_scaled">RC channel 6 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+      <field type="int16_t" name="chan7_scaled">RC channel 7 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+      <field type="int16_t" name="chan8_scaled">RC channel 8 value scaled, (-100%) -10000, (0%) 0, (100%) 10000, (invalid) INT16_MAX.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+    </message>
+    <message id="35" name="RC_CHANNELS_RAW">
+      <description>The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
+      <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+    </message>
+    <message id="36" name="SERVO_OUTPUT_RAW">
+      <description>The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.</description>
+      <field type="uint32_t" name="time_usec">Timestamp (microseconds since system boot)</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.</field>
+      <field type="uint16_t" name="servo1_raw">Servo output 1 value, in microseconds</field>
+      <field type="uint16_t" name="servo2_raw">Servo output 2 value, in microseconds</field>
+      <field type="uint16_t" name="servo3_raw">Servo output 3 value, in microseconds</field>
+      <field type="uint16_t" name="servo4_raw">Servo output 4 value, in microseconds</field>
+      <field type="uint16_t" name="servo5_raw">Servo output 5 value, in microseconds</field>
+      <field type="uint16_t" name="servo6_raw">Servo output 6 value, in microseconds</field>
+      <field type="uint16_t" name="servo7_raw">Servo output 7 value, in microseconds</field>
+      <field type="uint16_t" name="servo8_raw">Servo output 8 value, in microseconds</field>
+      <extensions/>
+      <field type="uint16_t" name="servo9_raw">Servo output 9 value, in microseconds</field>
+      <field type="uint16_t" name="servo10_raw">Servo output 10 value, in microseconds</field>
+      <field type="uint16_t" name="servo11_raw">Servo output 11 value, in microseconds</field>
+      <field type="uint16_t" name="servo12_raw">Servo output 12 value, in microseconds</field>
+      <field type="uint16_t" name="servo13_raw">Servo output 13 value, in microseconds</field>
+      <field type="uint16_t" name="servo14_raw">Servo output 14 value, in microseconds</field>
+      <field type="uint16_t" name="servo15_raw">Servo output 15 value, in microseconds</field>
+      <field type="uint16_t" name="servo16_raw">Servo output 16 value, in microseconds</field>
+    </message>
+    <message id="37" name="MISSION_REQUEST_PARTIAL_LIST">
+      <description>Request a partial list of mission items from the system/component. http://qgroundcontrol.org/mavlink/waypoint_protocol. If start and end index are the same, just send one waypoint.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="int16_t" name="start_index">Start index, 0 by default</field>
+      <field type="int16_t" name="end_index">End index, -1 by default (-1: send list to end). Else a valid index of the list</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="38" name="MISSION_WRITE_PARTIAL_LIST">
+      <description>This message is sent to the MAV to write a partial list. If start index == end index, only one item will be transmitted / updated. If the start index is NOT 0 and above the current list size, this request should be REJECTED!</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="int16_t" name="start_index">Start index, 0 by default and smaller / equal to the largest index of the current onboard list.</field>
+      <field type="int16_t" name="end_index">End index, equal or greater than start index.</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="39" name="MISSION_ITEM">
+      <description>Message encoding a mission item. This message is emitted to announce
                 the presence of a mission item and to set a mission item on the system. The mission item can be either in x, y, z meters (type: LOCAL) or x:lat, y:lon, z:altitude. Local frame is Z-down, right handed (NED), global frame is Z-up, right handed (ENU). See also http://qgroundcontrol.org/mavlink/waypoint_protocol.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint16_t" name="seq">Sequence</field>
-               <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
-               <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
-               <field type="uint8_t" name="current">false:0, true:1</field>
-               <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
-               <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
-               <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
-               <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
-               <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
-               <field type="float" name="x">PARAM5 / local: x position, global: latitude</field>
-               <field type="float" name="y">PARAM6 / y position: global: longitude</field>
-               <field type="float" name="z">PARAM7 / z position: global: altitude (relative or absolute, depending on frame.</field>
-          </message>
-          <message id="40" name="MISSION_REQUEST">
-               <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM message. http://qgroundcontrol.org/mavlink/waypoint_protocol</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint16_t" name="seq">Sequence</field>
-          </message>
-          <message id="41" name="MISSION_SET_CURRENT">
-               <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint16_t" name="seq">Sequence</field>
-          </message>
-          <message id="42" name="MISSION_CURRENT">
-               <description>Message that announces the sequence number of the current active mission item. The MAV will fly towards this mission item.</description>
-               <field type="uint16_t" name="seq">Sequence</field>
-          </message>
-          <message id="43" name="MISSION_REQUEST_LIST">
-               <description>Request the overall list of mission items from the system/component.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-          </message>
-          <message id="44" name="MISSION_COUNT">
-               <description>This message is emitted as response to MISSION_REQUEST_LIST by the MAV and to initiate a write transaction. The GCS can then request the individual mission item based on the knowledge of the total number of MISSIONs.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint16_t" name="count">Number of mission items in the sequence</field>
-          </message>
-          <message id="45" name="MISSION_CLEAR_ALL">
-               <description>Delete all mission items at once.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-          </message>
-          <message id="46" name="MISSION_ITEM_REACHED">
-               <description>A certain mission item has been reached. The system will either hold this position (or circle on the orbit) or (if the autocontinue on the WP was set) continue to the next MISSION.</description>
-               <field type="uint16_t" name="seq">Sequence</field>
-          </message>
-          <message id="47" name="MISSION_ACK">
-               <description>Ack message during MISSION handling. The type field states if this message is a positive ack (type=0) or if an error happened (type=non-zero).</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">See MAV_MISSION_RESULT enum</field>
-          </message>
-          <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
-               <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-          </message>
-          <message id="49" name="GPS_GLOBAL_ORIGIN">
-               <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
-               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="longitude">Longitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-          </message>
-          <message id="50" name="PARAM_MAP_RC">
-               <description>Bind a RC channel to a parameter. The parameter should change accoding to the RC channel value.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-               <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored), send -2 to disable any existing map for this rc_channel_index.</field>
-               <field type="uint8_t" name="parameter_rc_channel_index">Index of parameter RC channel. Not equal to the RC channel id. Typically correpsonds to a potentiometer-knob on the RC.</field>
-               <field type="float" name="param_value0">Initial parameter value</field>
-               <field type="float" name="scale">Scale, maps the RC range [-1, 1] to a parameter value</field>
-               <field type="float" name="param_value_min">Minimum param value. The protocol does not define if this overwrites an onboard minimum value. (Depends on implementation)</field>
-               <field type="float" name="param_value_max">Maximum param value. The protocol does not define if this overwrites an onboard maximum value. (Depends on implementation)</field>
-          </message>
-          <message id="51" name="MISSION_REQUEST_INT">
-               <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM_INT message. http://qgroundcontrol.org/mavlink/waypoint_protocol</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint16_t" name="seq">Sequence</field>
-          </message>
-          <message id="54" name="SAFETY_SET_ALLOWED_AREA">
-               <description>Set a safety zone (volume), which is defined by two corners of a cube. This message can be used to tell the MAV which setpoints/MISSIONs to accept and which to reject. Safety areas are often enforced by national or competition regulations.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
-               <field type="float" name="p1x">x position 1 / Latitude 1</field>
-               <field type="float" name="p1y">y position 1 / Longitude 1</field>
-               <field type="float" name="p1z">z position 1 / Altitude 1</field>
-               <field type="float" name="p2x">x position 2 / Latitude 2</field>
-               <field type="float" name="p2y">y position 2 / Longitude 2</field>
-               <field type="float" name="p2z">z position 2 / Altitude 2</field>
-          </message>
-          <message id="55" name="SAFETY_ALLOWED_AREA">
-               <description>Read out the safety zone the MAV currently assumes.</description>
-               <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
-               <field type="float" name="p1x">x position 1 / Latitude 1</field>
-               <field type="float" name="p1y">y position 1 / Longitude 1</field>
-               <field type="float" name="p1z">z position 1 / Altitude 1</field>
-               <field type="float" name="p2x">x position 2 / Latitude 2</field>
-               <field type="float" name="p2y">y position 2 / Longitude 2</field>
-               <field type="float" name="p2z">z position 2 / Altitude 2</field>
-          </message>
-          <message id="61" name="ATTITUDE_QUATERNION_COV">
-               <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
-               <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
-               <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
-               <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
-               <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
-               <field type="float[9]" name="covariance">Attitude covariance</field>
-          </message>
-          <message id="62" name="NAV_CONTROLLER_OUTPUT">
-               <description>The state of the fixed wing navigation and position controller.</description>
-               <field type="float" name="nav_roll">Current desired roll in degrees</field>
-               <field type="float" name="nav_pitch">Current desired pitch in degrees</field>
-               <field type="int16_t" name="nav_bearing">Current desired heading in degrees</field>
-               <field type="int16_t" name="target_bearing">Bearing to current MISSION/target in degrees</field>
-               <field type="uint16_t" name="wp_dist">Distance to active MISSION in meters</field>
-               <field type="float" name="alt_error">Current altitude error in meters</field>
-               <field type="float" name="aspd_error">Current airspeed error in meters/second</field>
-               <field type="float" name="xtrack_error">Current crosstrack error on x-y plane in meters</field>
-          </message>
-          <message id="63" name="GLOBAL_POSITION_INT_COV">
-              <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.</description>
-              <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
-              <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
-              <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-              <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
-              <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), above MSL</field>
-              <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
-              <field type="float" name="vx">Ground X Speed (Latitude), expressed as m/s</field>
-              <field type="float" name="vy">Ground Y Speed (Longitude), expressed as m/s</field>
-              <field type="float" name="vz">Ground Z Speed (Altitude), expressed as m/s</field>
-              <field type="float[36]" name="covariance">Covariance matrix (first six entries are the first ROW, next six entries are the second row, etc.)</field>
-          </message>
-          <message id="64" name="LOCAL_POSITION_NED_COV">
-              <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-              <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
-              <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
-              <field type="float" name="x">X Position</field>
-              <field type="float" name="y">Y Position</field>
-              <field type="float" name="z">Z Position</field>
-              <field type="float" name="vx">X Speed (m/s)</field>
-              <field type="float" name="vy">Y Speed (m/s)</field>
-              <field type="float" name="vz">Z Speed (m/s)</field>
-              <field type="float" name="ax">X Acceleration (m/s^2)</field>
-              <field type="float" name="ay">Y Acceleration (m/s^2)</field>
-              <field type="float" name="az">Z Acceleration (m/s^2)</field>
-              <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first nine entries are the first ROW, next eight entries are the second row, etc.)</field>
-          </message>
-          <message id="65" name="RC_CHANNELS">
-               <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="uint8_t" name="chancount">Total number of RC channels being received. This can be larger than 18, indicating that more channels are available but not given in this message. This value should be 0 when no RC channels are available.</field>
-               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan13_raw">RC channel 13 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan14_raw">RC channel 14 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan15_raw">RC channel 15 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan16_raw">RC channel 16 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan17_raw">RC channel 17 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint16_t" name="chan18_raw">RC channel 18 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
-               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
-          </message>
-          <message id="66" name="REQUEST_DATA_STREAM">
-               <description>THIS INTERFACE IS DEPRECATED. USE SET_MESSAGE_INTERVAL INSTEAD.</description>
-               <field type="uint8_t" name="target_system">The target requested to send the message stream.</field>
-               <field type="uint8_t" name="target_component">The target requested to send the message stream.</field>
-               <field type="uint8_t" name="req_stream_id">The ID of the requested data stream</field>
-               <field type="uint16_t" name="req_message_rate">The requested message rate</field>
-               <field type="uint8_t" name="start_stop">1 to start sending, 0 to stop sending.</field>
-          </message>
-          <message id="67" name="DATA_STREAM">
-               <description>THIS INTERFACE IS DEPRECATED. USE MESSAGE_INTERVAL INSTEAD.</description>
-               <field type="uint8_t" name="stream_id">The ID of the requested data stream</field>
-               <field type="uint16_t" name="message_rate">The message rate</field>
-               <field type="uint8_t" name="on_off">1 stream is enabled, 0 stream is stopped.</field>
-          </message>
-          <message id="69" name="MANUAL_CONTROL">
-               <description>This message provides an API for manually controlling the vehicle using standard joystick axes nomenclature, along with a joystick-like input device. Unused axes can be disabled an buttons are also transmit as boolean values of their </description>
-               <field type="uint8_t" name="target">The system to be controlled.</field>
-               <field type="int16_t" name="x">X-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to forward(1000)-backward(-1000) movement on a joystick and the pitch of a vehicle.</field>
-               <field type="int16_t" name="y">Y-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to left(-1000)-right(1000) movement on a joystick and the roll of a vehicle.</field>
-               <field type="int16_t" name="z">Z-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a separate slider movement with maximum being 1000 and minimum being -1000 on a joystick and the thrust of a vehicle. Positive values are positive thrust, negative values are negative thrust.</field>
-               <field type="int16_t" name="r">R-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a twisting of the joystick, with counter-clockwise being 1000 and clockwise being -1000, and the yaw of a vehicle.</field>
-               <field type="uint16_t" name="buttons">A bitfield corresponding to the joystick buttons' current state, 1 for pressed, 0 for released. The lowest bit corresponds to Button 1.</field>
-          </message>
-          <message id="70" name="RC_CHANNELS_OVERRIDE">
-               <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. A value of UINT16_MAX means no change to that channel. A value of 0 means control of that channel should be released back to the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-          </message>
-          <message id="73" name="MISSION_ITEM_INT">
-              <description>Message encoding a mission item. This message is emitted to announce
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+      <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
+      <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
+      <field type="uint8_t" name="current">false:0, true:1</field>
+      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+      <field type="float" name="x">PARAM5 / local: x position, global: latitude</field>
+      <field type="float" name="y">PARAM6 / y position: global: longitude</field>
+      <field type="float" name="z">PARAM7 / z position: global: altitude (relative or absolute, depending on frame.</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="40" name="MISSION_REQUEST">
+      <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM message. http://qgroundcontrol.org/mavlink/waypoint_protocol</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="41" name="MISSION_SET_CURRENT">
+      <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+    </message>
+    <message id="42" name="MISSION_CURRENT">
+      <description>Message that announces the sequence number of the current active mission item. The MAV will fly towards this mission item.</description>
+      <field type="uint16_t" name="seq">Sequence</field>
+    </message>
+    <message id="43" name="MISSION_REQUEST_LIST">
+      <description>Request the overall list of mission items from the system/component.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="44" name="MISSION_COUNT">
+      <description>This message is emitted as response to MISSION_REQUEST_LIST by the MAV and to initiate a write transaction. The GCS can then request the individual mission item based on the knowledge of the total number of MISSIONs.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="count">Number of mission items in the sequence</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="45" name="MISSION_CLEAR_ALL">
+      <description>Delete all mission items at once.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="46" name="MISSION_ITEM_REACHED">
+      <description>A certain mission item has been reached. The system will either hold this position (or circle on the orbit) or (if the autocontinue on the WP was set) continue to the next MISSION.</description>
+      <field type="uint16_t" name="seq">Sequence</field>
+    </message>
+    <message id="47" name="MISSION_ACK">
+      <description>Ack message during MISSION handling. The type field states if this message is a positive ack (type=0) or if an error happened (type=non-zero).</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">See MAV_MISSION_RESULT enum</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
+      <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
+      <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+    </message>
+    <message id="49" name="GPS_GLOBAL_ORIGIN">
+      <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
+      <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="longitude">Longitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+    </message>
+    <message id="50" name="PARAM_MAP_RC">
+      <description>Bind a RC channel to a parameter. The parameter should change accoding to the RC channel value.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored), send -2 to disable any existing map for this rc_channel_index.</field>
+      <field type="uint8_t" name="parameter_rc_channel_index">Index of parameter RC channel. Not equal to the RC channel id. Typically correpsonds to a potentiometer-knob on the RC.</field>
+      <field type="float" name="param_value0">Initial parameter value</field>
+      <field type="float" name="scale">Scale, maps the RC range [-1, 1] to a parameter value</field>
+      <field type="float" name="param_value_min">Minimum param value. The protocol does not define if this overwrites an onboard minimum value. (Depends on implementation)</field>
+      <field type="float" name="param_value_max">Maximum param value. The protocol does not define if this overwrites an onboard maximum value. (Depends on implementation)</field>
+    </message>
+    <message id="51" name="MISSION_REQUEST_INT">
+      <description>Request the information of the mission item with the sequence number seq. The response of the system to this message should be a MISSION_ITEM_INT message. http://qgroundcontrol.org/mavlink/waypoint_protocol</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Sequence</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="54" name="SAFETY_SET_ALLOWED_AREA">
+      <description>Set a safety zone (volume), which is defined by two corners of a cube. This message can be used to tell the MAV which setpoints/MISSIONs to accept and which to reject. Safety areas are often enforced by national or competition regulations.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
+      <field type="float" name="p1x">x position 1 / Latitude 1</field>
+      <field type="float" name="p1y">y position 1 / Longitude 1</field>
+      <field type="float" name="p1z">z position 1 / Altitude 1</field>
+      <field type="float" name="p2x">x position 2 / Latitude 2</field>
+      <field type="float" name="p2y">y position 2 / Longitude 2</field>
+      <field type="float" name="p2z">z position 2 / Altitude 2</field>
+    </message>
+    <message id="55" name="SAFETY_ALLOWED_AREA">
+      <description>Read out the safety zone the MAV currently assumes.</description>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame, as defined by MAV_FRAME enum in mavlink_types.h. Can be either global, GPS, right-handed with Z axis up or local, right handed, Z axis down.</field>
+      <field type="float" name="p1x">x position 1 / Latitude 1</field>
+      <field type="float" name="p1y">y position 1 / Longitude 1</field>
+      <field type="float" name="p1z">z position 1 / Altitude 1</field>
+      <field type="float" name="p2x">x position 2 / Latitude 2</field>
+      <field type="float" name="p2y">y position 2 / Longitude 2</field>
+      <field type="float" name="p2z">z position 2 / Altitude 2</field>
+    </message>
+    <message id="61" name="ATTITUDE_QUATERNION_COV">
+      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+      <field type="float" name="rollspeed">Roll angular speed (rad/s)</field>
+      <field type="float" name="pitchspeed">Pitch angular speed (rad/s)</field>
+      <field type="float" name="yawspeed">Yaw angular speed (rad/s)</field>
+      <field type="float[9]" name="covariance">Attitude covariance</field>
+    </message>
+    <message id="62" name="NAV_CONTROLLER_OUTPUT">
+      <description>The state of the fixed wing navigation and position controller.</description>
+      <field type="float" name="nav_roll">Current desired roll in degrees</field>
+      <field type="float" name="nav_pitch">Current desired pitch in degrees</field>
+      <field type="int16_t" name="nav_bearing">Current desired heading in degrees</field>
+      <field type="int16_t" name="target_bearing">Bearing to current MISSION/target in degrees</field>
+      <field type="uint16_t" name="wp_dist">Distance to active MISSION in meters</field>
+      <field type="float" name="alt_error">Current altitude error in meters</field>
+      <field type="float" name="aspd_error">Current airspeed error in meters/second</field>
+      <field type="float" name="xtrack_error">Current crosstrack error on x-y plane in meters</field>
+    </message>
+    <message id="63" name="GLOBAL_POSITION_INT_COV">
+      <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
+      <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
+      <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
+      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters), above MSL</field>
+      <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
+      <field type="float" name="vx">Ground X Speed (Latitude), expressed as m/s</field>
+      <field type="float" name="vy">Ground Y Speed (Longitude), expressed as m/s</field>
+      <field type="float" name="vz">Ground Z Speed (Altitude), expressed as m/s</field>
+      <field type="float[36]" name="covariance">Covariance matrix (first six entries are the first ROW, next six entries are the second row, etc.)</field>
+    </message>
+    <message id="64" name="LOCAL_POSITION_NED_COV">
+      <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since system boot or since UNIX epoch)</field>
+      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Class id of the estimator this estimate originated from.</field>
+      <field type="float" name="x">X Position</field>
+      <field type="float" name="y">Y Position</field>
+      <field type="float" name="z">Z Position</field>
+      <field type="float" name="vx">X Speed (m/s)</field>
+      <field type="float" name="vy">Y Speed (m/s)</field>
+      <field type="float" name="vz">Z Speed (m/s)</field>
+      <field type="float" name="ax">X Acceleration (m/s^2)</field>
+      <field type="float" name="ay">Y Acceleration (m/s^2)</field>
+      <field type="float" name="az">Z Acceleration (m/s^2)</field>
+      <field type="float[45]" name="covariance">Covariance matrix upper right triangular (first nine entries are the first ROW, next eight entries are the second row, etc.)</field>
+    </message>
+    <message id="65" name="RC_CHANNELS">
+      <description>The PPM values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="chancount">Total number of RC channels being received. This can be larger than 18, indicating that more channels are available but not given in this message. This value should be 0 when no RC channels are available.</field>
+      <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan13_raw">RC channel 13 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan14_raw">RC channel 14 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan15_raw">RC channel 15 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan16_raw">RC channel 16 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan17_raw">RC channel 17 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint16_t" name="chan18_raw">RC channel 18 value, in microseconds. A value of UINT16_MAX implies the channel is unused.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.</field>
+    </message>
+    <message id="66" name="REQUEST_DATA_STREAM">
+      <description>THIS INTERFACE IS DEPRECATED. USE SET_MESSAGE_INTERVAL INSTEAD.</description>
+      <field type="uint8_t" name="target_system">The target requested to send the message stream.</field>
+      <field type="uint8_t" name="target_component">The target requested to send the message stream.</field>
+      <field type="uint8_t" name="req_stream_id">The ID of the requested data stream</field>
+      <field type="uint16_t" name="req_message_rate">The requested message rate</field>
+      <field type="uint8_t" name="start_stop">1 to start sending, 0 to stop sending.</field>
+    </message>
+    <message id="67" name="DATA_STREAM">
+      <description>THIS INTERFACE IS DEPRECATED. USE MESSAGE_INTERVAL INSTEAD.</description>
+      <field type="uint8_t" name="stream_id">The ID of the requested data stream</field>
+      <field type="uint16_t" name="message_rate">The message rate</field>
+      <field type="uint8_t" name="on_off">1 stream is enabled, 0 stream is stopped.</field>
+    </message>
+    <message id="69" name="MANUAL_CONTROL">
+      <description>This message provides an API for manually controlling the vehicle using standard joystick axes nomenclature, along with a joystick-like input device. Unused axes can be disabled an buttons are also transmit as boolean values of their </description>
+      <field type="uint8_t" name="target">The system to be controlled.</field>
+      <field type="int16_t" name="x">X-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to forward(1000)-backward(-1000) movement on a joystick and the pitch of a vehicle.</field>
+      <field type="int16_t" name="y">Y-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to left(-1000)-right(1000) movement on a joystick and the roll of a vehicle.</field>
+      <field type="int16_t" name="z">Z-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a separate slider movement with maximum being 1000 and minimum being -1000 on a joystick and the thrust of a vehicle. Positive values are positive thrust, negative values are negative thrust.</field>
+      <field type="int16_t" name="r">R-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a twisting of the joystick, with counter-clockwise being 1000 and clockwise being -1000, and the yaw of a vehicle.</field>
+      <field type="uint16_t" name="buttons">A bitfield corresponding to the joystick buttons' current state, 1 for pressed, 0 for released. The lowest bit corresponds to Button 1.</field>
+    </message>
+    <message id="70" name="RC_CHANNELS_OVERRIDE">
+      <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. A value of UINT16_MAX means no change to that channel. A value of 0 means control of that channel should be released back to the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+    </message>
+    <message id="73" name="MISSION_ITEM_INT">
+      <description>Message encoding a mission item. This message is emitted to announce
                 the presence of a mission item and to set a mission item on the system. The mission item can be either in x, y, z meters (type: LOCAL) or x:lat, y:lon, z:altitude. Local frame is Z-down, right handed (NED), global frame is Z-up, right handed (ENU). See alsohttp://qgroundcontrol.org/mavlink/waypoint_protocol.</description>
-              <field type="uint8_t" name="target_system">System ID</field>
-              <field type="uint8_t" name="target_component">Component ID</field>
-              <field type="uint16_t" name="seq">Waypoint ID (sequence number). Starts at zero. Increases monotonically for each waypoint, no gaps in the sequence (0,1,2,3,4).</field>
-              <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
-              <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
-              <field type="uint8_t" name="current">false:0, true:1</field>
-              <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
-              <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
-              <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
-              <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
-              <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
-              <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
-              <field type="int32_t" name="y">PARAM6 / y position: local: x position in meters * 1e4, global: longitude in degrees *10^7</field>
-              <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
-          </message>
-          <message id="74" name="VFR_HUD">
-               <description>Metrics typically displayed on a HUD for fixed wing aircraft</description>
-               <field type="float" name="airspeed">Current airspeed in m/s</field>
-               <field type="float" name="groundspeed">Current ground speed in m/s</field>
-               <field type="int16_t" name="heading">Current heading in degrees, in compass units (0..360, 0=north)</field>
-               <field type="uint16_t" name="throttle">Current throttle setting in integer percent, 0 to 100</field>
-               <field type="float" name="alt">Current altitude (MSL), in meters</field>
-               <field type="float" name="climb">Current climb rate in meters/second</field>
-          </message>
-          <message id="75" name="COMMAND_INT">
-              <description>Message encoding a command with parameters as scaled integers. Scaling depends on the actual command value.</description>
-              <field type="uint8_t" name="target_system">System ID</field>
-              <field type="uint8_t" name="target_component">Component ID</field>
-              <field type="uint8_t" name="frame">The coordinate system of the COMMAND. see MAV_FRAME in mavlink_types.h</field>
-              <field type="uint16_t" name="command">The scheduled action for the mission item. see MAV_CMD in common.xml MAVLink specs</field>
-              <field type="uint8_t" name="current">false:0, true:1</field>
-              <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
-              <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
-              <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
-              <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
-              <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
-              <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
-              <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
-              <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
-          </message>
-          <message id="76" name="COMMAND_LONG">
-               <description>Send a command with up to seven parameters to the MAV</description>
-               <field type="uint8_t" name="target_system">System which should execute the command</field>
-               <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
-               <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
-               <field type="uint8_t" name="confirmation">0: First transmission of this command. 1-255: Confirmation transmissions (e.g. for kill command)</field>
-               <field type="float" name="param1">Parameter 1, as defined by MAV_CMD enum.</field>
-               <field type="float" name="param2">Parameter 2, as defined by MAV_CMD enum.</field>
-               <field type="float" name="param3">Parameter 3, as defined by MAV_CMD enum.</field>
-               <field type="float" name="param4">Parameter 4, as defined by MAV_CMD enum.</field>
-               <field type="float" name="param5">Parameter 5, as defined by MAV_CMD enum.</field>
-               <field type="float" name="param6">Parameter 6, as defined by MAV_CMD enum.</field>
-               <field type="float" name="param7">Parameter 7, as defined by MAV_CMD enum.</field>
-          </message>
-          <message id="77" name="COMMAND_ACK">
-               <description>Report status of a command. Includes feedback wether the command was executed.</description>
-               <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
-               <field type="uint8_t" name="result">See MAV_RESULT enum</field>
-          </message>
-         <message id="81" name="MANUAL_SETPOINT">
-             <description>Setpoint in roll, pitch, yaw and thrust from the operator</description>
-             <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-             <field type="float" name="roll">Desired roll rate in radians per second</field>
-             <field type="float" name="pitch">Desired pitch rate in radians per second</field>
-             <field type="float" name="yaw">Desired yaw rate in radians per second</field>
-             <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1</field>
-             <field type="uint8_t" name="mode_switch">Flight mode switch position, 0.. 255</field>
-             <field type="uint8_t" name="manual_override_switch">Override mode switch position, 0.. 255</field>
-         </message>
-          <message id="82" name="SET_ATTITUDE_TARGET">
-               <description>Sets a desired vehicle attitude. Used by an external controller to command the vehicle (manual controller or other system).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 6: reserved, bit 7: throttle, bit 8: attitude</field>
-               <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-               <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
-               <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
-               <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
-               <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
-          </message>
-          <message id="83" name="ATTITUDE_TARGET">
-               <description>Reports the current commanded attitude of the vehicle as specified by the autopilot. This should match the commands sent in a SET_ATTITUDE_TARGET message if the vehicle is being controlled this way.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-               <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 7: reserved, bit 8: attitude</field>
-               <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-               <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
-               <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
-               <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
-               <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
-          </message>
-          <message id="84" name="SET_POSITION_TARGET_LOCAL_NED">
-               <description>Sets a desired vehicle position in a local north-east-down coordinate frame. Used by an external controller to command the vehicle (manual controller or other system).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
-               <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-               <field type="float" name="x">X Position in NED frame in meters</field>
-               <field type="float" name="y">Y Position in NED frame in meters</field>
-               <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
-               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="yaw">yaw setpoint in rad</field>
-               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
-          </message>
-          <message id="85" name="POSITION_TARGET_LOCAL_NED">
-               <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_LOCAL_NED if the vehicle is being controlled this way.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
-               <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
-               <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-               <field type="float" name="x">X Position in NED frame in meters</field>
-               <field type="float" name="y">Y Position in NED frame in meters</field>
-               <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
-               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="yaw">yaw setpoint in rad</field>
-               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
-          </message>
-          <message id="86" name="SET_POSITION_TARGET_GLOBAL_INT">
-               <description>Sets a desired vehicle position, velocity, and/or acceleration in a global coordinate system (WGS84). Used by an external controller to command the vehicle (manual controller or other system).</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
-               <field type="uint8_t" name="target_system">System ID</field>
-               <field type="uint8_t" name="target_component">Component ID</field>
-               <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
-               <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-               <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
-               <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
-               <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
-               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="yaw">yaw setpoint in rad</field>
-               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
-          </message>
-          <message id="87" name="POSITION_TARGET_GLOBAL_INT">
-               <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_GLOBAL_INT if the vehicle is being controlled this way.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
-               <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
-               <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
-               <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
-               <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
-               <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
-               <field type="float" name="vx">X velocity in NED frame in meter / s</field>
-               <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
-               <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
-               <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
-               <field type="float" name="yaw">yaw setpoint in rad</field>
-               <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
-          </message>
-          <message id="89" name="LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET">
-               <description>The offset in X, Y, Z and yaw between the LOCAL_POSITION_NED messages of MAV X and the global coordinate frame in NED coordinates. Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="x">X Position</field>
-               <field type="float" name="y">Y Position</field>
-               <field type="float" name="z">Z Position</field>
-               <field type="float" name="roll">Roll</field>
-               <field type="float" name="pitch">Pitch</field>
-               <field type="float" name="yaw">Yaw</field>
-          </message>
-          <message id="90" name="HIL_STATE">
-               <description>DEPRECATED PACKET! Suffers from missing airspeed fields and singularities due to Euler angles. Please use HIL_STATE_QUATERNION instead. Sent from simulation to autopilot. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field type="float" name="roll">Roll angle (rad)</field>
-               <field type="float" name="pitch">Pitch angle (rad)</field>
-               <field type="float" name="yaw">Yaw angle (rad)</field>
-               <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
-               <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
-               <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
-               <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
-               <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
-               <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
-               <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
-               <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
-               <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
-               <field type="int16_t" name="xacc">X acceleration (mg)</field>
-               <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-               <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-          </message>
-          <message id="91" name="HIL_CONTROLS">
-               <description>Sent from autopilot to simulation. Hardware in the loop control outputs</description>
-               <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field name="roll_ailerons" type="float">Control output -1 .. 1</field>
-               <field name="pitch_elevator" type="float">Control output -1 .. 1</field>
-               <field name="yaw_rudder" type="float">Control output -1 .. 1</field>
-               <field name="throttle" type="float">Throttle 0 .. 1</field>
-               <field name="aux1" type="float">Aux 1, -1 .. 1</field>
-               <field name="aux2" type="float">Aux 2, -1 .. 1</field>
-               <field name="aux3" type="float">Aux 3, -1 .. 1</field>
-               <field name="aux4" type="float">Aux 4, -1 .. 1</field>
-               <field name="mode" type="uint8_t">System mode (MAV_MODE)</field>
-               <field name="nav_mode" type="uint8_t">Navigation mode (MAV_NAV_MODE)</field>
-          </message>
-          <message id="92" name="HIL_RC_INPUTS_RAW">
-               <description>Sent from simulation to autopilot. The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
-               <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds</field>
-               <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds</field>
-               <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds</field>
-               <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds</field>
-               <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds</field>
-               <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds</field>
-               <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds</field>
-               <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds</field>
-               <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds</field>
-               <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds</field>
-               <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds</field>
-               <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds</field>
-               <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 255: 100%</field>
-          </message>
-          <message id="93" name="HIL_ACTUATOR_CONTROLS">
-               <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>
-               <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-               <field name="controls" type="float[16]">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
-               <field name="mode" type="uint8_t">System mode (MAV_MODE), includes arming state.</field>
-               <field name="flags" type="uint64_t">Flags as bitfield, reserved for future use.</field>
-          </message>
-          <message id="100" name="OPTICAL_FLOW">
-               <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
-               <field type="uint64_t" name="time_usec">Timestamp (UNIX)</field>
-               <field type="uint8_t" name="sensor_id">Sensor ID</field>
-              <field type="int16_t" name="flow_x">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
-               <field type="int16_t" name="flow_y">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
-               <field type="float" name="flow_comp_m_x">Flow in meters in x-sensor direction, angular-speed compensated</field>
-               <field type="float" name="flow_comp_m_y">Flow in meters in y-sensor direction, angular-speed compensated</field>
-               <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
-               <field type="float" name="ground_distance">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
-          </message>
-          <message id="101" name="GLOBAL_VISION_POSITION_ESTIMATE">
-               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-               <field type="float" name="x">Global X position</field>
-               <field type="float" name="y">Global Y position</field>
-               <field type="float" name="z">Global Z position</field>
-               <field type="float" name="roll">Roll angle in rad</field>
-               <field type="float" name="pitch">Pitch angle in rad</field>
-               <field type="float" name="yaw">Yaw angle in rad</field>
-          </message>
-          <message id="102" name="VISION_POSITION_ESTIMATE">
-               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-               <field type="float" name="x">Global X position</field>
-               <field type="float" name="y">Global Y position</field>
-               <field type="float" name="z">Global Z position</field>
-               <field type="float" name="roll">Roll angle in rad</field>
-               <field type="float" name="pitch">Pitch angle in rad</field>
-               <field type="float" name="yaw">Yaw angle in rad</field>
-          </message>
-          <message id="103" name="VISION_SPEED_ESTIMATE">
-               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-               <field type="float" name="x">Global X speed</field>
-               <field type="float" name="y">Global Y speed</field>
-               <field type="float" name="z">Global Z speed</field>
-          </message>
-          <message id="104" name="VICON_POSITION_ESTIMATE">
-               <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-               <field type="float" name="x">Global X position</field>
-               <field type="float" name="y">Global Y position</field>
-               <field type="float" name="z">Global Z position</field>
-               <field type="float" name="roll">Roll angle in rad</field>
-               <field type="float" name="pitch">Pitch angle in rad</field>
-               <field type="float" name="yaw">Yaw angle in rad</field>
-          </message>
-          <message id="105" name="HIGHRES_IMU">
-             <description>The IMU readings in SI units in NED body frame</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-             <field type="float" name="xacc">X acceleration (m/s^2)</field>
-             <field type="float" name="yacc">Y acceleration (m/s^2)</field>
-             <field type="float" name="zacc">Z acceleration (m/s^2)</field>
-             <field type="float" name="xgyro">Angular speed around X axis (rad / sec)</field>
-             <field type="float" name="ygyro">Angular speed around Y axis (rad / sec)</field>
-             <field type="float" name="zgyro">Angular speed around Z axis (rad / sec)</field>
-             <field type="float" name="xmag">X Magnetic field (Gauss)</field>
-             <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
-             <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
-             <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
-             <field type="float" name="diff_pressure">Differential pressure in millibar</field>
-             <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
-             <field type="float" name="temperature">Temperature in degrees celsius</field>
-             <field type="uint16_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature</field>
-         </message>
-         <message id="106" name="OPTICAL_FLOW_RAD">
-             <description>Optical flow from an angular rate flow sensor (e.g. PX4FLOW or mouse sensor)</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-             <field type="uint8_t" name="sensor_id">Sensor ID</field>
-             <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
-             <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
-             <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
-             <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
-             <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
-             <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
-             <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
-             <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
-             <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
-             <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
-         </message>
-
-         <message id="107" name="HIL_SENSOR"> <description>The IMU readings in SI units in NED body frame</description>
-           <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-           <field type="float" name="xacc">X acceleration (m/s^2)</field>
-           <field type="float" name="yacc">Y acceleration (m/s^2)</field>
-           <field type="float" name="zacc">Z acceleration (m/s^2)</field>
-           <field type="float" name="xgyro">Angular speed around X axis in body frame (rad / sec)</field>
-           <field type="float" name="ygyro">Angular speed around Y axis in body frame (rad / sec)</field>
-           <field type="float" name="zgyro">Angular speed around Z axis in body frame (rad / sec)</field>
-           <field type="float" name="xmag">X Magnetic field (Gauss)</field>
-           <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
-           <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
-           <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
-           <field type="float" name="diff_pressure">Differential pressure (airspeed) in millibar</field>
-           <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
-           <field type="float" name="temperature">Temperature in degrees celsius</field>
-           <field type="uint32_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature, bit 31: full reset of attitude/position/velocities/etc was performed in sim.</field>
-         </message>
-
-	  <message name="SIM_STATE" id="108">
-	    <description>Status of simulation environment, if used</description>
-            <field type="float" name="q1">True attitude quaternion component 1, w (1 in null-rotation)</field>
-            <field type="float" name="q2">True attitude quaternion component 2, x (0 in null-rotation)</field>
-            <field type="float" name="q3">True attitude quaternion component 3, y (0 in null-rotation)</field>
-            <field type="float" name="q4">True attitude quaternion component 4, z (0 in null-rotation)</field>
-            <field type="float" name="roll">Attitude roll expressed as Euler angles, not recommended except for human-readable outputs</field>
-            <field type="float" name="pitch">Attitude pitch expressed as Euler angles, not recommended except for human-readable outputs</field>
-            <field type="float" name="yaw">Attitude yaw expressed as Euler angles, not recommended except for human-readable outputs</field>
-            <field type="float" name="xacc">X acceleration m/s/s</field>
-            <field type="float" name="yacc">Y acceleration m/s/s</field>
-            <field type="float" name="zacc">Z acceleration m/s/s</field>
-            <field type="float" name="xgyro">Angular speed around X axis rad/s</field>
-            <field type="float" name="ygyro">Angular speed around Y axis rad/s</field>
-            <field type="float" name="zgyro">Angular speed around Z axis rad/s</field>
-            <field type="float" name="lat">Latitude in degrees</field>
-            <field type="float" name="lon">Longitude in degrees</field>
-            <field type="float" name="alt">Altitude in meters</field>
-            <field type="float" name="std_dev_horz">Horizontal position standard deviation</field>
-            <field type="float" name="std_dev_vert">Vertical position standard deviation</field>
-            <field type="float" name="vn">True velocity in m/s in NORTH direction in earth-fixed NED frame</field>
-            <field type="float" name="ve">True velocity in m/s in EAST direction in earth-fixed NED frame</field>
-            <field type="float" name="vd">True velocity in m/s in DOWN direction in earth-fixed NED frame</field>
-	  </message>
-
-    	  <message name="RADIO_STATUS" id="109">
-    	      <description>Status generated by radio and injected into MAVLink stream.</description>
-            <field type="uint8_t" name="rssi">Local signal strength</field>
-            <field type="uint8_t" name="remrssi">Remote signal strength</field>
-            <field type="uint8_t" name="txbuf">Remaining free buffer space in percent.</field>
-            <field type="uint8_t" name="noise">Background noise level</field>
-            <field type="uint8_t" name="remnoise">Remote background noise level</field>
-            <field type="uint16_t" name="rxerrors">Receive errors</field>
-            <field type="uint16_t" name="fixed">Count of error corrected packets</field>
-    	  </message>
-        <message id="110" name="FILE_TRANSFER_PROTOCOL">
-            <description>File transfer message</description>
-            <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
-            <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
-            <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
-            <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
-        </message>
-        <message id="111" name="TIMESYNC">
-            <description>Time synchronization message.</description>
-            <field type="int64_t" name="tc1">Time sync timestamp 1</field>
-            <field type="int64_t" name="ts1">Time sync timestamp 2</field>
-        </message>
-        <message id="112" name="CAMERA_TRIGGER">
-            <description>Camera-IMU triggering and synchronisation message.</description>
-            <field type="uint64_t" name="time_usec">Timestamp for the image frame in microseconds</field>
-            <field type="uint32_t" name="seq">Image frame sequence</field>
-        </message>
-         <message id="113" name="HIL_GPS">
-             <description>The global position, as returned by the Global Positioning System (GPS). This is
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="seq">Waypoint ID (sequence number). Starts at zero. Increases monotonically for each waypoint, no gaps in the sequence (0,1,2,3,4).</field>
+      <field type="uint8_t" name="frame">The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h</field>
+      <field type="uint16_t" name="command">The scheduled action for the MISSION. see MAV_CMD in common.xml MAVLink specs</field>
+      <field type="uint8_t" name="current">false:0, true:1</field>
+      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+      <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
+      <field type="int32_t" name="y">PARAM6 / y position: local: x position in meters * 1e4, global: longitude in degrees *10^7</field>
+      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
+      <extensions/>
+      <field type="uint8_t" name="mission_type">Mission type, see MAV_MISSION_TYPE</field>
+    </message>
+    <message id="74" name="VFR_HUD">
+      <description>Metrics typically displayed on a HUD for fixed wing aircraft</description>
+      <field type="float" name="airspeed">Current airspeed in m/s</field>
+      <field type="float" name="groundspeed">Current ground speed in m/s</field>
+      <field type="int16_t" name="heading">Current heading in degrees, in compass units (0..360, 0=north)</field>
+      <field type="uint16_t" name="throttle">Current throttle setting in integer percent, 0 to 100</field>
+      <field type="float" name="alt">Current altitude (MSL), in meters</field>
+      <field type="float" name="climb">Current climb rate in meters/second</field>
+    </message>
+    <message id="75" name="COMMAND_INT">
+      <description>Message encoding a command with parameters as scaled integers. Scaling depends on the actual command value.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="frame">The coordinate system of the COMMAND. see MAV_FRAME in mavlink_types.h</field>
+      <field type="uint16_t" name="command">The scheduled action for the mission item. see MAV_CMD in common.xml MAVLink specs</field>
+      <field type="uint8_t" name="current">false:0, true:1</field>
+      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+      <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
+      <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
+      <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
+      <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
+      <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
+      <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
+      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
+    </message>
+    <message id="76" name="COMMAND_LONG">
+      <description>Send a command with up to seven parameters to the MAV</description>
+      <field type="uint8_t" name="target_system">System which should execute the command</field>
+      <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
+      <field type="uint8_t" name="confirmation">0: First transmission of this command. 1-255: Confirmation transmissions (e.g. for kill command)</field>
+      <field type="float" name="param1">Parameter 1, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param2">Parameter 2, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param3">Parameter 3, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param4">Parameter 4, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param5">Parameter 5, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param6">Parameter 6, as defined by MAV_CMD enum.</field>
+      <field type="float" name="param7">Parameter 7, as defined by MAV_CMD enum.</field>
+    </message>
+    <message id="77" name="COMMAND_ACK">
+      <description>Report status of a command. Includes feedback wether the command was executed.</description>
+      <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>
+      <field type="uint8_t" name="result">See MAV_RESULT enum</field>
+    </message>
+    <message id="81" name="MANUAL_SETPOINT">
+      <description>Setpoint in roll, pitch, yaw and thrust from the operator</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+      <field type="float" name="roll">Desired roll rate in radians per second</field>
+      <field type="float" name="pitch">Desired pitch rate in radians per second</field>
+      <field type="float" name="yaw">Desired yaw rate in radians per second</field>
+      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1</field>
+      <field type="uint8_t" name="mode_switch">Flight mode switch position, 0.. 255</field>
+      <field type="uint8_t" name="manual_override_switch">Override mode switch position, 0.. 255</field>
+    </message>
+    <message id="82" name="SET_ATTITUDE_TARGET">
+      <description>Sets a desired vehicle attitude. Used by an external controller to command the vehicle (manual controller or other system).</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 6: reserved, bit 7: throttle, bit 8: attitude</field>
+      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
+      <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
+      <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
+      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
+    </message>
+    <message id="83" name="ATTITUDE_TARGET">
+      <description>Reports the current commanded attitude of the vehicle as specified by the autopilot. This should match the commands sent in a SET_ATTITUDE_TARGET message if the vehicle is being controlled this way.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+      <field type="uint8_t" name="type_mask">Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 7: reserved, bit 8: attitude</field>
+      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float" name="body_roll_rate">Body roll rate in radians per second</field>
+      <field type="float" name="body_pitch_rate">Body roll rate in radians per second</field>
+      <field type="float" name="body_yaw_rate">Body roll rate in radians per second</field>
+      <field type="float" name="thrust">Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)</field>
+    </message>
+    <message id="84" name="SET_POSITION_TARGET_LOCAL_NED">
+      <description>Sets a desired vehicle position in a local north-east-down coordinate frame. Used by an external controller to command the vehicle (manual controller or other system).</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
+      <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
+      <field type="float" name="x">X Position in NED frame in meters</field>
+      <field type="float" name="y">Y Position in NED frame in meters</field>
+      <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
+      <field type="float" name="vx">X velocity in NED frame in meter / s</field>
+      <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
+      <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
+      <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="yaw">yaw setpoint in rad</field>
+      <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+    </message>
+    <message id="85" name="POSITION_TARGET_LOCAL_NED">
+      <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_LOCAL_NED if the vehicle is being controlled this way.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
+      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
+      <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
+      <field type="float" name="x">X Position in NED frame in meters</field>
+      <field type="float" name="y">Y Position in NED frame in meters</field>
+      <field type="float" name="z">Z Position in NED frame in meters (note, altitude is negative in NED)</field>
+      <field type="float" name="vx">X velocity in NED frame in meter / s</field>
+      <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
+      <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
+      <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="yaw">yaw setpoint in rad</field>
+      <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+    </message>
+    <message id="86" name="SET_POSITION_TARGET_GLOBAL_INT">
+      <description>Sets a desired vehicle position, velocity, and/or acceleration in a global coordinate system (WGS84). Used by an external controller to command the vehicle (manual controller or other system).</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
+      <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
+      <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
+      <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
+      <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+      <field type="float" name="vx">X velocity in NED frame in meter / s</field>
+      <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
+      <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
+      <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="yaw">yaw setpoint in rad</field>
+      <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+    </message>
+    <message id="87" name="POSITION_TARGET_GLOBAL_INT">
+      <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_GLOBAL_INT if the vehicle is being controlled this way.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot. The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
+      <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
+      <field type="uint16_t" name="type_mask">Bitmask to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 10 is set the floats afx afy afz should be interpreted as force instead of acceleration. Mapping: bit 1: x, bit 2: y, bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9: az, bit 10: is force setpoint, bit 11: yaw, bit 12: yaw rate</field>
+      <field type="int32_t" name="lat_int">X Position in WGS84 frame in 1e7 * meters</field>
+      <field type="int32_t" name="lon_int">Y Position in WGS84 frame in 1e7 * meters</field>
+      <field type="float" name="alt">Altitude in meters in AMSL altitude, not WGS84 if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+      <field type="float" name="vx">X velocity in NED frame in meter / s</field>
+      <field type="float" name="vy">Y velocity in NED frame in meter / s</field>
+      <field type="float" name="vz">Z velocity in NED frame in meter / s</field>
+      <field type="float" name="afx">X acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afy">Y acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="afz">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
+      <field type="float" name="yaw">yaw setpoint in rad</field>
+      <field type="float" name="yaw_rate">yaw rate setpoint in rad/s</field>
+    </message>
+    <message id="89" name="LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET">
+      <description>The offset in X, Y, Z and yaw between the LOCAL_POSITION_NED messages of MAV X and the global coordinate frame in NED coordinates. Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float" name="x">X Position</field>
+      <field type="float" name="y">Y Position</field>
+      <field type="float" name="z">Z Position</field>
+      <field type="float" name="roll">Roll</field>
+      <field type="float" name="pitch">Pitch</field>
+      <field type="float" name="yaw">Yaw</field>
+    </message>
+    <message id="90" name="HIL_STATE">
+      <description>DEPRECATED PACKET! Suffers from missing airspeed fields and singularities due to Euler angles. Please use HIL_STATE_QUATERNION instead. Sent from simulation to autopilot. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field type="float" name="roll">Roll angle (rad)</field>
+      <field type="float" name="pitch">Pitch angle (rad)</field>
+      <field type="float" name="yaw">Yaw angle (rad)</field>
+      <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
+      <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
+      <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
+      <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
+      <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
+      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
+      <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
+      <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
+      <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
+      <field type="int16_t" name="xacc">X acceleration (mg)</field>
+      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+    </message>
+    <message id="91" name="HIL_CONTROLS">
+      <description>Sent from autopilot to simulation. Hardware in the loop control outputs</description>
+      <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field name="roll_ailerons" type="float">Control output -1 .. 1</field>
+      <field name="pitch_elevator" type="float">Control output -1 .. 1</field>
+      <field name="yaw_rudder" type="float">Control output -1 .. 1</field>
+      <field name="throttle" type="float">Throttle 0 .. 1</field>
+      <field name="aux1" type="float">Aux 1, -1 .. 1</field>
+      <field name="aux2" type="float">Aux 2, -1 .. 1</field>
+      <field name="aux3" type="float">Aux 3, -1 .. 1</field>
+      <field name="aux4" type="float">Aux 4, -1 .. 1</field>
+      <field name="mode" type="uint8_t">System mode (MAV_MODE)</field>
+      <field name="nav_mode" type="uint8_t">Navigation mode (MAV_NAV_MODE)</field>
+    </message>
+    <message id="92" name="HIL_RC_INPUTS_RAW">
+      <description>Sent from simulation to autopilot. The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field type="uint16_t" name="chan1_raw">RC channel 1 value, in microseconds</field>
+      <field type="uint16_t" name="chan2_raw">RC channel 2 value, in microseconds</field>
+      <field type="uint16_t" name="chan3_raw">RC channel 3 value, in microseconds</field>
+      <field type="uint16_t" name="chan4_raw">RC channel 4 value, in microseconds</field>
+      <field type="uint16_t" name="chan5_raw">RC channel 5 value, in microseconds</field>
+      <field type="uint16_t" name="chan6_raw">RC channel 6 value, in microseconds</field>
+      <field type="uint16_t" name="chan7_raw">RC channel 7 value, in microseconds</field>
+      <field type="uint16_t" name="chan8_raw">RC channel 8 value, in microseconds</field>
+      <field type="uint16_t" name="chan9_raw">RC channel 9 value, in microseconds</field>
+      <field type="uint16_t" name="chan10_raw">RC channel 10 value, in microseconds</field>
+      <field type="uint16_t" name="chan11_raw">RC channel 11 value, in microseconds</field>
+      <field type="uint16_t" name="chan12_raw">RC channel 12 value, in microseconds</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator, 0: 0%, 255: 100%</field>
+    </message>
+    <message id="93" name="HIL_ACTUATOR_CONTROLS">
+      <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>
+      <field name="time_usec" type="uint64_t">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field name="controls" type="float[16]">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
+      <field name="mode" type="uint8_t">System mode (MAV_MODE), includes arming state.</field>
+      <field name="flags" type="uint64_t">Flags as bitfield, reserved for future use.</field>
+    </message>
+    <message id="100" name="OPTICAL_FLOW">
+      <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
+      <field type="uint64_t" name="time_usec">Timestamp (UNIX)</field>
+      <field type="uint8_t" name="sensor_id">Sensor ID</field>
+      <field type="int16_t" name="flow_x">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
+      <field type="int16_t" name="flow_y">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
+      <field type="float" name="flow_comp_m_x">Flow in meters in x-sensor direction, angular-speed compensated</field>
+      <field type="float" name="flow_comp_m_y">Flow in meters in y-sensor direction, angular-speed compensated</field>
+      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
+      <field type="float" name="ground_distance">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
+    </message>
+    <message id="101" name="GLOBAL_VISION_POSITION_ESTIMATE">
+      <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="float" name="x">Global X position</field>
+      <field type="float" name="y">Global Y position</field>
+      <field type="float" name="z">Global Z position</field>
+      <field type="float" name="roll">Roll angle in rad</field>
+      <field type="float" name="pitch">Pitch angle in rad</field>
+      <field type="float" name="yaw">Yaw angle in rad</field>
+    </message>
+    <message id="102" name="VISION_POSITION_ESTIMATE">
+      <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="float" name="x">Global X position</field>
+      <field type="float" name="y">Global Y position</field>
+      <field type="float" name="z">Global Z position</field>
+      <field type="float" name="roll">Roll angle in rad</field>
+      <field type="float" name="pitch">Pitch angle in rad</field>
+      <field type="float" name="yaw">Yaw angle in rad</field>
+    </message>
+    <message id="103" name="VISION_SPEED_ESTIMATE">
+      <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="float" name="x">Global X speed</field>
+      <field type="float" name="y">Global Y speed</field>
+      <field type="float" name="z">Global Z speed</field>
+    </message>
+    <message id="104" name="VICON_POSITION_ESTIMATE">
+      <field type="uint64_t" name="usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="float" name="x">Global X position</field>
+      <field type="float" name="y">Global Y position</field>
+      <field type="float" name="z">Global Z position</field>
+      <field type="float" name="roll">Roll angle in rad</field>
+      <field type="float" name="pitch">Pitch angle in rad</field>
+      <field type="float" name="yaw">Yaw angle in rad</field>
+    </message>
+    <message id="105" name="HIGHRES_IMU">
+      <description>The IMU readings in SI units in NED body frame</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="float" name="xacc">X acceleration (m/s^2)</field>
+      <field type="float" name="yacc">Y acceleration (m/s^2)</field>
+      <field type="float" name="zacc">Z acceleration (m/s^2)</field>
+      <field type="float" name="xgyro">Angular speed around X axis (rad / sec)</field>
+      <field type="float" name="ygyro">Angular speed around Y axis (rad / sec)</field>
+      <field type="float" name="zgyro">Angular speed around Z axis (rad / sec)</field>
+      <field type="float" name="xmag">X Magnetic field (Gauss)</field>
+      <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
+      <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
+      <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
+      <field type="float" name="diff_pressure">Differential pressure in millibar</field>
+      <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
+      <field type="float" name="temperature">Temperature in degrees celsius</field>
+      <field type="uint16_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature</field>
+    </message>
+    <message id="106" name="OPTICAL_FLOW_RAD">
+      <description>Optical flow from an angular rate flow sensor (e.g. PX4FLOW or mouse sensor)</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="uint8_t" name="sensor_id">Sensor ID</field>
+      <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
+      <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
+      <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
+      <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
+      <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
+      <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
+      <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
+      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
+      <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
+      <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
+    </message>
+    <message id="107" name="HIL_SENSOR">
+      <description>The IMU readings in SI units in NED body frame</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="float" name="xacc">X acceleration (m/s^2)</field>
+      <field type="float" name="yacc">Y acceleration (m/s^2)</field>
+      <field type="float" name="zacc">Z acceleration (m/s^2)</field>
+      <field type="float" name="xgyro">Angular speed around X axis in body frame (rad / sec)</field>
+      <field type="float" name="ygyro">Angular speed around Y axis in body frame (rad / sec)</field>
+      <field type="float" name="zgyro">Angular speed around Z axis in body frame (rad / sec)</field>
+      <field type="float" name="xmag">X Magnetic field (Gauss)</field>
+      <field type="float" name="ymag">Y Magnetic field (Gauss)</field>
+      <field type="float" name="zmag">Z Magnetic field (Gauss)</field>
+      <field type="float" name="abs_pressure">Absolute pressure in millibar</field>
+      <field type="float" name="diff_pressure">Differential pressure (airspeed) in millibar</field>
+      <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
+      <field type="float" name="temperature">Temperature in degrees celsius</field>
+      <field type="uint32_t" name="fields_updated">Bitmask for fields that have updated since last message, bit 0 = xacc, bit 12: temperature, bit 31: full reset of attitude/position/velocities/etc was performed in sim.</field>
+    </message>
+    <message name="SIM_STATE" id="108">
+      <description>Status of simulation environment, if used</description>
+      <field type="float" name="q1">True attitude quaternion component 1, w (1 in null-rotation)</field>
+      <field type="float" name="q2">True attitude quaternion component 2, x (0 in null-rotation)</field>
+      <field type="float" name="q3">True attitude quaternion component 3, y (0 in null-rotation)</field>
+      <field type="float" name="q4">True attitude quaternion component 4, z (0 in null-rotation)</field>
+      <field type="float" name="roll">Attitude roll expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="pitch">Attitude pitch expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="yaw">Attitude yaw expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="xacc">X acceleration m/s/s</field>
+      <field type="float" name="yacc">Y acceleration m/s/s</field>
+      <field type="float" name="zacc">Z acceleration m/s/s</field>
+      <field type="float" name="xgyro">Angular speed around X axis rad/s</field>
+      <field type="float" name="ygyro">Angular speed around Y axis rad/s</field>
+      <field type="float" name="zgyro">Angular speed around Z axis rad/s</field>
+      <field type="float" name="lat">Latitude in degrees</field>
+      <field type="float" name="lon">Longitude in degrees</field>
+      <field type="float" name="alt">Altitude in meters</field>
+      <field type="float" name="std_dev_horz">Horizontal position standard deviation</field>
+      <field type="float" name="std_dev_vert">Vertical position standard deviation</field>
+      <field type="float" name="vn">True velocity in m/s in NORTH direction in earth-fixed NED frame</field>
+      <field type="float" name="ve">True velocity in m/s in EAST direction in earth-fixed NED frame</field>
+      <field type="float" name="vd">True velocity in m/s in DOWN direction in earth-fixed NED frame</field>
+    </message>
+    <message name="RADIO_STATUS" id="109">
+      <description>Status generated by radio and injected into MAVLink stream.</description>
+      <field type="uint8_t" name="rssi">Local signal strength</field>
+      <field type="uint8_t" name="remrssi">Remote signal strength</field>
+      <field type="uint8_t" name="txbuf">Remaining free buffer space in percent.</field>
+      <field type="uint8_t" name="noise">Background noise level</field>
+      <field type="uint8_t" name="remnoise">Remote background noise level</field>
+      <field type="uint16_t" name="rxerrors">Receive errors</field>
+      <field type="uint16_t" name="fixed">Count of error corrected packets</field>
+    </message>
+    <message id="110" name="FILE_TRANSFER_PROTOCOL">
+      <description>File transfer message</description>
+      <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
+      <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
+    </message>
+    <message id="111" name="TIMESYNC">
+      <description>Time synchronization message.</description>
+      <field type="int64_t" name="tc1">Time sync timestamp 1</field>
+      <field type="int64_t" name="ts1">Time sync timestamp 2</field>
+    </message>
+    <message id="112" name="CAMERA_TRIGGER">
+      <description>Camera-IMU triggering and synchronisation message.</description>
+      <field type="uint64_t" name="time_usec">Timestamp for the image frame in microseconds</field>
+      <field type="uint32_t" name="seq">Image frame sequence</field>
+    </message>
+    <message id="113" name="HIL_GPS">
+      <description>The global position, as returned by the Global Positioning System (GPS). This is
                  NOT the global position estimate of the sytem, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-             <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.</field>
-             <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-             <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-             <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
-             <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: 65535</field>
-             <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: 65535</field>
-             <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: 65535</field>
-             <field type="int16_t" name="vn">GPS velocity in cm/s in NORTH direction in earth-fixed NED frame</field>
-             <field type="int16_t" name="ve">GPS velocity in cm/s in EAST direction in earth-fixed NED frame</field>
-             <field type="int16_t" name="vd">GPS velocity in cm/s in DOWN direction in earth-fixed NED frame</field>
-             <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: 65535</field>
-             <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
-         </message>
-         <message id="114" name="HIL_OPTICAL_FLOW">
-             <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
-             <field type="uint8_t" name="sensor_id">Sensor ID</field>
-             <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
-             <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
-             <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
-             <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
-             <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
-             <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
-             <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
-             <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
-             <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
-             <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
-         </message>
-         <message id="115" name="HIL_STATE_QUATERNION">
-             <description>Sent from simulation to autopilot, avoids in contrast to HIL_STATE singularities. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
-             <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-             <field type="float[4]" name="attitude_quaternion">Vehicle attitude expressed as normalized quaternion in w, x, y, z order (with 1 0 0 0 being the null-rotation)</field>
-             <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
-             <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
-             <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
-             <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
-             <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
-             <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
-             <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
-             <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
-             <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
-             <field type="uint16_t" name="ind_airspeed">Indicated airspeed, expressed as m/s * 100</field>
-             <field type="uint16_t" name="true_airspeed">True airspeed, expressed as m/s * 100</field>
-             <field type="int16_t" name="xacc">X acceleration (mg)</field>
-             <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-             <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-         </message>
-         <message id="116" name="SCALED_IMU2">
-           <description>The RAW IMU readings for secondary 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-           <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-           <field type="int16_t" name="xacc">X acceleration (mg)</field>
-           <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-           <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-           <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-           <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-           <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-           <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-           <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-           <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
-         </message>
-         <message id="117" name="LOG_REQUEST_LIST">
-          <description>Request a list of available logs. On some systems calling this may stop on-board logging until LOG_REQUEST_END is called.</description>
-          <field type="uint8_t" name="target_system">System ID</field>
-          <field type="uint8_t" name="target_component">Component ID</field>
-          <field type="uint16_t" name="start">First log id (0 for first available)</field>
-          <field type="uint16_t" name="end">Last log id (0xffff for last available)</field>
-         </message>
-         <message id="118" name="LOG_ENTRY">
-           <description>Reply to LOG_REQUEST_LIST</description>
-           <field type="uint16_t" name="id">Log id</field>
-           <field type="uint16_t" name="num_logs">Total number of logs</field>
-           <field type="uint16_t" name="last_log_num">High log number</field>
-           <field type="uint32_t" name="time_utc">UTC timestamp of log in seconds since 1970, or 0 if not available</field>
-           <field type="uint32_t" name="size">Size of the log (may be approximate) in bytes</field>
-         </message>
-         <message id="119" name="LOG_REQUEST_DATA">
-           <description>Request a chunk of a log</description>
-           <field type="uint8_t" name="target_system">System ID</field>
-           <field type="uint8_t" name="target_component">Component ID</field>
-           <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
-           <field type="uint32_t" name="ofs">Offset into the log</field>
-           <field type="uint32_t" name="count">Number of bytes</field>
-         </message>
-         <message id="120" name="LOG_DATA">
-           <description>Reply to LOG_REQUEST_DATA</description>
-           <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
-           <field type="uint32_t" name="ofs">Offset into the log</field>
-           <field type="uint8_t" name="count">Number of bytes (zero for end of log)</field>
-           <field type="uint8_t[90]" name="data">log data</field>
-         </message>
-         <message id="121" name="LOG_ERASE">
-           <description>Erase all logs</description>
-           <field type="uint8_t" name="target_system">System ID</field>
-           <field type="uint8_t" name="target_component">Component ID</field>
-         </message>
-         <message id="122" name="LOG_REQUEST_END">
-           <description>Stop log transfer and resume normal logging</description>
-           <field type="uint8_t" name="target_system">System ID</field>
-           <field type="uint8_t" name="target_component">Component ID</field>
-         </message>
-	       <message name="GPS_INJECT_DATA" id="123">
-           <description>data for injecting into the onboard GPS (used for DGPS)</description>
-           <field type="uint8_t" name="target_system">System ID</field>
-           <field type="uint8_t" name="target_component">Component ID</field>
-           <field type="uint8_t" name="len">data length</field>
-           <field type="uint8_t[110]" name="data">raw data (110 is enough for 12 satellites of RTCMv2)</field>
-         </message>
-         <message id="124" name="GPS2_RAW">
-           <description>Second GPS data. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
-           <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
-           <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
-           <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-           <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-           <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
-           <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
-           <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
-           <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
-           <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
-           <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
-           <field type="uint8_t" name="dgps_numch">Number of DGPS satellites</field>
-           <field type="uint32_t" name="dgps_age">Age of DGPS info</field>
-         </message>
-         <message id="125" name="POWER_STATUS">
-               <description>Power supply status</description>
-               <field type="uint16_t" name="Vcc">5V rail voltage in millivolts</field>
-               <field type="uint16_t" name="Vservo">servo rail voltage in millivolts</field>
-               <field type="uint16_t" name="flags">power supply status flags (see MAV_POWER_STATUS enum)</field>
-         </message>
-         <message name="SERIAL_CONTROL" id="126">
-           <description>Control a serial port. This can be used for raw access to an onboard serial peripheral such as a GPS or telemetry radio. It is designed to make it possible to update the devices firmware via MAVLink messages or change the devices settings. A message with zero bytes can be used to change just the baudrate.</description>
-           <field type="uint8_t" name="device">See SERIAL_CONTROL_DEV enum</field>
-           <field type="uint8_t" name="flags">See SERIAL_CONTROL_FLAG enum</field>
-           <field type="uint16_t" name="timeout">Timeout for reply data in milliseconds</field>
-           <field type="uint32_t" name="baudrate">Baudrate of transfer. Zero means no change.</field>
-           <field type="uint8_t" name="count">how many bytes in this transfer</field>
-           <field type="uint8_t[70]" name="data">serial data</field>
-         </message>
-         <message id="127" name="GPS_RTK">
-            <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
-            <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
-            <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
-            <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
-            <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
-            <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
-            <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
-            <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
-            <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
-            <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
-            <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
-            <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
-            <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
-            <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
-         </message>
-         <message id="128" name="GPS2_RTK">
-            <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
-            <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
-            <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
-            <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
-            <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
-            <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
-            <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
-            <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
-            <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
-            <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
-            <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
-            <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
-            <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
-            <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
-        </message>
-        <message id="129" name="SCALED_IMU3">
-          <description>The RAW IMU readings for 3rd 9DOF sensor setup. This message should contain the scaled values to the described units</description>
-          <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-          <field type="int16_t" name="xacc">X acceleration (mg)</field>
-          <field type="int16_t" name="yacc">Y acceleration (mg)</field>
-          <field type="int16_t" name="zacc">Z acceleration (mg)</field>
-          <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
-          <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
-          <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
-          <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
-          <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
-          <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
-        </message>
-        <message id="130" name="DATA_TRANSMISSION_HANDSHAKE">
-            <field type="uint8_t" name="type">type of requested/acknowledged data (as defined in ENUM DATA_TYPES in mavlink/include/mavlink_types.h)</field>
-            <field type="uint32_t" name="size">total data size in bytes (set on ACK only)</field>
-            <field type="uint16_t" name="width">Width of a matrix or image</field>
-            <field type="uint16_t" name="height">Height of a matrix or image</field>
-            <field type="uint16_t" name="packets">number of packets beeing sent (set on ACK only)</field>
-            <field type="uint8_t" name="payload">payload size per packet (normally 253 byte, see DATA field size in message ENCAPSULATED_DATA) (set on ACK only)</field>
-            <field type="uint8_t" name="jpg_quality">JPEG quality out of [1,100]</field>
-        </message>
-        <message id="131" name="ENCAPSULATED_DATA">
-            <field type="uint16_t" name="seqnr">sequence number (starting with 0 on every transmission)</field>
-            <field type="uint8_t[253]" name="data">image data bytes</field>
-        </message>
-        <message id="132" name="DISTANCE_SENSOR">
-            <field type="uint32_t" name="time_boot_ms">Time since system boot</field>
-            <field type="uint16_t" name="min_distance">Minimum distance the sensor can measure in centimeters</field>
-            <field type="uint16_t" name="max_distance">Maximum distance the sensor can measure in centimeters</field>
-            <field type="uint16_t" name="current_distance">Current distance reading</field>
-            <field type="uint8_t" name="type">Type from MAV_DISTANCE_SENSOR enum.</field>
-            <field type="uint8_t" name="id">Onboard ID of the sensor</field>
-            <field type="uint8_t" name="orientation">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
-            <field type="uint8_t" name="covariance">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
-         </message>
-         <message id="133" name="TERRAIN_REQUEST">
-            <description>Request for terrain data and terrain status</description>
-            <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
-            <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
-            <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
-            <field type="uint64_t" name="mask" print_format="0x%07x">Bitmask of requested 4x4 grids (row major 8x7 array of grids, 56 bits)</field>
-         </message>
-         <message id="134" name="TERRAIN_DATA">
-            <description>Terrain data sent from GCS. The lat/lon and grid_spacing must be the same as a lat/lon from a TERRAIN_REQUEST</description>
-            <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
-            <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
-            <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
-            <field type="uint8_t" name="gridbit">bit within the terrain request mask</field>
-            <field type="int16_t[16]" name="data">Terrain data in meters AMSL</field>
-         </message>
-         <message id="135" name="TERRAIN_CHECK">
-            <description>Request that the vehicle report terrain height at the given location. Used by GCS to check if vehicle has all terrain data needed for a mission.</description>
-            <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
-            <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
-         </message>
-         <message id="136" name="TERRAIN_REPORT">
-            <description>Response from a TERRAIN_CHECK request</description>
-            <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
-            <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
-            <field type="uint16_t" name="spacing">grid spacing (zero if terrain at this location unavailable)</field>
-            <field type="float" name="terrain_height">Terrain height in meters AMSL</field>
-            <field type="float" name="current_height">Current vehicle height above lat/lon terrain height (meters)</field>
-            <field type="uint16_t" name="pending">Number of 4x4 terrain blocks waiting to be received or read from disk</field>
-            <field type="uint16_t" name="loaded">Number of 4x4 terrain blocks in memory</field>
-         </message>
-         <message id="137" name="SCALED_PRESSURE2">
-           <description>Barometer readings for 2nd barometer</description>
-           <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-           <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-           <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-           <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
-         </message>
-        <message id="138" name="ATT_POS_MOCAP">
-          <description>Motion capture attitude and position</description>
-          <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-          <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-          <field type="float" name="x">X position in meters (NED)</field>
-          <field type="float" name="y">Y position in meters (NED)</field>
-          <field type="float" name="z">Z position in meters (NED)</field>
-        </message>
-        <message id="139" name="SET_ACTUATOR_CONTROL_TARGET">
-            <description>Set the vehicle attitude and body angular rates.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
-            <field type="uint8_t" name="target_system">System ID</field>
-            <field type="uint8_t" name="target_component">Component ID</field>
-            <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
-        </message>
-        <message id="140" name="ACTUATOR_CONTROL_TARGET">
-            <description>Set the vehicle attitude and body angular rates.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
-            <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
-        </message>
-        <message id="141" name="ALTITUDE">
-            <description>The current system altitude.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="float" name="altitude_monotonic">This altitude measure is initialized on system boot and monotonic (it is never reset, but represents the local altitude change). The only guarantee on this field is that it will never be reset and is consistent within a flight. The recommended value for this field is the uncorrected barometric altitude at boot time. This altitude will also drift and vary between flights.</field>
-            <field type="float" name="altitude_amsl">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output AMSL by default and not the WGS84 altitude.</field>
-            <field type="float" name="altitude_local">This is the local altitude in the local coordinate frame. It is not the altitude above home, but in reference to the coordinate origin (0, 0, 0). It is up-positive.</field>
-            <field type="float" name="altitude_relative">This is the altitude above the home position. It resets on each change of the current home position.</field>
-            <field type="float" name="altitude_terrain">This is the altitude above terrain. It might be fed by a terrain database or an altimeter. Values smaller than -1000 should be interpreted as unknown.</field>
-            <field type="float" name="bottom_clearance">This is not the altitude, but the clear space below the system according to the fused clearance estimate. It generally should max out at the maximum range of e.g. the laser altimeter. It is generally a moving target. A negative value indicates no measurement available.</field>
-        </message>
-        <message id="142" name="RESOURCE_REQUEST">
-            <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
-            <field type="uint8_t" name="request_id">Request ID. This ID should be re-used when sending back URI contents</field>
-            <field type="uint8_t" name="uri_type">The type of requested URI. 0 = a file via URL. 1 = a UAVCAN binary</field>
-            <field type="uint8_t[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
-            <field type="uint8_t" name="transfer_type">The way the autopilot wants to receive the URI. 0 = MAVLink FTP. 1 = binary stream.</field>
-            <field type="uint8_t[120]" name="storage">The storage path the autopilot wants the URI to be stored in. Will only be valid if the transfer_type has a storage associated (e.g. MAVLink FTP).</field>
-        </message>
-        <message id="143" name="SCALED_PRESSURE3">
-          <description>Barometer readings for 3rd barometer</description>
-          <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-          <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
-          <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
-           <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
-        </message>
-        <message id="144" name="FOLLOW_TARGET">
-              <description>current motion information from a designated system</description>
-              <field type="uint64_t" name="timestamp">Timestamp in milliseconds since system boot</field>
-              <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
-              <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-              <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-              <field type="float" name="alt">AMSL, in meters</field>
-              <field type="float[3]" name="vel">target velocity (0,0,0) for unknown</field>
-              <field type="float[3]" name="acc">linear target acceleration (0,0,0) for unknown</field>
-              <field type="float[4]" name="attitude_q">(1 0 0 0 for unknown)</field>
-              <field type="float[3]" name="rates">(0 0 0 for unknown)</field>
-              <field type="float[3]" name="position_cov">eph epv</field>
-              <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
-        </message>
-        <message id="146" name="CONTROL_SYSTEM_STATE">
-            <description>The smoothed, monotonic system state used to feed the control loops of the system.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="float" name="x_acc">X acceleration in body frame</field>
-            <field type="float" name="y_acc">Y acceleration in body frame</field>
-            <field type="float" name="z_acc">Z acceleration in body frame</field>
-            <field type="float" name="x_vel">X velocity in body frame</field>
-            <field type="float" name="y_vel">Y velocity in body frame</field>
-            <field type="float" name="z_vel">Z velocity in body frame</field>
-            <field type="float" name="x_pos">X position in local frame</field>
-            <field type="float" name="y_pos">Y position in local frame</field>
-            <field type="float" name="z_pos">Z position in local frame</field>
-            <field type="float" name="airspeed">Airspeed, set to -1 if unknown</field>
-            <field type="float[3]" name="vel_variance">Variance of body velocity estimate</field>
-            <field type="float[3]" name="pos_variance">Variance in local position</field>
-            <field type="float[4]" name="q">The attitude, represented as Quaternion</field>
-            <field type="float" name="roll_rate">Angular rate in roll axis</field>
-            <field type="float" name="pitch_rate">Angular rate in pitch axis</field>
-            <field type="float" name="yaw_rate">Angular rate in yaw axis</field>
-        </message>
-        <message id="147" name="BATTERY_STATUS">
-            <description>Battery information</description>
-            <field type="uint8_t" name="id">Battery ID</field>
-            <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
-            <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
-            <field type="int16_t" name="temperature">Temperature of the battery in centi-degrees celsius. INT16_MAX for unknown temperature.</field>
-            <field type="uint16_t[10]" name="voltages">Battery voltage of cells, in millivolts (1 = 1 millivolt). Cells above the valid cell count for this battery should have the UINT16_MAX value.</field>
-            <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
-            <field type="int32_t" name="current_consumed">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
-            <field type="int32_t" name="energy_consumed">Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
-            <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
-        </message>
-        <message id="148" name="AUTOPILOT_VERSION">
-            <description>Version and capability of autopilot software</description>
-            <field type="uint64_t" name="capabilities">bitmask of capabilities (see MAV_PROTOCOL_CAPABILITY enum)</field>
-            <field type="uint32_t" name="flight_sw_version">Firmware version number</field>
-            <field type="uint32_t" name="middleware_sw_version">Middleware version number</field>
-            <field type="uint32_t" name="os_sw_version">Operating system version number</field>
-            <field type="uint32_t" name="board_version">HW / board version (last 8 bytes should be silicon ID, if any)</field>
-            <field type="uint8_t[8]" name="flight_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
-            <field type="uint8_t[8]" name="middleware_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
-            <field type="uint8_t[8]" name="os_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
-            <field type="uint16_t" name="vendor_id">ID of the board vendor</field>
-            <field type="uint16_t" name="product_id">ID of the product</field>
-            <field type="uint64_t" name="uid">UID if provided by hardware</field>
-        </message>
-        <message id="149" name="LANDING_TARGET">
-            <description>The location of a landing area captured from a downward facing camera</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
-            <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
-            <field type="float" name="angle_x">X-axis angular offset (in radians) of the target from the center of the image</field>
-            <field type="float" name="angle_y">Y-axis angular offset (in radians) of the target from the center of the image</field>
-            <field type="float" name="distance">Distance to the target from the vehicle in meters</field>
-            <field type="float" name="size_x">Size in radians of target along x-axis</field>
-            <field type="float" name="size_y">Size in radians of target along y-axis</field>
-        </message>
-
-        <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
-        <message id="230" name="ESTIMATOR_STATUS">
-            <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovaton test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovaton test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field name="flags" type="uint16_t" enum="ESTIMATOR_STATUS_FLAGS">Integer bitmask indicating which EKF outputs are valid. See definition for ESTIMATOR_STATUS_FLAGS.</field>
-            <field name="vel_ratio" type="float">Velocity innovation test ratio</field>
-            <field name="pos_horiz_ratio" type="float">Horizontal position innovation test ratio</field>
-            <field name="pos_vert_ratio" type="float">Vertical position innovation test ratio</field>
-            <field name="mag_ratio" type="float">Magnetometer innovation test ratio</field>
-            <field name="hagl_ratio" type="float">Height above terrain innovation test ratio</field>
-            <field name="tas_ratio" type="float">True airspeed innovation test ratio</field>
-            <field name="pos_horiz_accuracy" type="float">Horizontal position 1-STD accuracy relative to the EKF local origin (m)</field>
-            <field name="pos_vert_accuracy" type="float">Vertical position 1-STD accuracy relative to the EKF local origin (m)</field>
-        </message>
-        <message id="231" name="WIND_COV">
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="float" name="wind_x">Wind in X (NED) direction in m/s</field>
-            <field type="float" name="wind_y">Wind in Y (NED) direction in m/s</field>
-            <field type="float" name="wind_z">Wind in Z (NED) direction in m/s</field>
-            <field type="float" name="var_horiz">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
-            <field type="float" name="var_vert">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
-            <field type="float" name="wind_alt">AMSL altitude (m) this measurement was taken at</field>
-            <field name="horiz_accuracy" type="float">Horizontal speed 1-STD accuracy</field>
-            <field name="vert_accuracy" type="float">Vertical speed 1-STD accuracy</field>
-        </message>
-        <message id="232" name="GPS_INPUT">
-            <description>GPS sensor input message.  This is a raw sensor value sent by the GPS. This is NOT the global position estimate of the sytem.</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS inputs</field>
-            <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_INPUT_IGNORE_FLAGS enum).  All other fields must be provided.</field>
-            <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
-            <field type="uint16_t" name="time_week">GPS week number</field>
-            <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
-            <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
-            <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
-            <field type="float" name="alt">Altitude (AMSL, not WGS84), in m (positive for up)</field>
-            <field type="float" name="hdop">GPS HDOP horizontal dilution of position in m</field>
-            <field type="float" name="vdop">GPS VDOP vertical dilution of position in m</field>
-            <field type="float" name="vn">GPS velocity in m/s in NORTH direction in earth-fixed NED frame</field>
-            <field type="float" name="ve">GPS velocity in m/s in EAST direction in earth-fixed NED frame</field>
-            <field type="float" name="vd">GPS velocity in m/s in DOWN direction in earth-fixed NED frame</field>
-            <field type="float" name="speed_accuracy">GPS speed accuracy in m/s</field>
-            <field type="float" name="horiz_accuracy">GPS horizontal accuracy in m</field>
-            <field type="float" name="vert_accuracy">GPS vertical accuracy in m</field>
-            <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
-        </message>
-        <message id="233" name="GPS_RTCM_DATA">
-           <description>WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)</description>
-           <field type="uint8_t" name="flags">LSB: 1 means message is fragmented</field>
-           <field type="uint8_t" name="len">data length</field>
-           <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>
-        </message>
-        <message id="234" name="HIGH_LATENCY">
-            <description>Message appropriate for high latency connections like Iridium</description>
-            <field name="base_mode" type="uint8_t">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
-            <field name="custom_mode" type="uint32_t">A bitfield for use for autopilot-specific flags.</field>
-            <field name="landed_state" type="uint8_t" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
-            <field name="roll" type="int16_t">roll (centidegrees)</field>
-            <field name="pitch" type="int16_t">pitch (centidegrees)</field>
-            <field name="heading" type="uint16_t">heading (centidegrees)</field>
-            <field name="throttle" type="int8_t">throttle (percentage)</field>
-            <field name="heading_sp" type="int16_t">heading setpoint (centidegrees)</field>
-            <field name="latitude" type="int32_t">Latitude, expressed as degrees * 1E7</field>
-            <field name="longitude" type="int32_t">Longitude, expressed as degrees * 1E7</field>
-            <field name="altitude_amsl" type="int16_t">Altitude above mean sea level (meters)</field>
-            <field name="altitude_sp" type="int16_t">Altitude setpoint relative to the home position (meters)</field>
-            <field name="airspeed" type="uint8_t">airspeed (m/s)</field>
-            <field name="airspeed_sp" type="uint8_t">airspeed setpoint (m/s)</field>
-            <field name="groundspeed" type="uint8_t">groundspeed (m/s)</field>
-            <field name="climb_rate" type="int8_t">climb rate (m/s)</field>
-            <field name="gps_nsat" type="uint8_t">Number of satellites visible. If unknown, set to 255</field>
-            <field name="gps_fix_type" type="uint8_t">See the GPS_FIX_TYPE enum.</field>
-            <field name="battery_remaining" type="uint8_t">Remaining battery (percentage)</field>
-            <field name="temperature" type="int8_t">Autopilot temperature (degrees C)</field>
-            <field name="temperature_air" type="int8_t">Air temperature (degrees C) from airspeed sensor</field>
-            <field name="failsafe" type="uint8_t">failsafe (each bit represents a failsafe where 0=ok, 1=failsafe active (bit0:RC, bit1:batt, bit2:GPS, bit3:GCS, bit4:fence)</field>
-            <field name="wp_num" type="uint8_t">current waypoint number</field>
-            <field name="wp_distance" type="uint16_t">distance to target (meters)</field>
-        </message>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.</field>
+      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
+      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: 65535</field>
+      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: 65535</field>
+      <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: 65535</field>
+      <field type="int16_t" name="vn">GPS velocity in cm/s in NORTH direction in earth-fixed NED frame</field>
+      <field type="int16_t" name="ve">GPS velocity in cm/s in EAST direction in earth-fixed NED frame</field>
+      <field type="int16_t" name="vd">GPS velocity in cm/s in DOWN direction in earth-fixed NED frame</field>
+      <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: 65535</field>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+    </message>
+    <message id="114" name="HIL_OPTICAL_FLOW">
+      <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="uint8_t" name="sensor_id">Sensor ID</field>
+      <field type="uint32_t" name="integration_time_us">Integration time in microseconds. Divide integrated_x and integrated_y by the integration time to obtain average flow. The integration time also indicates the.</field>
+      <field type="float" name="integrated_x">Flow in radians around X axis (Sensor RH rotation about the X axis induces a positive flow. Sensor linear motion along the positive Y axis induces a negative flow.)</field>
+      <field type="float" name="integrated_y">Flow in radians around Y axis (Sensor RH rotation about the Y axis induces a positive flow. Sensor linear motion along the positive X axis induces a positive flow.)</field>
+      <field type="float" name="integrated_xgyro">RH rotation around X axis (rad)</field>
+      <field type="float" name="integrated_ygyro">RH rotation around Y axis (rad)</field>
+      <field type="float" name="integrated_zgyro">RH rotation around Z axis (rad)</field>
+      <field type="int16_t" name="temperature">Temperature * 100 in centi-degrees Celsius</field>
+      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: no valid flow, 255: maximum quality</field>
+      <field type="uint32_t" name="time_delta_distance_us">Time in microseconds since the distance was sampled.</field>
+      <field type="float" name="distance">Distance to the center of the flow field in meters. Positive value (including zero): distance known. Negative value: Unknown distance.</field>
+    </message>
+    <message id="115" name="HIL_STATE_QUATERNION">
+      <description>Sent from simulation to autopilot, avoids in contrast to HIL_STATE singularities. This packet is useful for high throughput applications such as hardware in the loop simulations.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field type="float[4]" name="attitude_quaternion">Vehicle attitude expressed as normalized quaternion in w, x, y, z order (with 1 0 0 0 being the null-rotation)</field>
+      <field type="float" name="rollspeed">Body frame roll / phi angular speed (rad/s)</field>
+      <field type="float" name="pitchspeed">Body frame pitch / theta angular speed (rad/s)</field>
+      <field type="float" name="yawspeed">Body frame yaw / psi angular speed (rad/s)</field>
+      <field type="int32_t" name="lat">Latitude, expressed as * 1E7</field>
+      <field type="int32_t" name="lon">Longitude, expressed as * 1E7</field>
+      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1000 (millimeters)</field>
+      <field type="int16_t" name="vx">Ground X Speed (Latitude), expressed as m/s * 100</field>
+      <field type="int16_t" name="vy">Ground Y Speed (Longitude), expressed as m/s * 100</field>
+      <field type="int16_t" name="vz">Ground Z Speed (Altitude), expressed as m/s * 100</field>
+      <field type="uint16_t" name="ind_airspeed">Indicated airspeed, expressed as m/s * 100</field>
+      <field type="uint16_t" name="true_airspeed">True airspeed, expressed as m/s * 100</field>
+      <field type="int16_t" name="xacc">X acceleration (mg)</field>
+      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+    </message>
+    <message id="116" name="SCALED_IMU2">
+      <description>The RAW IMU readings for secondary 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="int16_t" name="xacc">X acceleration (mg)</field>
+      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+      <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
+      <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
+      <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
+      <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
+      <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
+      <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+    </message>
+    <message id="117" name="LOG_REQUEST_LIST">
+      <description>Request a list of available logs. On some systems calling this may stop on-board logging until LOG_REQUEST_END is called.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="start">First log id (0 for first available)</field>
+      <field type="uint16_t" name="end">Last log id (0xffff for last available)</field>
+    </message>
+    <message id="118" name="LOG_ENTRY">
+      <description>Reply to LOG_REQUEST_LIST</description>
+      <field type="uint16_t" name="id">Log id</field>
+      <field type="uint16_t" name="num_logs">Total number of logs</field>
+      <field type="uint16_t" name="last_log_num">High log number</field>
+      <field type="uint32_t" name="time_utc">UTC timestamp of log in seconds since 1970, or 0 if not available</field>
+      <field type="uint32_t" name="size">Size of the log (may be approximate) in bytes</field>
+    </message>
+    <message id="119" name="LOG_REQUEST_DATA">
+      <description>Request a chunk of a log</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
+      <field type="uint32_t" name="ofs">Offset into the log</field>
+      <field type="uint32_t" name="count">Number of bytes</field>
+    </message>
+    <message id="120" name="LOG_DATA">
+      <description>Reply to LOG_REQUEST_DATA</description>
+      <field type="uint16_t" name="id">Log id (from LOG_ENTRY reply)</field>
+      <field type="uint32_t" name="ofs">Offset into the log</field>
+      <field type="uint8_t" name="count">Number of bytes (zero for end of log)</field>
+      <field type="uint8_t[90]" name="data">log data</field>
+    </message>
+    <message id="121" name="LOG_ERASE">
+      <description>Erase all logs</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="122" name="LOG_REQUEST_END">
+      <description>Stop log transfer and resume normal logging</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message name="GPS_INJECT_DATA" id="123">
+      <description>data for injecting into the onboard GPS (used for DGPS)</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="len">data length</field>
+      <field type="uint8_t[110]" name="data">raw data (110 is enough for 12 satellites of RTCMv2)</field>
+    </message>
+    <message id="124" name="GPS2_RAW">
+      <description>Second GPS data. Coordinate frame is right-handed, Z-axis up (GPS frame).</description>
+      <field type="uint64_t" name="time_usec">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
+      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">See the GPS_FIX_TYPE enum.</field>
+      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="alt">Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)</field>
+      <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="vel">GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX</field>
+      <field type="uint16_t" name="cog">Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+      <field type="uint8_t" name="dgps_numch">Number of DGPS satellites</field>
+      <field type="uint32_t" name="dgps_age">Age of DGPS info</field>
+    </message>
+    <message id="125" name="POWER_STATUS">
+      <description>Power supply status</description>
+      <field type="uint16_t" name="Vcc">5V rail voltage in millivolts</field>
+      <field type="uint16_t" name="Vservo">servo rail voltage in millivolts</field>
+      <field type="uint16_t" name="flags">power supply status flags (see MAV_POWER_STATUS enum)</field>
+    </message>
+    <message name="SERIAL_CONTROL" id="126">
+      <description>Control a serial port. This can be used for raw access to an onboard serial peripheral such as a GPS or telemetry radio. It is designed to make it possible to update the devices firmware via MAVLink messages or change the devices settings. A message with zero bytes can be used to change just the baudrate.</description>
+      <field type="uint8_t" name="device">See SERIAL_CONTROL_DEV enum</field>
+      <field type="uint8_t" name="flags">See SERIAL_CONTROL_FLAG enum</field>
+      <field type="uint16_t" name="timeout">Timeout for reply data in milliseconds</field>
+      <field type="uint32_t" name="baudrate">Baudrate of transfer. Zero means no change.</field>
+      <field type="uint8_t" name="count">how many bytes in this transfer</field>
+      <field type="uint8_t[70]" name="data">serial data</field>
+    </message>
+    <message id="127" name="GPS_RTK">
+      <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
+      <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
+      <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
+      <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
+      <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
+      <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
+      <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
+      <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
+      <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
+      <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
+      <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
+      <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
+      <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
+      <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
+    </message>
+    <message id="128" name="GPS2_RTK">
+      <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>
+      <field type="uint32_t" name="time_last_baseline_ms">Time since boot of last baseline message received in ms.</field>
+      <field type="uint8_t" name="rtk_receiver_id">Identification of connected RTK receiver.</field>
+      <field type="uint16_t" name="wn">GPS Week Number of last baseline</field>
+      <field type="uint32_t" name="tow">GPS Time of Week of last baseline</field>
+      <field type="uint8_t" name="rtk_health">GPS-specific health report for RTK data.</field>
+      <field type="uint8_t" name="rtk_rate">Rate of baseline messages being received by GPS, in HZ</field>
+      <field type="uint8_t" name="nsats">Current number of sats used for RTK calculation.</field>
+      <field type="uint8_t" name="baseline_coords_type">Coordinate system of baseline. 0 == ECEF, 1 == NED</field>
+      <field type="int32_t" name="baseline_a_mm">Current baseline in ECEF x or NED north component in mm.</field>
+      <field type="int32_t" name="baseline_b_mm">Current baseline in ECEF y or NED east component in mm.</field>
+      <field type="int32_t" name="baseline_c_mm">Current baseline in ECEF z or NED down component in mm.</field>
+      <field type="uint32_t" name="accuracy">Current estimate of baseline accuracy.</field>
+      <field type="int32_t" name="iar_num_hypotheses">Current number of integer ambiguity hypotheses.</field>
+    </message>
+    <message id="129" name="SCALED_IMU3">
+      <description>The RAW IMU readings for 3rd 9DOF sensor setup. This message should contain the scaled values to the described units</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="int16_t" name="xacc">X acceleration (mg)</field>
+      <field type="int16_t" name="yacc">Y acceleration (mg)</field>
+      <field type="int16_t" name="zacc">Z acceleration (mg)</field>
+      <field type="int16_t" name="xgyro">Angular speed around X axis (millirad /sec)</field>
+      <field type="int16_t" name="ygyro">Angular speed around Y axis (millirad /sec)</field>
+      <field type="int16_t" name="zgyro">Angular speed around Z axis (millirad /sec)</field>
+      <field type="int16_t" name="xmag">X Magnetic field (milli tesla)</field>
+      <field type="int16_t" name="ymag">Y Magnetic field (milli tesla)</field>
+      <field type="int16_t" name="zmag">Z Magnetic field (milli tesla)</field>
+    </message>
+    <message id="130" name="DATA_TRANSMISSION_HANDSHAKE">
+      <field type="uint8_t" name="type">type of requested/acknowledged data (as defined in ENUM DATA_TYPES in mavlink/include/mavlink_types.h)</field>
+      <field type="uint32_t" name="size">total data size in bytes (set on ACK only)</field>
+      <field type="uint16_t" name="width">Width of a matrix or image</field>
+      <field type="uint16_t" name="height">Height of a matrix or image</field>
+      <field type="uint16_t" name="packets">number of packets beeing sent (set on ACK only)</field>
+      <field type="uint8_t" name="payload">payload size per packet (normally 253 byte, see DATA field size in message ENCAPSULATED_DATA) (set on ACK only)</field>
+      <field type="uint8_t" name="jpg_quality">JPEG quality out of [1,100]</field>
+    </message>
+    <message id="131" name="ENCAPSULATED_DATA">
+      <field type="uint16_t" name="seqnr">sequence number (starting with 0 on every transmission)</field>
+      <field type="uint8_t[253]" name="data">image data bytes</field>
+    </message>
+    <message id="132" name="DISTANCE_SENSOR">
+      <field type="uint32_t" name="time_boot_ms">Time since system boot</field>
+      <field type="uint16_t" name="min_distance">Minimum distance the sensor can measure in centimeters</field>
+      <field type="uint16_t" name="max_distance">Maximum distance the sensor can measure in centimeters</field>
+      <field type="uint16_t" name="current_distance">Current distance reading</field>
+      <field type="uint8_t" name="type">Type from MAV_DISTANCE_SENSOR enum.</field>
+      <field type="uint8_t" name="id">Onboard ID of the sensor</field>
+      <field type="uint8_t" name="orientation">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
+      <field type="uint8_t" name="covariance">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
+    </message>
+    <message id="133" name="TERRAIN_REQUEST">
+      <description>Request for terrain data and terrain status</description>
+      <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
+      <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
+      <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
+      <field type="uint64_t" name="mask" print_format="0x%07x">Bitmask of requested 4x4 grids (row major 8x7 array of grids, 56 bits)</field>
+    </message>
+    <message id="134" name="TERRAIN_DATA">
+      <description>Terrain data sent from GCS. The lat/lon and grid_spacing must be the same as a lat/lon from a TERRAIN_REQUEST</description>
+      <field type="int32_t" name="lat">Latitude of SW corner of first grid (degrees *10^7)</field>
+      <field type="int32_t" name="lon">Longitude of SW corner of first grid (in degrees *10^7)</field>
+      <field type="uint16_t" name="grid_spacing">Grid spacing in meters</field>
+      <field type="uint8_t" name="gridbit">bit within the terrain request mask</field>
+      <field type="int16_t[16]" name="data">Terrain data in meters AMSL</field>
+    </message>
+    <message id="135" name="TERRAIN_CHECK">
+      <description>Request that the vehicle report terrain height at the given location. Used by GCS to check if vehicle has all terrain data needed for a mission.</description>
+      <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
+      <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
+    </message>
+    <message id="136" name="TERRAIN_REPORT">
+      <description>Response from a TERRAIN_CHECK request</description>
+      <field type="int32_t" name="lat">Latitude (degrees *10^7)</field>
+      <field type="int32_t" name="lon">Longitude (degrees *10^7)</field>
+      <field type="uint16_t" name="spacing">grid spacing (zero if terrain at this location unavailable)</field>
+      <field type="float" name="terrain_height">Terrain height in meters AMSL</field>
+      <field type="float" name="current_height">Current vehicle height above lat/lon terrain height (meters)</field>
+      <field type="uint16_t" name="pending">Number of 4x4 terrain blocks waiting to be received or read from disk</field>
+      <field type="uint16_t" name="loaded">Number of 4x4 terrain blocks in memory</field>
+    </message>
+    <message id="137" name="SCALED_PRESSURE2">
+      <description>Barometer readings for 2nd barometer</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
+      <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
+      <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+    </message>
+    <message id="138" name="ATT_POS_MOCAP">
+      <description>Motion capture attitude and position</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="float[4]" name="q">Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float" name="x">X position in meters (NED)</field>
+      <field type="float" name="y">Y position in meters (NED)</field>
+      <field type="float" name="z">Z position in meters (NED)</field>
+    </message>
+    <message id="139" name="SET_ACTUATOR_CONTROL_TARGET">
+      <description>Set the vehicle attitude and body angular rates.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
+    </message>
+    <message id="140" name="ACTUATOR_CONTROL_TARGET">
+      <description>Set the vehicle attitude and body angular rates.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="uint8_t" name="group_mlx">Actuator group. The "_mlx" indicates this is a multi-instance message and a MAVLink parser should use this field to difference between instances.</field>
+      <field type="float[8]" name="controls">Actuator controls. Normed to -1..+1 where 0 is neutral position. Throttle for single rotation direction motors is 0..1, negative range for reverse direction. Standard mapping for attitude controls (group 0): (index 0-7): roll, pitch, yaw, throttle, flaps, spoilers, airbrakes, landing gear. Load a pass-through mixer to repurpose them as generic outputs.</field>
+    </message>
+    <message id="141" name="ALTITUDE">
+      <description>The current system altitude.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="float" name="altitude_monotonic">This altitude measure is initialized on system boot and monotonic (it is never reset, but represents the local altitude change). The only guarantee on this field is that it will never be reset and is consistent within a flight. The recommended value for this field is the uncorrected barometric altitude at boot time. This altitude will also drift and vary between flights.</field>
+      <field type="float" name="altitude_amsl">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output AMSL by default and not the WGS84 altitude.</field>
+      <field type="float" name="altitude_local">This is the local altitude in the local coordinate frame. It is not the altitude above home, but in reference to the coordinate origin (0, 0, 0). It is up-positive.</field>
+      <field type="float" name="altitude_relative">This is the altitude above the home position. It resets on each change of the current home position.</field>
+      <field type="float" name="altitude_terrain">This is the altitude above terrain. It might be fed by a terrain database or an altimeter. Values smaller than -1000 should be interpreted as unknown.</field>
+      <field type="float" name="bottom_clearance">This is not the altitude, but the clear space below the system according to the fused clearance estimate. It generally should max out at the maximum range of e.g. the laser altimeter. It is generally a moving target. A negative value indicates no measurement available.</field>
+    </message>
+    <message id="142" name="RESOURCE_REQUEST">
+      <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
+      <field type="uint8_t" name="request_id">Request ID. This ID should be re-used when sending back URI contents</field>
+      <field type="uint8_t" name="uri_type">The type of requested URI. 0 = a file via URL. 1 = a UAVCAN binary</field>
+      <field type="uint8_t[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
+      <field type="uint8_t" name="transfer_type">The way the autopilot wants to receive the URI. 0 = MAVLink FTP. 1 = binary stream.</field>
+      <field type="uint8_t[120]" name="storage">The storage path the autopilot wants the URI to be stored in. Will only be valid if the transfer_type has a storage associated (e.g. MAVLink FTP).</field>
+    </message>
+    <message id="143" name="SCALED_PRESSURE3">
+      <description>Barometer readings for 3rd barometer</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float" name="press_abs">Absolute pressure (hectopascal)</field>
+      <field type="float" name="press_diff">Differential pressure 1 (hectopascal)</field>
+      <field type="int16_t" name="temperature">Temperature measurement (0.01 degrees celsius)</field>
+    </message>
+    <message id="144" name="FOLLOW_TARGET">
+      <description>current motion information from a designated system</description>
+      <field type="uint64_t" name="timestamp">Timestamp in milliseconds since system boot</field>
+      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
+      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+      <field type="float" name="alt">AMSL, in meters</field>
+      <field type="float[3]" name="vel">target velocity (0,0,0) for unknown</field>
+      <field type="float[3]" name="acc">linear target acceleration (0,0,0) for unknown</field>
+      <field type="float[4]" name="attitude_q">(1 0 0 0 for unknown)</field>
+      <field type="float[3]" name="rates">(0 0 0 for unknown)</field>
+      <field type="float[3]" name="position_cov">eph epv</field>
+      <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
+    </message>
+    <message id="146" name="CONTROL_SYSTEM_STATE">
+      <description>The smoothed, monotonic system state used to feed the control loops of the system.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="float" name="x_acc">X acceleration in body frame</field>
+      <field type="float" name="y_acc">Y acceleration in body frame</field>
+      <field type="float" name="z_acc">Z acceleration in body frame</field>
+      <field type="float" name="x_vel">X velocity in body frame</field>
+      <field type="float" name="y_vel">Y velocity in body frame</field>
+      <field type="float" name="z_vel">Z velocity in body frame</field>
+      <field type="float" name="x_pos">X position in local frame</field>
+      <field type="float" name="y_pos">Y position in local frame</field>
+      <field type="float" name="z_pos">Z position in local frame</field>
+      <field type="float" name="airspeed">Airspeed, set to -1 if unknown</field>
+      <field type="float[3]" name="vel_variance">Variance of body velocity estimate</field>
+      <field type="float[3]" name="pos_variance">Variance in local position</field>
+      <field type="float[4]" name="q">The attitude, represented as Quaternion</field>
+      <field type="float" name="roll_rate">Angular rate in roll axis</field>
+      <field type="float" name="pitch_rate">Angular rate in pitch axis</field>
+      <field type="float" name="yaw_rate">Angular rate in yaw axis</field>
+    </message>
+    <message id="147" name="BATTERY_STATUS">
+      <description>Battery information</description>
+      <field type="uint8_t" name="id">Battery ID</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
+      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
+      <field type="int16_t" name="temperature">Temperature of the battery in centi-degrees celsius. INT16_MAX for unknown temperature.</field>
+      <field type="uint16_t[10]" name="voltages">Battery voltage of cells, in millivolts (1 = 1 millivolt). Cells above the valid cell count for this battery should have the UINT16_MAX value.</field>
+      <field type="int16_t" name="current_battery">Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+      <field type="int32_t" name="current_consumed">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
+      <field type="int32_t" name="energy_consumed">Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
+      <field type="int8_t" name="battery_remaining">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
+    </message>
+    <message id="148" name="AUTOPILOT_VERSION">
+      <description>Version and capability of autopilot software</description>
+      <field type="uint64_t" name="capabilities">bitmask of capabilities (see MAV_PROTOCOL_CAPABILITY enum)</field>
+      <field type="uint32_t" name="flight_sw_version">Firmware version number</field>
+      <field type="uint32_t" name="middleware_sw_version">Middleware version number</field>
+      <field type="uint32_t" name="os_sw_version">Operating system version number</field>
+      <field type="uint32_t" name="board_version">HW / board version (last 8 bytes should be silicon ID, if any)</field>
+      <field type="uint8_t[8]" name="flight_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+      <field type="uint8_t[8]" name="middleware_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+      <field type="uint8_t[8]" name="os_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
+      <field type="uint16_t" name="vendor_id">ID of the board vendor</field>
+      <field type="uint16_t" name="product_id">ID of the product</field>
+      <field type="uint64_t" name="uid">UID if provided by hardware</field>
+    </message>
+    <message id="149" name="LANDING_TARGET">
+      <description>The location of a landing area captured from a downward facing camera</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
+      <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
+      <field type="float" name="angle_x">X-axis angular offset (in radians) of the target from the center of the image</field>
+      <field type="float" name="angle_y">Y-axis angular offset (in radians) of the target from the center of the image</field>
+      <field type="float" name="distance">Distance to the target from the vehicle in meters</field>
+      <field type="float" name="size_x">Size in radians of target along x-axis</field>
+      <field type="float" name="size_y">Size in radians of target along y-axis</field>
+    </message>
+    <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
+    <message id="230" name="ESTIMATOR_STATUS">
+      <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovaton test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovaton test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field name="flags" type="uint16_t" enum="ESTIMATOR_STATUS_FLAGS">Integer bitmask indicating which EKF outputs are valid. See definition for ESTIMATOR_STATUS_FLAGS.</field>
+      <field name="vel_ratio" type="float">Velocity innovation test ratio</field>
+      <field name="pos_horiz_ratio" type="float">Horizontal position innovation test ratio</field>
+      <field name="pos_vert_ratio" type="float">Vertical position innovation test ratio</field>
+      <field name="mag_ratio" type="float">Magnetometer innovation test ratio</field>
+      <field name="hagl_ratio" type="float">Height above terrain innovation test ratio</field>
+      <field name="tas_ratio" type="float">True airspeed innovation test ratio</field>
+      <field name="pos_horiz_accuracy" type="float">Horizontal position 1-STD accuracy relative to the EKF local origin (m)</field>
+      <field name="pos_vert_accuracy" type="float">Vertical position 1-STD accuracy relative to the EKF local origin (m)</field>
+    </message>
+    <message id="231" name="WIND_COV">
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="float" name="wind_x">Wind in X (NED) direction in m/s</field>
+      <field type="float" name="wind_y">Wind in Y (NED) direction in m/s</field>
+      <field type="float" name="wind_z">Wind in Z (NED) direction in m/s</field>
+      <field type="float" name="var_horiz">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
+      <field type="float" name="var_vert">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
+      <field type="float" name="wind_alt">AMSL altitude (m) this measurement was taken at</field>
+      <field name="horiz_accuracy" type="float">Horizontal speed 1-STD accuracy</field>
+      <field name="vert_accuracy" type="float">Vertical speed 1-STD accuracy</field>
+    </message>
+    <message id="232" name="GPS_INPUT">
+      <description>GPS sensor input message.  This is a raw sensor value sent by the GPS. This is NOT the global position estimate of the sytem.</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="uint8_t" name="gps_id">ID of the GPS for multiple GPS inputs</field>
+      <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS">Flags indicating which fields to ignore (see GPS_INPUT_IGNORE_FLAGS enum).  All other fields must be provided.</field>
+      <field type="uint32_t" name="time_week_ms">GPS time (milliseconds from start of GPS week)</field>
+      <field type="uint16_t" name="time_week">GPS week number</field>
+      <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
+      <field type="int32_t" name="lat">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="lon">Longitude (WGS84), in degrees * 1E7</field>
+      <field type="float" name="alt">Altitude (AMSL, not WGS84), in m (positive for up)</field>
+      <field type="float" name="hdop">GPS HDOP horizontal dilution of position in m</field>
+      <field type="float" name="vdop">GPS VDOP vertical dilution of position in m</field>
+      <field type="float" name="vn">GPS velocity in m/s in NORTH direction in earth-fixed NED frame</field>
+      <field type="float" name="ve">GPS velocity in m/s in EAST direction in earth-fixed NED frame</field>
+      <field type="float" name="vd">GPS velocity in m/s in DOWN direction in earth-fixed NED frame</field>
+      <field type="float" name="speed_accuracy">GPS speed accuracy in m/s</field>
+      <field type="float" name="horiz_accuracy">GPS horizontal accuracy in m</field>
+      <field type="float" name="vert_accuracy">GPS vertical accuracy in m</field>
+      <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
+    </message>
+    <message id="233" name="GPS_RTCM_DATA">
+      <description>WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)</description>
+      <field type="uint8_t" name="flags">LSB: 1 means message is fragmented</field>
+      <field type="uint8_t" name="len">data length</field>
+      <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>
+    </message>
+    <message id="234" name="HIGH_LATENCY">
+      <description>Message appropriate for high latency connections like Iridium</description>
+      <field name="base_mode" type="uint8_t">System mode bitfield, see MAV_MODE_FLAG ENUM in mavlink/include/mavlink_types.h</field>
+      <field name="custom_mode" type="uint32_t">A bitfield for use for autopilot-specific flags.</field>
+      <field name="landed_state" type="uint8_t" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+      <field name="roll" type="int16_t">roll (centidegrees)</field>
+      <field name="pitch" type="int16_t">pitch (centidegrees)</field>
+      <field name="heading" type="uint16_t">heading (centidegrees)</field>
+      <field name="throttle" type="int8_t">throttle (percentage)</field>
+      <field name="heading_sp" type="int16_t">heading setpoint (centidegrees)</field>
+      <field name="latitude" type="int32_t">Latitude, expressed as degrees * 1E7</field>
+      <field name="longitude" type="int32_t">Longitude, expressed as degrees * 1E7</field>
+      <field name="altitude_amsl" type="int16_t">Altitude above mean sea level (meters)</field>
+      <field name="altitude_sp" type="int16_t">Altitude setpoint relative to the home position (meters)</field>
+      <field name="airspeed" type="uint8_t">airspeed (m/s)</field>
+      <field name="airspeed_sp" type="uint8_t">airspeed setpoint (m/s)</field>
+      <field name="groundspeed" type="uint8_t">groundspeed (m/s)</field>
+      <field name="climb_rate" type="int8_t">climb rate (m/s)</field>
+      <field name="gps_nsat" type="uint8_t">Number of satellites visible. If unknown, set to 255</field>
+      <field name="gps_fix_type" type="uint8_t">See the GPS_FIX_TYPE enum.</field>
+      <field name="battery_remaining" type="uint8_t">Remaining battery (percentage)</field>
+      <field name="temperature" type="int8_t">Autopilot temperature (degrees C)</field>
+      <field name="temperature_air" type="int8_t">Air temperature (degrees C) from airspeed sensor</field>
+      <field name="failsafe" type="uint8_t">failsafe (each bit represents a failsafe where 0=ok, 1=failsafe active (bit0:RC, bit1:batt, bit2:GPS, bit3:GCS, bit4:fence)</field>
+      <field name="wp_num" type="uint8_t">current waypoint number</field>
+      <field name="wp_distance" type="uint16_t">distance to target (meters)</field>
+    </message>
     <message id="235" name="MIXER_PARAM_VALUE">
       <description>Mixer parameter values emitted after a read or set request</description>
       <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
       <field type="int16_t" name="count">Total number of onboard parameters</field>
-      <field type="uint16_t" name="index">Index of this onboard parameter</field>      
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
       <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
       <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
-      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>      
+      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
       <field type="uint8_t" name="param_array_size">Size of the array for this parameter</field>
@@ -3739,275 +3780,272 @@
       <description>Mixer paraemter values to set</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="index">Index of this onboard parameter</field>      
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
       <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
       <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
-      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>      
+      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
       <field type="float[6]" name="param_values">Array of parameter values</field>
-    </message>    
+    </message>
     <message id="237" name="MIXER_PARAM_REQUEST_READ">
       <description>Mixer paraemter values to set</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="index">Index of this onboard parameter</field>      
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
       <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
       <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-    </message>    
-        <message id="241" name="VIBRATION">
-            <description>Vibration levels and accelerometer clipping</description>
-            <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
-            <field type="float" name="vibration_x">Vibration levels on X-axis</field>
-            <field type="float" name="vibration_y">Vibration levels on Y-axis</field>
-            <field type="float" name="vibration_z">Vibration levels on Z-axis</field>
-            <field type="uint32_t" name="clipping_0">first accelerometer clipping count</field>
-            <field type="uint32_t" name="clipping_1">second accelerometer clipping count</field>
-            <field type="uint32_t" name="clipping_2">third accelerometer clipping count</field>
-        </message>
-        <message id="242" name="HOME_POSITION">
-               <description>This message can be requested by sending the MAV_CMD_GET_HOME_POSITION command. The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The position the system will return to and land on. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
-               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-               <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
-               <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
-               <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
-               <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
-               <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-               <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-               <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-        </message>
-        <message id="243" name="SET_HOME_POSITION">
-               <description>The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
-               <field type="uint8_t" name="target_system">System ID.</field>
-               <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
-               <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
-               <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
-               <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
-               <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
-               <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
-               <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
-               <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-               <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-               <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
-        </message>
-        <message id="244" name="MESSAGE_INTERVAL">
-            <description>This interface replaces DATA_STREAM</description>
-            <field type="uint16_t" name="message_id">The ID of the requested MAVLink message. v1.0 is limited to 254 messages.</field>
-            <field type="int32_t" name="interval_us">The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, > 0 indicates the interval at which it is sent.</field>
-        </message>
-        <message id="245" name="EXTENDED_SYS_STATE">
-            <description>Provides state for additional features</description>
-            <field type="uint8_t" name="vtol_state" enum="MAV_VTOL_STATE">The VTOL state if applicable. Is set to MAV_VTOL_STATE_UNDEFINED if UAV is not in VTOL configuration.</field>
-            <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
-        </message>
-        <message id="246" name="ADSB_VEHICLE">
-          <description>The location and information of an ADSB vehicle</description>
-          <field type="uint32_t" name="ICAO_address">ICAO address</field>
-          <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
-          <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
-          <field type="uint8_t" name="altitude_type" enum="ADSB_ALTITUDE_TYPE">Type from ADSB_ALTITUDE_TYPE enum</field>
-          <field type="int32_t" name="altitude">Altitude(ASL) in millimeters</field>
-          <field type="uint16_t" name="heading">Course over ground in centidegrees</field>
-          <field type="uint16_t" name="hor_velocity">The horizontal velocity in centimeters/second</field>
-          <field type="int16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
-          <field type="char[9]" name="callsign">The callsign, 8+null</field>
-          <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">Type from ADSB_EMITTER_TYPE enum</field>
-          <field type="uint8_t" name="tslc">Time since last communication in seconds</field>
-          <field type="uint16_t" name="flags" enum="ADSB_FLAGS">Flags to indicate various statuses including valid data fields</field>
-          <field type="uint16_t" name="squawk">Squawk code</field>
-        </message>
-        <message id="247" name="COLLISION">
-          <description>Information about a potential collision</description>
-          <field type="uint8_t" name="src" enum="MAV_COLLISION_SRC">Collision data source</field>
-          <field type="uint32_t" name="id">Unique identifier, domain based on src field</field>
-          <field type="uint8_t" name="action" enum="MAV_COLLISION_ACTION">Action that is being taken to avoid this collision</field>
-          <field type="uint8_t" name="threat_level" enum="MAV_COLLISION_THREAT_LEVEL">How concerned the aircraft is about this collision</field>
-          <field type="float" name="time_to_minimum_delta">Estimated time until collision occurs (seconds)</field>
-          <field type="float" name="altitude_minimum_delta">Closest vertical distance in meters between vehicle and object</field>
-          <field type="float" name="horizontal_minimum_delta">Closest horizontal distance in meteres between vehicle and object</field>
-        </message>
-        <message id="248" name="V2_EXTENSION">
-            <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
-            <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
-            <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
-            <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
-            <field type="uint16_t" name="message_type">A code that identifies the software component that understands this message (analogous to usb device classes or mime type strings).  If this code is less than 32768, it is considered a 'registered' protocol extension and the corresponding entry should be added to https://github.com/mavlink/mavlink/extension-message-ids.xml.  Software creators can register blocks of message IDs as needed (useful for GCS specific metadata, etc...). Message_types greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
-            <field type="uint8_t[249]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
-        </message>
-          <message id="249" name="MEMORY_VECT">
-               <description>Send raw controller memory. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-               <field type="uint16_t" name="address">Starting address of the debug variables</field>
-               <field type="uint8_t" name="ver">Version code of the type variable. 0=unknown, type ignored and assumed int16_t. 1=as below</field>
-               <field type="uint8_t" name="type">Type code of the memory variables. for ver = 1: 0=16 x int16_t, 1=16 x uint16_t, 2=16 x Q15, 3=16 x 1Q14</field>
-               <field type="int8_t[32]" name="value">Memory contents at specified address</field>
-          </message>
-          <message id="250" name="DEBUG_VECT">
-               <field type="char[10]" name="name">Name</field>
-               <field type="uint64_t" name="time_usec">Timestamp</field>
-               <field type="float" name="x">x</field>
-               <field type="float" name="y">y</field>
-               <field type="float" name="z">z</field>
-          </message>
-          <message id="251" name="NAMED_VALUE_FLOAT">
-               <description>Send a key-value pair as float. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="char[10]" name="name">Name of the debug variable</field>
-               <field type="float" name="value">Floating point value</field>
-          </message>
-          <message id="252" name="NAMED_VALUE_INT">
-               <description>Send a key-value pair as integer. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="char[10]" name="name">Name of the debug variable</field>
-               <field type="int32_t" name="value">Signed integer value</field>
-          </message>
-          <message id="253" name="STATUSTEXT">
-               <description>Status text message. These messages are printed in yellow in the COMM console of QGroundControl. WARNING: They consume quite some bandwidth, so use only for important status and error messages. If implemented wisely, these messages are buffered on the MCU and sent only at a limited rate (e.g. 10 Hz).</description>
-               <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424. See enum MAV_SEVERITY.</field>
-               <field type="char[50]" name="text">Status text message, without null termination character</field>
-          </message>
-          <message id="254" name="DEBUG">
-               <description>Send a debug value. The index is used to discriminate between values. These values show up in the plot of QGroundControl as DEBUG N.</description>
-               <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="uint8_t" name="ind">index of debug variable</field>
-               <field type="float" name="value">DEBUG value</field>
-          </message>
-
-          <!-- messages with ID 256 and above are only available in MAVLink2 -->
-          <message id="256" name="SETUP_SIGNING">
-               <description>Setup a MAVLink2 signing key. If called with secret_key of all zero and zero initial_timestamp will disable signing</description>
-               <field type="uint8_t" name="target_system">system id of the target</field>
-               <field type="uint8_t" name="target_component">component ID of the target</field>
-               <field type="uint8_t[32]" name="secret_key">signing key</field>
-               <field type="uint64_t" name="initial_timestamp">initial timestamp</field>
-          </message>
-
-	  <message id="257" name="BUTTON_CHANGE">
-            <description>Report button state change</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field name="last_change_ms" type="uint32_t">Time of last change of button state</field>
-            <field name="state" type="uint8_t">Bitmap state of buttons</field>
-          </message>
-
-          <message id="258" name="PLAY_TUNE">
-            <description>Control vehicle tone generation (buzzer)</description>
-            <field name="target_system" type="uint8_t">System ID</field>
-            <field name="target_component" type="uint8_t">Component ID</field>
-            <field name="tune" type="char[30]">tune in board specific format</field>
-          </message>
-
-        <message id="259" name="CAMERA_INFORMATION">
-            <description>WIP: Information about a camera</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
-            <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
-            <field type="float" name="focal_length">Focal length in mm</field>
-            <field type="float" name="sensor_size_h">Image sensor size horizontal in mm</field>
-            <field type="float" name="sensor_size_v">Image sensor size vertical in mm</field>
-            <field type="uint16_t" name="resolution_h">Image resolution in pixels horizontal</field>
-            <field type="uint16_t" name="resolution_v">Image resolution in pixels vertical</field>
-            <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
-        </message>
-        <message id="260" name="CAMERA_SETTINGS">
-            <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="float" name="aperture">Aperture is 1/value</field>
-            <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
-            <field type="float" name="shutter_speed">Shutter speed in s</field>
-            <field type="uint8_t" name="shutter_speed_locked">Shutter speed locked (0: auto, 1: locked)</field>
-            <field type="float" name="iso_sensitivity">ISO sensitivity</field>
-            <field type="uint8_t" name="iso_sensitivity_locked">ISO sensitivity locked (0: auto, 1: locked)</field>
-            <field type="float" name="white_balance">Color temperature in K</field>
-            <field type="uint8_t" name="white_balance_locked">Color temperature locked (0: auto, 1: locked)</field>
-            <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
-            <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
-            <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
-        </message>
-        <message id="261" name="STORAGE_INFORMATION">
-            <description>WIP: Information about a storage medium</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
-            <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
-            <field type="float" name="total_capacity">Total capacity in MiB</field>
-            <field type="float" name="used_capacity">Used capacity in MiB</field>
-            <field type="float" name="available_capacity">Available capacity in MiB</field>
-            <field type="float" name="read_speed">Read speed in MiB/s</field>
-            <field type="float" name="write_speed">Write speed in MiB/s</field>
-        </message>
-        <message id="262" name="CAMERA_CAPTURE_STATUS">
-            <description>WIP: Information about the status of a capture</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
-            <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
-            <field type="float" name="image_interval">Image capture interval in seconds</field>
-            <field type="float" name="video_framerate">Video frame rate in Hz</field>
-            <field type="uint16_t" name="image_resolution_h">Image resolution in pixels horizontal</field>
-            <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
-            <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
-            <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
-        </message>
-        <message id="263" name="CAMERA_IMAGE_CAPTURED">
-            <description>WIP: Information about a captured image</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7 where image was taken</field>
-            <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7 where capture was taken</field>
-            <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
-            <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
-            <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
-            <field type="char[210]" name="file_path">File path of image taken.</field>
-        </message>
-
-        <message id="264" name="FLIGHT_INFORMATION">
-            <description>WIP: Information about flight since last arming</description>
-            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-            <field type="uint64_t" name="arming_time_utc">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
-            <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
-            <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
-        </message>
-
-        <message id="265" name="MOUNT_ORIENTATION">
-            <description>WIP: Orientation of a mount</description>
-                <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-               <field type="float" name="roll">Roll in degrees</field>
-               <field type="float" name="pitch">Pitch in degrees</field>
-               <field type="float" name="yaw">Yaw in degrees</field>
-        </message>
-
-        <message id="266" name="LOGGING_DATA">
-               <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>
-               <field type="uint8_t" name="target_system">system ID of the target</field>
-               <field type="uint8_t" name="target_component">component ID of the target</field>
-               <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
-               <field type="uint8_t" name="length">data length</field>
-               <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
-               <field type="uint8_t[249]" name="data">logged data</field>
-          </message>
-          <message id="267" name="LOGGING_DATA_ACKED">
-               <description>A message containing logged data which requires a LOGGING_ACK to be sent back</description>
-               <field type="uint8_t" name="target_system">system ID of the target</field>
-               <field type="uint8_t" name="target_component">component ID of the target</field>
-               <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
-               <field type="uint8_t" name="length">data length</field>
-               <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
-               <field type="uint8_t[249]" name="data">logged data</field>
-          </message>
-          <message id="268" name="LOGGING_ACK">
-               <description>An ack for a LOGGING_DATA_ACKED message</description>
-               <field type="uint8_t" name="target_system">system ID of the target</field>
-               <field type="uint8_t" name="target_component">component ID of the target</field>
-               <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
-          </message>
-    </messages>
+    </message>
+    <message id="241" name="VIBRATION">
+      <description>Vibration levels and accelerometer clipping</description>
+      <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
+      <field type="float" name="vibration_x">Vibration levels on X-axis</field>
+      <field type="float" name="vibration_y">Vibration levels on Y-axis</field>
+      <field type="float" name="vibration_z">Vibration levels on Z-axis</field>
+      <field type="uint32_t" name="clipping_0">first accelerometer clipping count</field>
+      <field type="uint32_t" name="clipping_1">second accelerometer clipping count</field>
+      <field type="uint32_t" name="clipping_2">third accelerometer clipping count</field>
+    </message>
+    <message id="242" name="HOME_POSITION">
+      <description>This message can be requested by sending the MAV_CMD_GET_HOME_POSITION command. The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The position the system will return to and land on. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
+      <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
+      <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+      <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
+      <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
+      <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
+      <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
+      <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+    </message>
+    <message id="243" name="SET_HOME_POSITION">
+      <description>The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitely set by the operator before or after. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
+      <field type="uint8_t" name="target_system">System ID.</field>
+      <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
+      <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
+      <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+      <field type="float" name="x">Local X position of this position in the local coordinate frame</field>
+      <field type="float" name="y">Local Y position of this position in the local coordinate frame</field>
+      <field type="float" name="z">Local Z position of this position in the local coordinate frame</field>
+      <field type="float[4]" name="q">World to surface normal and heading transformation of the takeoff position. Used to indicate the heading and slope of the ground</field>
+      <field type="float" name="approach_x">Local X position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <field type="float" name="approach_y">Local Y position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+      <field type="float" name="approach_z">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
+    </message>
+    <message id="244" name="MESSAGE_INTERVAL">
+      <description>This interface replaces DATA_STREAM</description>
+      <field type="uint16_t" name="message_id">The ID of the requested MAVLink message. v1.0 is limited to 254 messages.</field>
+      <field type="int32_t" name="interval_us">The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, &gt; 0 indicates the interval at which it is sent.</field>
+    </message>
+    <message id="245" name="EXTENDED_SYS_STATE">
+      <description>Provides state for additional features</description>
+      <field type="uint8_t" name="vtol_state" enum="MAV_VTOL_STATE">The VTOL state if applicable. Is set to MAV_VTOL_STATE_UNDEFINED if UAV is not in VTOL configuration.</field>
+      <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+    </message>
+    <message id="246" name="ADSB_VEHICLE">
+      <description>The location and information of an ADSB vehicle</description>
+      <field type="uint32_t" name="ICAO_address">ICAO address</field>
+      <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7</field>
+      <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7</field>
+      <field type="uint8_t" name="altitude_type" enum="ADSB_ALTITUDE_TYPE">Type from ADSB_ALTITUDE_TYPE enum</field>
+      <field type="int32_t" name="altitude">Altitude(ASL) in millimeters</field>
+      <field type="uint16_t" name="heading">Course over ground in centidegrees</field>
+      <field type="uint16_t" name="hor_velocity">The horizontal velocity in centimeters/second</field>
+      <field type="int16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
+      <field type="char[9]" name="callsign">The callsign, 8+null</field>
+      <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">Type from ADSB_EMITTER_TYPE enum</field>
+      <field type="uint8_t" name="tslc">Time since last communication in seconds</field>
+      <field type="uint16_t" name="flags" enum="ADSB_FLAGS">Flags to indicate various statuses including valid data fields</field>
+      <field type="uint16_t" name="squawk">Squawk code</field>
+    </message>
+    <message id="247" name="COLLISION">
+      <description>Information about a potential collision</description>
+      <field type="uint8_t" name="src" enum="MAV_COLLISION_SRC">Collision data source</field>
+      <field type="uint32_t" name="id">Unique identifier, domain based on src field</field>
+      <field type="uint8_t" name="action" enum="MAV_COLLISION_ACTION">Action that is being taken to avoid this collision</field>
+      <field type="uint8_t" name="threat_level" enum="MAV_COLLISION_THREAT_LEVEL">How concerned the aircraft is about this collision</field>
+      <field type="float" name="time_to_minimum_delta">Estimated time until collision occurs (seconds)</field>
+      <field type="float" name="altitude_minimum_delta">Closest vertical distance in meters between vehicle and object</field>
+      <field type="float" name="horizontal_minimum_delta">Closest horizontal distance in meteres between vehicle and object</field>
+    </message>
+    <message id="248" name="V2_EXTENSION">
+      <description>Message implementing parts of the V2 payload specs in V1 frames for transitional support.</description>
+      <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
+      <field type="uint16_t" name="message_type">A code that identifies the software component that understands this message (analogous to usb device classes or mime type strings).  If this code is less than 32768, it is considered a 'registered' protocol extension and the corresponding entry should be added to https://github.com/mavlink/mavlink/extension-message-ids.xml.  Software creators can register blocks of message IDs as needed (useful for GCS specific metadata, etc...). Message_types greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
+      <field type="uint8_t[249]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
+    </message>
+    <message id="249" name="MEMORY_VECT">
+      <description>Send raw controller memory. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+      <field type="uint16_t" name="address">Starting address of the debug variables</field>
+      <field type="uint8_t" name="ver">Version code of the type variable. 0=unknown, type ignored and assumed int16_t. 1=as below</field>
+      <field type="uint8_t" name="type">Type code of the memory variables. for ver = 1: 0=16 x int16_t, 1=16 x uint16_t, 2=16 x Q15, 3=16 x 1Q14</field>
+      <field type="int8_t[32]" name="value">Memory contents at specified address</field>
+    </message>
+    <message id="250" name="DEBUG_VECT">
+      <field type="char[10]" name="name">Name</field>
+      <field type="uint64_t" name="time_usec">Timestamp</field>
+      <field type="float" name="x">x</field>
+      <field type="float" name="y">y</field>
+      <field type="float" name="z">z</field>
+    </message>
+    <message id="251" name="NAMED_VALUE_FLOAT">
+      <description>Send a key-value pair as float. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="char[10]" name="name">Name of the debug variable</field>
+      <field type="float" name="value">Floating point value</field>
+    </message>
+    <message id="252" name="NAMED_VALUE_INT">
+      <description>Send a key-value pair as integer. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="char[10]" name="name">Name of the debug variable</field>
+      <field type="int32_t" name="value">Signed integer value</field>
+    </message>
+    <message id="253" name="STATUSTEXT">
+      <description>Status text message. These messages are printed in yellow in the COMM console of QGroundControl. WARNING: They consume quite some bandwidth, so use only for important status and error messages. If implemented wisely, these messages are buffered on the MCU and sent only at a limited rate (e.g. 10 Hz).</description>
+      <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424. See enum MAV_SEVERITY.</field>
+      <field type="char[50]" name="text">Status text message, without null termination character</field>
+    </message>
+    <message id="254" name="DEBUG">
+      <description>Send a debug value. The index is used to discriminate between values. These values show up in the plot of QGroundControl as DEBUG N.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="ind">index of debug variable</field>
+      <field type="float" name="value">DEBUG value</field>
+    </message>
+    <!-- messages with ID 256 and above are only available in MAVLink2 -->
+    <message id="256" name="SETUP_SIGNING">
+      <description>Setup a MAVLink2 signing key. If called with secret_key of all zero and zero initial_timestamp will disable signing</description>
+      <field type="uint8_t" name="target_system">system id of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint8_t[32]" name="secret_key">signing key</field>
+      <field type="uint64_t" name="initial_timestamp">initial timestamp</field>
+    </message>
+    <message id="257" name="BUTTON_CHANGE">
+      <description>Report button state change</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field name="last_change_ms" type="uint32_t">Time of last change of button state</field>
+      <field name="state" type="uint8_t">Bitmap state of buttons</field>
+    </message>
+    <message id="258" name="PLAY_TUNE">
+      <description>Control vehicle tone generation (buzzer)</description>
+      <field name="target_system" type="uint8_t">System ID</field>
+      <field name="target_component" type="uint8_t">Component ID</field>
+      <field name="tune" type="char[30]">tune in board specific format</field>
+    </message>
+    <message id="259" name="CAMERA_INFORMATION">
+      <description>WIP: Information about a camera</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+      <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
+      <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
+      <field type="float" name="focal_length">Focal length in mm</field>
+      <field type="float" name="sensor_size_h">Image sensor size horizontal in mm</field>
+      <field type="float" name="sensor_size_v">Image sensor size vertical in mm</field>
+      <field type="uint16_t" name="resolution_h">Image resolution in pixels horizontal</field>
+      <field type="uint16_t" name="resolution_v">Image resolution in pixels vertical</field>
+      <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
+    </message>
+    <message id="260" name="CAMERA_SETTINGS">
+      <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+      <field type="float" name="aperture">Aperture is 1/value</field>
+      <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
+      <field type="float" name="shutter_speed">Shutter speed in s</field>
+      <field type="uint8_t" name="shutter_speed_locked">Shutter speed locked (0: auto, 1: locked)</field>
+      <field type="float" name="iso_sensitivity">ISO sensitivity</field>
+      <field type="uint8_t" name="iso_sensitivity_locked">ISO sensitivity locked (0: auto, 1: locked)</field>
+      <field type="float" name="white_balance">Color temperature in K</field>
+      <field type="uint8_t" name="white_balance_locked">Color temperature locked (0: auto, 1: locked)</field>
+      <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
+      <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
+      <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
+    </message>
+    <message id="261" name="STORAGE_INFORMATION">
+      <description>WIP: Information about a storage medium</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
+      <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
+      <field type="float" name="total_capacity">Total capacity in MiB</field>
+      <field type="float" name="used_capacity">Used capacity in MiB</field>
+      <field type="float" name="available_capacity">Available capacity in MiB</field>
+      <field type="float" name="read_speed">Read speed in MiB/s</field>
+      <field type="float" name="write_speed">Write speed in MiB/s</field>
+    </message>
+    <message id="262" name="CAMERA_CAPTURE_STATUS">
+      <description>WIP: Information about the status of a capture</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+      <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
+      <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
+      <field type="float" name="image_interval">Image capture interval in seconds</field>
+      <field type="float" name="video_framerate">Video frame rate in Hz</field>
+      <field type="uint16_t" name="image_resolution_h">Image resolution in pixels horizontal</field>
+      <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
+      <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
+      <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
+      <field type="uint32_t" name="recording_time_ms">Time in milliseconds since recording started</field>
+      <field type="float" name="available_capacity">Available storage capacity in MiB</field>
+    </message>
+    <message id="263" name="CAMERA_IMAGE_CAPTURED">
+      <description>WIP: Information about a captured image</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
+      <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+      <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7 where image was taken</field>
+      <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7 where capture was taken</field>
+      <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
+      <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
+      <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
+      <field type="int32_t" name="image_index">Zero based index of this image (image count since armed -1)</field>
+      <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
+      <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
+    </message>
+    <message id="264" name="FLIGHT_INFORMATION">
+      <description>WIP: Information about flight since last arming</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint64_t" name="arming_time_utc">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+      <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+      <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
+    </message>
+    <message id="265" name="MOUNT_ORIENTATION">
+      <description>WIP: Orientation of a mount</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float" name="roll">Roll in degrees</field>
+      <field type="float" name="pitch">Pitch in degrees</field>
+      <field type="float" name="yaw">Yaw in degrees</field>
+    </message>
+    <message id="266" name="LOGGING_DATA">
+      <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>
+      <field type="uint8_t" name="target_system">system ID of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
+      <field type="uint8_t" name="length">data length</field>
+      <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
+      <field type="uint8_t[249]" name="data">logged data</field>
+    </message>
+    <message id="267" name="LOGGING_DATA_ACKED">
+      <description>A message containing logged data which requires a LOGGING_ACK to be sent back</description>
+      <field type="uint8_t" name="target_system">system ID of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint16_t" name="sequence">sequence number (can wrap)</field>
+      <field type="uint8_t" name="length">data length</field>
+      <field type="uint8_t" name="first_message_offset">offset into data where first message starts. This can be used for recovery, when a previous message got lost (set to 255 if no start exists).</field>
+      <field type="uint8_t[249]" name="data">logged data</field>
+    </message>
+    <message id="268" name="LOGGING_ACK">
+      <description>An ack for a LOGGING_DATA_ACKED message</description>
+      <field type="uint8_t" name="target_system">system ID of the target</field>
+      <field type="uint8_t" name="target_component">component ID of the target</field>
+      <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
+    </message>
+  </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3713,7 +3713,7 @@
         </message>
     <message id="235" name="MIXER_PARAM_VALUE">
       <description>Mixer parameter values emitted after a read or set request</description>
-      <field type="uint16_t" name="count">Total number of onboard parameters</field>
+      <field type="int16_t" name="count">Total number of onboard parameters</field>
       <field type="uint16_t" name="index">Index of this onboard parameter</field>      
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
       <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
@@ -3722,7 +3722,6 @@
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
       <field type="uint8_t" name="param_array_size">Size of the array for this parameter</field>
-      <field type="uint8_t" name="param_array_index">Array index to support oversized arrays</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
       <field type="float[6]" name="param_values">Array of parameter values</field>
     </message>
@@ -3737,8 +3736,6 @@
       <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>      
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-      <field type="uint8_t" name="param_array_write_count">Count of array values to write</field>
-      <field type="uint8_t" name="param_array_index">Array index</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
       <field type="float[6]" name="param_values">Array of parameter values</field>
     </message>    
@@ -3752,7 +3749,6 @@
       <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-      <field type="uint8_t" name="param_array_index">Array index</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
     </message>    
         <message id="241" name="VIBRATION">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1466,29 +1466,9 @@
                   <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
               </entry>
 
-      <entry value="4100" name="MAV_CMD_REQUEST_MIXER_PARAM_READ">
-        <description>Request to send mixer data in a group and a given mixer, submixer, type and parameter index.
-        </description>
-        <param index="1">Index</param>
-        <param index="2">Mixer Group</param>
-        <param index="3">Mixer Index</param>
-        <param index="4">Submixer Index</param>
-        <param index="5">Parameter Index</param>
-      </entry>
       <entry value="4101" name="MAV_CMD_REQUEST_MIXER_PARAM_LIST">
         <description>Request to send a list of all mixer data.</description>
         <param index="1">Mixer Group</param>
-      </entry>
-      <entry value="4102" name="MAV_CMD_SET_MIXER_PARAM">
-        <description>Request to set mixer parameter by index or by mixer and parameter address
-        </description>
-        <param index="1">Index</param>
-        <param index="2">Mixer Group</param>
-        <param index="3">Mixer Index</param>
-        <param index="4">Submixer Index</param>
-        <param index="5">Parameter Index</param>
-        <param index="6">Parameter array index</param>
-        <param index="7">Parameter</param>
       </entry>
       <entry value="4103" name="MAV_CMD_SAVE_MIXER_PARAMS">
         <description>Save mixer parameters</description>
@@ -2409,33 +2389,6 @@
                   <description>Static fixed, typically used for base stations</description>
               </entry>
           </enum>
-         <enum name="MIXER_DATA_TYPE">
-           <description>Mixer data type</description>
-           <entry value="0" name="MIXER_DATA_TYPE_MIXER_COUNT">
-             <description>Mixer count at a given group</description>
-           </entry>
-           <entry value="1" name="MIXER_DATA_TYPE_SUBMIXER_COUNT">
-             <description>Submixer count at a given group and mixer</description>
-           </entry>
-           <entry value="2" name="MIXER_DATA_TYPE_MIXTYPE">
-             <description>Mixer type at a given group, mixer and submixer</description>
-           </entry>
-           <entry value="3" name="MIXER_DATA_TYPE_PARAMETER">
-             <description>Parameter at a given group, mixer, submixer and parameter index</description>
-           </entry>
-           <entry value="4" name="MIXER_DATA_TYPE_CONNECTION">
-             <description>Parameter at a given group, mixer, submixer, connection type and connection index</description>
-           </entry>
-           <entry value="5" name="MIXER_DATA_TYPE_PARAMETER_COUNT">
-             <description>Parameter count at a given group, mixer and submixer</description>
-           </entry>
-           <entry value="6" name="MIXER_DATA_TYPE_CONNECTION_COUNT">
-             <description>Parameter at a given group, mixer, submixer and connection type</description>
-           </entry>
-           <entry value="7" name="MIXER_DATA_TYPE_GROUP_TYPE">
-             <description>The mixer type for a particular mixer group</description>
-           </entry>
-         </enum>
    <enum name="MIXER_GROUP">
       <description>Identifies a set of mixers to access</description>
       <entry value="0" name="MIXER_GROUP_NONE">
@@ -3758,8 +3711,8 @@
             <field name="wp_num" type="uint8_t">current waypoint number</field>
             <field name="wp_distance" type="uint16_t">distance to target (meters)</field>
         </message>
-    <message id="235" name="MIXER_PARAMETER">
-      <description>Mixer paraemter emitted after a read or set request</description>
+    <message id="235" name="MIXER_PARAM_VALUE">
+      <description>Mixer parameter values emitted after a read or set request</description>
       <field type="uint16_t" name="count">Total number of onboard parameters</field>
       <field type="uint16_t" name="index">Index of this onboard parameter</field>      
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
@@ -3769,10 +3722,39 @@
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
       <field type="uint8_t" name="param_array_size">Size of the array for this parameter</field>
+      <field type="uint8_t" name="param_array_index">Array index to support oversized arrays</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="float[8]" name="param_values">Array of parameter values</field>
+      <field type="float[6]" name="param_values">Array of parameter values</field>
+    </message>
+    <message id="236" name="MIXER_PARAM_SET">
+      <description>Mixer paraemter values to set</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>      
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
+      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
+      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>      
+      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="uint8_t" name="param_array_write_count">Count of array values to write</field>
+      <field type="uint8_t" name="param_array_index">Array index</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float[6]" name="param_values">Array of parameter values</field>
     </message>    
-
+    <message id="237" name="MIXER_PARAM_REQUEST_READ">
+      <description>Mixer paraemter values to set</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>      
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
+      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
+      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="uint8_t" name="param_array_index">Array index</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+    </message>    
         <message id="241" name="VIBRATION">
             <description>Vibration levels and accelerometer clipping</description>
             <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>


### PR DESCRIPTION
**BENEFITS**
Enables downloading and editing of a mixer specific list of parameters.  This parameter list is dynamic according to mixer configuration.

**FEATURES**
- Enables downloading and modifying parameters associated with mixers.  
- Parameters are indexed and named items with mixer metadata. 
- Parameters are accessed through index since names can be repeated
- Parameters value are arrays of  the same type with length up to 6 (fits in <64byte mavlink packet).
- Parameters with zero length can be used as name tags
- Parameters can be read only which is set through flags
    Enables transfer of connection data
- Metadata is optional depending on the particular implementation

[Description document](https://docs.google.com/document/d/1LeQC2qtxqdesNuJ3RAWH_MJ_30xjf-PMN3bd5wtUAUo/edit)

**NOTE**
The merges were clobbered by xml reformatting which makes them difficult.  Diff between PR branch and upstream master is looking clean.

This is a reopening of an old PR that won't reopen
[Old PR](https://github.com/mavlink/mavlink/pull/676)

Has PX4 Firmware, MAVProxy module and QGroundControl support in PRs.  Those PRs are waiting for this PR.
[PX4 Firmware PR](https://github.com/PX4/Firmware/pulls)
[QGroundControl PR](https://github.com/mavlink/qgroundcontrol/pull/4727)
[MAVProxy module PR](https://github.com/ArduPilot/MAVProxy/pull/399)
There is no support for Ardupilot since it does not yet have the scripted mixers that benefit from it.  That is only a matter of time.

**TODO**
Complete