### PR TITLE
Extend EXTENDED_SYS_STATE message to include flight stage and safety switch status

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2312,6 +2312,18 @@
         <description>MAV currently landing</description>
       </entry>
     </enum>
+    <enum name="MAV_SAFETY_STATE">
+      <description>Enumeration of safety switch states</description>
+      <entry value="0" name="MAV_SAFETY_STATE_UNDEFINED">
+        <description>Safety switch not connected or state unknown</description>
+      </entry>
+      <entry value="1" name="MAV_SAFETY_STATE_ON">
+        <description>Safety is on and the MAV cannot be armed</description>
+      </entry>
+      <entry value="2" name="MAV_SAFETY_STATE_OFF">
+        <description>Safety is off and the MAV can arm</description>
+      </entry>
+    </enum>
     <enum name="ADSB_ALTITUDE_TYPE">
       <description>Enumeration of the ADSB altimeter types</description>
       <entry value="0" name="ADSB_ALTITUDE_TYPE_PRESSURE_QNH">
@@ -3886,6 +3898,8 @@
       <description>Provides state for additional features</description>
       <field type="uint8_t" name="vtol_state" enum="MAV_VTOL_STATE">The VTOL state if applicable. Is set to MAV_VTOL_STATE_UNDEFINED if UAV is not in VTOL configuration.</field>
       <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+      <extensions/>
+      <field type="uint8_t" name="safety_state" enum="MAV_SAFETY_STATE">The safety state. Is set to MAV_SAFETY_STATE_UNDEFINED if safety state is unknown.</field>
     </message>
     <message id="246" name="ADSB_VEHICLE">
       <description>The location and information of an ADSB vehicle</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3900,6 +3900,7 @@
       <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
       <extensions/>
       <field type="uint8_t" name="safety_state" enum="MAV_SAFETY_STATE">The safety state. Is set to MAV_SAFETY_STATE_UNDEFINED if safety state is unknown.</field>
+      <field type="uint8_t" name="flight_stage">Autopilot-specific flight stage, used for providing information on sub-stages of a mode, 0 indicates unknown.</field>
     </message>
     <message id="246" name="ADSB_VEHICLE">
       <description>The location and information of an ADSB vehicle</description>


### PR DESCRIPTION
@LorenzMeier This adds safety switch state to the EXTENDED_SYS_STATE message.

We use this to control various things like starting VIO when pre-armed and switching the companion system's wifi off in favour of a long range link.

This change shouldn't break anything for those currently using the message, as it is implemented as a v2 extension.