### PR TITLE
Ardupilot: message with wheels' cumulative distances added.

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1318,6 +1318,11 @@
       <field type="float" name="rpm1">RPM Sensor1</field>
       <field type="float" name="rpm2">RPM Sensor2</field>
     </message>
+    <message id="227" name="WHEEL_DISTANCE">
+      <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
+      <field type="float[2]" name="distance">Distance for each wheel (m)</field>
+    </message>
     <!-- ardupilot specific mavlink2 messages starting at 11000-->
     <message id="11000" name="DEVICE_OP_READ">
       <description>Read registers for a device</description>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1318,12 +1318,6 @@
       <field type="float" name="rpm1">RPM Sensor1</field>
       <field type="float" name="rpm2">RPM Sensor2</field>
     </message>
-    <message id="227" name="WHEEL_DISTANCE">
-      <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
-      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
-      <field type="uint8_t" name="count">Number of wheels reported</field>
-      <field type="float[4]" name="distance" units="m">Distance traveled by each wheel (m)</field>
-    </message>
     <!-- ardupilot specific mavlink2 messages starting at 11000-->
     <message id="11000" name="DEVICE_OP_READ">
       <description>Read registers for a device</description>
@@ -1388,6 +1382,13 @@
       <field type="float[3]" name="angle_delta">Defines a rotation vector in body frame that rotates the vehicle from the previous to the current orientation</field>
       <field type="float[3]" name="position_delta">Change in position in meters from previous to current frame rotated into body frame (0=forward, 1=right, 2=down)</field>
       <field type="float" name="confidence">normalised confidence value from 0 to 100</field>
+    </message>
+    <!-- wheel traveled distance message -->
+    <message id="11020" name="WHEEL_DISTANCE">
+      <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
+      <field name="time_usec" type="uint64_t">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
+      <field type="uint8_t" name="count">Number of wheels reported</field>
+      <field type="float[4]" name="distance" units="m">Distance traveled by each wheel (m)</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1321,7 +1321,8 @@
     <message id="227" name="WHEEL_DISTANCE">
       <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float[2]" name="distance">Distance for each wheel (m)</field>
+      <field type="uint8_t" name="count">Number of wheels reported</field>
+      <field type="float[4]" name="distance" units="m">Distance traveled by each wheel (m)</field>
     </message>
     <!-- ardupilot specific mavlink2 messages starting at 11000-->
     <message id="11000" name="DEVICE_OP_READ">

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1384,7 +1384,7 @@
       <field type="float" name="confidence">normalised confidence value from 0 to 100</field>
     </message>
     <!-- wheel traveled distance message -->
-    <message id="11020" name="WHEEL_DISTANCE">
+    <message id="11030" name="WHEEL_DISTANCE">
       <description>Cumulative distances traveled by each wheel in meters (forward rotations increase these values, backward - decrease).</description>
       <field name="time_usec" type="uint64_t">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
       <field type="uint8_t" name="count">Number of wheels reported</field>


### PR DESCRIPTION
This PR is aimed to make possible computing of wheel odometry on a companion computer with encoders connected to autopilot. Instead of using existing [RPM](http://mavlink.org/messages/ardupilotmega#RPM) message, this message allows more accurate odometry calculations.
Corresponding topic is discussed in mavros PR [#863](https://github.com/mavlink/mavros/pull/863).