### PR TITLE
Common: Extend Battery Status with Remaining Time and Low Extent State

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2498,25 +2498,28 @@
         <description>Payload battery</description>
       </entry>
     </enum>
-    <enum name="MAV_BATTERY_LOW_STATE">
+    <enum name="MAV_BATTERY_CHARGE_STATE">
       <description>Enumeration for states of low battery extent</description>
-      <entry value="0" name="MAV_BATTERY_LOW_STATE_UNDEFINED">
+      <entry value="0" name="MAV_BATTERY_CHARGE_STATE_UNDEFINED">
         <description>Low battery state is not provided</description>
       </entry>
-      <entry value="1" name="MAV_BATTERY_LOW_STATE_OK">
+      <entry value="1" name="MAV_BATTERY_CHARGE_STATE_OK">
         <description>Battery is not nearly empty, normal operation</description>
       </entry>
-      <entry value="2" name="MAV_BATTERY_LOW_STATE_LOW">
+      <entry value="2" name="MAV_BATTERY_CHARGE_STATE_LOW">
         <description>Battery state is low, warn and monitor close</description>
       </entry>
-      <entry value="3" name="MAV_BATTERY_LOW_STATE_CRITICAL">
+      <entry value="3" name="MAV_BATTERY_CHARGE_STATE_CRITICAL">
         <description>Battry state is critical, return / abort immediately</description>
       </entry>
-      <entry value="4" name="MAV_BATTERY_LOW_STATE_EMERGENCY">
+      <entry value="4" name="MAV_BATTERY_CHARGE_STATE_EMERGENCY">
         <description>Battry state is too low for ordinary abortion, fastest possible emergency stop preventing damage</description>
       </entry>
-      <entry value="5" name="MAV_BATTERY_LOW_STATE_FAILED">
+      <entry value="5" name="MAV_BATTERY_CHARGE_STATE_FAILED">
         <description>Battry failed, damage unavoidable</description>
+      </entry>
+      <entry value="6" name="MAV_BATTERY_CHARGE_STATE_UNHEALTHY">
+        <description>Battry is diagnosed to be broken or an error occurred, usage is discouraged / prohibited</description>
       </entry>
     </enum>
     <enum name="MAV_VTOL_STATE">
@@ -4135,7 +4138,7 @@
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
       <extensions/>
       <field type="int32_t" name="time_remaining" units="s">Remaining battery time, in seconds (0 = 0s = 0% energy left), -1: autopilot does not provide remaining battery time estimate</field>
-      <field type="uint8_t" name="battery_low_state" enum="MAV_BATTERY_LOW_STATE">Low battery extent state, provided by autopilot for warning or futher reactions.</field>
+      <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2498,6 +2498,27 @@
         <description>Payload battery</description>
       </entry>
     </enum>
+    <enum name="MAV_BATTERY_LOW_STATE">
+      <description>Enumeration for states of low battery extent</description>
+      <entry value="0" name="MAV_BATTERY_LOW_STATE_UNDEFINED">
+        <description>Low battery state is not provided</description>
+      </entry>
+      <entry value="1" name="MAV_BATTERY_LOW_STATE_OK">
+        <description>Battery is not nearly empty, normal operation</description>
+      </entry>
+      <entry value="2" name="MAV_BATTERY_LOW_STATE_LOW">
+        <description>Battery state is low, warn and monitor close</description>
+      </entry>
+      <entry value="3" name="MAV_BATTERY_LOW_STATE_CRITICAL">
+        <description>Battry state is critical, return / abort immediately</description>
+      </entry>
+      <entry value="4" name="MAV_BATTERY_LOW_STATE_EMERGENCY">
+        <description>Battry state is too low for ordinary abortion, fastest possible emergency stop preventing damage</description>
+      </entry>
+      <entry value="5" name="MAV_BATTERY_LOW_STATE_FAILED">
+        <description>Battry failed, damage unavoidable</description>
+      </entry>
+    </enum>
     <enum name="MAV_VTOL_STATE">
       <description>Enumeration of VTOL states</description>
       <entry value="0" name="MAV_VTOL_STATE_UNDEFINED">
@@ -4114,6 +4135,7 @@
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
       <extensions/>
       <field type="int32_t" name="time_remaining" units="s">Remaining battery time, in seconds (0 = 0s = 0% energy left), -1: autopilot does not provide remaining battery time estimate</field>
+      <field type="uint8_t" name="battery_low_state" enum="MAV_BATTERY_LOW_STATE">Low battery extent state, provided by autopilot for warning or futher reactions.</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4137,7 +4137,7 @@
       <field type="int32_t" name="energy_consumed" units="hJ">Consumed energy, in HectoJoules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
       <extensions/>
-      <field type="int32_t" name="time_remaining" units="s">Remaining battery time, in seconds (0 = 0s = 0% energy left), -1: autopilot does not provide remaining battery time estimate</field>
+      <field type="int32_t" name="time_remaining" units="s">Remaining battery time, in seconds (1 = 1s = 0% energy left), 0: autopilot does not provide remaining battery time estimate</field>
       <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4112,6 +4112,8 @@
       <field type="int32_t" name="current_consumed" units="mAh">Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate</field>
       <field type="int32_t" name="energy_consumed" units="hJ">Consumed energy, in HectoJoules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate</field>
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot does not estimate the remaining battery</field>
+      <extensions/>
+      <field type="int32_t" name="time_remaining" units="s">Remaining battery time, in seconds (0 = 0s = 0% energy left), -1: autopilot does not provide remaining battery time estimate</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software</description>


### PR DESCRIPTION
Allow the autopilot to optionally publish its:
- estimation of the remaining time in seconds the battery can still be used before it's empty.
This information can be showed to the user or used by an external algorithm to further plan the usage of the battery/vehicle.
- low battery state telling the user or external components to what extent the battery is empty.
This information can be used to update the UI with appropriate warnings and inform external components to trigger energy saving or other risk minimizing behaviour.

FYI @julianoes @dogmaphobic 

**EDIT:** fixes #809 