### PR TITLE
Mount/gimbal: add angular rate inputs, stabilize API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.5"
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libxml2-dev
+  - sudo apt-get install -y libxml2-dev libxml2-utils
 script:
   - ./scripts/test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,3 @@ script:
 after_success:
   - ./scripts/travis_update_generated_repos.sh
 
-before_install:
-  - git submodule update --init --recursive
-

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1159,12 +1159,12 @@
       </entry>
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL">
         <description>Mission command to control a camera or antenna mount</description>
-        <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode (degrees or degrees/second depending on pitch input).</param>
-        <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode (degrees or degrees/second depending on roll input).</param>
-        <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode (degrees or degrees/second depending on yaw input).</param>
-        <param index="4">WIP: alt in meters depending on mount mode.</param>
-        <param index="5">WIP: latitude in degrees * 1E7, set if appropriate mount mode.</param>
-        <param index="6">WIP: longitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input).</param>
+        <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
+        <param index="3">yaw depending on mount mode (degrees or degrees/second depending on yaw input).</param>
+        <param index="4">alt in meters depending on mount mode.</param>
+        <param index="5">latitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="6">longitude in degrees * 1E7, set if appropriate mount mode.</param>
         <param index="7">MAV_MOUNT_MODE enum value</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1153,15 +1153,15 @@
         <param index="2">stabilize roll? (1 = yes, 0 = no)</param>
         <param index="3">stabilize pitch? (1 = yes, 0 = no)</param>
         <param index="4">stabilize yaw? (1 = yes, 0 = no)</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
+        <param index="5">roll input (0 = angle, 1 = angular rate)</param>
+        <param index="6">pitch input (0 = angle, 1 = angular rate)</param>
+        <param index="7">yaw input (0 = angle, 1 = angular rate)</param>
       </entry>
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL">
         <description>Mission command to control a camera or antenna mount</description>
-        <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode.</param>
-        <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode.</param>
-        <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode.</param>
+        <param index="1">pitch (WIP: DEPRECATED: or lat in degrees) depending on mount mode (degrees or degrees/second depending on pitch input).</param>
+        <param index="2">roll (WIP: DEPRECATED: or lon in degrees) depending on mount mode (degrees or degrees/second depending on roll input).</param>
+        <param index="3">yaw (WIP: DEPRECATED: or alt in meters) depending on mount mode (degrees or degrees/second depending on yaw input).</param>
         <param index="4">WIP: alt in meters depending on mount mode.</param>
         <param index="5">WIP: latitude in degrees * 1E7, set if appropriate mount mode.</param>
         <param index="6">WIP: longitude in degrees * 1E7, set if appropriate mount mode.</param>


### PR DESCRIPTION
This allows to control a gimbal in angular rate in degrees/second
instead of just setting a fixed angle. The setting can be chosen for
each axis individually.

Since this interface has already gone into a QGroundControl release and
there has not been any further feedback, it makes sense to remove the
WIP flags and stabilize it.