### PR TITLE
add time_boot_ms to GLOBAL_ORIGIN msgs

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2767,17 +2767,19 @@
     <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
       <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
       <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84), in degrees * 1E7</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84, in degrees * 1E7</field>
       <field type="int32_t" name="altitude" units="mm">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+      <extensions/>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
     </message>
     <message id="49" name="GPS_GLOBAL_ORIGIN">
       <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
-      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84), in degrees * 1E7</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84), in degrees * 1E7</field>
       <field type="int32_t" name="altitude" units="mm">Altitude (AMSL), in meters * 1000 (positive for up)</field>
+      <extensions/>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
     </message>
     <message id="50" name="PARAM_MAP_RC">
       <description>Bind a RC channel to a parameter. The parameter should change accoding to the RC channel value.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2764,12 +2764,14 @@
     <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
       <description>As local waypoints exist, the global MISSION reference allows to transform between the local coordinate frame and the global (GPS) coordinate frame. This can be necessary when e.g. in- and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
       <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
       <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
       <field type="int32_t" name="longitude">Longitude (WGS84, in degrees * 1E7</field>
       <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>
     </message>
     <message id="49" name="GPS_GLOBAL_ORIGIN">
       <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp in milliseconds since system boot</field>
       <field type="int32_t" name="latitude">Latitude (WGS84), in degrees * 1E7</field>
       <field type="int32_t" name="longitude">Longitude (WGS84), in degrees * 1E7</field>
       <field type="int32_t" name="altitude">Altitude (AMSL), in meters * 1000 (positive for up)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2771,7 +2771,7 @@
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84, in degrees * 1E7</field>
       <field type="int32_t" name="altitude" units="mm">Altitude (AMSL), in meters * 1000 (positive for up)</field>
       <extensions/>
-      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
     </message>
     <message id="49" name="GPS_GLOBAL_ORIGIN">
       <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
@@ -2779,7 +2779,7 @@
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84), in degrees * 1E7</field>
       <field type="int32_t" name="altitude" units="mm">Altitude (AMSL), in meters * 1000 (positive for up)</field>
       <extensions/>
-      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (microseconds since UNIX epoch or microseconds since system boot)</field>
     </message>
     <message id="50" name="PARAM_MAP_RC">
       <description>Bind a RC channel to a parameter. The parameter should change accoding to the RC channel value.</description>


### PR DESCRIPTION
This allows the companion computer system to properly sync when the global origin changes (for advanced navigation between indoor and outdoor environments).