### PR TITLE
HIGH_LATENCY2 revision

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -174,193 +174,49 @@
         <description>official stable release</description>
       </entry>
     </enum>
-    <enum name="FLIGHT_MODE">
-      <description>Flight modes of the MAV.</description>
-      <entry value="0" name="FLIGHT_MODE_MANUAL">
-        <description>Manual flight mode</description>
-      </entry>
-      <entry value="1" name="FLIGHT_MODE_ALTCTL">
-        <description>Altitude hold flight mode</description>
-      </entry>
-      <entry value="2" name="FLIGHT_MODE_POSCTL">
-        <description>Position control flight mode</description>
-      </entry>
-      <entry value="3" name="FLIGHT_MODE_STABILIZED">
-        <description>Stabilized mode</description>
-      </entry>
-      <entry value="4" name="FLIGHT_MODE_ACRO">
-        <description>Acro mode</description>
-      </entry>
-      <entry value="5" name="FLIGHT_MODE_RATTITIDE">
-        <description>Rattitude mode</description>
-      </entry>
-      <entry value="6" name="FLIGHT_MODE_AUTO_MISSION">
-        <description>Mission mode</description>
-      </entry>
-      <entry value="7" name="FLIGHT_MODE_AUTO_LOITER">
-        <description>Loiter mode</description>
-      </entry>
-      <entry value="8" name="FLIGHT_MODE_AUTO_RTL">
-        <description>Return to land mode</description>
-      </entry>
-      <entry value="9" name="FLIGHT_MODE_AUTO_RCRECOVER">
-        <description>RC recover mode</description>
-      </entry>
-      <entry value="10" name="FLIGHT_MODE_AUTO_RTGS">
-        <description>Return to ground station mode</description>
-      </entry>
-      <entry value="11" name="FLIGHT_MODE_AUTO_LANDENGFAIL">
-        <description>Land Engine Fail mode</description>
-      </entry>
-      <entry value="12" name="FLIGHT_MODE_AUTO_LANDGPSFAIL">
-        <description>Land GPS fail mode</description>
-      </entry>
-      <entry value="13" name="FLIGHT_MODE_AUTO_TAKEOFF">
-        <description>Takeoff mode</description>
-      </entry>
-      <entry value="14" name="FLIGHT_MODE_AUTO_LAND">
-        <description>Land mode</description>
-      </entry>
-      <entry value="15" name="FLIGHT_MODE_AUTO_FOLLOW_TARGET">
-        <description>Follow target/me mode</description>
-      </entry>
-      <entry value="16" name="FLIGHT_MODE_AUTO_PRECLAND">
-        <description>Precision landing mode</description>
-      </entry>
-      <entry value="17" name="FLIGHT_MODE_DESCEND">
-        <description>Descend mode</description>
-      </entry>
-      <entry value="18" name="FLIGHT_MODE_OFFBOARD">
-        <description>Offboard mode</description>
-      </entry>
-      <entry value="19" name="FLIGHT_MODE_TERMINATION">
-        <description>Termination mode</description>
-      </entry>
-      <entry value="20" name="FLIGHT_MODE_AUTO_TUNE">
-        <description>Auto tune mode</description>
-      </entry>
-      <entry value="21" name="FLIGHT_MODE_BRAKE">
-        <description>Brake mode</description>
-      </entry>
-      <entry value="22" name="FLIGHT_MODE_CIRCLE">
-        <description>Circle mode</description>
-      </entry>
-      <entry value="23" name="FLIGHT_MODE_DRIFT">
-        <description>Drift mode</description>
-      </entry>
-      <entry value="24" name="FLIGHT_MODE_GUIDED">
-        <description>Guided mode</description>
-      </entry>
-      <entry value="25" name="FLIGHT_MODE_SPORT">
-        <description>Sport mode</description>
-      </entry>
-      <entry value="26" name="FLIGHT_MODE_THROW">
-        <description>Throw mode</description>
-      </entry>
-      <entry value="27" name="FLIGHT_MODE_SUPER_SIMPLE">
-        <description>Simplified multicopter control mode</description>
-      </entry>
-      <entry value="28" name="FLIGHT_MODE_AVIOD_TRAFFIC">
-        <description>Avoid traffic mode</description>
-      </entry>
-      <entry value="29" name="FLIGHT_MODE_FBWA">
-        <description>Fly by wire (version A) mode</description>
-      </entry>
-      <entry value="30" name="FLIGHT_MODE_FBWB">
-        <description>Flz by wire (version B) mode</description>
-      </entry>
-      <entry value="31" name="FLIGHT_MODE_TRAINING">
-        <description>Position control flight mode</description>
-      </entry>
-      <entry value="32" name="FLIGHT_MODE_CRUISE">
-        <description>Cruise mode</description>
-      </entry>
-      <entry value="33" name="FLIGHT_MODE_HOLD">
-        <description>Position hold mode</description>
-      </entry>
-      <entry value="34" name="FLIGHT_MODE_STEERING">
-        <description>Steering mode</description>
-      </entry>
-      <entry value="35" name="FLIGHT_MODE_SMART_RTL">
-        <description>Smart return-to-land-mode</description>
-      </entry>
-    </enum>
-    <enum name="MAV_FAILSAFE_FLAG">
-      <description>These flags encode if a certain failsafe mode is triggered.</description>
-      <entry value="128" name="MAV_FAILSAFE_FLAG_RC_LOSS">
-        <description>0b10000000 RC loss failsafe active.</description>
-      </entry>
-      <entry value="64" name="MAV_FAILSAFE_FLAG_TELEM_LOSS">
-        <description>0b01000000 remote control input is enabled.</description>
-      </entry>
-      <entry value="32" name="MAV_FAILSAFE_FLAG_ENGINE">
-        <description>0b00100000 Engine failure failsafe active.</description>
-      </entry>
-      <entry value="16" name="MAV_FAILSAFE_FLAG_GPS">
-        <description>0b00010000 GPS failure failsafe active.</description>
-      </entry>
-      <entry value="8" name="MAV_FAILSAFE_FLAG_BATTERY">
-        <description>0b00001000 Battery failure failsafe active.</description>
-      </entry>
-      <entry value="4" name="MAV_FAILSAFE_FLAG_GEOFENCE">
-        <description>0b00000100 Geofence failsafe active.</description>
-      </entry>
-      <entry value="2" name="MAV_FAILSAFE_FLAG_RESERVED1">
-        <description>0b00000010 Reserved for future use.</description>
-      </entry>
-      <entry value="1" name="MAV_FAILSAFE_FLAG_RESERVED2">
-        <description>0b00000001 Reserved for future use.</description>
-      </entry>
-    </enum>
-    <enum name="MAV_FAILURE_FLAG">
-      <description>These flags encode if a certain failsafe mode is triggered.</description>
-      <entry value="1" name="MAV_FAILURE_FLAG_GPS">
+    <enum name="HL_FAILURE_FLAG">
+      <description>Flags to report failure cases over the high latency telemtry.</description>
+      <entry value="1" name="HL_FAILURE_FLAG_GPS">
         <description>GPS failure.</description>
       </entry>
