### PR TITLE
Companion status

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3006,11 +3006,11 @@
       <entry value="3" name="COMPANION_STATE_STARTING"/>
       <entry value="4" name="COMPANION_STATE_COMPONENT_FAIL"/>
    </enum>
-   <enum name="COMPANION_SOURCE">
+   <enum name="COMPANION_TYPE">
       <description>Status signal of the obstacle avoidance algorithm</description>
-      <entry value="0" name="COMPANION_SOURCE_GENERIC"/>
-      <entry value="1" name="COMPANION_SOURCE_AVOIDANCE"/>
-      <entry value="2" name="COMPANION_SOURCE_VIO"/>
+      <entry value="0" name="COMPANION_TYPE_GENERIC"/>
+      <entry value="1" name="COMPANION_TYPE_AVOIDANCE"/>
+      <entry value="2" name="COMPANION_TYPE_VIO"/>
    </enum>
   </enums>
   <messages>
@@ -4847,7 +4847,8 @@
       <description>WORK IN PROGRESS! DO NOT DEPLOY! </description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot or since UNIX epoch).</field>
       <field type="uint8_t" name="state" enum="COMPANION_STATE">Status of a component on the companion computer.</field>
-      <field type="uint8_t" name="source" enum="COMPANION_SOURCE">Source on the companion computer reporting the status.</field>
+      <field type="uint8_t" name="type" enum="COMPANION_TYPE">Source on the companion computer reporting the status.</field>
+      <field type="uint16_t" name="pid">process ID of source</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3005,13 +3005,13 @@
       <entry value="2" name="COMPANION_STATE_ABORT"/>
       <entry value="3" name="COMPANION_STATE_STARTING"/>
       <entry value="4" name="COMPANION_STATE_COMPONENT_FAIL"/>
-   </enum>
-   <enum name="COMPANION_TYPE">
+    </enum>
+    <enum name="COMPANION_TYPE">
       <description>Type of a companion process</description>
       <entry value="0" name="COMPANION_TYPE_GENERIC"/>
       <entry value="1" name="COMPANION_TYPE_AVOIDANCE"/>
       <entry value="2" name="COMPANION_TYPE_VIO"/>
-   </enum>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2998,19 +2998,19 @@
         <description>Ignore yaw rate</description>
       </entry>
     </enum>
-    <enum name="COMPANION_STATE">
+    <enum name="COMPANION_PROCESS_STATE">
       <description>Status of a companion process</description>
-      <entry value="0" name="COMPANION_STATE_HEALTHY"/>
-      <entry value="1" name="COMPANION_STATE_TIMEOUT"/>
-      <entry value="2" name="COMPANION_STATE_ABORT"/>
-      <entry value="3" name="COMPANION_STATE_STARTING"/>
-      <entry value="4" name="COMPANION_STATE_COMPONENT_FAIL"/>
+      <entry value="0" name="COMPANION_PROCESS_STATE_HEALTHY"/>
+      <entry value="1" name="COMPANION_PROCESS_STATE_TIMEOUT"/>
+      <entry value="2" name="COMPANION_PROCESS_STATE_ABORT"/>
+      <entry value="3" name="COMPANION_PROCESS_STATE_STARTING"/>
+      <entry value="4" name="COMPANION_PROCESS_STATE_COMPONENT_FAIL"/>
     </enum>
-    <enum name="COMPANION_TYPE">
+    <enum name="COMPANION_PROCESS_TYPE">
       <description>Type of a companion process</description>
-      <entry value="0" name="COMPANION_TYPE_GENERIC"/>
-      <entry value="1" name="COMPANION_TYPE_AVOIDANCE"/>
-      <entry value="2" name="COMPANION_TYPE_VIO"/>
+      <entry value="0" name="COMPANION_PROCESS_TYPE_GENERIC"/>
+      <entry value="1" name="COMPANION_PROCESS_TYPE_AVOIDANCE"/>
+      <entry value="2" name="COMPANION_PROCESS_TYPE_VIO"/>
     </enum>
   </enums>
   <messages>
@@ -4843,11 +4843,11 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
-    <message id="334" name="COMPANION_STATUS">
+    <message id="334" name="COMPANION_PROCESS_STATUS">
       <description>Message to monitor the state of processes on the companion computer </description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot or since UNIX epoch).</field>
-      <field type="uint8_t" name="state" enum="COMPANION_STATE">Status of a component on the companion computer.</field>
-      <field type="uint8_t" name="type" enum="COMPANION_TYPE">Source on the companion computer reporting the status.</field>
+      <field type="uint8_t" name="state" enum="COMPANION_PROCESS_STATE">Status of a component on the companion computer.</field>
+      <field type="uint8_t" name="type" enum="COMPANION_PROCESS_TYPE">Source on the companion computer reporting the status.</field>
       <field type="uint16_t" name="pid">process ID of source</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2998,6 +2998,14 @@
         <description>Ignore yaw rate</description>
       </entry>
     </enum>
