### PR TITLE
precision land: add description for precision land mode

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -709,7 +709,7 @@
       <entry value="21" name="MAV_CMD_NAV_LAND">
         <description>Land at location</description>
         <param index="1">Abort Alt</param>
-        <param index="2">Empty</param>
+        <param index="2">Precision land mode. (0 = normal landing, 1 = opportunistic precision landing, 2 = required precsion landing)</param>
         <param index="3">Empty</param>
         <param index="4">Desired yaw angle. NaN for unchanged.</param>
         <param index="5">Latitude</param>


### PR DESCRIPTION
This documents the usage of `param2` of `MAV_CMD_NAV_LAND` for precision landing.