### PR TITLE
avoidance msg

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2921,7 +2921,6 @@
         <param index="3">Z-coordinate of starting bezier point [m], set to NaN if not being used</param>
         <param index="4">Bezier time horizon [s], set to NaN if velocity/acceleration should not be incorporated</param>
         <param index="5">Yaw [rad], set to NaN for unchanged</param>
-        <param index="6">Yaw-rate [rad/s], set to NaN for unchanged</param>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4689,8 +4689,9 @@
       <field type="float" name="yawspeed" units="rad/s">Yaw angular speed</field>
       <field type="float[21]" name="pose_covariance">Pose (states: x, y, z, roll, pitch, yaw) covariance matrix upper right triangle (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
       <field type="float[21]" name="twist_covariance">Twist (states: vx, vy, vz, rollspeed, pitchspeed, yawspeed) covariance matrix upper right triangle (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
-    <message id="332" name="OBSTACLE_AVOIDANCE">
-      <description>Obstacle avoidance message with trajectory points and field of view</description>
+    </message>
+    <message id="332" name="TRAJECTORY">
+      <description>Message to describe a trajectory. Supported trajectory types are enumerated in MAV_TRAJECTORY_REPRESENTATION</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (microseconds since system boot or since UNIX epoch).</field>
       <field type="uint8_t" name="type" enum="MAV_TRAJECTORY_REPRESENTATION">Waypoints, Bezier etc. see MAV_TRAJECTORY_REPRESENTATION</field>
       <field type="float[11]" name="point_1">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
@@ -4699,10 +4700,6 @@
       <field type="float[11]" name="point_4">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
       <field type="float[11]" name="point_5">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
       <field type="uint8_t[5]" name="point_valid">States if respective point is valid</field>
-      <field type="int16_t[4]" name="field_of_view">Field of View of the sensor/s being used. The first two parameters are used to indicate the direction (Azimuth: 0 - 360 degrees and elevation: -90 - 90 degrees) and the last two indicate the range (Azimuth and elevation). The range is applied symmetrically in the direction. Set first element to -1 to mark as unknown.</field>
     </message>
   </messages>
 </mavlink>
-
-
-listener trajectory_waypoint 100

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2898,6 +2898,30 @@
         <description>Spektrum DSMX</description>
       </entry>
     </enum>
+    <enum name="MAV_TRAJECTORY_REPRESENTATION">
+      <description>Enumeration of possible waypoint/trajectory representation</description>
+      <entry value="0" name="MAV_TRAJECTORY_REPRESENTATION_WAYPOINTS">
+        <description>Array of waypoints with the following order</description>
+        <param index="1">X-coordinate of waypoint</param>
+        <param index="2">Y-coordinate of waypoint</param>
+        <param index="3">Z-coordinate of waypoint</param>
+        <param index="4">X-velocity of waypoint</param>
+        <param index="5">Y-velocity of waypoint</param>
+        <param index="6">Z-velocity of waypoint</param>
+        <param index="7">X-acceleration of waypoint</param>
+        <param index="8">Y-acceleration of waypoint</param>
+        <param index="9">Z-acceleration of waypoint</param>
+        <param index="10">Yaw</param>
+        <param index="11">Yaw-rate</param>
+      </entry>
+      <entry value="1" name="MAV_TRAJECTORY_REPRESENTATION_BEZIER">
+        <description>Array of bezier points with the following order</description>
+        <param index="1">X-coordinate of starting bezier point</param>
+        <param index="2">Y-coordinate of starting bezier point</param>
+        <param index="3">Z-coordinate of starting bezier point</param>
+        <param index="4">Bezier time horizon</param>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">
@@ -4663,6 +4687,17 @@
       <field type="float" name="yawspeed" units="rad/s">Yaw angular speed</field>
       <field type="float[21]" name="pose_covariance">Pose (states: x, y, z, roll, pitch, yaw) covariance matrix upper right triangle (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
       <field type="float[21]" name="twist_covariance">Twist (states: vx, vy, vz, rollspeed, pitchspeed, yawspeed) covariance matrix upper right triangle (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
+    <message id="332" name="OBSTACLE_AVOIDANCE">
+      <description>Obstacle avoidance message with trajectory points and field of view</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (microseconds since system boot or since UNIX epoch).</field>
+      <field type="uint8_t" name="type" enum="MAV_TRAJECTORY_REPRESENTATION">Waypoints, Bezier etc. see MAV_TRAJECTORY_REPRESENTATION</field>
+      <field type="float[11]" name="point_1">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
+      <field type="float[11]" name="point_2">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
+      <field type="float[11]" name="point_3">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
+      <field type="float[11]" name="point_4">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
+      <field type="float[11]" name="point_5">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
+      <field type="uint8_t[5]" name="point_valid">States if respective point is valid</field>
+      <field type="int16_t[4]" name="field_of_view">Field of View of the sensor/s being used. The first two parameters are used to indicate the direction (Azimuth: 0 - 360 degrees and elevation: -90 - 90 degrees) and the last two indicate the range (Azimuth and elevation). The range is applied symmetrically in the direction. Set first element to -1 to mark as unknown.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4691,7 +4691,7 @@
       <field type="float[21]" name="twist_covariance">Twist (states: vx, vy, vz, rollspeed, pitchspeed, yawspeed) covariance matrix upper right triangle (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
     </message>
     <message id="332" name="TRAJECTORY">
-      <description>Message to describe a trajectory. Supported trajectory types are enumerated in MAV_TRAJECTORY_REPRESENTATION</description>
+      <description>Message to describe a trajectory in the local frame. Supported trajectory types are enumerated in MAV_TRAJECTORY_REPRESENTATION</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (microseconds since system boot or since UNIX epoch).</field>
       <field type="uint8_t" name="type" enum="MAV_TRAJECTORY_REPRESENTATION">Waypoints, Bezier etc. see MAV_TRAJECTORY_REPRESENTATION</field>
       <field type="float[11]" name="point_1">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2902,24 +2902,24 @@
       <description>Enumeration of possible waypoint/trajectory representation</description>
       <entry value="0" name="MAV_TRAJECTORY_REPRESENTATION_WAYPOINTS">
         <description>Array of waypoints with the following order</description>
-        <param index="1">X-coordinate of waypoint</param>
-        <param index="2">Y-coordinate of waypoint</param>
-        <param index="3">Z-coordinate of waypoint</param>
-        <param index="4">X-velocity of waypoint</param>
-        <param index="5">Y-velocity of waypoint</param>
-        <param index="6">Z-velocity of waypoint</param>
-        <param index="7">X-acceleration of waypoint</param>
-        <param index="8">Y-acceleration of waypoint</param>
-        <param index="9">Z-acceleration of waypoint</param>
+        <param index="1">X-coordinate of waypoint, set to NaN if not being used</param>
+        <param index="2">Y-coordinate of waypoint, set to NaN if not being used</param>
+        <param index="3">Z-coordinate of waypoint, set to NaN if not being used</param>
+        <param index="4">X-velocity of waypoint, set to NaN if not being used</param>
+        <param index="5">Y-velocity of waypoint, set to NaN if not being used</param>
+        <param index="6">Z-velocity of waypoint, set to NaN if not being used</param>
+        <param index="7">X-acceleration of waypoint, set to NaN if not being used</param>
+        <param index="8">Y-acceleration of waypoint, set to NaN if not being used</param>
+        <param index="9">Z-acceleration of waypoint, set to NaN if not being used</param>
         <param index="10">Yaw, set to NaN for unchanged</param>
         <param index="11">Yaw-rate, set to NaN for unchanged</param>
       </entry>
       <entry value="1" name="MAV_TRAJECTORY_REPRESENTATION_BEZIER">
         <description>Array of bezier points with the following order</description>
-        <param index="1">X-coordinate of starting bezier point</param>
-        <param index="2">Y-coordinate of starting bezier point</param>
-        <param index="3">Z-coordinate of starting bezier point</param>
-        <param index="4">Bezier time horizon</param>
+        <param index="1">X-coordinate of starting bezier point, set to NaN if not being used</param>
+        <param index="2">Y-coordinate of starting bezier point, set to NaN if not being used</param>
+        <param index="3">Z-coordinate of starting bezier point, set to NaN if not being used</param>
+        <param index="4">Bezier time horizon, set to NaN if not being used</param>
         <param index="5">Yaw, set to NaN for unchanged</param>
         <param index="6">Yaw-rate, set to NaN for unchanged</param>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2902,26 +2902,26 @@
       <description>Enumeration of possible waypoint/trajectory representation</description>
       <entry value="0" name="MAV_TRAJECTORY_REPRESENTATION_WAYPOINTS">
         <description>Array of waypoints with the following order</description>
-        <param index="1">X-coordinate of waypoint, set to NaN if not being used</param>
-        <param index="2">Y-coordinate of waypoint, set to NaN if not being used</param>
-        <param index="3">Z-coordinate of waypoint, set to NaN if not being used</param>
-        <param index="4">X-velocity of waypoint, set to NaN if not being used</param>
-        <param index="5">Y-velocity of waypoint, set to NaN if not being used</param>
-        <param index="6">Z-velocity of waypoint, set to NaN if not being used</param>
-        <param index="7">X-acceleration of waypoint, set to NaN if not being used</param>
-        <param index="8">Y-acceleration of waypoint, set to NaN if not being used</param>
-        <param index="9">Z-acceleration of waypoint, set to NaN if not being used</param>
-        <param index="10">Yaw, set to NaN for unchanged</param>
-        <param index="11">Yaw-rate, set to NaN for unchanged</param>
+        <param index="1">X-coordinate of waypoint [m], set to NaN if not being used</param>
+        <param index="2">Y-coordinate of waypoint [m], set to NaN if not being used</param>
+        <param index="3">Z-coordinate of waypoint [m], set to NaN if not being used</param>
+        <param index="4">X-velocity of waypoint [m/s], set to NaN if not being used</param>
+        <param index="5">Y-velocity of waypoint [m/s], set to NaN if not being used</param>
+        <param index="6">Z-velocity of waypoint [m/s], set to NaN if not being used</param>
+        <param index="7">X-acceleration of waypoint [m/s/s], set to NaN if not being used</param>
+        <param index="8">Y-acceleration of waypoint [m/s/s], set to NaN if not being used</param>
+        <param index="9">Z-acceleration of waypoint [m/s/s], set to NaN if not being used</param>
+        <param index="10">Yaw [rad], set to NaN for unchanged</param>
+        <param index="11">Yaw-rate [rad/s], set to NaN for unchanged</param>
       </entry>
       <entry value="1" name="MAV_TRAJECTORY_REPRESENTATION_BEZIER">
         <description>Array of bezier points with the following order</description>
-        <param index="1">X-coordinate of starting bezier point, set to NaN if not being used</param>
-        <param index="2">Y-coordinate of starting bezier point, set to NaN if not being used</param>
-        <param index="3">Z-coordinate of starting bezier point, set to NaN if not being used</param>
-        <param index="4">Bezier time horizon, set to NaN if not being used</param>
-        <param index="5">Yaw, set to NaN for unchanged</param>
-        <param index="6">Yaw-rate, set to NaN for unchanged</param>
+        <param index="1">X-coordinate of starting bezier point [m], set to NaN if not being used</param>
+        <param index="2">Y-coordinate of starting bezier point [m], set to NaN if not being used</param>
+        <param index="3">Z-coordinate of starting bezier point [m], set to NaN if not being used</param>
+        <param index="4">Bezier time horizon [s], set to NaN if not being used</param>
+        <param index="5">Yaw [rad], set to NaN for unchanged</param>
+        <param index="6">Yaw-rate [rad/s], set to NaN for unchanged</param>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2919,7 +2919,7 @@
         <param index="1">X-coordinate of starting bezier point [m], set to NaN if not being used</param>
         <param index="2">Y-coordinate of starting bezier point [m], set to NaN if not being used</param>
         <param index="3">Z-coordinate of starting bezier point [m], set to NaN if not being used</param>
-        <param index="4">Bezier time horizon [s], set to NaN if not being used</param>
+        <param index="4">Bezier time horizon [s], set to NaN if velocity/acceleration should not be incorporated</param>
         <param index="5">Yaw [rad], set to NaN for unchanged</param>
         <param index="6">Yaw-rate [rad/s], set to NaN for unchanged</param>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4699,7 +4699,7 @@
       <field type="float[11]" name="point_3">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
       <field type="float[11]" name="point_4">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
       <field type="float[11]" name="point_5">Depending on the type (see MAV_TRAJECTORY_REPRESENTATION)</field>
-      <field type="uint8_t[5]" name="point_valid">States if respective point is valid</field>
+      <field type="uint8_t[5]" name="point_valid">States if respective point is valid (boolean)</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2911,8 +2911,8 @@
         <param index="7">X-acceleration of waypoint</param>
         <param index="8">Y-acceleration of waypoint</param>
         <param index="9">Z-acceleration of waypoint</param>
-        <param index="10">Yaw</param>
-        <param index="11">Yaw-rate</param>
+        <param index="10">Yaw, set to NaN for unchanged</param>
+        <param index="11">Yaw-rate, set to NaN for unchanged</param>
       </entry>
       <entry value="1" name="MAV_TRAJECTORY_REPRESENTATION_BEZIER">
         <description>Array of bezier points with the following order</description>
@@ -2920,6 +2920,8 @@
         <param index="2">Y-coordinate of starting bezier point</param>
         <param index="3">Z-coordinate of starting bezier point</param>
         <param index="4">Bezier time horizon</param>
+        <param index="5">Yaw, set to NaN for unchanged</param>
+        <param index="6">Yaw-rate, set to NaN for unchanged</param>
       </entry>
     </enum>
   </enums>
@@ -4701,3 +4703,6 @@
     </message>
   </messages>
 </mavlink>
+
+
+listener trajectory_waypoint 100


### PR DESCRIPTION
This is a first draft of the avoidance message according to the [obstacle avoidance interface proposal](https://docs.google.com/document/d/1BQp1a6yszl9f6LDrxrkKUDDGyXxBs5C86BzvJwVbRrU/edit#heading=h.huol20joi641)

The `enum` MAV_TRAJECTORY_REPRESENTATION can still be extended.

The field `field_of_view` probably needs to change a bit as it's currently only possible to have one continuous field of view. A solution would be to have e.g. up to 6 of these (array)?

[RFC](https://github.com/mavlink/rfcs/pull/4)