### PR TITLE
Expand battery status to include more information from a fuel gauge

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4058,12 +4058,12 @@
       <field type="int32_t" name="current_consumed" units="mAh">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
       <field type="int32_t" name="energy_consumed" units="hJ">Consumed energy, in HectoJoules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
-	  <field type="int16_t" name="average_current_battery" units="cA">Average battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
-	  <field type="uint16_t" name="serial_number">Battery serial number, 0: battery does not have a serial number</field>
-	  <field type="uint16_t" name="capacity" units="mAh">Actual capacity of the battery measured by the fuel gauge, 0: battery does not report actual capacity</field>
-	  <field type="uint16_t" name="cycle_count">Number of charge-discharge cycles reported by the fuel gauge, UINT16_MAX: battery does not report cycle count</field>
-	  <field type="uint16_t" name="run_time_to_empty" units="min">Predicted remaining battery capacity based on the present rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
-	  <field type="uint16_t" name="average_time_to_empty" units="min">Predicted remaining battery capacity based on the average rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
+      <field type="int16_t" name="average_current_battery" units="cA">Average battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+      <field type="uint16_t" name="serial_number">Battery serial number, 0: battery does not have a serial number</field>
+      <field type="uint16_t" name="capacity" units="mAh">Actual capacity of the battery measured by the fuel gauge, 0: battery does not report actual capacity</field>
+      <field type="uint16_t" name="cycle_count">Number of charge-discharge cycles reported by the fuel gauge, UINT16_MAX: battery does not report cycle count</field>
+      <field type="uint16_t" name="run_time_to_empty" units="min">Predicted remaining battery capacity based on the present rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
+      <field type="uint16_t" name="average_time_to_empty" units="min">Predicted remaining battery capacity based on the average rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4062,8 +4062,8 @@
       <field type="uint16_t" name="serial_number">Battery serial number, 0: battery does not have a serial number</field>
       <field type="uint16_t" name="capacity" units="mAh">Actual capacity of the battery measured by the fuel gauge, 0: battery does not report actual capacity</field>
       <field type="uint16_t" name="cycle_count">Number of charge-discharge cycles reported by the fuel gauge, UINT16_MAX: battery does not report cycle count</field>
-      <field type="uint16_t" name="run_time_to_empty" units="min">Predicted remaining battery capacity based on the present rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
-      <field type="uint16_t" name="average_time_to_empty" units="min">Predicted remaining battery capacity based on the average rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
+      <field type="uint16_t" name="run_time_to_empty" units="s">Predicted remaining battery capacity based on the present rate of discharge in seconds, 0: battery does not report predicted remaining capacity</field>
+      <field type="uint16_t" name="average_time_to_empty" units="s">Predicted remaining battery capacity based on the average rate of discharge in seconds, 0: battery does not report predicted remaining capacity</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software</description>
@@ -4190,7 +4190,7 @@
       <field type="int16_t" name="target_altitude" units="m">Altitude setpoint</field>
       <field type="uint8_t" name="heading" units="deg/2">Heading (degrees / 2)</field>
       <field type="uint8_t" name="target_heading" units="deg/2">Heading setpoint (degrees / 2)</field>
-      <field type="uint16_t" name="target_distance" units="dam">Distance to target waypoint or position (meters / 10)</field>
+      <field type="uint16_t" name="target_distance" units="dm">Distance to target waypoint or position (meters / 10)</field>
       <field type="uint8_t" name="throttle" units="%">Throttle (percentage)</field>
       <field type="uint8_t" name="airspeed" units="m/s*5">Airspeed (m/s * 5)</field>
       <field type="uint8_t" name="airspeed_sp" units="m/s*5">Airspeed setpoint (m/s * 5)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4062,8 +4062,8 @@
 	  <field type="uint16_t" name="serial_number">Battery serial number, 0: battery does not have a serial number</field>
 	  <field type="uint16_t" name="capacity" units="mAh">Actual capacity of the battery measured by the fuel gauge, 0: battery does not report actual capacity</field>
 	  <field type="uint16_t" name="cycle_count">Number of charge-discharge cycles reported by the fuel gauge, UINT16_MAX: battery does not report cycle count</field>
-	  <field type="uint16_t" name="run_time_to_empty" uinits="min">Predicted remaining battery capacity based on the present rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
-	  <field type="uint16_t" name="average_time_to_empty" uinits="min">Predicted remaining battery capacity based on the average rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
+	  <field type="uint16_t" name="run_time_to_empty" units="min">Predicted remaining battery capacity based on the present rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
+	  <field type="uint16_t" name="average_time_to_empty" units="min">Predicted remaining battery capacity based on the average rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4058,6 +4058,12 @@
       <field type="int32_t" name="current_consumed" units="mAh">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
       <field type="int32_t" name="energy_consumed" units="hJ">Consumed energy, in HectoJoules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
+	  <field type="int16_t" name="average_current_battery" units="cA">Average battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current</field>
+	  <field type="uint16_t" name="serial_number">Battery serial number, 0: battery does not have a serial number</field>
+	  <field type="uint16_t" name="capacity" units="mAh">Actual capacity of the battery measured by the fuel gauge, 0: battery does not report actual capacity</field>
+	  <field type="uint16_t" name="cycle_count">Number of charge-discharge cycles reported by the fuel gauge, UINT16_MAX: battery does not report cycle count</field>
+	  <field type="uint16_t" name="run_time_to_empty" uinits="min">Predicted remaining battery capacity based on the present rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
+	  <field type="uint16_t" name="average_time_to_empty" uinits="min">Predicted remaining battery capacity based on the average rate of discharge in min, 0: battery does not report predicted remaining capacity</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software</description>


### PR DESCRIPTION
Added more information to the battery status message to include parameters read from a fuel gauge IC.