### PR TITLE
add distance sensor orientation convention

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3783,7 +3783,7 @@
       <field type="uint16_t" name="current_distance">Current distance reading</field>
       <field type="uint8_t" name="type" enum="MAV_DISTANCE_SENSOR">Type from MAV_DISTANCE_SENSOR enum.</field>
       <field type="uint8_t" name="id">Onboard ID of the sensor</field>
-      <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum.</field>
+      <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces from MAV_SENSOR_ORIENTATION enum. downward-facing: ROTATION_PITCH_270, upward-facing: ROTATION_PITCH_90, backward-facing: ROTATION_PITCH_180, forward-facing: ROTATION_NONE, left-facing: ROTATION_YAW_90, right-facing: ROTATION_YAW_270</field>
       <field type="uint8_t" name="covariance" units="cm">Measurement covariance in centimeters, 0 for unknown / invalid readings</field>
     </message>
     <message id="133" name="TERRAIN_REQUEST">


### PR DESCRIPTION
Before there was no convention on the distance sensor convention.
See also https://github.com/PX4/Devguide/pull/269 and https://github.com/PX4/Firmware/pull/7984

I added it to `MAV_SENSOR_ORIENTATION` as the distance sensor is the only sensor using it so far. If that should stay general we can add the comments to the `DISTANCE_SENSOR` message.