### PR TITLE
common.xml: Correct default values of SET_VIDEO_STREAM_SETTINGS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4557,9 +4557,9 @@
       <field type="uint8_t" name="target_component">component ID of the target</field>
       <field type="uint8_t" name="camera_id">Camera ID (1 for first, 2 for second, etc.)</field>
       <field type="float" name="framerate" units="Hz">Frames per second (set to -1 for highest framerate possible)</field>
-      <field type="uint16_t" name="resolution_h" units="pix">Resolution horizontal in pixels (set to -1 for highest resolution possible)</field>
-      <field type="uint16_t" name="resolution_v" units="pix">Resolution vertical in pixels (set to -1 for highest resolution possible)</field>
-      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second (set to -1 for auto)</field>
+      <field type="uint16_t" name="resolution_h" units="pix">Resolution horizontal in pixels (set to UINT16_MAX for highest resolution possible)</field>
+      <field type="uint16_t" name="resolution_v" units="pix">Resolution vertical in pixels (set to UINT16_MAX for highest resolution possible)</field>
+      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second (set to 0 for auto)</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
       <field type="char[230]" name="uri">Video stream URI</field>
     </message>


### PR DESCRIPTION
Default values for `resolution_h`, `resolution_v` and `bitrate` are -1. However, all these are of `unsigned` type. Hence it must have zero or similar to represent these default settings.