### PR TITLE
Correct trigger-once specification

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1472,6 +1472,7 @@
         <param index="1">Trigger enable/disable (0 for disable, 1 for start), -1 to ignore</param>
         <param index="2">1 to reset the trigger sequence, -1 or 0 to ignore</param>
         <param index="3">1 to pause triggering, but without switching the camera off or retracting it. -1 to ignore</param>
+        <param index="4">1 to trigger camera once immediately, -1 or 0 to ignore</param>
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
         <description>WIP: Starts video capture (recording). Use NAN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1151,9 +1151,9 @@
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST">
         <description>Mission command to set camera trigger distance for this flight. The camera is trigerred each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera.</description>
-        <param index="1">Camera trigger distance (meters). 0 to stop triggering.</param>
+        <param index="1">Camera trigger distance (meters). -1 or 0 to ignore</param>
         <param index="2">Camera shutter integration time (milliseconds). -1 or 0 to ignore</param>
-        <param index="3">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
+        <param index="3">Empty</param>
         <param index="4">Empty</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>


### PR DESCRIPTION
@DonLakeFlyer @LorenzMeier @WickedShell 

Please do have a look at this. I understand that APM uses the SET_TRIGG_DIST command to start/stop triggering, but this is non-optimal. We have had DO_TRIGGER_CONTROL as a part of the spec for some time now. Very specific changes like those made in https://github.com/mavlink/mavlink/pull/746 should have gone into this "new" command.