### PR TITLE
Use consistent altitude references

### DIFF
--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -70,7 +70,7 @@
       <field type="float" name="param4">PARAM4, see MAV_CMD enum</field>
       <field type="int32_t" name="x">PARAM5 / local: x position in meters * 1e4, global: latitude in degrees * 10^7</field>
       <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
-      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (relative or absolute, depending on frame.</field>
+      <field type="float" name="z">PARAM7 / z position: global: altitude in meters (MSL, WGS84, AGL or relative to home - depending on frame).</field>
     </message>
     <message id="79" name="COMMAND_LONG_STAMPED">
       <description>Send a command with up to seven parameters to the MAV and additional metadata</description>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1299,8 +1299,8 @@
       <!-- per camera image index, should be unique+sequential within a mission, preferably non-wrapping -->
       <field type="int32_t" name="lat" units="degE7">Latitude.</field>
       <field type="int32_t" name="lng" units="degE7">Longitude.</field>
-      <field type="float" name="alt_msl" units="m">Altitude Absolute (AMSL).</field>
-      <field type="float" name="alt_rel" units="m">Altitude Relative (above HOME location).</field>
+      <field type="float" name="alt_msl" units="m">Altitude (MSL).</field>
+      <field type="float" name="alt_rel" units="m">Altitude (Relative to HOME location).</field>
       <field type="float" name="roll" units="deg">Camera Roll angle (earth frame, +-180).</field>
       <!-- initially only supporting fixed cameras, in future we'll need feedback messages from the gimbal so we can include that offset here -->
       <field type="float" name="pitch" units="deg">Camera Pitch angle (earth frame, +-180).</field>

--- a/message_definitions/v1.0/autoquad.xml
+++ b/message_definitions/v1.0/autoquad.xml
@@ -55,7 +55,7 @@
         <description>Dynamic Velocity Hold is active (PH with proportional manual direction override)</description>
       </entry>
       <entry value="0x02000000" name="AQ_NAV_STATUS_DAO">
-        <description>ynamic Altitude Override is active (AH with proportional manual adjustment)</description>
+        <description>Dynamic Altitude Override is active (AH with proportional manual adjustment)</description>
       </entry>
       <entry value="0x04000000" name="AQ_NAV_STATUS_CEILING_REACHED">
         <description>Craft is at ceiling altitude</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1401,7 +1401,7 @@
         <description>Set limits for external control</description>
         <param index="1">Timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout.</param>
         <param index="2">Altitude (MSL) min, in meters - if vehicle moves below this alt, the command will be aborted and the mission will continue. 0 means no lower altitude limit.</param>
-        <param index="3">Absolute altitude (MSL) max, in meters - if vehicle moves above this alt, the command will be aborted and the mission will continue. 0 means no upper altitude limit.</param>
+        <param index="3">Altitude (MSL) max, in meters - if vehicle moves above this alt, the command will be aborted and the mission will continue. 0 means no upper altitude limit.</param>
         <param index="4">Horizontal move limit, in meters - if vehicle moves more than this distance from its location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal move limit.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
@@ -3688,7 +3688,7 @@
       <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
       <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
       <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
-      <field type="float" name="alt" units="m">Altitude (MSL or AGL, depending on frame)</field>
+      <field type="float" name="alt" units="m">Altitude (MSL, AGL or relative to home altitude, depending on frame)</field>
       <field type="float" name="vx" units="m/s">X velocity in NED frame</field>
       <field type="float" name="vy" units="m/s">Y velocity in NED frame</field>
       <field type="float" name="vz" units="m/s">Z velocity in NED frame</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -608,10 +608,10 @@
         <description>Offset in body NED frame. This makes sense if adding setpoints to the current flight path, to avoid an obstacle - e.g. useful to command 2 m/s^2 acceleration to the east.</description>
       </entry>
       <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">
-        <description>Global coordinate frame with AGL altitude. WGS84 coordinate system, with AGL altitude at the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+        <description>Global (WGS84) coordinate frame with AGL altitude (at the waypoint coordinate). First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
       </entry>
       <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
-        <description>Global coordinate frame with AGL altitude. WGS84 coordinate system, with AGL altitude at the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+        <description>Global (WGS84) coordinate frame with AGL altitude (at the waypoint coordinate). First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
       </entry>
       <entry value="12" name="MAV_FRAME_BODY_FRD">
         <description>Body fixed frame of reference, Z-down (x: forward, y: right, z: down).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3688,7 +3688,7 @@
       <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
       <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
       <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
-      <field type="float" name="alt" units="m">Altitude (MSL) if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+      <field type="float" name="alt" units="m">Altitude (MSL or AGL, depending on frame)</field>
       <field type="float" name="vx" units="m/s">X velocity in NED frame</field>
       <field type="float" name="vy" units="m/s">Y velocity in NED frame</field>
       <field type="float" name="vz" units="m/s">Z velocity in NED frame</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -608,10 +608,10 @@
         <description>Offset in body NED frame. This makes sense if adding setpoints to the current flight path, to avoid an obstacle - e.g. useful to command 2 m/s^2 acceleration to the east.</description>
       </entry>
       <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">
-        <description>Global coordinate frame with AGL altitude. WGS84 coordinate system, with altitude AGL (over terrain) at the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+        <description>Global coordinate frame with AGL altitude. WGS84 coordinate system, with AGL altitude at the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
       </entry>
       <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
-        <description>Global coordinate frame with AGL altitude. WGS84 coordinate system, relative altitude over terrain at the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+        <description>Global coordinate frame with AGL altitude. WGS84 coordinate system, with AGL altitude at the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
       </entry>
       <entry value="12" name="MAV_FRAME_BODY_FRD">
         <description>Body fixed frame of reference, Z-down (x: forward, y: right, z: down).</description>
@@ -896,7 +896,7 @@
         <param index="4">Reserved (e.g. for dynamic center beacon options)</param>
         <param index="5">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="6">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
-        <param index="7">Center point altitude (AMSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
+        <param index="7">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>
@@ -1821,7 +1821,7 @@
         <param index="4">Minimum altitude clearance to the release position in meters. A negative value indicates the system can define the clearance at will.</param>
         <param index="5">Latitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
         <param index="6">Longitude unscaled for MISSION_ITEM or in 1e7 degrees for MISSION_ITEM_INT</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="30002" name="MAV_CMD_PAYLOAD_CONTROL_DEPLOY">
         <description>Control the payload deployment.</description>
@@ -1843,7 +1843,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31001" name="MAV_CMD_WAYPOINT_USER_2">
         <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
@@ -1853,7 +1853,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31002" name="MAV_CMD_WAYPOINT_USER_3">
         <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
@@ -1863,7 +1863,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31003" name="MAV_CMD_WAYPOINT_USER_4">
         <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
@@ -1873,7 +1873,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31004" name="MAV_CMD_WAYPOINT_USER_5">
         <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
@@ -1883,7 +1883,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31005" name="MAV_CMD_SPATIAL_USER_1">
         <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
@@ -1893,7 +1893,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31006" name="MAV_CMD_SPATIAL_USER_2">
         <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
@@ -1903,7 +1903,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31007" name="MAV_CMD_SPATIAL_USER_3">
         <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
@@ -1913,7 +1913,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31008" name="MAV_CMD_SPATIAL_USER_4">
         <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
@@ -1923,7 +1923,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31009" name="MAV_CMD_SPATIAL_USER_5">
         <description>User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.</description>
@@ -1933,7 +1933,7 @@
         <param index="4">User defined</param>
         <param index="5">Latitude unscaled</param>
         <param index="6">Longitude unscaled</param>
-        <param index="7">Altitude (AMSL), in meters</param>
+        <param index="7">Altitude (MSL), in meters</param>
       </entry>
       <entry value="31010" name="MAV_CMD_USER_1">
         <description>User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.</description>
@@ -3098,7 +3098,7 @@
       <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">GPS fix type.</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84, EGM96 ellipsoid)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84, EGM96 ellipsoid)</field>
-      <field type="int32_t" name="alt" units="mm">Altitude (AMSL). Positive for up. Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL). Positive for up. Note that virtually all GPS modules provide the MSL altitude in addition to the WGS84 altitude.</field>
       <field type="uint16_t" name="eph">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="epv">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="vel" units="cm/s">GPS ground speed. If unknown, set to: UINT16_MAX</field>
@@ -3198,7 +3198,7 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="int32_t" name="lat" units="degE7">Latitude, expressed</field>
       <field type="int32_t" name="lon" units="degE7">Longitude, expressed</field>
-      <field type="int32_t" name="alt" units="mm">Altitude (AMSL). Note that virtually all GPS modules provide both WGS84 and AMSL.</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL). Note that virtually all GPS modules provide both WGS84 and MSL.</field>
       <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
       <field type="int16_t" name="vx" units="cm/s">Ground X Speed (Latitude, positive north)</field>
       <field type="int16_t" name="vy" units="cm/s">Ground Y Speed (Longitude, positive east)</field>
