### PR TITLE
Fix typo in explanation of vz

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2878,7 +2878,7 @@
       <field type="int32_t" name="relative_alt" units="mm">Altitude above ground in meters, expressed as * 1000 (millimeters)</field>
       <field type="int16_t" name="vx" units="cm/s">Ground X Speed (Latitude, positive north), expressed as m/s * 100</field>
       <field type="int16_t" name="vy" units="cm/s">Ground Y Speed (Longitude, positive east), expressed as m/s * 100</field>
-      <field type="int16_t" name="vz" units="cm/s">Ground Z Speed (Altitude, positive down), expressed as m/s * 100</field>
+      <field type="int16_t" name="vz" units="cm/s">Ground Z Speed (Altitude, positive up), expressed as m/s * 100</field>
       <field type="uint16_t" name="hdg" units="cdeg">Vehicle heading (yaw angle) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX</field>
     </message>
     <message id="34" name="RC_CHANNELS_SCALED">


### PR DESCRIPTION
The description of GLOBAL_POSITION_INT mentions the following: "The position is in GPS-frame (right-handed, Z-up)". Now the explanation used for vz is saying "Ground Z Speed (Altitude, positive down), expressed as m/s * 100". One of the two is fault. The simulator is giving Z-up. I.e. the vz description is fault.