### PR TITLE
TRIGG_DIST: Support trigger before/after distance trigger start/stop

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1151,9 +1151,9 @@
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST">
         <description>Mission command to set camera trigger distance for this flight. The camera is trigerred each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera.</description>
-        <param index="1">Camera trigger distance (meters). -1 or 0 to ignore</param>
+        <param index="1">Camera trigger distance (meters). 0 to stop triggering.</param>
         <param index="2">Camera shutter integration time (milliseconds). -1 or 0 to ignore</param>
-        <param index="3">Empty</param>
+        <param index="3">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
         <param index="4">Empty</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>


### PR DESCRIPTION
The reason for these changes is to make it way easier to create survey missions which have consistent coverage over a polygonal area. The basic idea is to modify the TRIGG_DIST command such that:
* When you start distance triggering the first image is taken right away (optional) instead of waiting until the first distance passes.
* When turning off distance triggering you can also take one last image at that point (optional).

This makes it possible to simply set up missions which generate transects that have full coverage from the entrance of the survey area to the exit of the survey area. Specifically for the case where images are not taken in the turnarounds. But this also helps when taking images throughout an entire survey. Since it will close up possible holes in the coverage at the entrance and exit of the survey.

The simple use case example for a single transect works like this:
* You have a single transect which identifies the flight path for images. You want to cover the path with images from entry to exit.
* The entrance/exit points are waypoints.
* After the entrance waypoint you start trigger by distance with trigger once immediately.
* After the exit waypoint you stop trigger by distance and also set trigger once immediately.

This way you have full coverage with images at both ends of the transect.

This pull also changes the wording on how the trigger distance value works:
* I don't understand the "ignore" concept for trigger distance. If you want to ignore this value, why are you using the command at all? Maybe I am missing something.
* Setting trigger distance to 0 simply stops the triggering. Only 0 is supported since although PX4 may support -1 as well, ArduPilot does not. I don't see why -1 is needed as well?

Note: The explanation above is written assuming TRIGG_DIST does not trigger immediately but only after the distance has passed. This is how ArduPilot works. This is not how PX4 work. PX4 triggers immediately. The reason for that is because I asked for it in order to solve part of the above problem. In hindsight I think that was a bad request. And this proposal is better since it can keep both firmwares working the same way.