### PR TITLE
Add a terminating state

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -300,6 +300,9 @@
       <entry name="MAV_STATE_POWEROFF">
         <description>System just initialized its power-down sequence, will shut down now.</description>
       </entry>
+      <entry name="MAV_STATE_FLIGHT_TERMINATION">
+        <description>System is terminating itself.</description>
+      </entry>
     </enum>
     <enum name="MAV_COMPONENT">
       <entry value="0" name="MAV_COMP_ID_ALL">


### PR DESCRIPTION
It would be nice to have an unequivocal indication to a GCS/operator that the system is performing a commanded flight termination. MAV_STATE_EMERGENCY could be sent for this, but there are other reasons to get into that state, so I'd prefer to have an unambiguous message for termination if that's fine with others.