### PR TITLE
Update scripts to generate markdown message definitions

### DIFF
--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -1,54 +1,47 @@
 #! /usr/bin/python
 
 """
-This script generates a markdown file (message-definitions.md) that can be imported into a gitbook to display the MAVLink Common message format (HTML).
-(this is a mechanism of bringing the current docs into the gitbook: http://mavlink.org/messages/common )
+This script generates markdown files for all the MAVLink message definition XML at: 
+https://github.com/mavlink/mavlink/tree/master/message_definitions/v1.0
+  
+The files can be imported into a gitbook to display the messages as HTML
 
 The script runs on both Python2 and Python 3. The following libraries must be imported: lxml, requests, bs4.
 
-The file is generated using an XSLT transformation from the XML at "https://raw.github.com/mavlink/mavlink/master/message_definitions/v1.0/common.xml". 
+The file is run in mavlink/doc/ with no arguments. It writes the files to /messages/
 """
 
 import lxml.etree as ET
 import requests
 from bs4 import BeautifulSoup as bs
 import re
-import os
+import os # for walk
 
-xml_file_url = "https://raw.github.com/mavlink/mavlink/master/message_definitions/v1.0/common.xml";
-xsl_file_url= "https://raw.github.com/mavlink/mavlink/master/doc/mavlink_to_html_table_gitbook.xsl";
+
+xsl_file_name = "mavlink_to_html_table_gitbook.xsl"
+xml_message_definitions_dir_name = "../message_definitions/v1.0/"
+
 output_dir = "./messages/"
-output_file_name = output_dir+"common.md"
 if not os.path.exists(output_dir):
     os.makedirs(output_dir)
-    
 
-# Get files from published URLs
-r = requests.get(xml_file_url)
-xml_file = r.text
-r = requests.get(xsl_file_url)
-xsl_file = r.text
+# File for index
+index_file_name = "README.md"
+index_file_name = output_dir + index_file_name
 
-dom = ET.fromstring(xml_file)
+# Get XSLT
+with open(xsl_file_name, 'r') as content_file:
+    xsl_file = content_file.read()
 xslt = ET.fromstring(xsl_file)
 
-transform = ET.XSLT(xslt)
-newdom = transform(dom)
+#initialise text for index file. 
+index_text='<!-- THIS FILE IS AUTO-GENERATED (DO NOT UPDATE GITBOOK): https://github.com/mavlink/mavlink/blob/master/doc/mavlink_gitbook.py -->'
+index_text+='\n# Message Definitions'
+index_text+='\n\nMAVLink messages are defined in XML files in the [mavlink/message definitions](https://github.com/mavlink/mavlink/blob/master/message_definitions/) folder. The messages that are common to all systems are defined in [common.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml) (only messages contained in this file are considered standard messages). MAVLink protocol-specific messages and vendor-specific messages are stored in separate XML files.'
+index_text+='\n\nThe common messages are provided as human-readable tables in: [Common](../messages/common.md).'
+index_text+='\n\n> **Note** Vendor forks of MAVLink may contain messages that are not get merged, and hence will not appear in this documentation.'
+index_text+='\n\nThe human-readable forms of the vendor XML files are linked below:'
 
-#Prettify the HTML using BeautifulSoup
-soup=bs(str(newdom), "lxml")
-prettyHTML=soup.prettify()
-
-
-# Strip out all text before "<html>" - not needed in the output
-def slicer(my_str,sub):
-    index=my_str.find(sub)
-    if index !=-1 :
-        return my_str[index:] 
-    else :
-        return my_str
-        
-prettyHTML=slicer(prettyHTML,'<html>')
 
 #Fix up the BeautifulSoup output so to fix build-link errors in the generated gitbook.
 ## BS puts each tag/content in its own line. Gitbook generates anchors using the spaces/newlines. 
@@ -62,13 +55,85 @@ def fix_content_in_tags(input_html):
     input_html=re.sub(r'\>(\s+?\w+?.*?)\<', remove_space_between_content_tags, input_html,flags=re.DOTALL)
     return input_html
     
