### PR TITLE
Add protocol capability bit for flight information

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2147,6 +2147,9 @@
       <entry value="32768" name="MAV_PROTOCOL_CAPABILITY_MISSION_RALLY">
         <description>Autopilot supports mission rally point protocol.</description>
       </entry>
+      <entry value="65536" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION">
+        <description>Autopilot supports the flight information protocol.</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">
       <description>Type of mission items being requested/sent in mission protocol.</description>


### PR DESCRIPTION
This sub-protocol allows to request flight information (start, end, duration, current flight status, distance covered, time remaining) from the autopilot and helps to avoid having a huge state machine in the GCS trying to track the autopilot state.

It consists of the (WIP) request message:
http://mavlink.org/messages/common#MAV_CMD_REQUEST_FLIGHT_INFORMATION

And the (WIP) response:
http://mavlink.org/messages/common#FLIGHT_INFORMATION

I think in particular the response is incomplete in terms of meta information / fields. Suggestions? Note that is is all a proposal and not deployed, so we can be still very creative.

Suggestions for fields that might make sense:

  * Battery remaining in time (at current velocity)
  * Maximum safe distance (at current battery level and assuming an RTL at cruise velocity)
  * Configured cruise velocity
  * Turn radius at cruise velocity (useful for hatching for survey)
  * Parameters that allow to calculate a simple battery consumption measure from speed and time