### PR TITLE
Add covariance to estimation msgs

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3450,6 +3450,8 @@
       <field type="float" name="roll" units="rad">Roll angle in rad</field>
       <field type="float" name="pitch" units="rad">Pitch angle in rad</field>
       <field type="float" name="yaw" units="rad">Yaw angle in rad</field>
+      <extensions/>
+      <field type="float[21]" name="covariance">Pose covariance matrix upper right triangular (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
     </message>
     <message id="102" name="VISION_POSITION_ESTIMATE">
       <field type="uint64_t" name="usec" units="us">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
@@ -3459,12 +3461,16 @@
       <field type="float" name="roll" units="rad">Roll angle in rad</field>
       <field type="float" name="pitch" units="rad">Pitch angle in rad</field>
       <field type="float" name="yaw" units="rad">Yaw angle in rad</field>
+      <extensions/>
+      <field type="float[21]" name="covariance">Pose covariance matrix upper right triangular (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
     </message>
     <message id="103" name="VISION_SPEED_ESTIMATE">
       <field type="uint64_t" name="usec" units="us">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
       <field type="float" name="x" units="m/s">Global X speed</field>
       <field type="float" name="y" units="m/s">Global Y speed</field>
       <field type="float" name="z" units="m/s">Global Z speed</field>
+      <extensions/>
+      <field type="float[9]" name="covariance">Linear velocity covariance matrix (1st three entries - 1st row, etc.)</field>
     </message>
     <message id="104" name="VICON_POSITION_ESTIMATE">
       <field type="uint64_t" name="usec" units="us">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
@@ -3474,6 +3480,8 @@
       <field type="float" name="roll" units="rad">Roll angle in rad</field>
       <field type="float" name="pitch" units="rad">Pitch angle in rad</field>
       <field type="float" name="yaw" units="rad">Yaw angle in rad</field>
+      <extensions/>
+      <field type="float[21]" name="covariance">Pose covariance matrix upper right triangular (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
     </message>
     <message id="105" name="HIGHRES_IMU">
       <description>The IMU readings in SI units in NED body frame</description>
@@ -3830,6 +3838,8 @@
       <field type="float" name="x" units="m">X position in meters (NED)</field>
       <field type="float" name="y" units="m">Y position in meters (NED)</field>
       <field type="float" name="z" units="m">Z position in meters (NED)</field>
+      <extensions/>
+      <field type="float[21]" name="covariance">Pose covariance matrix upper right triangular (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
     </message>
     <message id="139" name="SET_ACTUATOR_CONTROL_TARGET">
       <description>Set the vehicle attitude and body angular rates.</description>


### PR DESCRIPTION
Given some position estimation/filters maybe be feeding data into onboard position and attitude estimators, and since IEKF, LPE, EFK2 may use covariance matrices to improve the estimation, this PR allows sending these same covariances through specific messages (vision, mocap).

@jgoppert this may interest you as one can send the odometry data from external sources through these specific msgs and receive feedback though `LOCAL_POSITION_NED_COV` and `ATTITUDE_QUATERNION_COV` respectively.