### PR TITLE
common.xml: added message DEBUG_ARRAY_FLOAT

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3963,7 +3963,6 @@
       <field type="uint8_t" name="ind">index of debug variable</field>
       <field type="float" name="value">DEBUG value</field>
     </message>
-
     <!-- messages with ID 256 and above are only available in MAVLink2 -->
     <message id="256" name="SETUP_SIGNING">
       <description>Setup a MAVLink2 signing key. If called with secret_key of all zero and zero initial_timestamp will disable signing</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4129,7 +4129,7 @@
     </message>
     <message id="350" name="DEBUG_ARRAY_FLOAT">
       <description>Large debug array. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
-      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t" name="id">Unique ID used to discriminate between arrays</field>
       <field type="char[10]" name="name">Name, for human-friendly display in QGC</field>
       <field type="float[60]" name="data">data</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3958,6 +3958,7 @@
       <field type="uint8_t" name="ind">index of debug variable</field>
       <field type="float" name="value">DEBUG value</field>
     </message>
+
     <!-- messages with ID 256 and above are only available in MAVLink2 -->
     <message id="256" name="SETUP_SIGNING">
       <description>Setup a MAVLink2 signing key. If called with secret_key of all zero and zero initial_timestamp will disable signing</description>
@@ -4112,6 +4113,14 @@
       <field type="uint32_t" name="bitrate" units="b/s">Bit rate in bits per second (set to -1 for auto)</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
       <field type="char[230]" name="uri">Video stream URI</field>
+    </message>
+
+    <message id="350" name="DEBUG_ARRAY_FLOAT">
+      <description>Large debug array. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
+      <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="id">Unique ID used to discriminate between arrays</field>
+      <field type="char[10]" name="name">Name, for human-friendly display in QGC</field>
+      <field type="float[60]" name="data">data</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Adds the message DEBUG_ARRAY. 
This is similiar to DEBUG_VECT, but with 60 entries instead of 3. It basically fills the maximum payload.
I have been using it for long and it proved really useful to debug large float arrays.