### PR TITLE
[WIP] common: add ODOMETRY msg and Odometry related MAV_FRAMEs

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -601,6 +601,30 @@
       <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
         <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
       </entry>
+      <entry value="12" name="MAV_FRAME_BODY_FRD">
+        <description>Body fixed frame of reference, Z-down (x: forward, y: right, z: down).</description>
+      </entry>
+      <entry value="13" name="MAV_FRAME_BODY_FLU">
+        <description>Body fixed frame of reference, Z-up (x: forward, y: left, z: up).</description>
+      </entry>
+      <entry value="14" name="MAV_FRAME_MOCAP_NED">
+        <description>Odometry local coordinate frame of data given by a motion capture system, Z-down (x: north, y: east, z: down).</description>
+      </entry>
+      <entry value="15" name="MAV_FRAME_MOCAP_ENU">
+        <description>Odometry local coordinate frame of data given by a motion capture system, Z-up (x: east, y: north, z: up).</description>
+      </entry>
+      <entry value="16" name="MAV_FRAME_VISION_NED">
+        <description>Odometry local coordinate frame of data given by a vision estimation system, Z-down (x: north, y: east, z: down).</description>
+      </entry>
+      <entry value="17" name="MAV_FRAME_VISION_ENU">
+        <description>Odometry local coordinate frame of data given by a vision estimation system, Z-up (x: east, y: north, z: up).</description>
+      </entry>
+      <entry value="18" name="MAV_FRAME_ESTIM_NED">
+        <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-down (x: north, y: east, z: down).</description>
+      </entry>
+      <entry value="19" name="MAV_FRAME_ESTIM_ENU">
+        <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: east, y: noth, z: up).</description>
+      </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
       <entry name="MAVLINK_DATA_STREAM_IMG_JPEG">
@@ -4571,6 +4595,23 @@
       <field type="uint8_t" name="increment" units="deg">Angular width in degrees of each array element.</field>
       <field type="uint16_t" name="min_distance" units="cm">Minimum distance the sensor can measure in centimeters.</field>
       <field type="uint16_t" name="max_distance" units="cm">Maximum distance the sensor can measure in centimeters.</field>
+    </message>
+    <message id="331" name="ODOMETRY">
+      <description>Odometry message to communicate odometry information with an external interface. Fits ROS REP 147 standard for aerial vehicles (http://www.ros.org/reps/rep-0147.html).</description>
+      <field type="uint8_t" name="frame_id" enum="MAV_FRAME">Coordinate frame of reference for the pose data, as defined by MAV_FRAME enum.</field>
+      <field type="uint8_t" name="child_frame_id" enum="MAV_FRAME">Coordinate frame of reference for the velocity in free space (twist) data, as defined by MAV_FRAME enum.</field>
+      <field type="float" name="x" units="m">X Position</field>
+      <field type="float" name="y" units="m">Y Position</field>
+      <field type="float" name="z" units="m">Z Position</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+      <field type="float" name="vx" units="m/s">X linear speed</field>
+      <field type="float" name="vy" units="m/s">Y linear speed</field>
+      <field type="float" name="vz" units="m/s">Z linear speed</field>
+      <field type="float" name="rollspeed" units="rad/s">Roll angular speed</field>
+      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed</field>
+      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed</field>
+      <field type="float[21]" name="pose_covariance">Pose (states: x, y, z, roll, pitch, yaw) covariance matrix upper right triangle (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
+      <field type="float[21]" name="twist_covariance">Twist (states: vx, vy, vz, rollspeed, pitchspeed, yawspeed) covariance matrix upper right triangle (first six entries are the first ROW, next five entries are the second ROW, etc.)</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Adresses https://github.com/mavlink/mavlink/issues/721. I added some related Odometry frames to `MAV_FRAME` but we probably should discuss the RFC proposal for local frames of reference in https://github.com/mavlink/rfcs/pull/2. 