### PR TITLE
Mixer parameter tuning

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1465,6 +1465,14 @@
         <param index="5">Unscaled target latitude of center of circle in CIRCLE_MODE</param>
         <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
       </entry>
+      <entry value="4101" name="MAV_CMD_REQUEST_MIXER_PARAM_LIST">
+        <description>Request to send a list of all mixer data.</description>
+        <param index="1">Mixer Group</param>
+      </entry>
+      <entry value="4102" name="MAV_CMD_SAVE_MIXER_PARAMS">
+        <description>Save mixer parameters</description>
+        <param index="1">Mixer Group</param>
+      </entry>
       <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT">
         <description>Fence return point. There can only be one fence return point.
         </description>
@@ -2432,6 +2440,33 @@
       </entry>
       <entry value="7" name="GPS_FIX_TYPE_STATIC">
         <description>Static fixed, typically used for base stations</description>
+      </entry>
+    </enum>
+    <enum name="MIXER_GROUP">
+      <description>Identifies a set of mixers to access</description>
+      <entry value="0" name="MIXER_GROUP_NONE">
+        <description>No specific group selected</description>
+      </entry>
+      <entry value="1" name="MIXER_GROUP_LOCAL">
+        <description>Mixers on the local processor</description>
+      </entry>
+      <entry value="2" name="MIXER_GROUP_FAILSAFE">
+        <description>Mixers on a failsafe device</description>
+      </entry>
+    </enum>
+    <enum name="MIXER_PARAM_FLAGS">
+      <description>Flags for different parameter qualities and states</description>
+      <entry value="1" name="MIXER_PARAM_FLAG_READ_ONLY">
+        <description>Parameter is read only</description>
+      </entry>
+      <entry value="2" name="MIXER_PARAM_FLAG_MIX_CONN">
+        <description>Parameter is describing a mixer connection to a group</description>
+      </entry>
+      <entry value="4" name="MIXER_PARAM_FLAG_TYPE">
+        <description>Parameter is describing a mixer type</description>
+      </entry>
+      <entry value="8" name="MIXER_PARAM_FLAG_CONN_GROUP">
+        <description>Parameter is describing a connection group</description>
       </entry>
     </enum>
   </enums>
@@ -3763,6 +3798,47 @@
       <field type="uint8_t" name="failsafe">failsafe (each bit represents a failsafe where 0=ok, 1=failsafe active (bit0:RC, bit1:batt, bit2:GPS, bit3:GCS, bit4:fence)</field>
       <field type="uint8_t" name="wp_num">current waypoint number</field>
       <field type="uint16_t" name="wp_distance" units="m">distance to target (meters)</field>
+    </message>
+    <message id="235" name="MIXER_PARAM_VALUE">
+      <description>Mixer parameter values emitted after a read or set request</description>
+      <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
+      <field type="int16_t" name="count">Total number of onboard parameters</field>
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
+      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
+      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>
+      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="uint8_t" name="param_array_size">Size of the array for this parameter</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float[6]" name="param_values">Array of parameter values</field>
+    </message>
+    <message id="236" name="MIXER_PARAM_SET">
+      <description>Mixer paraemter values to set</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
+      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
+      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>
+      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float[6]" name="param_values">Array of parameter values</field>
+    </message>
+    <message id="237" name="MIXER_PARAM_REQUEST_READ">
+      <description>Mixer paraemter values to set</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="index">Index of this onboard parameter</field>
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
+      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
+      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
     </message>
     <message id="241" name="VIBRATION">
       <description>Vibration levels and accelerometer clipping</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4098,6 +4098,6 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
       <field type="uint16_t" name="index">Index of the parameter in the group</field>
-    </message>    
+    </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2459,6 +2459,9 @@
       <entry value="1" name="MIXER_PARAM_FLAG_READ_ONLY">
         <description>Parameter is read only</description>
       </entry>
+      <entry value="64" name="MIXER_PARAM_FLAG_ERROR">
+        <description>Value is in error.  Error code can be returned in value[0]}</description>
+      </entry>
     </enum>
     <enum name="MIXER_PARAM_TYPE">
       <description>Flags for different parameter data types</description>
