### PR TITLE
common.xml: support absolute mount/gimbal angles

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1288,9 +1288,9 @@
         <param index="2">stabilize roll? (1 = yes, 0 = no)</param>
         <param index="3">stabilize pitch? (1 = yes, 0 = no)</param>
         <param index="4">stabilize yaw? (1 = yes, 0 = no)</param>
-        <param index="5">roll input (0 = angle, 1 = angular rate)</param>
-        <param index="6">pitch input (0 = angle, 1 = angular rate)</param>
-        <param index="7">yaw input (0 = angle, 1 = angular rate)</param>
+        <param index="5">roll input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)</param>
+        <param index="6">pitch input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)</param>
+        <param index="7">yaw input (0 = angle body frame, 1 = angular rate, 2 = angle absolute frame)</param>
       </entry>
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL">
         <description>Mission command to control a camera or antenna mount</description>


### PR DESCRIPTION
This change 1) clearly specifies the frame of an angle to set (body or
absolute) and 2) adds support to set absolute angles.

This is as suggested by @bkueng.