### PR TITLE
Generate common message specs in gitbook format

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -1,6 +1,16 @@
 MAVLink Micro Air Vehicle Message Marshalling Library
 
-The mavlink_to_html_table.xsl file is used to transform the MAVLink XML into a human-readable HTML table for online documentation.
+Files:
+
+- **Doxyfile**: -
+- **MAVLink2.md**: MAVLink2 Documentation
+- **README**: This file
+- **mavlink.php**: Generates online documentation from MAVLink XML - http://mavlink.org/messages/common
+  - **mavlink_to_html_table.xsl**: XSL transform used by **mavlink.php**
+  - **mavlink.css**: CSS used by online documentation
+- **mavlink_gitbook.py**: Generates documentation from MAVLink XML that can be imported into gitbook
+  - **mavlink_to_html_table_gitbook.xsl**: XSL transform used by **mavlink_gitbook.py**
+----
 
 For more information, please visit:
 

--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -1,0 +1,70 @@
+#! /usr/bin/python
+
+"""
+This script generates a markdown file (message-definitions.md) that can be imported into a gitbook to display the MAVLink Common message format (HTML).
+(this is a mechanism of bringing the current docs into the gitbook: http://mavlink.org/messages/common )
+
+The file is generated using an XSLT transformation from the XML at "https://raw.github.com/mavlink/mavlink/master/message_definitions/v1.0/common.xml". 
+"""
+
+import lxml.etree as ET
+import requests
+from bs4 import BeautifulSoup as bs
+import re
+
+xml_file_url = "https://raw.github.com/mavlink/mavlink/master/message_definitions/v1.0/common.xml";
+#xsl_file_url= "https://raw.github.com/mavlink/mavlink/master/doc/mavlink_to_html_table_gitbook.xsl";
+xsl_file_url= "https://raw.githubusercontent.com/hamishwillee/mavlink/hhgw_gitbook_mavlink_messages/doc/mavlink_to_html_table_gitbook.xsl";
+
+output_file_name = "./message-definitions.md"
+
+# Get files from published URLs
+r = requests.get(xml_file_url)
+xml_file = r.text
+r = requests.get(xsl_file_url)
+xsl_file = r.text
+
+dom = ET.fromstring(xml_file)
+xslt = ET.fromstring(xsl_file)
+
+transform = ET.XSLT(xslt)
+newdom = transform(dom)
+
+#Prettify the HTML using BeautifulSoup
+soup=bs(str(newdom), "lxml")
+prettyHTML=soup.prettify()
+
+
+# Strip out all text before "<html>" - not needed in the output
+def slicer(my_str,sub):
+    index=my_str.find(sub)
+    if index !=-1 :
+        return my_str[index:] 
+    else :
+        return my_str
+        
+prettyHTML=slicer(prettyHTML,'<html>')
+
+#Fix up the BeautifulSoup output so to fix build-link errors in the generated gitbook.
+## BS puts each tag/content in its own line. Gitbook generates anchors using the spaces/newlines. 
+## This puts displayed text content immediately within tags so that anchors/links generate properly
+def fix_content_in_tags(input_html):
+    #print("fix_content_in_tags was called")
+    def remove_space_between_content_tags(matchobj):
+        stripped_string=matchobj.group(1).strip()
+        return '>%s<' % stripped_string
+
+    input_html=re.sub(r'\>(\s+?\w+?.*?)\<', remove_space_between_content_tags, input_html,flags=re.DOTALL)
+    return input_html
+    
+prettyHTML = fix_content_in_tags(prettyHTML)
+
+    
+    
+with open(output_file_name, 'w') as out:
+    out.write(prettyHTML )
+    
+print("COMPLETED")
+
+
+

--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -13,9 +13,7 @@ from bs4 import BeautifulSoup as bs
 import re
 
 xml_file_url = "https://raw.github.com/mavlink/mavlink/master/message_definitions/v1.0/common.xml";
