### PR TITLE
Common: Ability to specify ground altitude for landing waypoints

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -686,7 +686,7 @@
         <description>Land at location</description>
         <param index="1">Abort Alt</param>
         <param index="2">Empty</param>
-        <param index="3">Empty</param>
+        <param index="3">Ground altitude (with the same reference as the Altitude field). NaN if unspecified.</param>
         <param index="4">Desired yaw angle. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
@@ -816,7 +816,7 @@
         <description>Land using VTOL mode</description>
         <param index="1">Empty</param>
         <param index="2">Empty</param>
-        <param index="3">Empty</param>
+        <param index="3">Ground altitude (with the same reference as the Altitude field). NaN if unspecified.</param>
         <param index="4">Yaw angle in degrees. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -686,11 +686,11 @@
         <description>Land at location</description>
         <param index="1">Abort Alt</param>
         <param index="2">Empty</param>
-        <param index="3">Ground altitude (with the same reference as the Altitude field). NaN if unspecified.</param>
+        <param index="3">Empty</param>
         <param index="4">Desired yaw angle. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
+        <param index="7">Altitude (ground level)</param>
       </entry>
       <entry value="22" name="MAV_CMD_NAV_TAKEOFF">
         <description>Takeoff from ground / hand</description>
@@ -816,11 +816,11 @@
         <description>Land using VTOL mode</description>
         <param index="1">Empty</param>
         <param index="2">Empty</param>
-        <param index="3">Ground altitude (with the same reference as the Altitude field). NaN if unspecified.</param>
+        <param index="3">Approach altitude (with the same reference as the Altitude field). NaN if unspecified.</param>
         <param index="4">Yaw angle in degrees. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
+        <param index="7">Altitude (ground level)</param>
       </entry>
       <!-- IDs 90 and 91 are reserved until the end of 2014,
                     as they were used in some conflicting proposals


### PR DESCRIPTION
This is an attempt to consolidate approaches on vertical landings. I don't know all the methods used but I believe that this currently solved differently across implementations. Possibly someone already has an elegant solution for this problem, if so, please let me know :).

**The problem**: With only one altitude field for a landing mission item we have to decide if the vehicle approaches on that altitude (horizontally) until it's above the landing spot **OR** if that altitude marks the height where we should expect ground (can be used in two step vertical landing or as fallback for a failed distance sensor).

For fixed-wing vehicles doing a glide slope landing these two altitudes are the same in the final phase which is why I'm focusing only on vertical landings right now.

My proposal is to use parameter 3 to specify the ground altitude. That way the actual altitude field is preserved as the target flying altitude and won't change it's meaning depending on the `MAV_CMD`.

I believe that would be a sensible solution, however it is worth mentioning that there are already other options:
1. Use 2 waypoints: One for the approach and one for the actual landing where the altitude field serves as ground altitude.
2. Use actual terrain data on the flight controller.

