### PR TITLE
RFC: Support for Wi-Fi settings

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1580,6 +1580,16 @@
         <param index="6">Longitude</param>
         <param index="7">Altitude</param>
       </entry>
+      <entry value="6000" name="MAV_CMD_REQUEST_WIFI_NETWORKS">
+        <description>Request saved Wi-Fi networks (WIFI_NETWORK_INFORMATION).</description>
+        <param index="1">0: No Action 1: Request messages with wifi network information</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="6001" name="MAV_CMD_WIFI_START_AP">
+        <description>Start in AP (Access Point) mode.</description>
+        <param index="1">0: No Action 1: Start in AP mode</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
       <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
       <!-- BEGIN of payload range (30000 to 30999) -->
       <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY">
@@ -4130,6 +4140,26 @@
       <field type="uint32_t" name="bitrate" units="b/s">Bit rate in bits per second (set to -1 for auto)</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
       <field type="char[230]" name="uri">Video stream URI</field>
+    </message>
+    <message id="300" name="WIFI_NETWORK_INFORMATION">
+      <description>WIP: </description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network</field>
+      <field type="uint8_t" name="security_type" enum="WIFI_SECURITY_TYPE">See the WIFI_SECURITY_TYPE enum.</field>
+      <field type="uint8_t" name="state">Current status of connection (0: not connected 1: connected)</field>
+    </message>
+    <message id="301" name="WIFI_NETWORK_CONNECT">
+      <description>WIP: </description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network</field>
+    </message>
+    <message id="302" name="WIFI_NETWORK_ADD">
+      <description>WIP: </description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network</field>
+      <field type="uint8_t" name="security_type" enum="WIFI_SECURITY_TYPE">See the WIFI_SECURITY_TYPE enum.</field>
+      <field type="char[64]" name="password">Password</field>
+    </message>
+    <message id="303" name="WIFI_NETWORK_DELETE">
+      <description>WIP: </description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2511,6 +2511,21 @@
         <description>Static fixed, typically used for base stations</description>
       </entry>
     </enum>
+    <enum name="WIFI_SECURITY_TYPE">
+      <description>Type of Wi-Fi security</description>
+      <entry value="0" name="WIFI_SECURITY_TYPE_OPEN">
+        <description>No security</description>
+      </entry>
+      <entry value="1" name="WIFI_SECURITY_TYPE_WEP">
+        <description>WEP (Wired Equivalent Privacy) security</description>
+      </entry>
+      <entry value="2" name="WIFI_SECURITY_TYPE_WPA">
+        <description>WPA (Wi-Fi Protected Access) security</description>
+      </entry>
+      <entry value="3" name="WIFI_SECURITY_TYPE_WPA2">
+        <description>WPA2 (Wi-Fi Protected Access II) security</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -401,6 +401,9 @@
       <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
         <description/>
       </entry>
+      <entry value="242" name="MAV_COMP_ID_WIFI">
+        <description/>
+      </entry>
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
         <description/>
       </entry>


### PR DESCRIPTION
In this PR I propose to add new messages for setup Wi-Fi of the vehicle using ground control station.
Description:
Vehicle can be in 2 state: connected to selected network or create it's own AP (access point). Vehicle will have list of networks to which it will try to connect alternately. If vehicle can't connect to any network then it will start in AP mode.
Communication with GCS:
First of all GCS request for saved Wi-Fi networks from vehicle using command MAV_CMD_REQUEST_WIFI_NETWORKS. After it get N (number of saved networks) messages WIFI_NETWORK_INFORMATION, using that it can create list in UI.
User now can do:
- Start vehicle in AP mode using MAV_CMD_WIFI_START_AP command.
- Connect to selected network from the list using WIFI_NETWORK_CONNECT message.
- Add new network (SSID, protocol, password) to saved networks using WIFI_NETWORK_ADD message.
- Delete selected network from saved networks using WIFI_NETWORK_DELETE message.