@@ -3817,7 +3820,7 @@
     <message id="235" name="MIXER_PARAM_VALUE">
       <description>Mixer parameter values emitted after a read or set request</description>
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
-      <field type="int16_t" name="count">Total number of parameters in the group</field>
+      <field type="uint16_t" name="count">Total number of parameters in the group</field>
       <field type="uint16_t" name="index">Index of the parameter in the group</field>
       <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
       <field type="uint8_t" name="type" enum="MIXER_PARAM_TYPE">Type of the parameter - Used for connections, mixer names etc..</field>
@@ -3826,8 +3829,8 @@
       <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-      <field type="uint8_t" name="param_array_size">Size of the array for this parameter</field>
-      <field type="char[20]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 20 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="uint8_t" name="param_array_size">Size of the array for this parameter.  Cannot be more than 8</field>
+      <field type="char[20]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 20 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 20 chars - applications have to provide 20+1 bytes storage if the ID is stored as string</field>
       <field type="float[8]" name="param_values">Array of parameter values</field>
     </message>
     <message id="236" name="MIXER_PARAM_SET">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2463,28 +2463,28 @@
         <description>Value is in error.  Error code can be returned in value[0]}</description>
       </entry>
     </enum>
-    <enum name="MIXER_PARAM_TYPE">
+    <enum name="MIXER_PARAM_MSG_TYPE">
       <description>Flags for different parameter data types</description>
-      <entry value="0" name="MIXER_PARAM_TYPE_PARAMETER">
+      <entry value="0" name="MIXER_PARAM_MSG_TYPE_PARAMETER">
         <description>Parameter is a standard parameter value</description>
       </entry>
-      <entry value="1" name="MIXER_PARAM_TYPE_CAPABILITY">
-        <description>Parameter is describing capabilities of the mixer. values[0] as a uint bitfield type. Name describes the mixer type</description>
+      <entry value="1" name="MIXER_PARAM_MSG_TYPE_CAPABILITY">
+        <description>Parameter is describing capabilities of the mixer. param_id is "CAPABILITY". default is values[0] as a uint bitfield type.</description>
       </entry>
-      <entry value="2" name="MIXER_PARAM_TYPE_CONFIGURATION">
-        <description>Parameter configuring the mixer. default name is CONFIG. default is values[0] as a uint bitfield type</description>
+      <entry value="2" name="MIXER_PARAM_MSGTYPE_CONFIGURATION">
+        <description>Parameter configuring the mixer. param_id is "CONFIG". default is values[0] as a uint bitfield type</description>
       </entry>
-      <entry value="3" name="MIXER_PARAM_TYPE_MIX_CONN">
+      <entry value="3" name="MIXER_PARAM_MSG_TYPE_MIX_CONN">
         <description>Parameter is describing a mixer connection to a group.  Values[0] is the group index. Values[1] is the index into the group</description>
       </entry>
-      <entry value="4" name="MIXER_PARAM_FLAG_CONN_GROUP">
-        <description>Parameter is describing a connection group. Read only. Values[0] is group size. Values[1] is the group size</description>
+      <entry value="4" name="MIXER_PARAM_MSG_FLAG_CONN_GROUP">
+        <description>Parameter is describing a connection group. Read only. param_id is group name. Values[0] is group size. Values[1] is the group size</description>
       </entry>
-      <entry value="5" name="MIXER_PARAM_TYPE_MIXTYPE">
-        <description>Parameter is describing a mixer type. Name is the script name of the mixer.  mixer_type is the mixer enumeration at the AP</description>
+      <entry value="5" name="MIXER_PARAM_MSG_TYPE_MIXTYPE">
+        <description>Parameter is describing a mixer type. param_id is the name of the mixer.  Values[0] is the mixer enumeration at the AP. </description>
       </entry>