-      <entry value="2" name="MAV_FAILURE_FLAG_AIRSPEED">
-        <description>Airspeed failure.</description>
+      <entry value="2" name="HL_FAILURE_FLAG_DIFFERENTIAL_PRESSURE">
+        <description>Differential pressure sensor failure.</description>
       </entry>
-      <entry value="4" name="MAV_FAILURE_FLAG_BAROMETER">
-        <description>Barometer failure.</description>
+      <entry value="4" name="HL_FAILURE_FLAG_ABSOLUTE_PRESSURE">
+        <description>Absolute pressure sensor failure.</description>
       </entry>
-      <entry value="8" name="MAV_FAILURE_FLAG_ACCELEROMETER">
-        <description>Accelerometer failure.</description>
+      <entry value="8" name="HL_FAILURE_FLAG_3D_ACCEL">
+        <description>Accelerometer sensor failure.</description>
       </entry>
-      <entry value="16" name="MAV_FAILURE_FLAG_GYROSCOPE">
-        <description>Gyroscope failure.</description>
+      <entry value="16" name="HL_FAILURE_FLAG_3D_GYRO">
+        <description>Gyroscope sensor failure.</description>
       </entry>
-      <entry value="32" name="MAV_FAILURE_FLAG_MAGNETOMETER">
-        <description>Magnetometer.</description>
+      <entry value="32" name="HL_FAILURE_FLAG_3D_MAG">
+        <description>Magnetometer sensor failure.</description>
       </entry>
