### PR TITLE
message_definitions: improve image capture status

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4122,8 +4122,8 @@
       <description>WIP: Information about the status of a capture</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t" name="camera_id">Camera ID (1 for first, 2 for second, etc.)</field>
-      <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
-      <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
+      <field type="uint8_t" name="image_status">Current status of image capturing (0: idle, 1: capture in progress, 2: interval set but idle, 3: interval set and capture in progress)</field>
+      <field type="uint8_t" name="video_status">Current status of video capturing (0: idle, 1: capture in progress)</field>
       <field type="float" name="image_interval" units="s">Image capture interval in seconds</field>
       <field type="uint32_t" name="recording_time_ms" units="ms">Time in milliseconds since recording started</field>
       <field type="float" name="available_capacity" units="Mibytes">Available storage capacity in MiB</field>


### PR DESCRIPTION
The camera status needs to inform if the camera is currently taking a
picture and therefore busy, but also if it is set for an interval.