-      <entry value="6" name="MIXER_PARAM_TYPE_MIX_NAME">
-        <description>Parameter is a name for a mixer.  Should have zero data length</description>
+      <entry value="6" name="MIXER_PARAM_MSG_TYPE_MIX_NAME">
+        <description>Parameter is an assigned name for a mixer other than its functional mixer name.  param_id is the name tag.  Should have zero data length</description>
       </entry>
     </enum>
   </enums>
@@ -3823,11 +3823,9 @@
       <field type="uint16_t" name="count">Total number of parameters in the group</field>
       <field type="uint16_t" name="index">Index of the parameter in the group</field>
       <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
-      <field type="uint8_t" name="type" enum="MIXER_PARAM_TYPE">Type of the parameter - Used for connections, mixer names etc..</field>
+      <field type="uint8_t" name="type" enum="MIXER_PARAM_MSG_TYPE">Type of the parameter - Used for connections, mixer names etc..</field>
       <field type="uint16_t" name="mixer_index">Index of the mixer in the mixer collection</field>
       <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
-      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>
-      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
       <field type="uint8_t" name="param_array_size">Size of the array for this parameter.  Cannot be more than 8</field>
       <field type="char[20]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 20 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 20 chars - applications have to provide 20+1 bytes storage if the ID is stored as string</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2475,16 +2475,19 @@
         <description>Parameter configuring the mixer. param_id is "CONFIG". default is values[0] as a uint bitfield type</description>
       </entry>
       <entry value="3" name="MIXER_PARAM_MSG_TYPE_MIX_CONN">
-        <description>Parameter is describing a mixer connection to a group.  Values[0] is the group index. Values[1] is the index into the group</description>
+        <description>Parameter is describing a mixer connection to a group.  param_id is the connection type (Input/output). Values[0] is the group index. Values[1] is the index into the group</description>
       </entry>
       <entry value="4" name="MIXER_PARAM_MSG_FLAG_CONN_GROUP">
-        <description>Parameter is describing a connection group. Read only. param_id is group name. Values[0] is group size. Values[1] is the group size</description>
+        <description>Parameter is describing a connection group. Read only. param_id is group name. Values[0] is group index. Values[1] is the group size</description>
       </entry>
       <entry value="5" name="MIXER_PARAM_MSG_TYPE_MIXTYPE">
-        <description>Parameter is describing a mixer type. param_id is the name of the mixer.  Values[0] is the mixer enumeration at the AP. </description>
+        <description>Parameter is describing a mixer type. param_id is the name of the mixer.  Should have zero data length</description>
       </entry>
       <entry value="6" name="MIXER_PARAM_MSG_TYPE_MIX_NAME">
         <description>Parameter is an assigned name for a mixer other than its functional mixer name.  param_id is the name tag.  Should have zero data length</description>
+      </entry>
+      <entry value="7" name="MIXER_PARAM_MSG_TYPE_CHECKSUM">
+        <description>Parameter is checksum of the mixer config script.  param_id is normally "CHECKSUM_SCRIPT" but can describe other checksums.  Values[0] is normally uint CRC16 checksum</description>
       </entry>
     </enum>
   </enums>
@@ -3817,36 +3820,6 @@
       <field type="uint8_t" name="wp_num">current waypoint number</field>
       <field type="uint16_t" name="wp_distance" units="m">distance to target (meters)</field>
     </message>
