### PR TITLE
message_definitions: fix the camera mode enum name

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1429,7 +1429,7 @@
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE">
         <description>Set camera running mode. Use NAN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
-        <param index="2">Camera mode (CAM_MODE 0: photo/image mode, 1: video mode)</param>
+        <param index="2">Camera mode (CAMERA_MODE 0: photo/image mode, 1: video mode)</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
@@ -4117,7 +4117,7 @@
     <message id="260" name="CAMERA_SETTINGS">
       <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="mode_id" enum="CAM_MODE">Camera mode (CAM_MODE)</field>
+      <field type="uint8_t" name="mode_id" enum="CAMERA_MODE">Camera mode (CAMERA_MODE)</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
       <description>WIP: Information about a storage medium.</description>


### PR DESCRIPTION
This was inconsistent.