### PR TITLE
Mission: Add command to delay state machine until position gate has b…

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1537,6 +1537,16 @@
         <param index="5">Unscaled target latitude of center of circle in CIRCLE_MODE</param>
         <param index="6">Unscaled target longitude of center of circle in CIRCLE_MODE</param>
       </entry>
+      <entry value="4501" name="MAV_CMD_CONDITION_GATE">
+        <description>WIP: Delay mission state machine until gate has been reached.</description>
+        <param index="1">Geometry: 0: orthogonal to path between previous and next waypoint.</param>
+        <param index="2">Altitude: 0: ignore altitude</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
+        <param index="7">Altitude</param>
+      </entry>
       <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT">
         <description>Fence return point. There can only be one fence return point.
         </description>


### PR DESCRIPTION
…een reached.

This helps to structure missions where certain 3D coordinates need to be reached before continuing the mission plan, but where adding a state to the navigation controller is undesirable.