-prettyHTML = fix_content_in_tags(prettyHTML)
+def fix_include_file_extension(input_html):
+    ## Fixes up file extension .xml.md.unlikely (easier than fixing up the XSLT to strip file extensions!)
+    input_html=input_html.replace('.xml.md.unlikely','.md')
+    return input_html
+    
+def inject_top_level_docs(input_html,filename):
+    #Inject top level heading and other details.
+    print('FILENAME: %s' % filename)
+    insert_text='<!-- THIS FILE IS AUTO-GENERATED: https://github.com/mavlink/mavlink/blob/master/doc/mavlink_gitbook.py -->'
+    if filename == 'common.xml':
+        insert_text+='\n# MAVLINK Common Message Set'
+        insert_text+='\n\nThese messages define the common message set, which is the reference message set implemented by most ground control stations and autopilots.'
+        insert_text+='\n\n*This is a human-readable form of the XML definition file: [common.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml).*'
+    elif filename == 'ardupilotmega.xml':
+        insert_text+='\n# MAVLINK ArduPilotMega Message Set'
+        insert_text+='\n\nThese messages define the APM specific message set, which is custom to [http://ardupilot.org](http://ardupilot.org).'
+        insert_text+='\n\n*This is a human-readable form of the XML definition file: [ardupilotmega.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/ardupilotmega.xml).*'
+        insert_text+='\n\n> **Warning** The ArduPilot MAVLink fork of [ardupilotmega.xml](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/ardupilotmega.xml) may contain messages that have not yet been merged into this documentation.'
+    else:
+        insert_text+='\n# MAVLINK Message Set: %s' % filename
+        insert_text+='\n\n*This is a human-readable form of the XML definition file: [%s](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/%s).*' % (filename, filename)
+
+
+    insert_text+='\n\n<span></span>\n> **Note** MAVLink 2 messages have an ID > 255 and are marked up using **(MAVLink 2)** in their description.'
+    insert_text+='\n\n<span id="mav2_extension_field"></span>\n> **Note** MAVLink 2 extension fields that have been added to MAVLink 1 messages are displayed in blue.'
+    input_html=insert_text+'\n\n'+input_html
+    #print(input_html)
+    return input_html
+    
+    
+
+for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
+    for file in files:
+        print file
+        xml_file_name = xml_message_definitions_dir_name+file
+        with open(xml_file_name, 'r') as content_file:
+            xml_file = content_file.read()
+            dom = ET.fromstring(xml_file)
+            transform = ET.XSLT(xslt)
+            newdom = transform(dom)
+
+            #Prettify the HTML using BeautifulSoup
+            soup=bs(str(newdom), "lxml")
+            prettyHTML=soup.prettify()
+
+            # Strip out all text before "<html>" - not needed in the output
+            def slicer(my_str,sub):
+                index=my_str.find(sub)
+                if index !=-1 :
+                    return my_str[index:] 
+                else :
+                    return my_str
+                    
+            prettyHTML=slicer(prettyHTML,'<html>')
+            prettyHTML = fix_content_in_tags(prettyHTML)
+            
+            #Inject a heading and doc-type intro (markdown format)
+            prettyHTML = inject_top_level_docs(prettyHTML,file)
+            
+            #Replace invalid file extensions (workaround for xslt)
+            prettyHTML = fix_include_file_extension(prettyHTML)
+            
+            #Write output file
+            output_file_name = file[:-4]+".md"
+            output_file_name_withdir = output_dir+output_file_name
+            print("Output filename: %s" % output_file_name)
 
     
-    
-with open(output_file_name, 'w') as out:
-    out.write(prettyHTML )
-    
+            with open(output_file_name_withdir, 'w') as out:
+                out.write(prettyHTML )
+            
+            if not file=='common.xml':
+                index_text+='\n* [%s](%s)' % (file,output_file_name)
+            
+#Write the index - Disabled for now.
+#with open(index_file_name, 'w') as content_file:
+#    content_file.write(index_text)
+
+
 print("COMPLETED")
 
 

--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -60,6 +60,14 @@ def fix_include_file_extension(input_html):
     input_html=input_html.replace('.xml.md.unlikely','.md')
     return input_html
     
