### PR TITLE
Clarify custom messages can either replace or extend the common set

### DIFF
--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -37,7 +37,7 @@ xslt = ET.fromstring(xsl_file)
 #initialise text for index file. 
 index_text='<!-- THIS FILE IS AUTO-GENERATED (DO NOT UPDATE GITBOOK): https://github.com/mavlink/mavlink/blob/master/doc/mavlink_gitbook.py -->'
 index_text+='\n# Message Definitions'
-index_text+='\n\nMAVLink messages are defined in XML files in the [mavlink/message definitions](https://github.com/mavlink/mavlink/blob/master/message_definitions/) folder. The messages that are common to all systems are defined in [common.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml) (only messages contained in this file are considered standard messages). MAVLink protocol-specific messages and vendor-specific messages are stored in separate XML files.'
+index_text+='\n\nMAVLink messages are defined in XML files in the [mavlink/message definitions](https://github.com/mavlink/mavlink/blob/master/message_definitions/) folder. The messages that are common to all systems are defined in [common.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml) (only messages contained in this file are considered *standard* messages). MAVLink protocol-specific messages and vendor-specific messages are stored in separate XML files that can either *replace* or *extend* (include) the standard messages.'
 index_text+='\n\nThe common messages are provided as human-readable tables in: [Common](../messages/common.md).'
 index_text+='\n\n> **Note** Vendor forks of MAVLink may contain messages that are not get merged, and hence will not appear in this documentation.'
 index_text+='\n\nThe human-readable forms of the vendor XML files are linked below:'


### PR DESCRIPTION
This is update to the script that auto-generates the text at the top of this page: https://mavlink.io/en/messages/