### PR TITLE
mavlink_defs: image quality, metering, flicker

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1347,6 +1347,16 @@
         <param index="4">Reserved for camera mode ID</param>
         <param index="5">Reserved for color mode ID</param>
         <param index="6">Reserved for image format ID</param>
+        <param index="7">Reserved for image quality ID</param>
+      </entry>
+      <entry value="529" name="MAV_CMD_SET_CAMERA_SETTINGS_3">
+        <description>WIP: Set the camera settings part 3 (CAMERA_SETTINGS)</description>
+        <param index="1">Camera ID</param>
+        <param index="2">Reserved for metering mode ID</param>
+        <param index="3">Reserved for flicker mode ID</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
         <param index="7">Reserved</param>
       </entry>
       <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
@@ -3926,6 +3936,9 @@
       <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
       <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
       <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
+      <field type="uint8_t" name="image_quality_id">Reserved for image quality ID</field>
+      <field type="uint8_t" name="metering_mode_id">Reserved for metering mode ID</field>
+      <field type="uint8_t" name="flicker_mode_id">Reserved for flicker mode ID</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
       <description>WIP: Information about a storage medium</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3908,7 +3908,7 @@
       <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
-      <field type="uint8_t[16]" name="firmware_version">Version of the camera firmware</field>
+      <field type="uint32_t" name="firmware_version">Version of the camera firmware</field>
       <field type="float" name="focal_length" units="mm">Focal length in mm</field>
       <field type="float" name="sensor_size_h" units="mm">Image sensor size horizontal in mm</field>
       <field type="float" name="sensor_size_v" units="mm">Image sensor size vertical in mm</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1357,7 +1357,7 @@
         <param index="4">Reserved</param>
         <param index="5">Reserved</param>
         <param index="6">Reserved</param>
-        <param index="7">Reserved</param>
+        <param index="7">1: reset all camera settings, 0: no action.</param>
       </entry>
       <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
         <description>WIP: Request storage information (STORAGE_INFORMATION)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1330,34 +1330,24 @@
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS_1">
-        <description>WIP: Set the camera settings part 1 (CAMERA_SETTINGS)</description>
+        <description>WIP: Set the camera settings part 1 (CAMERA_SETTINGS). Use NAN for values you don't want to change.</description>
         <param index="1">Camera ID</param>
         <param index="2">Aperture (1/value)</param>
-        <param index="3">Aperture locked (0: auto, 1: locked)</param>
-        <param index="4">Shutter speed in s</param>
-        <param index="5">Shutter speed locked (0: auto, 1: locked)</param>
-        <param index="6">ISO sensitivity</param>
-        <param index="7">ISO sensitivity locked (0: auto, 1: locked)</param>
+        <param index="3">Shutter speed in s</param>
+        <param index="4">ISO sensitivity</param>
+        <param index="5">AE mode (Auto Exposure) (0: full auto 1: full manual 2: aperture priority 3: shutter priority)</param>
+        <param index="6">EV value (when in auto exposure)</param>
+        <param index="7">White balance (color temperature in K) (0: Auto WB)</param>
       </entry>
       <entry value="524" name="MAV_CMD_SET_CAMERA_SETTINGS_2">
-        <description>WIP: Set the camera settings part 2 (CAMERA_SETTINGS)</description>
+        <description>WIP: Set the camera settings part 2 (CAMERA_SETTINGS). Use NAN for values you don't want to change.</description>
         <param index="1">Camera ID</param>
-        <param index="2">White balance locked (0: auto, 1: locked)</param>
-        <param index="3">White balance (color temperature in K)</param>
-        <param index="4">Reserved for camera mode ID</param>
-        <param index="5">Reserved for color mode ID</param>
-        <param index="6">Reserved for image format ID</param>
-        <param index="7">Reserved for image quality ID</param>
-      </entry>
-      <entry value="529" name="MAV_CMD_SET_CAMERA_SETTINGS_3">
-        <description>WIP: Set the camera settings part 3 (CAMERA_SETTINGS)</description>
-        <param index="1">Camera ID</param>
-        <param index="2">Reserved for metering mode ID</param>
-        <param index="3">Reserved for flicker mode ID</param>
-        <param index="4">Reserved</param>
-        <param index="5">Reserved</param>
-        <param index="6">Reserved</param>
-        <param index="7">1: reset all camera settings, 0: no action.</param>
+        <param index="2">Camera mode (0: photo, 1: video)</param>
+        <param index="3">Audio recording enabled (0: off 1: on)</param>
+        <param index="4">Reserved for metering mode ID (Average, Center, Spot, etc.)</param>
+        <param index="5">Reserved for image format ID (Jpeg/Raw/Jpeg+Raw)</param>
+        <param index="6">Reserved for image quality ID (Compression)</param>
+        <param index="7">Reserved for color mode ID (Neutral, Vivid, etc.)</param>
       </entry>
       <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
         <description>WIP: Request storage information (STORAGE_INFORMATION)</description>
@@ -1367,14 +1357,14 @@
       </entry>
       <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
         <description>WIP: Format a storage medium</description>
-        <param index="1">1: Format storage</param>
-        <param index="2">Storage ID</param>
+        <param index="1">Storage ID</param>
+        <param index="2">0: No action 1: Format storage</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
         <description>WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
-        <param index="1">1: Request camera capture status</param>
-        <param index="2">Camera ID</param>
+        <param index="1">Camera ID</param>
+        <param index="2">0: No Action 1: Request camera capture status</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
@@ -1382,18 +1372,23 @@
         <param index="1">1: Request flight information</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
