### PR TITLE
Common: Add an enum for RC reciever types

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1484,7 +1484,7 @@
       <entry value="500" name="MAV_CMD_START_RX_PAIR">
         <description>Starts receiver pairing</description>
         <param index="1">0:Spektrum</param>
-        <param index="2">0:Spektrum DSM2, 1:Spektrum DSMX</param>
+        <param index="2">RC type (see RC_TYPE enum)</param>
       </entry>
       <entry value="510" name="MAV_CMD_GET_MESSAGE_INTERVAL">
         <description>Request the interval between messages for a particular MAVLink message ID</description>
@@ -2883,6 +2883,15 @@
       </entry>
       <entry value="1" name="RTK_BASELINE_COORDINATE_SYSTEM_NED">
         <description>North, East, Down</description>
+      </entry>
+    </enum>
+    <enum name="RC_TYPE">
+      <description>RC type</description>
+      <entry value="0" name="RC_TYPE_SPEKTRUM_DSM2">
+        <description>Spektrum DSM2</description>
+      </entry>
+      <entry value="1" name="RC_TYPE_SPEKTRUM_DSMX">
+        <description>Spektrum DSMX</description>
       </entry>
     </enum>
   </enums>


### PR DESCRIPTION
Adds an enum for GCS's to use rather then simply hardcoding the values in MAV_CMD_START_RX_PAIR.