### PR TITLE
[WIP] Added fields for RTL and LAND time estimates

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5116,11 +5116,11 @@
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Time/duration estimates for various events and actions given the current vehicle state and position.</description>
-      <field type="int32_t" name="rtl" units="s">Estimated time duration for RTL given current vehicle position. The estimate reflects whatever type of RTL is curently configured. -1 means already landed or no time estimate available.</field>
-      <field type="int32_t" name="land" units="s">Estimated time duration for LAND action given current vehicle position. -1 means already landed or no time estimate available.</field>
-      <field type="int32_t" name="mission_next_item" units="s">Estimated time duration for reaching/completing the currently active mission item. -1 means no time estimate available.</field>
-      <field type="int32_t" name="mission_end" units="s">Estimated time duration for completing the current mission. -1 means no mission active and/or no estimate available.</field>
-      <field type="int32_t" name="non_mission_action" units="s">Estimated time duration for completing the current action that is not a mission (i.e. Go To, Orbit, takeoff, land, etc.). -1 means no action active and/or no estimate available.</field>
+      <field type="int32_t" name="rtl" units="s">Estimated time to complete the vehicle's configured "safe return" action (e.g. RTL, Smart RTL, etc.) from its current position. -1 indicates that the vehicle is landed, or that no time estimate available.</field>
+      <field type="int32_t" name="land" units="s">Estimated time for vehicle to complete the LAND action from its current position. -1 indicates that the vehicle is landed, or that no time estimate available.</field>
+      <field type="int32_t" name="mission_next_item" units="s">Estimated time for reaching/completing the currently active mission item. -1 means no time estimate available.</field>
+      <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission. -1 means no mission active and/or no estimate available.</field>
+      <field type="int32_t" name="commanded_action" units="s">Estimated time for completing the current commanded action (i.e. Go To, Takeoff, Land, etc.). -1 means no action active and/or no estimate available.</field>
     </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4472,6 +4472,8 @@
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy. Values: [0-100], -1: autopilot does not estimate the remaining battery.</field>
       <extensions/>
       <field type="int32_t" name="time_remaining" units="s">Remaining battery time, 0: autopilot does not provide remaining battery time estimate</field>
+      <field type="int32_t" name="time_estimate_rtl" units="s">Estimated time for RTL action, 0: Already landed or autopilot does not provide RTL time estimate</field>
+      <field type="int32_t" name="time_estimate_land" units="s">Estimated time for LAND action, 0: Already landed or autopilot does not provide remaining battery time estimate</field>
       <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5118,7 +5118,7 @@
       <description>Time/duration estimates for various events and actions given the current vehicle state and position.</description>
       <field type="int32_t" name="rtl" units="s">Estimated time duration for RTL given current vehicle position. The estimate reflects whatever type of RTL is curently configured. -1 means already landed or no time estimate available.</field>
       <field type="int32_t" name="land" units="s">Estimated time duration for LAND action given current vehicle position. -1 means already landed or no time estimate available.</field>
-      <field type="int32_t" name="mission_nex_item" units="s">Estimated time duration for reaching/completing the currently active mission item. -1 means no time estimate available.</field>
+      <field type="int32_t" name="mission_next_item" units="s">Estimated time duration for reaching/completing the currently active mission item. -1 means no time estimate available.</field>
       <field type="int32_t" name="mission_end" units="s">Estimated time duration for completing the current mission. -1 means no mission active and/or no estimate available.</field>
       <field type="int32_t" name="non_mission_action" units="s">Estimated time duration for completing the current action that is not a mission (i.e. Go To, Orbit, takeoff, land, etc.). -1 means no action active and/or no estimate available.</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5132,7 +5132,7 @@
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Time/duration estimates for various events and actions given the current vehicle state and position.</description>
-      <field type="int32_t" name="rtl" units="s">Estimated time to complete the vehicle's configured "safe return" action (e.g. RTL, Smart RTL, etc.) from its current position. -1 indicates that the vehicle is landed, or that no time estimate available.</field>
+      <field type="int32_t" name="safe_return" units="s">Estimated time to complete the vehicle's configured "safe return" action from its current position. -1 indicates that the vehicle is landed, or that no time estimate available.</field>
       <field type="int32_t" name="land" units="s">Estimated time for vehicle to complete the LAND action from its current position. -1 indicates that the vehicle is landed, or that no time estimate available.</field>
       <field type="int32_t" name="mission_next_item" units="s">Estimated time for reaching/completing the currently active mission item. -1 means no time estimate available.</field>
       <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission. -1 means no mission active and/or no estimate available.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5113,10 +5113,14 @@
       <field type="uint16_t[16]" name="voltages" units="mV">Individual cell voltages. Batteries with more 16 cells can use the cell_offset field to specify the cell offset for the array specified in the current message . Index values above the valid cell count for this battery should have the UINT16_MAX value.</field>
     </message>
     <message id="380" name="TIME_ESTIMATE_TO_TARGET">
