### PR TITLE
common: extend RC_CHANNELS_OVERRIDE to 18 channels

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3348,15 +3348,15 @@
       <field type="uint16_t" name="chan8_raw" units="us">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
       <extensions/>
       <field type="uint16_t" name="chan9_raw" units="us">RC channel 9 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan13_raw" units="us">RC channel 13 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan14_raw" units="us">RC channel 14 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan15_raw" units="us">RC channel 15 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan16_raw" units="us">RC channel 16 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan17_raw" units="us">RC channel 17 value, in microseconds. A value of 0 means to ignore this field.</field>
-      <field type="uint16_t" name="chan18_raw" units="us">RC channel 18 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan13_raw" units="us">RC channel 13 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan14_raw" units="us">RC channel 14 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan15_raw" units="us">RC channel 15 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan16_raw" units="us">RC channel 16 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan17_raw" units="us">RC channel 17 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan18_raw" units="us">RC channel 18 value, in microseconds. A value of 0 or UINT16_MAX means to ignore this field.</field>
     </message>
     <message id="73" name="MISSION_ITEM_INT">
       <description>Message encoding a mission item. This message is emitted to announce

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3347,16 +3347,16 @@
       <field type="uint16_t" name="chan7_raw" units="us">RC channel 7 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
       <field type="uint16_t" name="chan8_raw" units="us">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
       <extensions/>
-      <field type="uint16_t" name="chan9_raw" units="us">RC channel 9 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan13_raw" units="us">RC channel 13 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan14_raw" units="us">RC channel 14 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan15_raw" units="us">RC channel 15 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan16_raw" units="us">RC channel 16 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan17_raw" units="us">RC channel 17 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
-      <field type="uint16_t" name="chan18_raw" units="us">RC channel 18 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan9_raw" units="us">RC channel 9 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan13_raw" units="us">RC channel 13 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan14_raw" units="us">RC channel 14 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan15_raw" units="us">RC channel 15 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan16_raw" units="us">RC channel 16 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan17_raw" units="us">RC channel 17 value, in microseconds. A value of 0 means to ignore this field.</field>
+      <field type="uint16_t" name="chan18_raw" units="us">RC channel 18 value, in microseconds. A value of 0 means to ignore this field.</field>
     </message>
     <message id="73" name="MISSION_ITEM_INT">
       <description>Message encoding a mission item. This message is emitted to announce

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3346,6 +3346,17 @@
       <field type="uint16_t" name="chan6_raw" units="us">RC channel 6 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
       <field type="uint16_t" name="chan7_raw" units="us">RC channel 7 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
       <field type="uint16_t" name="chan8_raw" units="us">RC channel 8 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <extensions/>
+      <field type="uint16_t" name="chan9_raw" units="us">RC channel 9 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan13_raw" units="us">RC channel 13 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan14_raw" units="us">RC channel 14 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan15_raw" units="us">RC channel 15 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan16_raw" units="us">RC channel 16 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan17_raw" units="us">RC channel 17 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
+      <field type="uint16_t" name="chan18_raw" units="us">RC channel 18 value, in microseconds. A value of UINT16_MAX means to ignore this field.</field>
     </message>
     <message id="73" name="MISSION_ITEM_INT">
       <description>Message encoding a mission item. This message is emitted to announce


### PR DESCRIPTION
This raises the channel count possible for RC override channels to 18,
so on par with RC_CHANNELS.
These channels can be used to send RC input via mavlink (e.g. over wifi)
to a drone.