### PR TITLE
Components: Add minimum set and mark deprecated components.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -311,6 +311,11 @@
       <entry value="1" name="MAV_COMP_ID_AUTOPILOT1">
         <description/>
       </entry>
+      <!-- WIP: 2-3 intended for more autopilots -->
+      <entry value="20" name="MAV_COMP_ID_LINK1">
+        <description/>
+      </entry>
+      <!-- WIP: 21-22 intended for more links -->
       <entry value="100" name="MAV_COMP_ID_CAMERA">
         <description/>
       </entry>
@@ -374,6 +379,7 @@
       <entry value="154" name="MAV_COMP_ID_GIMBAL">
         <description/>
       </entry>
+      <!-- WIP: might be refactored and removed (if not deployed) -->
       <entry value="155" name="MAV_COMP_ID_LOG">
         <description/>
       </entry>
@@ -386,15 +392,19 @@
       <entry value="158" name="MAV_COMP_ID_PERIPHERAL">
         <description>Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter sub-protocol</description>
       </entry>
+      <!-- WIP: Will likely be refactored out -->
       <entry value="159" name="MAV_COMP_ID_QX1_GIMBAL">
         <description/>
       </entry>
+      <!-- WIP: originally used only at ETH. Will likely be refactored out -->
       <entry value="180" name="MAV_COMP_ID_MAPPER">
         <description/>
       </entry>
+      <!-- WIP: originally used only at ETH. Will likely be refactored out -->
       <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
         <description/>
       </entry>
+      <!-- WIP: originally used only at ETH. Will likely be refactored out -->
       <entry value="195" name="MAV_COMP_ID_PATHPLANNER">
         <description/>
       </entry>
@@ -419,6 +429,7 @@
       <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
         <description/>
       </entry>
+      <!-- WIP: originally used only at ETH. Will likely be refactored out -->
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
         <description/>
       </entry>


### PR DESCRIPTION
A number of the components were unused and we do not want to spend the ID space on them. At the same time we need more standard IDs to help adopters choose sensible de-confliction defaults.

The proposal would be to register classes on offsets of 10's:

- 1-9: Autopilots
- 20-29: Communication equipment
- 30-39: Routing components
- etc