### PR TITLE
common: deprecate DIGICAM_CONFIGURE/CONTROL

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1161,9 +1161,8 @@
         <param index="7">MAV_ROI_WPNEXT: yaw offset from next waypoint, MAV_ROI_LOCATION: altitude</param>
       </entry>
       <!-- Camera Controller Mission Commands Enumeration -->
-      <!-- MAV_CMD_DO_DIGICAM_CONFIGURE should be deprecated and replaced with PARAM_EXT_XXX messages -->
       <entry value="202" name="MAV_CMD_DO_DIGICAM_CONFIGURE">
-        <description>Mission command to configure an on-board camera controller system.</description>
+        <description>THIS INTERFACE IS DEPRECATED since 2018-01. Please use PARAM_EXT_XXX messages and the camera definition format described in https://mavlink.io/en/protocol/camera_def.html.</description>
         <param index="1">Modes: P, TV, AV, M, Etc</param>
         <param index="2">Shutter speed: Divisor number for one second</param>
         <param index="3">Aperture: F stop number</param>
@@ -1173,7 +1172,7 @@
         <param index="7">Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)</param>
       </entry>
       <entry value="203" name="MAV_CMD_DO_DIGICAM_CONTROL">
-        <description>Mission command to control an on-board camera controller system.</description>
+        <description>THIS INTERFACE IS DEPRECATED since 2018-01. Please use PARAM_EXT_XXX messages and the camera definition format described in https://mavlink.io/en/protocol/camera_def.html.</description>
         <param index="1">Session control e.g. show/hide lens</param>
         <param index="2">Zoom's absolute position</param>
         <param index="3">Zooming step value to offset zoom from the current position</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1428,12 +1428,12 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
-        <description>WIP: Request camera information (CAMERA_INFORMATION).</description>
+        <description>Request camera information (CAMERA_INFORMATION).</description>
         <param index="1">0: No action 1: Request camera capabilities</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
-        <description>WIP: Request camera settings (CAMERA_SETTINGS).</description>
+        <description>Request camera settings (CAMERA_SETTINGS).</description>
         <param index="1">0: No Action 1: Request camera settings</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
@@ -1450,7 +1450,7 @@
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
-        <description>WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
+        <description>Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
         <param index="1">0: No Action 1: Request camera capture status</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
@@ -1460,7 +1460,7 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="529" name="MAV_CMD_RESET_CAMERA_SETTINGS">
-        <description>WIP: Reset all camera settings to Factory Default</description>
+        <description>Reset all camera settings to Factory Default</description>
         <param index="1">0: No Action 1: Reset all settings</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
@@ -4267,7 +4267,7 @@
       <field type="char[30]" name="tune">tune in board specific format</field>
     </message>
     <message id="259" name="CAMERA_INFORMATION">
-      <description>WIP: Information about a camera</description>
+      <description>Information about a camera</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
@@ -4283,7 +4283,7 @@
       <field type="char[140]" name="cam_definition_uri">Camera definition URI (if any, otherwise only basic functions will be available).</field>
     </message>
     <message id="260" name="CAMERA_SETTINGS">
-      <description>WIP: Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS.</description>
+      <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t" name="mode_id" enum="CAMERA_MODE">Camera mode (CAMERA_MODE)</field>
     </message>
@@ -4300,7 +4300,7 @@
       <field type="float" name="write_speed" units="Mibytes/s">Write speed in MiB/s</field>
     </message>
     <message id="262" name="CAMERA_CAPTURE_STATUS">
-      <description>WIP: Information about the status of a capture</description>
+      <description>Information about the status of a capture</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="uint8_t" name="image_status">Current status of image capturing (0: idle, 1: capture in progress, 2: interval set but idle, 3: interval set and capture in progress)</field>
       <field type="uint8_t" name="video_status">Current status of video capturing (0: idle, 1: capture in progress)</field>


### PR DESCRIPTION
The DIGICAM_CONFIGURE and DIGICAM_CONTROL commands have been replaced
by the Dronecode camera working group, and the implementation of camera
definitions and the new PARAM_EXT_XXX parameters.

For more info, check: https://mavlink.io/en/protocol/camera_def.html

Therefore, this commit deprecates these two commands in order to
encourage adoption of the new interface.

@dagar this was your question in the strategy call last week.