### PR TITLE
Set WiFi SSID and/or password.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4221,6 +4221,11 @@
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
       <field type="char[230]" name="uri">Video stream URI</field>
     </message>
+    <message id="299" name="WIFI_CONFIG_AP">
+      <description>Configure AP SSID and Password.</description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network (SSID). Leave it blank to leave it unchanged.</field>
+      <field type="char[64]" name="password">Password. Leave it blank for an open AP.</field>
+    </message>
     <message id="300" name="PROTOCOL_VERSION">
       <description>WIP: Version and capability of protocol version. This message is the response to REQUEST_PROTOCOL_VERSION and is used as part of the handshaking to establish which MAVLink version should be used on the network. Every node should respond to REQUEST_PROTOCOL_VERSION to enable the handshaking. Library implementers should consider adding this into the default decoding state machine to allow the protocol core to respond directly.</description>
       <field type="uint16_t" name="version">Currently active MAVLink version number * 100: v1.0 is 100, v2.0 is 200, etc.</field>


### PR DESCRIPTION
Given that there has been no development with PR #730, I've adding this one message here. It's used for setting an Access Point SSID and its password.

If further progress is done with #730, they can add those message above this one.