### PR TITLE
Pymavlink updates

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3711,8 +3711,8 @@
       <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="uint8_t" name="sensor_id">Sensor ID</field>
-      <field type="int16_t" name="flow_x" units="dpixels">Flow in pixels in x-sensor direction</field>
-      <field type="int16_t" name="flow_y" units="dpixels">Flow in pixels in y-sensor direction</field>
+      <field type="int16_t" name="flow_x" units="dpix">Flow in x-sensor direction</field>
+      <field type="int16_t" name="flow_y" units="dpix">Flow in y-sensor direction</field>
       <field type="float" name="flow_comp_m_x" units="m">Flow in x-sensor direction, angular-speed compensated</field>
       <field type="float" name="flow_comp_m_y" units="m">Flow in y-sensor direction, angular-speed compensated</field>
       <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>


### PR DESCRIPTION
Correct kibibyte and mebibyte units
Add support for marking messages as work-in-progress
Correct the XML validation of Mavlink 2.0 extensions
Replace dpixels with dpix for consistency with already existing pix units
mavlogdump: default to mavlink2
