### PR TITLE
common.xml: Add COMP_ID and MAV_TYPE for FLARM periphery

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -164,6 +164,9 @@
       <entry value="31" name="MAV_TYPE_CHARGING_STATION">
         <description>Charging station</description>
       </entry>
+      <entry value="32" name="MAV_TYPE_FLARM">
+        <description>Onboard FLARM collision avoidance system</description>
+      </entry>
     </enum>
     <enum name="FIRMWARE_VERSION_TYPE">
       <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>
@@ -447,6 +450,9 @@
         <description>Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter sub-protocol</description>
       </entry>
       <entry value="159" name="MAV_COMP_ID_QX1_GIMBAL">
+        <description/>
+      </entry>
+      <entry value="160" name="MAV_COMP_ID_FLARM">
         <description/>
       </entry>
       <entry value="180" name="MAV_COMP_ID_MAPPER">


### PR DESCRIPTION
FLARM is a cooperative collision avoidance device comparable to ADS-B. It outputs ADSB_VEHICLE packets, like other ADS-B receivers. To distinguish from "real" ADS-B receivers, and to operate both FLARM and ADS-B on the same vehicle, these changes are proposed.

