### PR TITLE
Reserved slot for where camera id used to be.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1427,19 +1427,22 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE">
-        <description>WIP: Set camera running mode. Use NAN for reserved values and values you don't want to change.</description>
-        <param index="1">Camera mode (CAM_MODE 0: photo/image mode, 1: video mode)</param>
-        <param index="2">Reserved (all remaining params)</param>
+        <description>Set camera running mode. Use NAN for reserved values.</description>
+        <param index="1">Reserved (Set to 0)</param>
+        <param index="2">Camera mode (CAM_MODE 0: photo/image mode, 1: video mode)</param>
+        <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
-        <description>WIP: Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NAN for reserved values.</description>
-        <param index="1">Duration between two consecutive pictures (in seconds)</param>
-        <param index="2">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="3">Reserved</param>
+        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NAN for reserved values.</description>
+        <param index="1">Reserved (Set to 0)</param>
+        <param index="2">Duration between two consecutive pictures (in seconds)</param>
+        <param index="3">Number of images to capture total - 0 for unlimited capture</param>
+        <param index="4">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
-        <description>WIP: Stop image capture sequence</description>
-        <param index="1">Reserved</param>
+        <description>Stop image capture sequence Use NAN for reserved values.</description>
+        <param index="1">Reserved (Set to 0)</param>
+        <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2002" name="MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE">
         <description>WIP: Re-request a CAMERA_IMAGE_CAPTURE packet. Use NAN for reserved values.</description>
@@ -1453,13 +1456,15 @@
         <param index="3">1 to pause triggering, but without switching the camera off or retracting it. -1 to ignore</param>
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
-        <description>WIP: Starts video capture (recording). Use NAN for reserved values.</description>
-        <param index="1">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency in Hz)</param>
-        <param index="2">Reserved</param>
+        <description>Starts video capture (recording). Use NAN for reserved values.</description>
+        <param index="1">Reserved (Set to 0)</param>
+        <param index="2">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency in Hz)</param>
+        <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
-        <description>WIP: Stop the current video capture (recording). Use NAN for reserved values.</description>
-        <param index="1">Reserved</param>
+        <description>Stop the current video capture (recording). Use NAN for reserved values.</description>
+        <param index="1">Reserved (Set to 0)</param>
+        <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING">
         <description>WIP: Start video streaming</description>


### PR DESCRIPTION
These 5 commands are used by QGroundControl and it expects param1 to be 0.

```
SET_CAMERA_MODE
IMAGE_START_CAPTURE
IMAGE_STOP_CAPTURE
VIDEO_START_CAPTURE
VIDEO_STOP_CAPTURE
```

Also removing the "WIP" comment given that they are now locked down.