-      <entry value="64" name="MAV_FAILURE_FLAG_MISSION">
-        <description>Mission failure.</description>
+      <entry value="64" name="HL_FAILURE_FLAG_TERRAIN">
+        <description>Terrain subsystem failure.</description>
       </entry>
-      <entry value="128" name="MAV_FAILURE_FLAG_ESTIMATOR">
-        <description>Estimator failure.</description>
+      <entry value="128" name="HL_FAILURE_FLAG_BATTERY">
+        <description>Battery failure/critical low battery.</description>
       </entry>
-      <entry value="256" name="MAV_FAILURE_FLAG_LIDAR">
-        <description>Lidar failure.</description>
+      <entry value="256" name="HL_FAILURE_FLAG_RC_RECEIVER">
+        <description>RC receiver failure/no rc connection.</description>
       </entry>
-      <entry value="512" name="MAV_FAILURE_FLAG_OFFBOARD_LINK">
+      <entry value="512" name="HL_FAILURE_FLAG_OFFBOARD_LINK">
         <description>Offboard link failure.</description>
       </entry>
-      <entry value="1024" name="MAV_FAILURE_FLAG_RESERVED1">
-        <description>Reserved for future use.</description>
+      <entry value="1024" name="HL_FAILURE_FLAG_ENGINE">
+        <description>Engine failure.</description>
       </entry>
-      <entry value="2048" name="MAV_FAILURE_FLAG_RESERVED2">
-        <description>Reserved for future use.</description>
+      <entry value="2048" name="HL_FAILURE_FLAG_GEOFENCE">
+        <description>Geofence violation.</description>
       </entry>
-      <entry value="4096" name="MAV_FAILURE_FLAG_RESERVED3">
-        <description>Reserved for future use.</description>
+      <entry value="4096" name="HL_FAILURE_FLAG_ESTIMATOR">
+        <description>Estimator failure, for example measurement rejection or large variances.</description>
       </entry>
-      <entry value="8192" name="MAV_FAILURE_FLAG_RESERVED4">
-        <description>Reserved for future use.</description>
-      </entry>
-      <entry value="16384" name="MAV_FAILURE_FLAG_RESERVED5">
-        <description>Reserved for future use.</description>
-      </entry>
-      <entry value="32768" name="MAV_FAILURE_FLAG_RESERVED6">
-        <description>Reserved for future use.</description>
+      <entry value="8192" name="HL_FAILURE_FLAG_MISSION">
+        <description>Mission failure.</description>
       </entry>
     </enum>
     <!-- WARNING: MAV_ACTION Enum is no longer supported - has been removed. Please use MAV_CMD -->
@@ -4318,28 +4174,27 @@
       <field type="uint32_t" name="timestamp" units="ms">Timestamp (milliseconds since boot or Unix epoch)</field>
       <field type="uint8_t" name="type" enum="MAV_TYPE">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
       <field type="uint8_t" name="autopilot" enum="MAV_AUTOPILOT">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
-      <field type="uint8_t" name="flight_mode" enum="FLIGHT_MODE">Flight Mode of the vehicle as defined in the FLIGHT_MODE ENUM</field>
+      <field type="uint16_t" name="custom_mode" display="bitmask">A bitfield for use for autopilot-specific flags (2 byte version).</field>
       <field type="int32_t" name="latitude" units="degE7">Latitude, expressed as degrees * 1E7</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude, expressed as degrees * 1E7</field>
       <field type="int16_t" name="altitude" units="m">Altitude above mean sea level</field>
       <field type="int16_t" name="target_altitude" units="m">Altitude setpoint</field>
