### PR TITLE
Camera Settings must define a camera.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1444,7 +1444,7 @@
       </entry>
       <entry value="531" name="MAV_CMD_SET_CAMERA_SETTINGS_3">
         <description>WIP: Set the camera settings part 3 (CAMERA_SETTINGS). Use NAN for values you don't want to change.</description>
-        <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
+        <param index="1">Camera ID (1 for first, 2 for second, etc.)</param>
         <param index="2">Photo resolution ID (4000x3000, 2560x1920, etc., -1 for maximum possible)</param>
         <param index="3">Video resolution and rate ID (4K 60 Hz, 4K 30 Hz, HD 60 Hz, HD 30 Hz, etc., -1 for maximum possible)</param>
         <param index="4">Reserved (all remaining params)</param>


### PR DESCRIPTION
Change to comment only. When setting a camera setting, you must define a camera ID rather than allowing *All Cameras*. This is consistent with the remaining `SET_CAMERA_SETTINGS_XX` commands.
