### PR TITLE
Ci plus

### DIFF
--- a/scripts/format_xml.sh
+++ b/scripts/format_xml.sh
@@ -18,28 +18,28 @@ while getopts "h?c" opt; do
     esac
 done
 
-xml_files=`find . -name *.xml`
+xml_files=$(find . -name "*.xml")
 ret=0
 for  f in $xml_files
 do
-	xmllint -format ${f} > ${f}.new
+	xmllint -format "${f}" > "${f}".new
 	case "$mode" in
 	format)
-		if ! cmp ${f} ${f}.new >/dev/null 2>&1
+		if ! cmp "${f}" "${f}".new >/dev/null 2>&1
 		then
 			echo "formatting $f"
-			cp ${f}.new ${f}
+			cp "${f}".new "${f}"
 		fi
 		;;
 	check)
-		if ! cmp ${f} ${f}.new >/dev/null 2>&1
+		if ! cmp "${f}" "${f}".new >/dev/null 2>&1
 		then
 			echo "$f needs formatting - run ./scripts/format_xml.sh $f"
 			ret=1
 		fi
 		;;
 	esac
-	rm ${f}.new
+	rm "${f}".new
 done
 
 exit $ret

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -23,7 +23,7 @@ echo $sep
 cd "$SRC_DIR"
 
 user_arg="--user"
-if [ "$TRAVIS" == true ]
+if [ "$TRAVIS" == true ] || [ "$CI" == true ]
 then
 	user_arg=""
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,9 +3,7 @@ set -e
 
 SRC_DIR=$(pwd)
 
-git submodule update --init --recursive
-
-# NOTE: we must do all testing on the installed python package, not 
+# NOTE: we must do all testing on the installed python package, not
 # on the build tree. Otherwise the testing is invalid and may not
 # indicate the code actually works
 

--- a/scripts/travis_update_generated_repos.sh
+++ b/scripts/travis_update_generated_repos.sh
@@ -3,7 +3,7 @@
 # Do only build for Python 2.7
 # as we only want to deploy for one
 # unique generator.
-PYTHONVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
+PYTHONVER=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
 
 if [[ $PYTHONVER != "2.7"* ]]
 then
@@ -28,7 +28,7 @@ git remote rename origin upstream
 git config --global user.email "bot@pixhawk.org"
 git config --global user.name "PX4BuildBot"
 git config --global credential.helper "store --file=$HOME/.git-credentials"
-echo "https://${GH_TOKEN}:@github.com" > $HOME/.git-credentials
+echo "https://${GH_TOKEN}:@github.com" > "$HOME"/.git-credentials
 
 # Build C library
 GEN_START_PATH=$PWD
@@ -38,7 +38,7 @@ git clone https://github.com/mavlink/c_library_v2.git
 cd ../../..
 ./scripts/update_c_library.sh 2
 # v1.0 legacy
-cd $GEN_START_PATH
+cd "$GEN_START_PATH"
 mkdir -p include/mavlink/v1.0
 cd include/mavlink/v1.0
 git clone https://github.com/mavlink/c_library_v1.git


### PR DESCRIPTION
reformat script with https://www.shellcheck.net/
remove submodules update from test.sh : this is always handle by CI jobs. It will allow to have smaller CI image to run mavlink test by removing explicite git dependency.
add CI variable to test.sh to notify that we use a CI system the same way TRAVIS one is done.

