### PR TITLE
Modify markdown generator to split output

### DIFF
--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -43,7 +43,7 @@ index_text+='\n\n## Vendor Specific Extensions (Dialects) {#dialects}'
 index_text+='\n\nMAVLink protocol-specific and vendor-specific messages (dialects) are stored in separate XML files. These often include the [common](../messages/common.md) message definition, extending it with needed vendor or protocol specific messages.'
 index_text+='\n\n> **Note** While a dialect can include any other message definition, care should be taken when including a definition file that includes another file (only a single level of nesting is tested).'
 index_text+='\n\n<span></span>\n> **Note** Vendor forks of MAVLink may contain messages that are not yet merged, and hence will not appear in this documentation.'
-index_text+='\n\nThe human-readable forms of the vendor XML files are linked below:'
+index_text+='\n\nThe human-readable forms of all the XML files are linked below:'
 
 #Fix up the BeautifulSoup output so to fix build-link errors in the generated gitbook.
 ## BS puts each tag/content in its own line. Gitbook generates anchors using the spaces/newlines. 
@@ -134,8 +134,8 @@ for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
             with open(output_file_name_withdir, 'w') as out:
                 out.write(prettyHTML )
             
-            if not file=='common.xml':
-                index_text+='\n* [%s](%s)' % (file,output_file_name)
+            #if not file=='common.xml':
+            index_text+='\n* [%s](%s)' % (file,output_file_name)
             
 #Write the index - Disabled for now.
 with open(index_file_name, 'w') as content_file:


### PR DESCRIPTION
This splits the generated markdown into an md file (the intro) and html file (the html format of the xml). The markdown includes the html so the rendered output is identical. However this allows the file to be translated (the translation software choked on it). It is also better for translators to work in html. 

This is tested, and I already dumped the output into the devguide.