### PR TITLE
Remove link to non-existent example

### DIFF
--- a/examples/linux/README
+++ b/examples/linux/README
@@ -1,9 +1,4 @@
-A more detailed version of this quickstart is available at:
-
-http://qgroundcontrol.org/dev/mavlink_linux_integration_tutorial
-
-MAVLINK UDP QUICKSTART INSTRUCTIONS
-===================================
+# MAVLink UDP Quickstart Instructions
 
 MAVLink UDP Example for *nix system (Linux, MacOS, BSD, etc.)
 
@@ -19,5 +14,4 @@ To run, type:
 
 ./mavlink_udp
 
-
-If you run QGroundControl on the same machine, a MAV should pop up.
+If you run *QGroundControl* on the same machine, a MAV should pop up.


### PR DESCRIPTION
This linked to a "more comprehensive example" on defunct mavlink site. (ie that did not exist). Simply removed link. Longer term, need to look at topic and migrate into new devguide. 