-      <description>Time estimates until specific targets are reached or actions performed, given the current vehicle state and position</description>
-      <field type="int32_t" name="rtl" units="s">Estimated time for RTL action given current vehicle position, 0: Already landed or autopilot does not provide RTL time estimate</field>
-      <field type="int32_t" name="land" units="s">Estimated time for LAND action given current vehicle position, 0: Already landed or autopilot does not provide LAND time estimate</field>
-      <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission, 0: Mission complete or no mission active</field>
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Time/duration estimates for various events and actions given the current vehicle state and position.</description>
+      <field type="int32_t" name="rtl" units="s">Estimated time duration for RTL given current vehicle position. The estimate reflects whatever type of RTL is curently configured. -1 means already landed or no time estimate available.</field>
+      <field type="int32_t" name="land" units="s">Estimated time duration for LAND action given current vehicle position. -1 means already landed or no time estimate available.</field>
+      <field type="int32_t" name="mission_nex_item" units="s">Estimated time duration for reaching/completing the currently active mission item. -1 means no time estimate available.</field>
+      <field type="int32_t" name="mission_end" units="s">Estimated time duration for completing the current mission. -1 means no mission active and/or no estimate available.</field>
+      <field type="int32_t" name="non_mission_action" units="s">Estimated time duration for completing the current action that is not a mission (i.e. Go To, Orbit, takeoff, land, etc.). -1 means no action active and/or no estimate available.</field>
     </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4472,8 +4472,6 @@
       <field type="int8_t" name="battery_remaining" units="%">Remaining battery energy. Values: [0-100], -1: autopilot does not estimate the remaining battery.</field>
       <extensions/>
       <field type="int32_t" name="time_remaining" units="s">Remaining battery time, 0: autopilot does not provide remaining battery time estimate</field>
-      <field type="int32_t" name="time_estimate_rtl" units="s">Estimated time for RTL action, 0: Already landed or autopilot does not provide RTL time estimate</field>
-      <field type="int32_t" name="time_estimate_land" units="s">Estimated time for LAND action, 0: Already landed or autopilot does not provide remaining battery time estimate</field>
       <field type="uint8_t" name="charge_state" enum="MAV_BATTERY_CHARGE_STATE">State for extent of discharge, provided by autopilot for warning or external reactions</field>
     </message>
     <message id="148" name="AUTOPILOT_VERSION">
@@ -4509,6 +4507,12 @@
       <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
       <field type="uint8_t" name="position_valid">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
+    </message>
+    <message id="150" name="TIME_ESTIMATE_TO_TARGET">
+      <description>Time estimates until specific targets are reached or actions performed, given the current vehicle state and position</description>
+      <field type="int32_t" name="rtl" units="s">Estimated time for RTL action given current position, 0: Already landed or autopilot does not provide RTL time estimate</field>
+      <field type="int32_t" name="land" units="s">Estimated time for LAND action given current position, 0: Already landed or autopilot does not provide remaining battery time estimate</field>
+      <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission, 0: Mission complete or no mission active</field>
     </message>
     <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
     <message id="230" name="ESTIMATOR_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4508,12 +4508,6 @@
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
       <field type="uint8_t" name="position_valid">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
     </message>
-    <message id="150" name="TIME_ESTIMATE_TO_TARGET">
-      <description>Time estimates until specific targets are reached or actions performed, given the current vehicle state and position</description>
-      <field type="int32_t" name="rtl" units="s">Estimated time for RTL action given current position, 0: Already landed or autopilot does not provide RTL time estimate</field>
-      <field type="int32_t" name="land" units="s">Estimated time for LAND action given current position, 0: Already landed or autopilot does not provide remaining battery time estimate</field>
-      <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission, 0: Mission complete or no mission active</field>
-    </message>
     <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
     <message id="230" name="ESTIMATOR_STATUS">
       <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovation test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovation test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>
@@ -5117,6 +5111,12 @@
       <field type="int32_t" name="time_remaining" units="s">Estimated remaining battery time. -1: field not provided.</field>
       <field type="uint16_t" default="0" name="cell_offset">The cell number of the first index in the 'voltages' array field. Using this field allows you to specify cell voltages for batteries with more than 16 cells.</field>
       <field type="uint16_t[16]" name="voltages" units="mV">Individual cell voltages. Batteries with more 16 cells can use the cell_offset field to specify the cell offset for the array specified in the current message . Index values above the valid cell count for this battery should have the UINT16_MAX value.</field>
+    </message>
+    <message id="380" name="TIME_ESTIMATE_TO_TARGET">
+      <description>Time estimates until specific targets are reached or actions performed, given the current vehicle state and position</description>
+      <field type="int32_t" name="rtl" units="s">Estimated time for RTL action given current vehicle position, 0: Already landed or autopilot does not provide RTL time estimate</field>
+      <field type="int32_t" name="land" units="s">Estimated time for LAND action given current vehicle position, 0: Already landed or autopilot does not provide LAND time estimate</field>
+      <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission, 0: Mission complete or no mission active</field>
     </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">


### PR DESCRIPTION
[**don't merge**]

There has frequently been a mention of "Smart RTL" and similar things, where the drone does not only return based on battery capacity, but also the distance to home. I'm not working on smart RTL, but a feature that estimates the time to perform RTL and LAND actions given the current location. This can then be used to trigger RTL in time, in case the drone is far away from home. 

In my tests, the drone publishes a uorb message at 1Hz for the RTL/Land time estimates. 

Now, for a GroundStation to be able to display the remaining effectively remaining flight time, which is "battery-based remaining flight time" minus "RTL time estimate", we need to convey the data via mavlink. And I am not sure where it best belongs. 

The estimated time to perform RTL would in my opinion best fit into the message `<message id="242" name="HOME_POSITION">`, since it is data depending on and derived from the home position. But the LAND time estimate does not fit in there, since LAND just happens wherever the drone is currently located.

@MaEtUgR suggested to add it next to the total remaining flight time, which is inside the `BATTERY_STATUS` message.

Thoughts?