### PR TITLE
Remove WIP label from GPS_RTCM_DATA

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3719,7 +3719,7 @@
       <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
     </message>
     <message id="233" name="GPS_RTCM_DATA">
-      <description>WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)</description>
+      <description>RTCM message for injecting into the onboard GPS (used for DGPS)</description>
       <field type="uint8_t" name="flags">LSB: 1 means message is fragmented, next 2 bits are the fragment ID, the remaining 5 bits are used for the sequence ID. Messages are only to be flushed to the GPS when the entire message has been reconstructed on the autopilot. The fragment ID specifies which order the fragments should be assembled into a buffer, while the sequence ID is used to detect a mismatch between different buffers. The buffer is considered fully reconstructed when either all 4 fragments are present, or all the fragments before the first fragment with a non full payload is received. This management is used to ensure that normal GPS operation doesn't corrupt RTCM data, and to recover from a unreliable transport delivery order.</field>
       <field type="uint8_t" name="len">data length</field>
       <field type="uint8_t[180]" name="data">RTCM message (may be fragmented)</field>


### PR DESCRIPTION
GPS_RTCM_DATA is used in releases, and is no longer a WIP message.