### PR TITLE
common.xml: added message DEBUG_FLOAT_ARRAY

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4774,8 +4774,7 @@
       <field type="float[5]" name="delta" units="s">Bezier time horizon, set to NaN if velocity/acceleration should not be incorporated</field>
       <field type="float[5]" name="pos_yaw" units="rad">Yaw, set to NaN for unchanged</field>
     </message>
-    <message id="350" name="DEBUG_ARRAY">
-      <description>Large debug array. The message fills the maximum payload with a packet size of 263 bytes.</description>
+    <message id="350" name="DEBUG_FLOAT_ARRAY">
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t" name="array_id">Unique ID used to discriminate between arrays</field>
       <field type="char[10]" name="name">Name, for human-friendly display in a Ground Control Station</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4775,6 +4775,7 @@
       <field type="float[5]" name="pos_yaw" units="rad">Yaw, set to NaN for unchanged</field>
     </message>
     <message id="350" name="DEBUG_FLOAT_ARRAY">
+      <description>Large debug/prototyping array. The message uses the maximum available payload for data. The array_id and name fields are used to discriminate between messages in code and in user interfaces (respectively). Do not use in production code.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t" name="array_id">Unique ID used to discriminate between arrays</field>
       <field type="char[10]" name="name">Name, for human-friendly display in a Ground Control Station</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4776,11 +4776,11 @@
     </message>
     <message id="350" name="DEBUG_FLOAT_ARRAY">
       <description>Large debug/prototyping array. The message uses the maximum available payload for data. The array_id and name fields are used to discriminate between messages in code and in user interfaces (respectively). Do not use in production code.</description>
-      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="array_id">Unique ID used to discriminate between arrays</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="char[10]" name="name">Name, for human-friendly display in a Ground Control Station</field>
+      <field type="uint16_t" name="array_id">Unique ID used to discriminate between arrays</field>
       <extensions/>
-      <field type="float[60]" name="data">data</field>
+      <field type="float[58]" name="data">data</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4779,6 +4779,7 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t" name="array_id">Unique ID used to discriminate between arrays</field>
       <field type="char[10]" name="name">Name, for human-friendly display in a Ground Control Station</field>
+      <extensions/>
       <field type="float[60]" name="data">data</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4774,5 +4774,12 @@
       <field type="float[5]" name="delta" units="s">Bezier time horizon, set to NaN if velocity/acceleration should not be incorporated</field>
       <field type="float[5]" name="pos_yaw" units="rad">Yaw, set to NaN for unchanged</field>
     </message>
+    <message id="350" name="DEBUG_ARRAY">
+      <description>Large debug array. The message fills the maximum payload with a packet size of 263 bytes.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+      <field type="uint8_t" name="array_id">Unique ID used to discriminate between arrays</field>
+      <field type="char[10]" name="name">Name, for human-friendly display in a Ground Control Station</field>
+      <field type="float[60]" name="data">data</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
This PR adds the message DEBUG_ARRAY. This is a follow up of #732 with clean history.

I have been using this message for long and it proved really useful to debug large float arrays.
The message is similar to DEBUG_VECT, but with 60 entries instead of 3. It basically fills the maximum payload with a packet size of 263 bytes.

@LorenzMeier I placed it in v2 namespace, using id 350 as recommended by @magicrub. PRs for PX4 Firmware and QGC are coming.