### PR TITLE
Add new PWM output message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5107,6 +5107,12 @@
       <field type="uint16_t" default="0" name="cell_offset">The cell number of the first index in the 'voltages' array field. Using this field allows you to specify cell voltages for batteries with more than 16 cells.</field>
       <field type="uint16_t[16]" name="voltages" units="mV">Individual cell voltages. Batteries with more 16 cells can use the cell_offset field to specify the cell offset for the array specified in the current message . Index values above the valid cell count for this battery should have the UINT16_MAX value.</field>
     </message>
+    <message id="375" name="ACTUATOR_OUTPUT_STATUS">
+      <description>The raw values of the actuator outputs.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot).</field>
+      <field type="uint32_t" name="active" display="bitmask">Active outputs</field>
+      <field type="float[32]" name="actuator">Servo / motor output array values. Zero values indicate unused channels.</field>
+    </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>


### PR DESCRIPTION
This new message is streamlined and ensures correct timestamping. It also has improved wording to not be specific to servos.

It fixes https://github.com/mavlink/mavlink/issues/153#issuecomment-392452592

Please comment on the fields and make suggestions for improvements.