@@ -3350,7 +3350,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
-      <field type="int32_t" name="altitude" units="mm">Altitude (AMSL). Positive for up.</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
       <extensions/>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
     </message>
@@ -3358,7 +3358,7 @@
       <description>Once the MAV sets a new GPS-Local correspondence, this message announces the origin (0,0,0) position</description>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
-      <field type="int32_t" name="altitude" units="mm">Altitude (AMSL). Positive for up.</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
       <extensions/>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
     </message>
@@ -3688,7 +3688,7 @@
       <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
       <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
       <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
-      <field type="float" name="alt" units="m">Altitude (AMSL) if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+      <field type="float" name="alt" units="m">Altitude (MSL) if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
       <field type="float" name="vx" units="m/s">X velocity in NED frame</field>
       <field type="float" name="vy" units="m/s">Y velocity in NED frame</field>
       <field type="float" name="vz" units="m/s">Z velocity in NED frame</field>
@@ -3934,7 +3934,7 @@
       <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
-      <field type="int32_t" name="alt" units="mm">Altitude (AMSL). Positive for up.</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL). Positive for up.</field>
       <field type="uint16_t" name="eph" units="cm">GPS HDOP horizontal dilution of position. If unknown, set to: 65535</field>
       <field type="uint16_t" name="epv" units="cm">GPS VDOP vertical dilution of position. If unknown, set to: 65535</field>
       <field type="uint16_t" name="vel" units="cm/s">GPS ground speed. If unknown, set to: 65535</field>
