### PR TITLE
common: clarify BATTERY_STATUS description

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4226,7 +4226,7 @@
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy. Values: [0-100], -1: autopilot does not estimate the remaining battery.</field>
       <extensions/>
       <field type="int32_t" name="time_remaining" units="s">Remaining battery time, 0: autopilot does not provide remaining battery time estimate</field>
-      <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
+      <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge or detected battery problems, provided by autopilot for warning or external reactions according to MAV_BATTERY_CHARGE_STATE</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software</description>


### PR DESCRIPTION
The enum MAV_BATTERY_CHARGE_STATE is mentioned in XML by enum="MAV_BATTERY_CHARGE_STATE" but does not show up in documentation as far as I see. So I made it clear in the description.

FYI @julianoes 