+    <enum name="OBS_AVOID_STATUS">
+      <description>Status signal of the obstacle avoidance algorithm</description>
+      <entry value="0" name="OBS_AVOID_STATUS_HEALTHY"/>
+      <entry value="1" name="OBS_AVOID_STATUS_TIMEOUT"/>
+      <entry value="2" name="OBS_AVOID_STATUS_ABORT"/>
+      <entry value="3" name="OBS_AVOID_STATUS_NOT_READY"/>
+      <entry value="4" name="OBS_AVOID_STATUS_CAMERA_FAIL"/>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2998,14 +2998,20 @@
         <description>Ignore yaw rate</description>
       </entry>
     </enum>
-    <enum name="OBS_AVOID_STATUS">
+    <enum name="COMPANION_STATE">
       <description>Status signal of the obstacle avoidance algorithm</description>
-      <entry value="0" name="OBS_AVOID_STATUS_HEALTHY"/>
-      <entry value="1" name="OBS_AVOID_STATUS_TIMEOUT"/>
-      <entry value="2" name="OBS_AVOID_STATUS_ABORT"/>
-      <entry value="3" name="OBS_AVOID_STATUS_NOT_READY"/>
-      <entry value="4" name="OBS_AVOID_STATUS_CAMERA_FAIL"/>
-    </enum>
+      <entry value="0" name="COMPANION_STATE_HEALTHY"/>
+      <entry value="1" name="COMPANION_STATE_TIMEOUT"/>
+      <entry value="2" name="COMPANION_STATE_ABORT"/>
+      <entry value="3" name="COMPANION_STATE_STARTING"/>
+      <entry value="4" name="COMPANION_STATE_COMPONENT_FAIL"/>
+   </enum>
+   <enum name="COMPANION_SOURCE">
+      <description>Status signal of the obstacle avoidance algorithm</description>
+      <entry value="0" name="COMPANION_SOURCE_GENERIC"/>
+      <entry value="1" name="COMPANION_SOURCE_AVOIDANCE"/>
+      <entry value="2" name="COMPANION_SOURCE_VIO"/>
+   </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">
@@ -4837,10 +4843,11 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
-    <message id="334" name="AVOIDANCE_STATUS">
+    <message id="334" name="COMPANION_STATUS">
       <description>WORK IN PROGRESS! DO NOT DEPLOY! </description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot or since UNIX epoch).</field>
-      <field type="uint8_t" name="status" enum="OBS_AVOID_STATUS">Status of the avoidance algorithm on the companion computer.</field>
+      <field type="uint8_t" name="state" enum="COMPANION_STATE">Status of a component on the companion computer.</field>
+      <field type="uint8_t" name="source" enum="COMPANION_SOURCE">Source on the companion computer reporting the status.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2999,7 +2999,7 @@
       </entry>
     </enum>
     <enum name="COMPANION_STATE">
-      <description>Status signal of the obstacle avoidance algorithm</description>
+      <description>Status of a companion process</description>
       <entry value="0" name="COMPANION_STATE_HEALTHY"/>
       <entry value="1" name="COMPANION_STATE_TIMEOUT"/>
       <entry value="2" name="COMPANION_STATE_ABORT"/>
@@ -3007,7 +3007,7 @@
       <entry value="4" name="COMPANION_STATE_COMPONENT_FAIL"/>
    </enum>
    <enum name="COMPANION_TYPE">
-      <description>Status signal of the obstacle avoidance algorithm</description>
+      <description>Type of a companion process</description>
       <entry value="0" name="COMPANION_TYPE_GENERIC"/>
       <entry value="1" name="COMPANION_TYPE_AVOIDANCE"/>
       <entry value="2" name="COMPANION_TYPE_VIO"/>
@@ -4844,7 +4844,7 @@
       <field type="float[58]" name="data">data</field>
     </message>
     <message id="334" name="COMPANION_STATUS">
-      <description>WORK IN PROGRESS! DO NOT DEPLOY! </description>
+      <description> Message to monitor the state of processes on the companion computer </description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot or since UNIX epoch).</field>
       <field type="uint8_t" name="state" enum="COMPANION_STATE">Status of a component on the companion computer.</field>
       <field type="uint8_t" name="type" enum="COMPANION_TYPE">Source on the companion computer reporting the status.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4844,7 +4844,7 @@
       <field type="float[58]" name="data">data</field>
     </message>
     <message id="334" name="COMPANION_STATUS">
-      <description> Message to monitor the state of processes on the companion computer </description>
+      <description>Message to monitor the state of processes on the companion computer </description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot or since UNIX epoch).</field>
       <field type="uint8_t" name="state" enum="COMPANION_STATE">Status of a component on the companion computer.</field>
       <field type="uint8_t" name="type" enum="COMPANION_TYPE">Source on the companion computer reporting the status.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4829,5 +4829,10 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
+    <message id="334" name="AVOIDANCE_STATUS">
+      <description>WORK IN PROGRESS! DO NOT DEPLOY! </description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot or since UNIX epoch).</field>
+      <field type="uint8_t" name="status" enum="OBS_AVOID_STATUS">Status of the avoidance algorithm on the companion computer.</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Add a MAVLink message to monitor processes on the companion computer. The companion process will report a state including its PID, the type of process.

Currently the autopilot has no knowledge about the state of processes running on the companion computer. Those are potentially critical processes like the avoidance algorithm or VIO which the user relies on. Having those processes report a state allows for user warnings in QGC if something is not running correctly or eventually integraton in the preflight checks.

[RFC PR #11](https://github.com/mavlink/rfcs/pull/11)