@@ -4044,7 +4044,7 @@
       <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">GPS fix type.</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
-      <field type="int32_t" name="alt" units="mm">Altitude (AMSL). Positive for up.</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL). Positive for up.</field>
       <field type="uint16_t" name="eph" units="cm">GPS HDOP horizontal dilution of position. If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="epv" units="cm">GPS VDOP vertical dilution of position. If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="vel" units="cm/s">GPS ground speed. If unknown, set to: UINT16_MAX</field>
@@ -4152,7 +4152,7 @@
       <field type="int32_t" name="lon" units="degE7">Longitude of SW corner of first grid</field>
       <field type="uint16_t" name="grid_spacing" units="m">Grid spacing</field>
       <field type="uint8_t" name="gridbit">bit within the terrain request mask</field>
-      <field type="int16_t[16]" name="data" units="m">Terrain data AMSL</field>
+      <field type="int16_t[16]" name="data" units="m">Terrain data MSL</field>
     </message>
     <message id="135" name="TERRAIN_CHECK">
       <description>Request that the vehicle report terrain height at the given location. Used by GCS to check if vehicle has all terrain data needed for a mission.</description>
@@ -4164,7 +4164,7 @@
       <field type="int32_t" name="lat" units="degE7">Latitude</field>
       <field type="int32_t" name="lon" units="degE7">Longitude</field>
       <field type="uint16_t" name="spacing">grid spacing (zero if terrain at this location unavailable)</field>
-      <field type="float" name="terrain_height" units="m">Terrain height AMSL</field>
+      <field type="float" name="terrain_height" units="m">Terrain height MSL</field>
       <field type="float" name="current_height" units="m">Current vehicle height above lat/lon terrain height</field>
       <field type="uint16_t" name="pending">Number of 4x4 terrain blocks waiting to be received or read from disk</field>
       <field type="uint16_t" name="loaded">Number of 4x4 terrain blocks in memory</field>
@@ -4204,7 +4204,7 @@
       <description>The current system altitude.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="float" name="altitude_monotonic" units="m">This altitude measure is initialized on system boot and monotonic (it is never reset, but represents the local altitude change). The only guarantee on this field is that it will never be reset and is consistent within a flight. The recommended value for this field is the uncorrected barometric altitude at boot time. This altitude will also drift and vary between flights.</field>
