### PR TITLE
Add a MAV_CMD version of MISSION_SET_CURRENT

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1411,6 +1411,17 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+      <entry value="224" name="MAV_CMD_DO_SET_MISSION_CURRENT">
+        <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
+        <param index="1">Mission sequence value to set</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <entry value="240" name="MAV_CMD_DO_LAST">
         <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
         <param index="1">Empty</param>


### PR DESCRIPTION
This is a command version of MISSION_SET_CURRENT. This is useful as one can make sure with an acknowledge that the command arrived on the vehicle and is accepted. MAV_CMD_MISSION_START can not be used as that one is supposed also to start the mission.