+def strip_text_before_string(original_text,strip_text):
+    # Strip out all text before some string
+    index=original_text.find(strip_text)
+    stripped_string=original_text
+    if index !=-1 :
+        stripped_string = stripped_string[index:] 
+    return stripped_string
+    
 def inject_top_level_docs(input_html,filename):
     #Inject top level heading and other details.
     print('FILENAME: %s' % filename)
@@ -88,7 +96,9 @@ def inject_top_level_docs(input_html,filename):
 
 for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
     for file in files:
-        print file
+        print(file)
+        if not file.endswith('.xml'): #only process xml files.
+           continue
         xml_file_name = xml_message_definitions_dir_name+file
         with open(xml_file_name, 'r') as content_file:
             xml_file = content_file.read()
@@ -100,15 +110,8 @@ for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
             soup=bs(str(newdom), "lxml")
             prettyHTML=soup.prettify()
 
-            # Strip out all text before "<html>" - not needed in the output
-            def slicer(my_str,sub):
-                index=my_str.find(sub)
-                if index !=-1 :
-                    return my_str[index:] 
-                else :
-                    return my_str
-                    
-            prettyHTML=slicer(prettyHTML,'<html>')
+            #Strip out text before <html> tag in XSLT output
+            prettyHTML=strip_text_before_string(prettyHTML,'<html>')
             prettyHTML = fix_content_in_tags(prettyHTML)
             
             #Inject a heading and doc-type intro (markdown format)
@@ -117,12 +120,11 @@ for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
             #Replace invalid file extensions (workaround for xslt)
             prettyHTML = fix_include_file_extension(prettyHTML)
             
-            #Write output file
-            output_file_name = file[:-4]+".md"
+            #Write output markdown file
+            output_file_name = file.rsplit('.',1)[0]+".md"
             output_file_name_withdir = output_dir+output_file_name
             print("Output filename: %s" % output_file_name)
 
-    
             with open(output_file_name_withdir, 'w') as out:
                 out.write(prettyHTML )
             

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -3,36 +3,31 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:template match="//include">
-   <h1>MAVLink Include Files</h1>
-   <p><strong><em>Including files: </em><xsl:value-of select="." /></strong></p>
+   <p><strong>MAVLink Include Files: </strong> <a><xsl:attribute name="href"><xsl:value-of select="."/>.md.unlikely</xsl:attribute><xsl:value-of select="." /></a> </p>
 </xsl:template>
 
 <xsl:template match="//enums">
-   <h1>MAVLink Type Enumerations</h1>
+   <h2>MAVLink Type Enumerations</h2>
    <xsl:apply-templates />
 </xsl:template>
 
 <xsl:template match="//messages">
-   <h1>MAVLink Messages</h1>
+   <h2>MAVLink Messages</h2>
    <xsl:apply-templates />
 </xsl:template>
 
 <xsl:template match="//message">
-  
-  <h2>
-    <xsl:attribute name="class">mavlink_message_name</xsl:attribute>
-    <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
-    <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
-  <xsl:value-of select="@name" /> (
+  <h3 class="mavlink_message_name">
+   <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
+   <xsl:value-of select="@name" /> (
    <a>
-    <xsl:attribute name="href">
-      #<xsl:value-of select="@name"/>
-    </xsl:attribute>
-   #<xsl:value-of select="@id" />
+    <xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute>
+    #<xsl:value-of select="@id" />
    </a>
-   )</h2>  
-  
-   <p class="description"><xsl:value-of select="description" /></p>
+  )</h3>
+   <p class="description">
+     <xsl:if test='@id > 255'><strong>(MAVLink 2) </strong></xsl:if>
+     <xsl:value-of select="description" /></p>
    <table class="sortable">
    <thead>
    <tr>
@@ -42,31 +37,48 @@
    </tr>
    </thead>
    <tbody>
-   <xsl:apply-templates select="field" />
+   <xsl:apply-templates select="field" /> 
   </tbody>
   </table>
 </xsl:template>
 
 <xsl:template match="//field">
    <tr class="mavlink_field">