-    <message id="235" name="MIXER_PARAM_VALUE">
-      <description>Mixer parameter values emitted after a read or set request</description>
-      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
-      <field type="uint16_t" name="count">Total number of parameters in the group</field>
-      <field type="uint16_t" name="index">Index of the parameter in the group</field>
-      <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
-      <field type="uint8_t" name="type" enum="MIXER_PARAM_MSG_TYPE">Type of the parameter - Used for connections, mixer names etc..</field>
-      <field type="uint16_t" name="mixer_index">Index of the mixer in the mixer collection</field>
-      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
-      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-      <field type="uint8_t" name="param_array_size">Size of the array for this parameter.  Cannot be more than 8</field>
-      <field type="char[20]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 20 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 20 chars - applications have to provide 20+1 bytes storage if the ID is stored as string</field>
-      <field type="float[8]" name="param_values">Array of parameter values</field>
-    </message>
-    <message id="236" name="MIXER_PARAM_SET">
-      <description>Mixer paraemter values to set</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
-      <field type="uint16_t" name="index">Index of the parameter in the group</field>
-      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-      <field type="float[8]" name="param_values">Array of parameter values</field>
-    </message>
-    <message id="237" name="MIXER_PARAM_REQUEST_READ">
-      <description>Mixer paraemter values to set</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
-      <field type="uint16_t" name="index">Index of the parameter in the group</field>
-    </message>
     <message id="241" name="VIBRATION">
       <description>Vibration levels and accelerometer clipping</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (micros since boot or Unix epoch)</field>
@@ -4096,5 +4069,35 @@
       <field type="uint8_t" name="target_component">component ID of the target</field>
       <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
     </message>
+    <message id="270" name="MIXER_PARAM_VALUE">
+      <description>WIP: Mixer parameter values emitted after a read or set request</description>
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="count">Total number of parameters in the group</field>
+      <field type="uint16_t" name="index">Index of the parameter in the group</field>
+      <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
+      <field type="uint8_t" name="type" enum="MIXER_PARAM_MSG_TYPE">Type of the parameter - Used for connections, mixer names etc..</field>
+      <field type="uint16_t" name="mixer_index">Index of the mixer in the mixer collection</field>
+      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="uint8_t" name="param_array_size">Size of the array for this parameter.  Cannot be more than 8</field>
+      <field type="char[20]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 20 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 20 chars - applications have to provide 20+1 bytes storage if the ID is stored as string</field>
+      <field type="float[8]" name="param_values">Array of parameter values</field>
+    </message>
+    <message id="271" name="MIXER_PARAM_SET">
+      <description>WIP: Mixer paraemter values to set</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="index">Index of the parameter in the group</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
+      <field type="float[8]" name="param_values">Array of parameter values</field>
+    </message>
+    <message id="272" name="MIXER_PARAM_REQUEST_READ">
+      <description>WIP: Mixer paraemter values to set</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
+      <field type="uint16_t" name="index">Index of the parameter in the group</field>
+    </message>    
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2469,16 +2469,16 @@
         <description>Parameter is a standard parameter value</description>
       </entry>
       <entry value="1" name="MIXER_PARAM_MSG_TYPE_CAPABILITY">
-        <description>Parameter is describing capabilities of the mixer. param_id is "CAPABILITY". default is values[0] as a uint bitfield type.</description>
+        <description>Parameter is describing capabilities of the mixer. param_id is "CAPABILITY". values[0] is uint bitfield.</description>
       </entry>
-      <entry value="2" name="MIXER_PARAM_MSGTYPE_CONFIGURATION">
-        <description>Parameter configuring the mixer. param_id is "CONFIG". default is values[0] as a uint bitfield type</description>
+      <entry value="2" name="MIXER_PARAM_MSG_TYPE_CONFIGURATION">
+        <description>Parameter configuring the mixer. param_id is "CONFIG". values[0] is uint32 bitfield</description>
       </entry>
       <entry value="3" name="MIXER_PARAM_MSG_TYPE_MIX_CONN">
-        <description>Parameter is describing a mixer connection to a group.  param_id is the connection type (Input/output). Values[0] is the group index. Values[1] is the index into the group</description>
+        <description>Parameter is describing a mixer connection to a group.  param_id is "INPUT" or "OUTPUT"). Values[0] is uint group index. Values[1] is uint index into the group</description>
       </entry>
