### PR TITLE
Update MAV_SENSOR_ORIENTATION for more entries

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2405,8 +2405,17 @@
       <entry value="37" name="MAV_SENSOR_ROTATION_ROLL_90_YAW_270">
         <description>Roll: 90, Pitch: 0, Yaw: 270</description>
       </entry>
-      <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_315_PITCH_315_YAW_315">
-        <description>Roll: 315, Pitch: 315, Yaw: 315</description>
+      <entry value="38" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_68_YAW_293">
+        <description>Roll: 90, Pitch: 68, Yaw: 293</description>
+      </entry>
+      <entry value="39" name="MAV_SENSOR_ROTATION_PITCH_315">
+        <description>Pitch: 315</description>
+      </entry>
+      <entry value="40" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_315">
+        <description>Roll: 90, Pitch: 315</description>
+      </entry>
+      <entry value="100" name="MAV_SENSOR_ROTATION_CUSTOM">
+        <description>Custom orientation</description>
       </entry>
     </enum>
     <enum name="MAV_PROTOCOL_CAPABILITY">


### PR DESCRIPTION
Replaces the value of 38 to match the ArduPilot usage, which is the only current user that I could find of the enum. Tridge and I looked recently and couldn't find anyone using `MAV_SENSOR_ROTATION_ROLL_315_PITCH_315_YAW_315` in production publicly. If we can change this value to match the current ArduPilot map of rotations that would be quite useful as there are a couple of places we are sending the internal rotations out via MAVLink at the moment, and I'd like to be able to tag them as the enum (and allow GCS's to have proper documentation on the meanings).

I'd also like to note that this enum violates the normal naming rules we have. The enum is called `MAV_SENSOR_ORIENTATION` while the entries are all `MAV_SENSOR_ROTATION_`