### PR TITLE
Remove duplicate command to MAV_CMD_DO_SET_ROI

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -793,16 +793,6 @@
         <param index="6">X offset from target (m)</param>
         <param index="7">Y offset from target (m)</param>
       </entry>
-      <entry value="80" name="MAV_CMD_NAV_ROI">
-        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
-        <param index="1">Region of intereset mode. (see MAV_ROI enum)</param>
-        <param index="2">Waypoint index/ target ID. (see MAV_ROI enum)</param>
-        <param index="3">ROI index (allows a vehicle to manage multiple ROI's)</param>
-        <param index="4">Empty</param>
-        <param index="5">x the location of the fixed ROI (see MAV_FRAME)</param>
-        <param index="6">y</param>
-        <param index="7">z</param>
-      </entry>
       <entry value="81" name="MAV_CMD_NAV_PATHPLANNING">
         <description>Control autonomous path planning on the MAV.</description>
         <param index="1">0: Disable local obstacle avoidance / local path planning (without resetting map), 1: Enable local path planning, 2: Enable and reset local path planning</param>


### PR DESCRIPTION
MAV_CMD_NAV_ROI is an exact duplicate of MAV_CMD_DO_SET_ROI. PX4 supports both it seems and ArduPilot only supports MAV_CMD_DO_SET_ROI. This pull removes the duplicate MAV_CMD_NAV_ROI which just ends up confusing things at least from a ground station standpoint.