-      <field type="uint8_t" name="heading" units="deg / 2">Heading (degrees / 2)</field>
-      <field type="uint8_t" name="target_heading" units="deg / 2">Heading setpoint (degrees / 2)</field>
-      <field type="uint16_t" name="target_distance" units="m">Distance to target waypoint or position (meters / 10)</field>
+      <field type="uint8_t" name="heading" units="deg/2">Heading (degrees / 2)</field>
+      <field type="uint8_t" name="target_heading" units="deg/2">Heading setpoint (degrees / 2)</field>
+      <field type="uint16_t" name="target_distance" units="m/10">Distance to target waypoint or position (meters / 10)</field>
       <field type="uint8_t" name="throttle" units="%">Throttle (percentage)</field>
-      <field type="uint8_t" name="airspeed" units="m/s * 5">Airspeed (m/s * 5)</field>
-      <field type="uint8_t" name="airspeed_sp" units="m/s * 5">Airspeed setpoint (m/s * 5)</field>
-      <field type="uint8_t" name="groundspeed" units="m/s * 5">Groundspeed (m/s * 5)</field>
-      <field type="uint8_t" name="windspeed" units="m/s * 5">Windspeed (m/s * 5)</field>
-      <field type="uint8_t" name="wind_heading" units="deg / 2">Wind heading (deg / 2)</field>
-      <field type="uint8_t" name="eph" units="m * 10">Maximum error horizontal position since last message (m * 10)</field>
-      <field type="uint8_t" name="epv" units="m * 10">Maximum error vertical position since last message (m * 10)</field>
+      <field type="uint8_t" name="airspeed" units="m/s*5">Airspeed (m/s * 5)</field>
+      <field type="uint8_t" name="airspeed_sp" units="m/s*5">Airspeed setpoint (m/s * 5)</field>
+      <field type="uint8_t" name="groundspeed" units="m/s*5">Groundspeed (m/s * 5)</field>
+      <field type="uint8_t" name="windspeed" units="m/s*5">Windspeed (m/s * 5)</field>
+      <field type="uint8_t" name="wind_heading" units="deg/2">Wind heading (deg / 2)</field>
+      <field type="uint8_t" name="eph" units="dm">Maximum error horizontal position since last message (m * 10)</field>
+      <field type="uint8_t" name="epv" units="dm">Maximum error vertical position since last message (m * 10)</field>
       <field type="int8_t" name="temperature_air" units="degC">Air temperature (degrees C) from airspeed sensor</field>
-      <field type="int8_t" name="climb_rate" units="m/s * 10">Maximum climb rate magnitude since last message (m/s * 10)</field>
+      <field type="int8_t" name="climb_rate" units="dm/s">Maximum climb rate magnitude since last message (m/s * 10)</field>
       <field type="int8_t" name="battery" units="%">Battery (percentage, -1 for DNU)</field>
       <field type="uint16_t" name="wp_num">Current waypoint number</field>
-      <field type="uint16_t" name="failure_flags" enum="MAV_FAILURE_FLAG">Indicates failures as defined in MAV_FAILURE_FLAG ENUM. </field>
-      <field type="uint8_t" name="failsafe" enum="MAV_FAILSAFE_FLAG">Indicates if a failsafe mode is triggered, defined in MAV_FAILSAFE_FLAG ENUM</field>
+      <field type="uint16_t" name="failure_flags" enum="HL_FAILURE_FLAG" display="bitmask">Indicates failures as defined in HL_FAILURE_FLAG ENUM. </field>
       <field type="int8_t" name="custom0">Field for custom payload.</field>
       <field type="int8_t" name="custom1">Field for custom payload.</field>
       <field type="int8_t" name="custom2">Field for custom payload.</field>


### PR DESCRIPTION
- Use the 2 bytes custom_mode instead of a custom defined flight mode.

- Merge `failure_flags` and `failsafe` into one 2 byte bitfield.

- Change the naming of the `failure_flags` so that it is closer to `MAV_SYS_STATUS_SENSOR` wherever possible.

@dagar @DonLakeFlyer can you check it?