-      <field type="float" name="altitude_amsl" units="m">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output AMSL by default and not the WGS84 altitude.</field>
+      <field type="float" name="altitude_amsl" units="m">This altitude measure is strictly above mean sea level and might be non-monotonic (it might reset on events like GPS lock or when a new QNH value is set). It should be the altitude to which global altitude waypoints are compared to. Note that it is *not* the GPS altitude, however, most GPS modules already output MSL by default and not the WGS84 altitude.</field>
       <field type="float" name="altitude_local" units="m">This is the local altitude in the local coordinate frame. It is not the altitude above home, but in reference to the coordinate origin (0, 0, 0). It is up-positive.</field>
       <field type="float" name="altitude_relative" units="m">This is the altitude above the home position. It resets on each change of the current home position.</field>
       <field type="float" name="altitude_terrain" units="m">This is the altitude above terrain. It might be fed by a terrain database or an altimeter. Values smaller than -1000 should be interpreted as unknown.</field>
@@ -4231,7 +4231,7 @@
       <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
-      <field type="float" name="alt" units="m">Altitude (AMSL)</field>
+      <field type="float" name="alt" units="m">Altitude (MSL)</field>
       <field type="float[3]" name="vel" units="m/s">target velocity (0,0,0) for unknown</field>
       <field type="float[3]" name="acc" units="m/s/s">linear target acceleration (0,0,0) for unknown</field>
       <field type="float[4]" name="attitude_q">(1 0 0 0 for unknown)</field>
@@ -4330,7 +4330,7 @@
       <field type="float" name="wind_z" units="m/s">Wind in Z (NED) direction</field>
       <field type="float" name="var_horiz" units="m/s">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
       <field type="float" name="var_vert" units="m/s">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
-      <field type="float" name="wind_alt" units="m">Altitude (AMSL) that this measurement was taken at</field>
+      <field type="float" name="wind_alt" units="m">Altitude (MSL) that this measurement was taken at</field>
       <field type="float" name="horiz_accuracy" units="m">Horizontal speed 1-STD accuracy</field>
       <field type="float" name="vert_accuracy" units="m">Vertical speed 1-STD accuracy</field>
     </message>
@@ -4344,7 +4344,7 @@
       <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
-      <field type="float" name="alt" units="m">Altitude (AMSL). Positive for up.</field>
+      <field type="float" name="alt" units="m">Altitude (MSL). Positive for up.</field>
       <field type="float" name="hdop" units="m">GPS HDOP horizontal dilution of position</field>
       <field type="float" name="vdop" units="m">GPS VDOP vertical dilution of position</field>
       <field type="float" name="vn" units="m/s">GPS velocity in NORTH direction in earth-fixed NED frame</field>
@@ -4434,7 +4434,7 @@
       <description>This message can be requested by sending the MAV_CMD_GET_HOME_POSITION command. The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitly set by the operator before or after. The position the system will return to and land on. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
-      <field type="int32_t" name="altitude" units="mm">Altitude (AMSL). Positive for up.</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
       <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame</field>
       <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame</field>
       <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame</field>
@@ -4450,7 +4450,7 @@
       <field type="uint8_t" name="target_system">System ID.</field>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
-      <field type="int32_t" name="altitude" units="mm">Altitude (AMSL). Positive for up.</field>
+      <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
       <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame</field>
       <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame</field>
       <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame</field>
@@ -4616,7 +4616,7 @@
       <field type="uint8_t" name="camera_id">Camera ID (1 for first, 2 for second, etc.)</field>
       <field type="int32_t" name="lat" units="degE7">Latitude where image was taken</field>
       <field type="int32_t" name="lon" units="degE7">Longitude where capture was taken</field>
-      <field type="int32_t" name="alt" units="mm">Altitude (AMSL) where image was taken</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL) where image was taken</field>
       <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
       <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 0, 0, 0, 0)</field>
       <field type="int32_t" name="image_index">Zero based index of this image (image count since armed -1)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1402,7 +1402,7 @@
         <param index="1">Timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout.</param>
         <param index="2">Altitude (MSL) min, in meters - if vehicle moves below this alt, the command will be aborted and the mission will continue. 0 means no lower altitude limit.</param>
         <param index="3">Absolute altitude (MSL) max, in meters - if vehicle moves above this alt, the command will be aborted and the mission will continue. 0 means no upper altitude limit.</param>
