### PR TITLE
Add timestamp to the COMMAND_INT and COMMAND_LONG message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3484,6 +3484,7 @@
     </message>
     <message id="75" name="COMMAND_INT">
       <description>Message encoding a command with parameters as scaled integers. Scaling depends on the actual command value.</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND, as defined by MAV_FRAME enum</field>
@@ -3500,6 +3501,7 @@
     </message>
     <message id="76" name="COMMAND_LONG">
       <description>Send a command with up to seven parameters to the MAV</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (microseconds, synced to UNIX time or since system boot)</field>
       <field type="uint8_t" name="target_system">System which should execute the command</field>
       <field type="uint8_t" name="target_component">Component which should execute the command, 0 for all components</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">Command ID, as defined by MAV_CMD enum.</field>


### PR DESCRIPTION
Adding a timestamp to the command messages helps to identify outdated commands and rejecting/ignoring them.

This is important once there are multiple links with different latencies connected to the vehicle. In this setup it can happen that a command sent earlier from the ground station appears after a later sent one and therefore the order of execution is different.

Here is one example which happened during our flight:

- Our setup includes a radio link with a negligible latency and a satellite link with a latency of minimum ten seconds up to a couple of minutes. What happened during one flight is that we sent a "camera door open" command over the satellite link due to bad signal it took over one minute to transmit the message. In the meantime we sent the "camera door close" command. In the end, due to the different latencies, the close command arrived before the open command on the plane so for the rest of the flight the camera door was open.

The same could happen with more safety critical commands such as: `MAV_CMD_DO_CHANGE_ALTITUDE` or `MAV_CMD_DO_REPOSITION` where the vehicle suddenly flies at the wrong altitude or to the wrong position.

