### PR TITLE
Add MAV_TYPE_CHARGING_STATION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -161,6 +161,9 @@
       <entry value="30" name="MAV_TYPE_CAMERA">
         <description>Camera</description>
       </entry>
+      <entry value="31" name="MAV_TYPE_CHARGING_STATION">
+        <description>Charging station</description>
+      </entry>
     </enum>
     <enum name="FIRMWARE_VERSION_TYPE">
       <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>


### PR DESCRIPTION
Nowadays, a lot of companies are developing charging stations for autonomous drones ([\[1\]](https://www.youtube.com/watch?v=MD3cQNd-iSA), [\[2\]](https://www.youtube.com/watch?v=RjX6nUqw1mI), [\[3\]](https://www.youtube.com/watch?v=061Qhkr7XCE)).

MAVLink protocol looks a good choice to make a communication between the drone and charging stations. The automatic charging station can send its telemetry using some standard messages (global position, pressure, etc), its state (open/closed lid, charging/idling) via `HEARTBEAT`'s custom mode, and execute some commands (open lid, start charging) using `COMMAND_LONG`.

Such stations can advertise themselves in MAVLink network as the proposed new device type: `MAV_TYPE_CHARGING_STATION`.