-   <td class="mavlink_name" valign="top"><xsl:value-of select="@name" /></td>
+   <xsl:choose>
+     <xsl:when test="preceding-sibling::extensions">
+       <td class="mavlink_name" valign="top" style="color:blue;"><xsl:value-of select="@name" />&#160;<a href="#mav2_extension_field" title="MAVLink2 extension field">**</a></td>
+     </xsl:when>
+     <xsl:otherwise>
+       <td class="mavlink_name" valign="top"><xsl:value-of select="@name" /></td>
+     </xsl:otherwise>
+   </xsl:choose>
+  
    <td class="mavlink_type" valign="top"><xsl:value-of select="@type" /></td>
-   <td class="mavlink_comment"><xsl:value-of select="." /></td>
+   <td class="mavlink_comment"> <xsl:value-of select="." />
+     <xsl:if test='@units'>
+     (Units: <xsl:value-of select="@units" />)
+     </xsl:if>
+     <xsl:if test='@enum'>
+     (Enum: <a><xsl:attribute name="href">#ENUM_<xsl:value-of select="@enum" /></xsl:attribute><xsl:value-of select="@enum" /></a>)
+     </xsl:if>
+   </td>
    </tr>
 </xsl:template>
 
 <xsl:template match="//version">
-   <h1>MAVLink Protocol Version</h1>
-   <p>This file has protocol version: <xsl:value-of select="." />. The version numbers range from 1-255.</p>
+   <h2>MAVLink Protocol Version</h2>
+   <p>This file has protocol version: <xsl:value-of select="." />. The version numbers range from 1-255. </p>
+</xsl:template>
+
+<xsl:template match="//dialect">
+   <p>This file has protocol dialect: <xsl:value-of select="." />.</p>
 </xsl:template>
 
 <xsl:template match="//enum">
-   <h2>
-    <xsl:attribute name="name">ENUM_<xsl:value-of select="@name"/></xsl:attribute>
-    <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
-    <xsl:attribute name="class">mavlink_message_name</xsl:attribute>
-    <xsl:value-of select="@name" />
-   </h2>
+   <h3 class="mavlink_message_name">    
+     <xsl:attribute name="id">ENUM_<xsl:value-of select="@name"/></xsl:attribute>
+     <a><xsl:attribute name="href">#ENUM_<xsl:value-of select="@name"/></xsl:attribute>
+     <xsl:value-of select="@name" /></a></h3>
 
    <p class="description"><xsl:value-of select="description" /></p>
    <table class="sortable">
@@ -86,9 +98,21 @@
 <xsl:template match="//entry">
    <tr class="mavlink_field" id="{@name}">
    <td class="mavlink_type" valign="top"><xsl:value-of select="@value" /></td>
-   <td class="mavlink_name" valign="top"><xsl:value-of select="@name" /></td>
+   <td class="mavlink_name" valign="top"><a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute>
+   <xsl:value-of select="@name" /></a></td>
    <td class="mavlink_comment"><xsl:value-of select="description" /></td>
-   </tr>   
+   </tr>
+<xsl:if test='param'>
+   <tr>
+     <td></td>
+     <xsl:apply-templates select="param" />
+   </tr>
+   <tr>
+    <td colspan="3"><br /></td>
+   </tr>
+</xsl:if>
+   
+
 </xsl:template>
 
 <xsl:template match="//param">

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -59,7 +59,7 @@
      (Units: <xsl:value-of select="@units" />)
      </xsl:if>
      <xsl:if test='@enum'>
-     (Enum: <a><xsl:attribute name="href">#ENUM_<xsl:value-of select="@enum" /></xsl:attribute><xsl:value-of select="@enum" /></a>)
+     (Enum: <a><xsl:attribute name="href">#<xsl:value-of select="@enum" /></xsl:attribute><xsl:value-of select="@enum" /></a>)
      </xsl:if>
    </td>
    </tr>
@@ -76,8 +76,8 @@
 
 <xsl:template match="//enum">
    <h3 class="mavlink_message_name">    
-     <xsl:attribute name="id">ENUM_<xsl:value-of select="@name"/></xsl:attribute>
-     <a><xsl:attribute name="href">#ENUM_<xsl:value-of select="@name"/></xsl:attribute>
+     <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
+     <a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute>
      <xsl:value-of select="@name" /></a></h3>
 
    <p class="description"><xsl:value-of select="description" /></p>


### PR DESCRIPTION
Scripts provide much better interlinking of generated message definitions. The tools are now run over all message definitions, not just the common.xml