### PR TITLE
common.xml: add capture sequence to START_CAPTURE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1553,7 +1553,8 @@
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Duration between two consecutive pictures (in seconds)</param>
         <param index="3">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="4">Reserved (all remaining params)</param>
+        <param index="4">Capture sequence (ID to prevent double captures when a command is retransmitted)</param>
+        <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
         <description>Stop image capture sequence Use NAN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1553,7 +1553,7 @@
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Duration between two consecutive pictures (in seconds)</param>
         <param index="3">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="4">Capture sequence (ID to prevent double captures when a command is retransmitted)</param>
+        <param index="4">Capture sequence (ID to prevent double captures when a command is retransmitted, 0: unused, &gt;= 1: used)</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">


### PR DESCRIPTION
The sequence/ID as a param allows to distinguish if a command was
retransmitted or if actually yet another capture has been requested.

This can avoid double captures but stil allows to retransmit the
command to make sure it arrives over a lossy link.