### PR TITLE
Add spec for NaN on yaw angle

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -593,7 +593,7 @@
         <param index="1">Hold time in decimal seconds. (ignored by fixed wing, time to stay at MISSION for rotary wing)</param>
         <param index="2">Acceptance radius in meters (if the sphere with this radius is hit, the MISSION counts as reached)</param>
         <param index="3">0 to pass through the WP, if &gt; 0 radius in meters to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
-        <param index="4">Desired yaw angle at MISSION (rotary wing)</param>
+        <param index="4">Desired yaw angle at MISSION (rotary wing). NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
         <param index="7">Altitude</param>
@@ -643,7 +643,7 @@
         <param index="1">Abort Alt</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
-        <param index="4">Desired yaw angle</param>
+        <param index="4">Desired yaw angle. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
         <param index="7">Altitude</param>
@@ -653,7 +653,7 @@
         <param index="1">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
-        <param index="4">Yaw angle (if magnetometer present), ignored without magnetometer</param>
+        <param index="4">Yaw angle (if magnetometer present), ignored without magnetometer. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
         <param index="7">Altitude</param>
@@ -763,7 +763,7 @@
         <param index="1">Empty</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
-        <param index="4">Yaw angle in degrees</param>
+        <param index="4">Yaw angle in degrees. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
         <param index="7">Altitude</param>
@@ -773,7 +773,7 @@
         <param index="1">Empty</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
-        <param index="4">Yaw angle in degrees</param>
+        <param index="4">Yaw angle in degrees. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
         <param index="7">Altitude</param>


### PR DESCRIPTION
This specifies that NaN for yaw on these commands means no change in yaw:
```
MAV_CMD_NAV_WAYPOINT
MAV_CMD_NAV_LAND
MAV_CMD_NAV_TAKEOFF
MAV_CMD_NAV_VTOL_TAKEOFF
MAV_CMD_NAV_VTOL_LAND
```

This is the way PX4 Pro works. I believe that for a number of these, ArduPilot does not support the Yaw field. Can this be checked to work on ArduPilot as well. This allows for things like running a survey at a fixed yaw angle (relative to ground, not vehicle) without needing to specify yaw on every single waypoint in the survey as an example.

@tridge Can someone on the ArduPilot side help out with verification?