### PR TITLE
mavlink_autopilot_version_t: add extended uid2 hardware identifier

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3928,7 +3928,9 @@
       <field type="uint8_t[8]" name="os_custom_version">Custom version field, commonly the first 8 bytes of the git hash. This is not an unique identifier, but should allow to identify the commit using the main version number even for very large code bases.</field>
       <field type="uint16_t" name="vendor_id">ID of the board vendor</field>
       <field type="uint16_t" name="product_id">ID of the product</field>
-      <field type="uint64_t" name="uid">UID if provided by hardware</field>
+      <field type="uint64_t" name="uid">UID if provided by hardware (see uid2)</field>
+      <extensions/>
+      <field type="uint8_t[18]" name="uid2">UID if provided by hardware (supersedes the uid field. If this is non-zero, use this field, otherwise use uid)</field>
     </message>
     <message id="149" name="LANDING_TARGET">
       <description>The location of a landing area captured from a downward facing camera</description>


### PR DESCRIPTION
Newer HW chips provide a 128 bit identifier. To make use of that we extend
the message with a longer uid, and use an uint8 array, so that the byte
ordering is clear.
The new field is 18 bytes, so that 2 bytes can be used to differentiate
between multiple SoC's.