### PR TITLE
WIP: MAV_CMD_DO_SET_ROI - Add optional offsets to MAV_ROI_WPNEXT mode

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1123,9 +1123,9 @@
         <param index="2">Waypoint index/ target ID. (see MAV_ROI enum)</param>
         <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
         <param index="4">Empty</param>
-        <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
-        <param index="6">y</param>
-        <param index="7">z</param>
+        <param index="5">MAV_ROI_WPNEXT: pitch offset from next waypoint, MAV_ROI_LOCATION: latitude</param>
+        <param index="6">MAV_ROI_WPNEXT: roll offset from next waypoint, MAV_ROI_LOCATION: longitude</param>
+        <param index="7">MAV_ROI_WPNEXT: yaw offset from next waypoint, MAV_ROI_LOCATION: altitude</param>
       </entry>
       <!-- Camera Controller Mission Commands Enumeration -->
       <!-- MAV_CMD_DO_DIGICAM_CONFIGURE should be deprecated and replaced with PARAM_EXT_XXX messages -->
@@ -1853,7 +1853,7 @@
         <description>No region of interest.</description>
       </entry>
       <entry value="1" name="MAV_ROI_WPNEXT">
-        <description>Point toward next waypoint.</description>
+        <description>Point toward next waypoint, with optional pitch/roll/yaw offset.</description>
       </entry>
       <entry value="2" name="MAV_ROI_WPINDEX">
         <description>Point toward given waypoint.</description>


### PR DESCRIPTION
Here is the problem. QGC supports polygonal Structure Scan. Here are some examples:
<img width="1060" alt="32257927-0f1a0082-be75-11e7-83da-8ff9ab18e78e" src="https://user-images.githubusercontent.com/5876851/34429059-e4b561ae-ec07-11e7-8806-dcd08fe073d7.png">
<img width="754" alt="32257937-1cff649e-be75-11e7-9a3a-926ede918116" src="https://user-images.githubusercontent.com/5876851/34429060-e4d695ea-ec07-11e7-91b8-212b1a6aaffc.png">

The current implementation yaws the gimbal 90 degrees in order to keep the camera pointed at the structure during flight using a DO_MOUNT_CONTROL command. The issue is how do you do this when you don't have a gimbal that supports yaw. As far as I can tell the current answer is that there is no way to do this. You end up fighting with the fact that default mission flight path parameter setting is to point to the next waypoint. And you can't change that from a mission.

So this change is to use MAV_ROI_WPNEXT with offsets to get an ROI which can be an offset from the direction to the next waypoint. Using the structure scan as an example I would set the yaw into param 7 to 90 degrees of MAV_CMD_DO_SET_ROI and set the mode to MAV_ROI_WPNEXT.

Then if the gimbal supported it, it would use the gimbal to achieve the ROI. If not, it would just yaw the vehicle itself.

Then you would use a  MAV_ROI_NONE command to reset back to whatever the mission flight parameter settings is.

Maybe there is some other way to do this, but hopefully this can start the discussion.