-      <entry value="4" name="MIXER_PARAM_MSG_FLAG_CONN_GROUP">
-        <description>Parameter is describing a connection group. Read only. param_id is group name. Values[0] is group index. Values[1] is the group size</description>
+      <entry value="4" name="MIXER_PARAM_MSG_TYPE_CONN_GROUP">
+        <description>Parameter is describing a connection group. Read only. param_id is group name. Values[0] is uint group index. Values[1] is uint group size</description>
       </entry>
       <entry value="5" name="MIXER_PARAM_MSG_TYPE_MIXTYPE">
         <description>Parameter is describing a mixer type. param_id is the name of the mixer.  Should have zero data length</description>
@@ -2487,7 +2487,10 @@
         <description>Parameter is an assigned name for a mixer other than its functional mixer name.  param_id is the name tag.  Should have zero data length</description>
       </entry>
       <entry value="7" name="MIXER_PARAM_MSG_TYPE_CHECKSUM">
-        <description>Parameter is checksum of the mixer config script.  param_id is normally "CHECKSUM_SCRIPT" but can describe other checksums.  Values[0] is normally uint CRC16 checksum</description>
+        <description>Parameter is checksum of the mixer config script.  param_id is normally "CHECKSUM_SCRIPT" but can describe other checksums.  Values[0] is uint CRC32 checksum</description>
+      </entry>
+      <entry value="8" name="MIXER_PARAM_MSG_TYPE_PARAM_METADATA">
+        <description>Parameter is metadata describing how to use parameters.  param_id is "METADATA_GLOBAL","METADATA_MIXER","METADATA_PARAM". Values[0]=default, Values[1]=max, Values[2]=min, Values[3]=step.  Normally read only</description>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2459,14 +2459,29 @@
       <entry value="1" name="MIXER_PARAM_FLAG_READ_ONLY">
         <description>Parameter is read only</description>
       </entry>
-      <entry value="2" name="MIXER_PARAM_FLAG_MIX_CONN">
-        <description>Parameter is describing a mixer connection to a group</description>
+    </enum>
+    <enum name="MIXER_PARAM_TYPE">
+      <description>Flags for different parameter data types</description>
+      <entry value="0" name="MIXER_PARAM_TYPE_PARAMETER">
+        <description>Parameter is a standard parameter value</description>
       </entry>
-      <entry value="4" name="MIXER_PARAM_FLAG_TYPE">
-        <description>Parameter is describing a mixer type</description>
+      <entry value="1" name="MIXER_PARAM_TYPE_CAPABILITY">
+        <description>Parameter is describing capabilities of the mixer. values[0] as a uint bitfield type. Name describes the mixer type</description>
       </entry>
-      <entry value="8" name="MIXER_PARAM_FLAG_CONN_GROUP">
-        <description>Parameter is describing a connection group</description>
+      <entry value="2" name="MIXER_PARAM_TYPE_CONFIGURATION">
+        <description>Parameter configuring the mixer. default name is CONFIG. default is values[0] as a uint bitfield type</description>
+      </entry>
+      <entry value="3" name="MIXER_PARAM_TYPE_MIX_CONN">
+        <description>Parameter is describing a mixer connection to a group.  Values[0] is the group index. Values[1] is the index into the group</description>
+      </entry>
+      <entry value="4" name="MIXER_PARAM_FLAG_CONN_GROUP">
+        <description>Parameter is describing a connection group. Read only. Values[0] is group size. Values[1] is the group size</description>
+      </entry>
+      <entry value="5" name="MIXER_PARAM_TYPE_MIXTYPE">
+        <description>Parameter is describing a mixer type. Name is the script name of the mixer.  mixer_type is the mixer enumeration at the AP</description>
+      </entry>
+      <entry value="6" name="MIXER_PARAM_TYPE_MIX_NAME">
+        <description>Parameter is a name for a mixer.  Should have zero data length</description>
       </entry>
     </enum>
   </enums>
@@ -3801,44 +3816,35 @@
     </message>
     <message id="235" name="MIXER_PARAM_VALUE">
       <description>Mixer parameter values emitted after a read or set request</description>