-        <param index="4">Horizontal move limit (MSL), in meters - if vehicle moves more than this distance from its location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal altitude limit.</param>
+        <param index="4">Horizontal move limit, in meters - if vehicle moves more than this distance from its location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal move limit.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1398,11 +1398,11 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="222" name="MAV_CMD_DO_GUIDED_LIMITS">
-        <description>set limits for external control</description>
-        <param index="1">timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout</param>
-        <param index="2">Absolute altitude (AMSL) min, in meters - if vehicle moves below this alt, the command will be aborted and the mission will continue. 0 means no lower altitude limit</param>
-        <param index="3">Absolute altitude (AMSL) max, in meters - if vehicle moves above this alt, the command will be aborted and the mission will continue. 0 means no upper altitude limit</param>
-        <param index="4">Horizontal move limit (AMSL), in meters - if vehicle moves more than this distance from its location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal altitude limit</param>
+        <description>Set limits for external control</description>
+        <param index="1">Timeout - maximum time (in seconds) that external controller will be allowed to control vehicle. 0 means no timeout.</param>
+        <param index="2">Altitude (MSL) min, in meters - if vehicle moves below this alt, the command will be aborted and the mission will continue. 0 means no lower altitude limit.</param>
+        <param index="3">Absolute altitude (MSL) max, in meters - if vehicle moves above this alt, the command will be aborted and the mission will continue. 0 means no upper altitude limit.</param>
+        <param index="4">Horizontal move limit (MSL), in meters - if vehicle moves more than this distance from its location at the moment the command was executed, the command will be aborted and the mission will continue. 0 means no horizontal altitude limit.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>
@@ -3671,7 +3671,7 @@
       <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
       <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
       <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
-      <field type="float" name="alt" units="m">Altitude (AMSL) if absolute or relative, above terrain if GLOBAL_TERRAIN_ALT_INT</field>
+      <field type="float" name="alt" units="m">Altitude (MSL, Relative to home, or AGL - depending on frame)</field>
       <field type="float" name="vx" units="m/s">X velocity in NED frame</field>
       <field type="float" name="vy" units="m/s">Y velocity in NED frame</field>
       <field type="float" name="vz" units="m/s">Z velocity in NED frame</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -608,10 +608,10 @@
         <description>Offset in body NED frame. This makes sense if adding setpoints to the current flight path, to avoid an obstacle - e.g. useful to command 2 m/s^2 acceleration to the east.</description>
       </entry>
       <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">
-        <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+        <description>Global coordinate frame with AGL altitude. WGS84 coordinate system, with altitude AGL (over terrain) at the waypoint coordinate. First value / x: latitude in degrees, second value / y: longitude in degrees, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
       </entry>
       <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
-        <description>Global coordinate frame with above terrain level altitude. WGS84 coordinate system, relative altitude over terrain with respect to the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
+        <description>Global coordinate frame with AGL altitude. WGS84 coordinate system, relative altitude over terrain at the waypoint coordinate. First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
       </entry>
       <entry value="12" name="MAV_FRAME_BODY_FRD">
         <description>Body fixed frame of reference, Z-down (x: forward, y: right, z: down).</description>

--- a/message_definitions/v1.0/matrixpilot.xml
+++ b/message_definitions/v1.0/matrixpilot.xml
@@ -269,7 +269,7 @@
     <message id="181" name="ALTITUDES">
       <description>The altitude measured by sensors and IMU</description>
       <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
-      <field type="int32_t" name="alt_gps">GPS altitude in meters, expressed as * 1000 (millimeters), above MSL</field>
+      <field type="int32_t" name="alt_gps">GPS altitude (MSL) in meters, expressed as * 1000 (millimeters)</field>
       <field type="int32_t" name="alt_imu">IMU altitude above ground in meters, expressed as * 1000 (millimeters)</field>
       <field type="int32_t" name="alt_barometric">barometeric altitude above ground in meters, expressed as * 1000 (millimeters)</field>
       <field type="int32_t" name="alt_optical_flow">Optical flow altitude above ground in meters, expressed as * 1000 (millimeters)</field>

--- a/message_definitions/v1.0/slugs.xml
+++ b/message_definitions/v1.0/slugs.xml
@@ -164,7 +164,7 @@
       <field name="dist2Go" type="float">Remaining distance to Run on this leg of Navigation</field>
       <field name="fromWP" type="uint8_t">Origin WP</field>
       <field name="toWP" type="uint8_t">Destination WP</field>
-      <field name="h_c" type="uint16_t" units="dm">Commanded altitude (relative to home position)</field>
+      <field name="h_c" type="uint16_t" units="dm">Commanded altitude (MSL)</field>
     </message>
     <message name="DATA_LOG" id="177">
       <description>Configurable data log probes to be used inside Simulink</description>
