### PR TITLE
common.xml: add global yaw angle, clarify comments

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4426,6 +4426,7 @@
       <field type="float" name="roll" units="deg">Roll in global frame in degrees (set to NaN for invalid).</field>
       <field type="float" name="pitch" units="deg">Pitch in global frame in degrees (set to NaN for invalid).</field>
       <field type="float" name="yaw" units="deg">Yaw relative to vehicle in degrees (set to NaN for invalid).</field>
+      <extensions/>
       <field type="float" name="yaw_absolute" units="deg">Yaw in absolute frame in degrees, North is 0 (set to NaN for invalid).</field>
     </message>
     <message id="266" name="LOGGING_DATA">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4426,7 +4426,7 @@
       <field type="float" name="roll" units="deg">Roll in global frame in degrees.</field>
       <field type="float" name="pitch" units="deg">Pitch in global frame in degrees.</field>
       <field type="float" name="yaw" units="deg">Yaw relative to vehicle in degrees</field>
-      <field type="float" name="yaw_global" units="deg">Yaw in global frame in degrees, North is 0.</field>
+      <field type="float" name="yaw_absolute" units="deg">Yaw in absolute frame in degrees, North is 0.</field>
     </message>
     <message id="266" name="LOGGING_DATA">
       <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4423,10 +4423,10 @@
     <message id="265" name="MOUNT_ORIENTATION">
       <description>WIP: Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="roll" units="deg">Roll in global frame in degrees.</field>
-      <field type="float" name="pitch" units="deg">Pitch in global frame in degrees.</field>
-      <field type="float" name="yaw" units="deg">Yaw relative to vehicle in degrees</field>
-      <field type="float" name="yaw_absolute" units="deg">Yaw in absolute frame in degrees, North is 0.</field>
+      <field type="float" name="roll" units="deg">Roll in global frame in degrees (set to NaN for invalid).</field>
+      <field type="float" name="pitch" units="deg">Pitch in global frame in degrees (set to NaN for invalid).</field>
+      <field type="float" name="yaw" units="deg">Yaw relative to vehicle in degrees (set to NaN for invalid).</field>
+      <field type="float" name="yaw_absolute" units="deg">Yaw in absolute frame in degrees, North is 0 (set to NaN for invalid).</field>
     </message>
     <message id="266" name="LOGGING_DATA">
       <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4421,7 +4421,7 @@
       <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
     </message>
     <message id="265" name="MOUNT_ORIENTATION">
-      <description>WIP: Orientation of a mount</description>
+      <description>Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
       <field type="float" name="roll" units="deg">Roll in global frame in degrees (set to NaN for invalid).</field>
       <field type="float" name="pitch" units="deg">Pitch in global frame in degrees (set to NaN for invalid).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4423,9 +4423,10 @@
     <message id="265" name="MOUNT_ORIENTATION">
       <description>WIP: Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (milliseconds since system boot)</field>
-      <field type="float" name="roll" units="deg">Roll in degrees</field>
-      <field type="float" name="pitch" units="deg">Pitch in degrees</field>
-      <field type="float" name="yaw" units="deg">Yaw in degrees</field>
+      <field type="float" name="roll" units="deg">Roll in global frame in degrees.</field>
+      <field type="float" name="pitch" units="deg">Pitch in global frame in degrees.</field>
+      <field type="float" name="yaw" units="deg">Yaw relative to vehicle in degrees</field>
+      <field type="float" name="yaw_global" units="deg">Yaw in global frame in degrees, North is 0.</field>
     </message>
     <message id="266" name="LOGGING_DATA">
       <description>A message containing logged data (see also MAV_CMD_LOGGING_START)</description>


### PR DESCRIPTION
The current yaw field was implemented as a yaw relative to the vehicle's
heading in QGC and is therefore stabilized that way.
However, we sometimes also would like to know the absolute orientation
of a mount/gimbal relative to North, so that's why the field
`yaw_global` is added.