-#xsl_file_url= "https://raw.github.com/mavlink/mavlink/master/doc/mavlink_to_html_table_gitbook.xsl";
-xsl_file_url= "https://raw.githubusercontent.com/hamishwillee/mavlink/hhgw_gitbook_mavlink_messages/doc/mavlink_to_html_table_gitbook.xsl";
-
+xsl_file_url= "https://raw.github.com/mavlink/mavlink/master/doc/mavlink_to_html_table_gitbook.xsl";
 output_file_name = "./message-definitions.md"
 
 # Get files from published URLs

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:template match="//include">
+   <h1>MAVLink Include Files</h1>
+   <p><strong><em>Including files: </em><xsl:value-of select="." /></strong></p>
+</xsl:template>
+
+<xsl:template match="//enums">
+   <h1>MAVLink Type Enumerations</h1>
+   <xsl:apply-templates />
+</xsl:template>
+
+<xsl:template match="//messages">
+   <h1>MAVLink Messages</h1>
+   <xsl:apply-templates />
+</xsl:template>
+
+<xsl:template match="//message">
+  
+  <h2>
+    <xsl:attribute name="class">mavlink_message_name</xsl:attribute>
+    <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
+    <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+  <xsl:value-of select="@name" /> (
+   <a>
+    <xsl:attribute name="href">
+      #<xsl:value-of select="@name"/>
+    </xsl:attribute>
+   #<xsl:value-of select="@id" />
+   </a>
+   )</h2>  
+  
+   <p class="description"><xsl:value-of select="description" /></p>
+   <table class="sortable">
+   <thead>
+   <tr>
+     <th class="mavlink_field_header">Field Name</th>
+     <th class="mavlink_field_header">Type</th>
+     <th class="mavlink_field_header">Description</th>
+   </tr>
+   </thead>
+   <tbody>
+   <xsl:apply-templates select="field" />
+  </tbody>
+  </table>
+</xsl:template>
+
+<xsl:template match="//field">
+   <tr class="mavlink_field">
+   <td class="mavlink_name" valign="top"><xsl:value-of select="@name" /></td>
+   <td class="mavlink_type" valign="top"><xsl:value-of select="@type" /></td>
+   <td class="mavlink_comment"><xsl:value-of select="." /></td>
+   </tr>
+</xsl:template>
+
+<xsl:template match="//version">
+   <h1>MAVLink Protocol Version</h1>
+   <p>This file has protocol version: <xsl:value-of select="." />. The version numbers range from 1-255.</p>
+</xsl:template>
+
+<xsl:template match="//enum">
+   <h2>
+    <xsl:attribute name="name">ENUM_<xsl:value-of select="@name"/></xsl:attribute>
+    <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
+    <xsl:attribute name="class">mavlink_message_name</xsl:attribute>
+    <xsl:value-of select="@name" />
+   </h2>
+
+   <p class="description"><xsl:value-of select="description" /></p>
+   <table class="sortable">
+   <thead>
+   <tr>
+     <th class="mavlink_field_header">CMD ID</th>
+     <th class="mavlink_field_header">Field Name</th>
+     <th class="mavlink_field_header">Description</th>
+   </tr>
+   </thead>
+   <tbody>
+   <xsl:apply-templates select="entry" />
+  </tbody>
+  </table>
+</xsl:template>
+
+<xsl:template match="//entry">
+   <tr class="mavlink_field" id="{@name}">
+   <td class="mavlink_type" valign="top"><xsl:value-of select="@value" /></td>
+   <td class="mavlink_name" valign="top"><xsl:value-of select="@name" /></td>
+   <td class="mavlink_comment"><xsl:value-of select="description" /></td>
+   </tr>   
+</xsl:template>
+
+<xsl:template match="//param">
+   <tr>
+   <td></td>
+   <td class="mavlink_mission_param" valign="top">Mission Param #<xsl:value-of select="@index" /></td>
+   <td class="mavlink_comment"><xsl:value-of select="." /></td>
+   </tr>
+</xsl:template>
+
+
+</xsl:stylesheet>


### PR DESCRIPTION
Script generates a file message-definitions.md that can be imported into a gitbook. This depends on XSL file being added to master. 