+      <entry value="529" name="MAV_CMD_RESET_CAMERA_SETTINGS">
+        <description>WIP: Reset all camera settings to Factory Default (CAMERA_SETTINGS)</description>
+        <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
+        <param index="2">0: No Action 1: Reset all settings</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
-        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture.</description>
-        <param index="1">Duration between two consecutive pictures (in seconds)</param>
-        <param index="2">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
-        <param index="4">WIP: Resolution horizontal in pixels</param>
-        <param index="5">WIP: Resolution horizontal in pixels</param>
-        <param index="6">WIP: Camera ID</param>
+        <description>WIP: Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture.</description>
+        <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
+        <param index="2">Duration between two consecutive pictures (in seconds)</param>
+        <param index="3">Number of images to capture total - 0 for unlimited capture</param>
+        <param index="4">Resolution horizontal in pixels (set to -1 for highest resolution possible)</param>
+        <param index="5">Resolution vertical in pixels (set to -1 for highest resolution possible)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
-        <description>Stop image capture sequence</description>
-        <param index="1">Camera ID</param>
+        <description>WIP: Stop image capture sequence</description>
+        <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
         <param index="2">Reserved</param>
       </entry>
       <entry value="2003" name="MAV_CMD_DO_TRIGGER_CONTROL">
@@ -1403,17 +1398,16 @@
         <param index="3">Reserved</param>
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
-        <description>Starts video capture (recording)</description>
+        <description>WIP: Starts video capture (recording)</description>
         <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
         <param index="2">Frames per second, set to -1 for highest framerate possible.</param>
-        <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used, set to -1 for highest resolution possible.</param>
-        <param index="4">WIP: Resolution horizontal in pixels</param>
-        <param index="5">WIP: Resolution horizontal in pixels</param>
-        <param index="6">WIP: Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise time in Hz)</param>
+        <param index="3">Resolution horizontal in pixels (set to -1 for highest resolution possible)</param>
+        <param index="4">Resolution vertical in pixels (set to -1 for highest resolution possible)</param>
+        <param index="5">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise time in Hz)</param>
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
-        <description>Stop the current video capture (recording)</description>
-        <param index="1">WIP: Camera ID</param>
+        <description>WIP: Stop the current video capture (recording)</description>
+        <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
         <param index="2">Reserved</param>
       </entry>
       <entry value="2510" name="MAV_CMD_LOGGING_START">
@@ -3914,31 +3908,30 @@
       <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
+      <field type="uint8_t[16]" name="firmware_version">Version of the camera firmware</field>
       <field type="float" name="focal_length" units="mm">Focal length in mm</field>
       <field type="float" name="sensor_size_h" units="mm">Image sensor size horizontal in mm</field>
       <field type="float" name="sensor_size_v" units="mm">Image sensor size vertical in mm</field>
       <field type="uint16_t" name="resolution_h" units="pix">Image resolution in pixels horizontal</field>
       <field type="uint16_t" name="resolution_v" units="pix">Image resolution in pixels vertical</field>
-      <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
+      <field type="uint8_t" name="lens_id">Reserved for a lens ID</field>
     </message>
     <message id="260" name="CAMERA_SETTINGS">
       <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+      <field type="uint8_t" name="exposure_mode">0: full auto 1: full manual 2: aperture priority 3: shutter priority</field>
       <field type="float" name="aperture">Aperture is 1/value</field>
-      <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
       <field type="float" name="shutter_speed" units="s">Shutter speed in s</field>
-      <field type="uint8_t" name="shutter_speed_locked">Shutter speed locked (0: auto, 1: locked)</field>
       <field type="float" name="iso_sensitivity">ISO sensitivity</field>
-      <field type="uint8_t" name="iso_sensitivity_locked">ISO sensitivity locked (0: auto, 1: locked)</field>
-      <field type="float" name="white_balance" units="K">Color temperature in degrees Kelvin</field>
-      <field type="uint8_t" name="white_balance_locked">Color temperature locked (0: auto, 1: locked)</field>
-      <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
-      <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
-      <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
-      <field type="uint8_t" name="image_quality_id">Reserved for image quality ID</field>
-      <field type="uint8_t" name="metering_mode_id">Reserved for metering mode ID</field>
-      <field type="uint8_t" name="flicker_mode_id">Reserved for flicker mode ID</field>
+      <field type="float" name="ev">Exposure Value</field>
+      <field type="float" name="white_balance" units="K">Color temperature in degrees Kelvin. (0: Auto WB)</field>
+      <field type="uint8_t" name="mode_id">Reserved for a camera mode ID. (0: Photo 1: Video)</field>
+      <field type="uint8_t" name="audio_recording">Audio recording enabled (0: off 1: on)</field>
+      <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID (Neutral, Vivid, etc.)</field>
+      <field type="uint8_t" name="image_format_id">Reserved for image format ID (Jpeg/Raw/Jpeg+Raw)</field>
+      <field type="uint8_t" name="image_quality_id">Reserved for image quality ID (Compression)</field>
+      <field type="uint8_t" name="metering_mode_id">Reserved for metering mode ID (Average, Center, Spot, etc.)</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
       <description>WIP: Information about a storage medium</description>


### PR DESCRIPTION
This adds more camera settings:
- image quality ID (e.g. for JPG this could translate to 0-100)
- metering mode ID (this is for different metering modes specific to a
  camera)
- flicker mode ID (this is for different flicker modes, also specific to
  a camera.