### PR TITLE
Ardupilot: Timestamp added to RPM message.

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1315,6 +1315,7 @@
     <!-- 219 to 224 RESERVED for more GOPRO-->
     <message id="226" name="RPM">
       <description>RPM sensor output</description>
+      <field name="time_usec" type="uint64_t">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
       <field type="float" name="rpm1">RPM Sensor1</field>
       <field type="float" name="rpm2">RPM Sensor2</field>
     </message>


### PR DESCRIPTION
This PR is done for better synchronization of RPMs of wheel encoders connected to autopilot on a companion computer (e.g. to compute wheel odometry).