-      <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
-      <field type="int16_t" name="count">Total number of onboard parameters</field>
-      <field type="uint16_t" name="index">Index of this onboard parameter</field>
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
-      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
+      <field type="int16_t" name="count">Total number of parameters in the group</field>
+      <field type="uint16_t" name="index">Index of the parameter in the group</field>
+      <field type="uint8_t" name="flags" enum="MIXER_PARAM_FLAGS">Flags for the parameter</field>
+      <field type="uint8_t" name="type" enum="MIXER_PARAM_TYPE">Type of the parameter - Used for connections, mixer names etc..</field>
+      <field type="uint16_t" name="mixer_index">Index of the mixer in the mixer collection</field>
       <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
       <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>
       <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
       <field type="uint8_t" name="param_array_size">Size of the array for this parameter</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="float[6]" name="param_values">Array of parameter values</field>
+      <field type="char[20]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 20 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float[8]" name="param_values">Array of parameter values</field>
     </message>
     <message id="236" name="MIXER_PARAM_SET">
       <description>Mixer paraemter values to set</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="index">Index of this onboard parameter</field>
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
-      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
-      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
-      <field type="uint8_t" name="mixer_type">Implementation specific identifier for mixer type</field>
-      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
+      <field type="uint16_t" name="index">Index of the parameter in the group</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="float[6]" name="param_values">Array of parameter values</field>
+      <field type="float[8]" name="param_values">Array of parameter values</field>
     </message>
     <message id="237" name="MIXER_PARAM_REQUEST_READ">
       <description>Mixer paraemter values to set</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="index">Index of this onboard parameter</field>
       <field type="uint8_t" name="mixer_group" enum="MIXER_GROUP">Access to different sets of mixers</field>
-      <field type="uint16_t" name="mixer_index">Index of the mixer in the group</field>
-      <field type="uint8_t" name="mixer_sub_index">Index of the sub mixer in the mixer</field>
-      <field type="uint16_t" name="parameter_index">Index of the parameter in a mixer or something else</field>
-      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type: see the MAV_PARAM_TYPE enum for supported data types.</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="uint16_t" name="index">Index of the parameter in the group</field>
     </message>
     <message id="241" name="VIBRATION">
       <description>Vibration levels and accelerometer clipping</description>


### PR DESCRIPTION
**BENEFITS**
Enables downloading and editing of a mixer specific list of parameters. This parameter list is dynamic according to mixer configuration.

**FEATURES**
- Parameters are indexed and named items with mixer metadata.
- Parameters are accessed through index since names can be repeated
- Parameters value are arrays of the same type with length up to 8.
- Parameters have human readable identifiers with length up to 20 chars
- Parameters have type so they can be used to describe more metadata
- Parameters with zero length can be used as name tags
- Parameters can be read only which is set through flags
- Metadata and type support is optional depending on the particular implementation

**CHANGES SINCE INITIAL PR**
- Changed from 16 chars to 20
- Changed from max array size of 6 to 8
- Added parameter message type enumeration
- Simplified set param and param request messages
- Removed parameter_index as unused
- Removed mixer_type as that is supported by specific parameter type
- Error reported in flags instead of being encoded in the count value
- Moved from MAVLink1 to MAVLink2 namespace
- Added checksum parameter type so a gcs knows if the downloaded script is up-to-date
- Marked messages as WIP

[Mavlink mixer tuning description document](https://docs.google.com/document/d/1LeQC2qtxqdesNuJ3RAWH_MJ_30xjf-PMN3bd5wtUAUo/edit#heading=h.3cs7tuenkkib)


**TODO**
Tidy up into a single commit

Screenshot from typical shell output of all parameter data.  This is close to the complete data seen through mavlink.
![image](https://cloud.githubusercontent.com/assets/351261/25417950/54b93872-2a48-11e7-9e24-8904304ef218.png)
