### PR TITLE
Add MAVLink version handshake

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1329,6 +1329,11 @@
         <param index="1">The MAVLink message ID</param>
         <param index="2">The interval between two messages, in microseconds. Set to -1 to disable and 0 to request default rate.</param>
       </entry>
+      <entry value="519" name="MAV_CMD_REQUEST_PROTOCOL_VERSION">
+        <description>Request MAVLink protocol version compatibility</description>
+        <param index="1">1: Request supported protocol versions by all nodes on the network</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
       <entry value="520" name="MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES">
         <description>Request autopilot capabilities</description>
         <param index="1">1: Request autopilot version</param>
@@ -4112,6 +4117,14 @@
       <field type="uint32_t" name="bitrate" units="b/s">Bit rate in bits per second (set to -1 for auto)</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
       <field type="char[230]" name="uri">Video stream URI</field>
+    </message>
+    <message id="300" name="PROTOCOL_VERSION">
+      <description>WIP: Version and capability of protocol version. This message is the response to REQUEST_PROTOCOL_VERSION and is used as part of the handshaking to establish which MAVLink version should be used on the network. Every node should respond to REQUEST_PROTOCOL_VERSION to enable the handshaking. Library implementers should consider adding this into the default decoding state machine to allow the protocol core to respond directly.</description>
+      <field type="uint16_t" name="version">Currently active MAVLink version number * 100: v1.0 is 100, v2.0 is 200, etc.</field>
+      <field type="uint16_t" name="min_version">Minimum MAVLink version supported</field>
+      <field type="uint16_t" name="max_version">Maximum MAVLink version supported (set to the same value as version by default)</field>
+      <field type="uint8_t[8]" name="spec_version_hash">The first 8 bytes (not characters printed in hex!) of the git hash.</field>
+      <field type="uint8_t[8]" name="library_version_hash">The first 8 bytes (not characters printed in hex!) of the git hash.</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
When a radio or similar device is MAVLink 1 enabled but does not support MAVLink 2 and is connected between two nodes supporting MAVLink 2 it is nontrivial to discover if MAVLink 2 can be enabled: Both ends of the communication channel support it and show their support in the MAV_PROTOCOL_CAPABILITY flags but enabling it would still make the radio fail.
This extension allows to send a MAVLink 2 message as a test to see if it passes correctly through the link. As the request for the message is implemented as a command which should be NACKed as unsupported any node not having added support for this would default to MAVLink 1. This should allow a safe and robust handshake, including command retransmission if required.

This is an attempt to solve the problem described in the commit message. Feedback appreciated.