### PR TITLE
Common: Add GPS_FIX_TYPE_PPP

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2570,6 +2570,9 @@
       <entry value="7" name="GPS_FIX_TYPE_STATIC">
         <description>Static fixed, typically used for base stations</description>
       </entry>
+      <entry value="8" name="GPS_FIX_TYPE_PPP">
+        <description>PPP, 3D position.</description>
+      </entry>
     </enum>
     <enum name="LANDING_TARGET_TYPE">
       <description>Type of landing target</description>


### PR DESCRIPTION
PPP GPS's are readily available for use these days, and the fix type can't be communicated to the ground correctly.