### PR TITLE
common: add orbit execution telemetry message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4829,5 +4829,16 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
+    <message id="360" name="ORBIT_EXECUTION_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Vehicle status report that is sent out while orbit execution is in progress (see MAV_CMD_DO_ORBIT).</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
+      <field type="float" name="radius" units="m">Radius of the orbit circle. Positive values orbit clockwise, negative values orbit counter-clockwise.</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the fields: x, y, z.</field>
+      <field type="int32_t" name="x">X coordinate of center point. Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
+      <field type="int32_t" name="y">Y coordinate of center point.  Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
+      <field type="float" name="z" units="m">Altitude of center point. Coordinate system depends on frame field.</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
References:
- https://github.com/mavlink/mavlink/pull/924 introduced a message to command the vehicle to do an orbit
- QGroundcontrol added support for this command https://github.com/mavlink/qgroundcontrol/pull/6608, https://github.com/mavlink/qgroundcontrol/pull/6711, https://github.com/mavlink/qgroundcontrol/pull/6753 thanks to @DonLakeFlyer 
- On PX4 autopilot the implementation to execute the orbit can be found here: https://github.com/PX4/Firmware/tree/master/src/lib/FlightTasks/tasks/Orbit

New:
This PR adds a message for the vehicle to report the current status, parameters and therefore planned trajectory to the ground control station while flying an orbit to allow the UI to show a live visualization for the pilot.

Use case:
After commanding an orbit the circle in the qgc UI disappears and the user can only remember where it was and see the tail line of the vehicle forming the same circle again. Even if the circle was kept on the UI after successful command acknowledgement the user might change the parameters of the orbit e.g. tangential speed and radius by sticks or SDK which would then not be reflected in the UI anymore.