### PR TITLE
Add MAV_CMD for starting/stopping high latency telemetry

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1601,6 +1601,16 @@
         <param index="6">Reserved, set to NAN</param>
         <param index="7">Reserved, set to NAN</param>
       </entry>
+      <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY">
+        <description>Request to start/stop transmitting over the high latency telemetry</description>
+        <param index="1">Control transmittion over high latency telemetry (0: stop, 1: start)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <entry value="2800" name="MAV_CMD_PANORAMA_CREATE">
         <description>Create a panorama at the current position</description>
         <param index="1">Viewing angle horizontal of the panorama (in degrees, +- 0.5 the total angle)</param>


### PR DESCRIPTION
Adds the interface to request starting/stopping the high latency telemetry on the autopilot.