### PR TITLE
Common: Allow CMD_DO_LAND_START to change the flight mode

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -993,7 +993,7 @@
       </entry>
       <entry value="189" name="MAV_CMD_DO_LAND_START">
         <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>
-        <param index="1">Empty</param>
+        <param index="1">1.0 indicates if the vehicle should change into a flight mode where it can perform the landing sequence. Only applicable if sent as part of a COMMAND_LONG</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>


### PR DESCRIPTION
Useful for simplifying the number of commands and state machine used to safely transition a vehicle to flying a landing sequence. An example use case would be changing the flight mode to AUTO for ArduPlane.