### PR TITLE
Common: Ability to specify the direction of the VTOL forwards transition

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -805,7 +805,7 @@
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
         <description>Takeoff from ground using VTOL mode</description>
         <param index="1">Empty</param>
-        <param index="2">Empty</param>
+        <param index="2">Forwards transition heading: 0: use the heading towards the next waypoint, 1: use the heading on takeoff, 2: use the specified heading in parameter 4, 3: use the current heading when reaching takeoff altitude (facing the wind when weather-vaning is active).</param>
         <param index="3">Empty</param>
         <param index="4">Yaw angle in degrees. NaN for unchanged.</param>
         <param index="5">Latitude</param>
@@ -1540,6 +1540,8 @@
       <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION">
         <description>Request VTOL transition</description>
         <param index="1">The target VTOL state, as defined by ENUM MAV_VTOL_STATE. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
+        <param index="2">Forwards transition heading: 0: use the heading towards the next waypoint, 1: ignored, 2: use the specified heading in parameter 4, 3: use the current heading when executing this command (facing the wind when weather-vaning is active).</param>
+        <param index="4">Yaw angle in degrees.</param>
       </entry>
       <entry value="4000" name="MAV_CMD_SET_GUIDED_SUBMODE_STANDARD">
         <description>This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -805,7 +805,7 @@
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
         <description>Takeoff from ground using VTOL mode</description>
         <param index="1">Empty</param>
-        <param index="2">Forwards transition heading, see VTOL_TRANSITION_HEADING enum.</param>
+        <param index="2">Front transition heading, see VTOL_TRANSITION_HEADING enum.</param>
         <param index="3">Empty</param>
         <param index="4">Yaw angle in degrees. NaN for unchanged.</param>
         <param index="5">Latitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2605,6 +2605,7 @@
       </entry>
       <entry value="4" name="VTOL_TRANSITION_HEADING_ANY">
         <description>Use the current heading when reaching takeoff altitude (potentially facing the wind when weather-vaning is active).</description>
+      </entry>
     </enum>
     <enum name="CAMERA_CAP_FLAGS">
       <description>Camera capability flags (Bitmap).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2588,17 +2588,20 @@
     </enum>
     <enum name="VTOL_TRANSITION_HEADING">
       <description>Direction of VTOL transition</description>
-      <entry value="0" name="VTOL_TRANSITION_HEADING_NEXT_WAYPOINT">
+      <entry value="0" name="VTOL_TRANSITION_HEADING_VEHICLE_DEFAULT">
+        <description>Respect the heading configuration of the vehicle.</description>
+      </entry>
+      <entry value="1" name="VTOL_TRANSITION_HEADING_NEXT_WAYPOINT">
         <description>Use the heading pointing towards the next waypoint.</description>
       </entry>
-      <entry value="1" name="VTOL_TRANSITION_HEADING_TAKEOFF">
+      <entry value="2" name="VTOL_TRANSITION_HEADING_TAKEOFF">
         <description>Use the heading on takeoff (while sitting on the ground).</description>
       </entry>
-      <entry value="2" name="VTOL_TRANSITION_HEADING_SPECIFIED">
+      <entry value="3" name="VTOL_TRANSITION_HEADING_SPECIFIED">
         <description>Use the specified heading in parameter 4.</description>
       </entry>
-      <entry value="3" name="VTOL_TRANSITION_HEADING_WEATHERVANE">
-        <description>Use the current heading when reaching takeoff altitude (facing the wind when weather-vaning is active).</description>
+      <entry value="4" name="VTOL_TRANSITION_HEADING_ANY">
+        <description>Use the current heading when reaching takeoff altitude (potentially facing the wind when weather-vaning is active).</description>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -805,7 +805,7 @@
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
         <description>Takeoff from ground using VTOL mode</description>
         <param index="1">Empty</param>
-        <param index="2">Forwards transition heading: 0: use the heading towards the next waypoint, 1: use the heading on takeoff, 2: use the specified heading in parameter 4, 3: use the current heading when reaching takeoff altitude (facing the wind when weather-vaning is active).</param>
+        <param index="2">Forwards transition heading, see VTOL_TRANSITION_HEADING enum.</param>
         <param index="3">Empty</param>
         <param index="4">Yaw angle in degrees. NaN for unchanged.</param>
         <param index="5">Latitude</param>
@@ -1540,8 +1540,6 @@
       <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION">
         <description>Request VTOL transition</description>
         <param index="1">The target VTOL state, as defined by ENUM MAV_VTOL_STATE. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
-        <param index="2">Forwards transition heading: 0: use the heading towards the next waypoint, 1: ignored, 2: use the specified heading in parameter 4, 3: use the current heading when executing this command (facing the wind when weather-vaning is active).</param>
-        <param index="4">Yaw angle in degrees.</param>
       </entry>
       <entry value="4000" name="MAV_CMD_SET_GUIDED_SUBMODE_STANDARD">
         <description>This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
@@ -2586,6 +2584,21 @@
       </entry>
       <entry value="3" name="LANDING_TARGET_TYPE_VISION_OTHER">
         <description>Landing target represented by a pre-defined visual shape/feature (ex: X-marker, H-marker, square)</description>
+      </entry>
+    </enum>
+    <enum name="VTOL_TRANSITION_HEADING">
+      <description>Direction of VTOL transition</description>
+      <entry value="0" name="VTOL_TRANSITION_HEADING_NEXT_WAYPOINT">
+        <description>Use the heading pointing towards the next waypoint.</description>
+      </entry>
+      <entry value="1" name="VTOL_TRANSITION_HEADING_TAKEOFF">
+        <description>Use the heading on takeoff (while sitting on the ground).</description>
+      </entry>
+      <entry value="2" name="VTOL_TRANSITION_HEADING_SPECIFIED">
+        <description>Use the specified heading in parameter 4.</description>
+      </entry>
+      <entry value="3" name="VTOL_TRANSITION_HEADING_WEATHERVANE">
+        <description>Use the current heading when reaching takeoff altitude (facing the wind when weather-vaning is active).</description>
       </entry>
     </enum>
   </enums>


### PR DESCRIPTION
Proposal to standardize in which direction the VTOL transitions. This is relevant for VTOL takeoff as well as for the independent transition command.

Basically there are 4 options we use so far (there might me more, please comment):
1) (default) Direction of the next waypoint. This should be expected when planning a mission on the map since we are supposed to track the line from A to B.
2) (only relevant for takeoff) Use the heading of the vehicle on the ground before takeoff, makes sense if the user positions the vehicle consciously into the wind.
3) Use the specified heading.
4) Use whatever heading the vehicle has when getting the transition command (reaching the waypoint), especially useful for takeoff with enabled weather-vaning.