@@ -193,7 +193,7 @@
     <message name="MID_LVL_CMDS" id="180">
       <description>Mid Level commands sent from the GS to the autopilot. These are only sent when being operated in mid-level commands mode from the ground.</description>
       <field name="target" type="uint8_t">The system setting the commands</field>
-      <field name="hCommand" type="float" units="m">Commanded altitude (relative to home position)</field>
+      <field name="hCommand" type="float" units="m">Commanded altitude (MSL)</field>
       <field name="uCommand" type="float" units="m/s">Commanded Airspeed</field>
       <field name="rCommand" type="float" units="rad/s">Commanded Turnrate</field>
     </message>

--- a/message_definitions/v1.0/slugs.xml
+++ b/message_definitions/v1.0/slugs.xml
@@ -164,7 +164,7 @@
       <field name="dist2Go" type="float">Remaining distance to Run on this leg of Navigation</field>
       <field name="fromWP" type="uint8_t">Origin WP</field>
       <field name="toWP" type="uint8_t">Destination WP</field>
-      <field name="h_c" type="uint16_t" units="dm">Commanded altitude</field>
+      <field name="h_c" type="uint16_t" units="dm">Commanded altitude (relative to home position)</field>
     </message>
     <message name="DATA_LOG" id="177">
       <description>Configurable data log probes to be used inside Simulink</description>
@@ -193,7 +193,7 @@
     <message name="MID_LVL_CMDS" id="180">
       <description>Mid Level commands sent from the GS to the autopilot. These are only sent when being operated in mid-level commands mode from the ground.</description>
       <field name="target" type="uint8_t">The system setting the commands</field>
-      <field name="hCommand" type="float" units="m">Commanded Altitude</field>
+      <field name="hCommand" type="float" units="m">Commanded altitude (relative to home position)</field>
       <field name="uCommand" type="float" units="m/s">Commanded Airspeed</field>
       <field name="rCommand" type="float" units="rad/s">Commanded Turnrate</field>
     </message>

--- a/message_definitions/v1.0/uAvionix.xml
+++ b/message_definitions/v1.0/uAvionix.xml
@@ -99,10 +99,10 @@
       <field type="uint32_t" name="utcTime" units="s">UTC time in seconds since GPS epoch (Jan 6, 1980). If unknown set to UINT32_MAX</field>
       <field type="int32_t" name="gpsLat" units="degE7">Latitude WGS84 (deg * 1E7). If unknown set to INT32_MAX</field>
       <field type="int32_t" name="gpsLon" units="degE7">Longitude WGS84 (deg * 1E7). If unknown set to INT32_MAX</field>
-      <field type="int32_t" name="gpsAlt" units="mm">Altitude in mm (m * 1E-3) UP +ve. WGS84 altitude. If unknown set to INT32_MAX</field>
+      <field type="int32_t" name="gpsAlt" units="mm">Altitude (WGS84). UP +ve. If unknown set to INT32_MAX</field>
       <field type="uint8_t" name="gpsFix" enum="UAVIONIX_ADSB_OUT_DYNAMIC_GPS_FIX">0-1: no fix, 2: 2D fix, 3: 3D fix, 4: DGPS, 5: RTK</field>
       <field type="uint8_t" name="numSats">Number of satellites visible. If unknown set to UINT8_MAX</field>
-      <field type="int32_t" name="baroAltMSL" units="mbar">Barometric pressure altitude relative to a standard atmosphere of 1013.2 mBar and NOT bar corrected altitude (m * 1E-3). (up +ve). If unknown set to INT32_MAX</field>
+      <field type="int32_t" name="baroAltMSL" units="mbar">Barometric pressure altitude (MSL) relative to a standard atmosphere of 1013.2 mBar and NOT bar corrected altitude (m * 1E-3). (up +ve). If unknown set to INT32_MAX</field>
       <field type="uint32_t" name="accuracyHor" units="mm">Horizontal accuracy in mm (m * 1E-3). If unknown set to UINT32_MAX</field>
       <field type="uint16_t" name="accuracyVert" units="cm">Vertical accuracy in cm. If unknown set to UINT16_MAX</field>
       <field type="uint16_t" name="accuracyVel" units="mm/s">Velocity accuracy in mm/s (m * 1E-3). If unknown set to UINT16_MAX</field>


### PR DESCRIPTION
Globally we want to use the most "standard" terminology for frames possible. For altitude those are WGS84, MSL and AGL. The use of "Absolute" is redundant.