### PR TITLE
Work on video streams, camera zoom and focusing

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2950,7 +2950,7 @@
         <description>Continuous zoom up/down until stopped (-1 for wide, 1 for tele, 0 to stop zooming)</description>
       </entry>
       <entry value="2" name="ZOOM_TYPE_RANGE">
-        <description>Zoom value as proportion of full camera range (a value between 0.0 and 1.0)</description>
+        <description>Zoom value as proportion of full camera range (a value between 0.0 and 100.0)</description>
       </entry>
     </enum>
     <enum name="SET_FOCUS_TYPE">
@@ -2962,7 +2962,7 @@
         <description>Continuous focus up/down until stopped (-1 for focusing in, 1 for focusing out towards infinity, 0 to stop focusing)</description>
       </entry>
       <entry value="2" name="FOCUS_TYPE_RANGE">
-        <description>Zoom value as proportion of full camera range (a value between 0.0 and 1.0)</description>
+        <description>Zoom value as proportion of full camera range (a value between 0.0 and 100.0)</description>
       </entry>
     </enum>
     <enum name="PARAM_ACK">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1592,12 +1592,16 @@
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
+      <wip/>
+        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
         <description>Set camera zoom. Use NAN for reserved values.</description>
         <param index="1">Step zoom up/down (-1 for wide, 1 for tele, 0 for no action)</param>
         <param index="2">Continuous zoom up/down (-1 for wide, 1 for tele, 0 for stop zooming)</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
+      <wip/>
+        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
         <description>Set camera focus. Use NAN for reserved values.</description>
         <param index="1">Step focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for no action)</param>
         <param index="2">Continuous focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for stop focusing)</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1592,7 +1592,7 @@
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
-      <wip/>
+        <wip/>
         <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
         <description>Set camera zoom. Use NAN for reserved values.</description>
         <param index="1">Step zoom up/down (-1 for wide, 1 for tele, 0 for no action)</param>
@@ -1600,7 +1600,7 @@
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
-      <wip/>
+        <wip/>
         <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
         <description>Set camera focus. Use NAN for reserved values.</description>
         <param index="1">Step focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for no action)</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4693,8 +4693,8 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="mode_id" enum="CAMERA_MODE">Camera mode</field>
       <extensions/>
-      <field type="float" name="zoomLevel">Current zoom level (0.0 to 1.0)</field>
-      <field type="float" name="focusLevel">Current focus level (0.0 to 1.0)</field>
+      <field type="float" name="zoomLevel">Current zoom level (0.0 to 100.0)</field>
+      <field type="float" name="focusLevel">Current focus level (0.0 to 100.0)</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1594,7 +1594,7 @@
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera zoom. Use NAN for reserved values.</description>
+        <description>Set camera zoom. Returns CAMERA_SETTINGS message. Use NAN for reserved values.</description>
         <param index="1">Zoom type (See SET_ZOOM_TYPE enum)</param>
         <param index="2">Zoom value</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -1602,9 +1602,9 @@
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera focus. Use NAN for reserved values.</description>
-        <param index="1">Step focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for no action)</param>
-        <param index="2">Continuous focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for stop focusing)</param>
+        <description>Set camera focus. Returns CAMERA_SETTINGS message. Use NAN for reserved values.</description>
+        <param index="1">Focus type (See SET_FOCUS_TYPE enum)</param>
+        <param index="2">Focus value</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
@@ -2899,12 +2899,12 @@
       </entry>
     </enum>
     <enum name="CAMERA_CAP_FLAGS">
-      <description>Camera capability flags (Bitmap).</description>
+      <description>Camera capability flags (Bitmap)</description>
       <entry value="1" name="CAMERA_CAP_FLAGS_CAPTURE_VIDEO">
-        <description>Camera is able to record video.</description>
+        <description>Camera is able to record video</description>
       </entry>
       <entry value="2" name="CAMERA_CAP_FLAGS_CAPTURE_IMAGE">
-        <description>Camera is able to capture images.</description>
+        <description>Camera is able to capture images</description>
       </entry>
       <entry value="4" name="CAMERA_CAP_FLAGS_HAS_MODES">
         <description>Camera has separate Video and Image/Photo modes (MAV_CMD_SET_CAMERA_MODE)</description>
@@ -2926,23 +2926,35 @@
       </entry>
     </enum>
     <enum name="VIDEO_STREAM_STATUS_FLAGS">
-      <description>Stream status flags (Bitmap).</description>
+      <description>Stream status flags (Bitmap)</description>
       <entry value="1" name="VIDEO_STREAM_STATUS_FLAGS_RUNNING">
-        <description>Stream is active (running).</description>
+        <description>Stream is active (running)</description>
       </entry>
       <entry value="2" name="VIDEO_STREAM_STATUS_FLAGS_THERMAL">
-        <description>Stream is thermal imaging.</description>
+        <description>Stream is thermal imaging</description>
       </entry>
     </enum>
     <enum name="SET_ZOOM_TYPE">
-      <description>Zoom types for MAV_CMD_SET_CAMERA_ZOOM.</description>
+      <description>Zoom types for MAV_CMD_SET_CAMERA_ZOOM</description>
       <entry value="0" name="ZOOM_TYPE_STEP">
-        <description>Zoom one step increment (-1 for wide, 1 for tele).</description>
+        <description>Zoom one step increment (-1 for wide, 1 for tele)</description>
       </entry>
       <entry value="1" name="ZOOM_TYPE_CONTINUOUS">
         <description>Continuous zoom up/down until stopped (-1 for wide, 1 for tele, 0 to stop zooming)</description>
       </entry>
       <entry value="2" name="ZOOM_TYPE_RANGE">
+        <description>Zoom value as proportion of full camera range (a value between 0.0 and 1.0)</description>
+      </entry>
+    </enum>
+    <enum name="SET_FOCUS_TYPE">
+      <description>Focus types for MAV_CMD_SET_CAMERA_FOCUS</description>
+      <entry value="0" name="FOCUS_TYPE_STEP">
+        <description>Focus one step increment (-1 for focusing in, 1 for focusing out towards infinity).</description>
+      </entry>
+      <entry value="1" name="FOCUS_TYPE_CONTINUOUS">
+        <description>Continuous focus up/down until stopped (-1 for focusing in, 1 for focusing out towards infinity, 0 to stop focusing)</description>
+      </entry>
+      <entry value="2" name="FOCUS_TYPE_RANGE">
         <description>Zoom value as proportion of full camera range (a value between 0.0 and 1.0)</description>
       </entry>
     </enum>
@@ -4628,6 +4640,9 @@
       <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="mode_id" enum="CAMERA_MODE">Camera mode</field>
+      <extensions/>
+      <field type="float" name="zoomLevel">Current zoom level (0.0 to 1.0)</field>
+      <field type="float" name="focusLevel">Current focus level (0.0 to 1.0)</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4693,8 +4693,8 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="mode_id" enum="CAMERA_MODE">Camera mode</field>
       <extensions/>
-      <field type="float" name="zoomLevel">Current zoom level (0.0 to 100.0)</field>
-      <field type="float" name="focusLevel">Current focus level (0.0 to 100.0)</field>
+      <field type="float" name="zoomLevel">Current zoom level (0.0 to 100.0, NaN if not known)</field>
+      <field type="float" name="focusLevel">Current focus level (0.0 to 100.0, NaN if not known)</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2926,8 +2926,6 @@
       </entry>
     </enum>
     <enum name="VIDEO_STREAM_STATUS_FLAGS">
-      <wip/>
-      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments -->
       <description>Stream status flags (Bitmap).</description>
       <entry value="1" name="VIDEO_STREAM_STATUS_FLAGS_RUNNING">
         <description>Stream is active (running).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4720,7 +4720,7 @@
       <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution</field>
       <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
-      <field type="uint16_t" name="fov" units="deg">Field of view</field>
+      <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
       <field type="char[160]" name="uri">Video stream URI</field>
     </message>
     <message id="270" name="SET_VIDEO_STREAM_SETTINGS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1596,7 +1596,7 @@
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Set camera zoom. Use NAN for reserved values.</description>
         <param index="1">Zoom type (See SET_ZOOM_TYPE enum)</param>
-        <param index="2">Zoom Value</param>
+        <param index="2">Zoom value</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
@@ -2937,13 +2937,13 @@
     <enum name="SET_ZOOM_TYPE">
       <description>Zoom types for MAV_CMD_SET_CAMERA_ZOOM.</description>
       <entry value="0" name="ZOOM_TYPE_STEP">
-        <description>Step zoom up/down (-1 for wide, 1 for tele)</description>
+        <description>Zoom one step increment (-1 for wide, 1 for tele).</description>
       </entry>
       <entry value="1" name="ZOOM_TYPE_CONTINUOUS">
-        <description>Continuous zoom up/down (-1 for wide, 1 for tele, 0 for stop zooming)</description>
+        <description>Continuous zoom up/down until stopped (-1 for wide, 1 for tele, 0 to stop zooming)</description>
       </entry>
       <entry value="2" name="ZOOM_TYPE_RANGE">
-        <description>Zoom range (a value between 0 and 1)</description>
+        <description>Zoom value as proportion of full camera range (a value between 0.0 and 1.0)</description>
       </entry>
     </enum>
     <enum name="PARAM_ACK">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1591,6 +1591,18 @@
         <param index="2">Camera mode (see CAMERA_MODE enum)</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
+      <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
+        <description>Set camera zoom. Use NAN for reserved values.</description>
+        <param index="1">Step zoom up/down (-1 for wide, 1 for tele, 0 for no action)</param>
+        <param index="2">Continuous zoom up/down (-1 for wide, 1 for tele, 0 for stop zooming)</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
+        <description>Set camera focus. Use NAN for reserved values.</description>
+        <param index="1">Step focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for no action)</param>
+        <param index="2">Continuous focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for stop focusing)</param>
+        <param index="3">Reserved (all remaining params)</param>
+      </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NAN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
@@ -1632,21 +1644,21 @@
         <wip/>
         <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
         <description>Start video streaming</description>
-        <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
+        <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved</param>
       </entry>
       <entry value="2503" name="MAV_CMD_VIDEO_STOP_STREAMING">
         <wip/>
         <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
         <description>Stop the current video streaming</description>
-        <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
+        <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved</param>
       </entry>
       <entry value="2504" name="MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION">
         <wip/>
         <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
         <description>Request video stream information (VIDEO_STREAM_INFORMATION)</description>
-        <param index="1">Camera ID (0 for all cameras, 1 for first, 2 for second, etc.)</param>
+        <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">0: No Action 1: Request video stream information</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
@@ -2901,6 +2913,21 @@
       </entry>
       <entry value="32" name="CAMERA_CAP_FLAGS_HAS_IMAGE_SURVEY_MODE">
         <description>Camera has image survey mode (MAV_CMD_SET_CAMERA_MODE)</description>
+      </entry>
+      <entry value="64" name="CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM">
+        <description>Camera has basic zoom control (MAV_CMD_SET_CAMERA_ZOOM)</description>
+      </entry>
+      <entry value="128" name="CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS">
+        <description>Camera has basic focus control (MAV_CMD_SET_CAMERA_FOCUS)</description>
+      </entry>
+    </enum>
+    <enum name="STREAM_STATUS_FLAGS">
+      <description>Stream status flags (Bitmap).</description>
+      <entry value="1" name="STREAM_STATUS_FLAGS_RUNNING">
+        <description>Stream is active (running).</description>
+      </entry>
+      <entry value="2" name="STREAM_STATUS_FLAGS_THERMAL">
+        <description>Stream is thermal imaging.</description>
       </entry>
     </enum>
     <enum name="PARAM_ACK">
@@ -4669,14 +4696,16 @@
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Information about video stream</description>
-      <field type="uint8_t" name="camera_id">Camera ID (1 for first, 2 for second, etc.)</field>
-      <field type="uint8_t" name="status">Current status of video streaming (0: not running, 1: in progress)</field>
+      <field type="uint8_t" name="stream_id">Stream ID (1 for first, 2 for second, etc.)</field>
+      <field type="uint8_t" name="count">Number of streams available</field>
+      <field type="uint16_t" name="flags" enum="STREAM_STATUS_FLAGS">Bitmap of stream status flags.</field>
       <field type="float" name="framerate" units="Hz">Frame rate</field>
       <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution</field>
       <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution</field>
       <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
-      <field type="char[230]" name="uri">Video stream URI</field>
+      <field type="uint16_t" name="fov" units="deg">Field of view</field>
+      <field type="char[160]" name="uri">Video stream URI</field>
     </message>
     <message id="270" name="SET_VIDEO_STREAM_SETTINGS">
       <wip/>
@@ -4684,13 +4713,13 @@
       <description>Message that sets video stream settings</description>
       <field type="uint8_t" name="target_system">system ID of the target</field>
       <field type="uint8_t" name="target_component">component ID of the target</field>
-      <field type="uint8_t" name="camera_id">Camera ID (1 for first, 2 for second, etc.)</field>
+      <field type="uint8_t" name="camera_id">Stream ID (1 for first, 2 for second, etc.)</field>
       <field type="float" name="framerate" units="Hz">Frame rate (set to -1 for highest framerate possible)</field>
       <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution (set to -1 for highest resolution possible)</field>
       <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution (set to -1 for highest resolution possible)</field>
       <field type="uint32_t" name="bitrate" units="bits/s">Bit rate (set to -1 for auto)</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
-      <field type="char[230]" name="uri">Video stream URI</field>
+      <field type="char[160]" name="uri">Video stream URI (mostly for UDP/RTP)</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1595,7 +1595,7 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Set camera zoom. Returns CAMERA_SETTINGS message. Use NAN for reserved values.</description>
-        <param index="1">Zoom type (See SET_ZOOM_TYPE enum)</param>
+        <param index="1" enum="SET_ZOOM_TYPE">Zoom type</param>
         <param index="2">Zoom value</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
@@ -1603,7 +1603,7 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Set camera focus. Returns CAMERA_SETTINGS message. Use NAN for reserved values.</description>
-        <param index="1">Focus type (See SET_FOCUS_TYPE enum)</param>
+        <param index="1" enum="SET_FOCUS_TYPE">Focus type</param>
         <param index="2">Focus value</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -888,7 +888,7 @@
       </entry>
       <entry value="34" name="MAV_CMD_DO_ORBIT">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Start orbiting on the circumference of a circle defined by the parameters. Setting any value NaN results in using defaults.</description>
         <param index="1">Radius of the circle in meters. positive: Orbit clockwise. negative: Orbit counter-clockwise.</param>
         <param index="2">Velocity tangential in m/s. NaN: Vehicle configuration default.</param>
@@ -1554,7 +1554,7 @@
       </entry>
       <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Request storage information (STORAGE_INFORMATION). Use the command's target_component to target a specific component's storage.</description>
         <param index="1">Storage ID (0 for all, 1 for first, 2 for second, etc.)</param>
         <param index="2">0: No Action 1: Request storage information</param>
@@ -1562,7 +1562,7 @@
       </entry>
       <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Format a storage medium. Once format is complete, a STORAGE_INFORMATION message is sent. Use the command's target_component to target a specific component's storage.</description>
         <param index="1">Storage ID (1 for first, 2 for second, etc.)</param>
         <param index="2">0: No action 1: Format storage</param>
@@ -1575,7 +1575,7 @@
       </entry>
       <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Request flight information (FLIGHT_INFORMATION)</description>
         <param index="1">1: Request flight information</param>
         <param index="2">Reserved (all remaining params)</param>
@@ -1593,7 +1593,7 @@
       </entry>
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Set camera zoom. Use NAN for reserved values.</description>
         <param index="1">Step zoom up/down (-1 for wide, 1 for tele, 0 for no action)</param>
         <param index="2">Continuous zoom up/down (-1 for wide, 1 for tele, 0 for stop zooming)</param>
@@ -1601,7 +1601,7 @@
       </entry>
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Set camera focus. Use NAN for reserved values.</description>
         <param index="1">Step focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for no action)</param>
         <param index="2">Continuous focus up/down (-1 for focusing in, 1 for focusing out towards infinity, 0 for stop focusing)</param>
@@ -1622,7 +1622,7 @@
       </entry>
       <entry value="2002" name="MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Re-request a CAMERA_IMAGE_CAPTURE packet. Use NAN for reserved values.</description>
         <param index="1">Sequence number for missing CAMERA_IMAGE_CAPTURE packet</param>
         <param index="2">Reserved (all remaining params)</param>
@@ -1646,21 +1646,21 @@
       </entry>
       <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Start video streaming</description>
         <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved</param>
       </entry>
       <entry value="2503" name="MAV_CMD_VIDEO_STOP_STREAMING">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Stop the current video streaming</description>
         <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved</param>
       </entry>
       <entry value="2504" name="MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Request video stream information (VIDEO_STREAM_INFORMATION)</description>
         <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">0: No Action 1: Request video stream information</param>
@@ -1738,7 +1738,7 @@
       </entry>
       <entry value="4501" name="MAV_CMD_CONDITION_GATE">
         <wip/>
-        <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Delay mission state machine until gate has been reached.</description>
         <param index="1">Geometry: 0: orthogonal to path between previous and next waypoint.</param>
         <param index="2">Altitude: 0: ignore altitude</param>
@@ -2925,12 +2925,14 @@
         <description>Camera has basic focus control (MAV_CMD_SET_CAMERA_FOCUS)</description>
       </entry>
     </enum>
-    <enum name="STREAM_STATUS_FLAGS">
+    <enum name="VIDEO_STREAM_STATUS_FLAGS">
+      <wip/>
+      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments -->
       <description>Stream status flags (Bitmap).</description>
-      <entry value="1" name="STREAM_STATUS_FLAGS_RUNNING">
+      <entry value="1" name="VIDEO_STREAM_STATUS_FLAGS_RUNNING">
         <description>Stream is active (running).</description>
       </entry>
-      <entry value="2" name="STREAM_STATUS_FLAGS_THERMAL">
+      <entry value="2" name="VIDEO_STREAM_STATUS_FLAGS_THERMAL">
         <description>Stream is thermal imaging.</description>
       </entry>
     </enum>
@@ -4421,7 +4423,7 @@
     </message>
     <message id="235" name="HIGH_LATENCY2">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message appropriate for high latency connections like Iridium (version 2)</description>
       <field type="uint32_t" name="timestamp" units="ms">Timestamp (milliseconds since boot or Unix epoch)</field>
       <field type="uint8_t" name="type" enum="MAV_TYPE">Type of the MAV (quadrotor, helicopter, etc.)</field>
@@ -4619,7 +4621,7 @@
     </message>
     <message id="261" name="STORAGE_INFORMATION">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about a storage medium.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="storage_id">Storage ID (1 for first, 2 for second, etc.)</field>
@@ -4656,7 +4658,7 @@
     </message>
     <message id="264" name="FLIGHT_INFORMATION">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about flight since last arming.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint64_t" name="arming_time_utc" units="us">Timestamp at arming (time since UNIX epoch) in UTC, 0 for unknown</field>
@@ -4698,11 +4700,11 @@
     </message>
     <message id="269" name="VIDEO_STREAM_INFORMATION">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about video stream</description>
       <field type="uint8_t" name="stream_id">Stream ID (1 for first, 2 for second, etc.)</field>
       <field type="uint8_t" name="count">Number of streams available</field>
-      <field type="uint16_t" name="flags" enum="STREAM_STATUS_FLAGS">Bitmap of stream status flags.</field>
+      <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags</field>
       <field type="float" name="framerate" units="Hz">Frame rate</field>
       <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution</field>
       <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution</field>
@@ -4713,7 +4715,7 @@
     </message>
     <message id="270" name="SET_VIDEO_STREAM_SETTINGS">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message that sets video stream settings</description>
       <field type="uint8_t" name="target_system">system ID of the target</field>
       <field type="uint8_t" name="target_component">component ID of the target</field>
@@ -4732,7 +4734,7 @@
     </message>
     <message id="300" name="PROTOCOL_VERSION">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Version and capability of protocol version. This message is the response to REQUEST_PROTOCOL_VERSION and is used as part of the handshaking to establish which MAVLink version should be used on the network. Every node should respond to REQUEST_PROTOCOL_VERSION to enable the handshaking. Library implementers should consider adding this into the default decoding state machine to allow the protocol core to respond directly.</description>
       <field type="uint16_t" name="version">Currently active MAVLink version number * 100: v1.0 is 100, v2.0 is 200, etc.</field>
       <field type="uint16_t" name="min_version">Minimum MAVLink version supported</field>
@@ -4826,7 +4828,7 @@
     </message>
     <message id="332" name="TRAJECTORY_REPRESENTATION_WAYPOINTS">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Describe a trajectory using an array of up-to 5 waypoints in the local frame.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="uint8_t" name="valid_points">Number of valid points (up-to 5 waypoints are possible)</field>
@@ -4844,7 +4846,7 @@
     </message>
     <message id="333" name="TRAJECTORY_REPRESENTATION_BEZIER">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Describe a trajectory using an array of up-to 5 bezier points in the local frame.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="uint8_t" name="valid_points">Number of valid points (up-to 5 waypoints are possible)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1595,8 +1595,8 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Set camera zoom. Use NAN for reserved values.</description>
-        <param index="1">Step zoom up/down (-1 for wide, 1 for tele, 0 for no action)</param>
-        <param index="2">Continuous zoom up/down (-1 for wide, 1 for tele, 0 for stop zooming)</param>
+        <param index="1">Zoom type (See SET_ZOOM_TYPE enum)</param>
+        <param index="2">Zoom Value</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
@@ -2932,6 +2932,18 @@
       </entry>
       <entry value="2" name="VIDEO_STREAM_STATUS_FLAGS_THERMAL">
         <description>Stream is thermal imaging.</description>
+      </entry>
+    </enum>
+    <enum name="SET_ZOOM_TYPE">
+      <description>Zoom types for MAV_CMD_SET_CAMERA_ZOOM.</description>
+      <entry value="0" name="ZOOM_TYPE_STEP">
+        <description>Step zoom up/down (-1 for wide, 1 for tele)</description>
+      </entry>
+      <entry value="1" name="ZOOM_TYPE_CONTINUOUS">
+        <description>Continuous zoom up/down (-1 for wide, 1 for tele, 0 for stop zooming)</description>
+      </entry>
+      <entry value="2" name="ZOOM_TYPE_RANGE">
+        <description>Zoom range (a value between 0 and 1)</description>
       </entry>
     </enum>
     <enum name="PARAM_ACK">


### PR DESCRIPTION
#### Add support for basic camera zoom and focus.

#### Zoom
If a camera sets `CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM` in its capabilities flag, it tells us it can handle basic zoom functions and supports the `MAV_CMD_SET_CAMERA_ZOOM` command.

For the `MAV_CMD_SET_CAMERA_ZOOM` command, you either use Step (one step at a time) or continuous zooming (start/stop zooming). For step zoom, you define if its Tele or Wide using `param1` (-1 for wide or 1 for tele). The camera will move the zoom back or forward one step. For continuous zoom, you send the `MAV_CMD_SET_CAMERA_ZOOM` command with `param2` set to -1 to start zooming out (wide) or 1 for zooming in (tele). To stop zooming, you send a new `MAV_CMD_SET_CAMERA_ZOOM` command with `param2` set to 0.

#### Focus
The same idea applies to basic focusing. If a camera sets `CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS` in its capabilities flag, it tells us it can handle basic focusing and supports the `MAV_CMD_SET_CAMERA_FOCUS` command, which behaves in the same way as the zoom command above but handling focusing instead.

#### Tweaks to video streaming messages and commands.
For all video streaming messages and commands, I've renamed "Camera" with "Stream". You are processing streams and not cameras. A single camera may contain multiple streams.

I've added the stream count and FOV to the `VIDEO_STREAM_INFORMATION` message. The count tells you how many `VIDEO_STREAM_INFORMATION` messages you should expect. The FOV allows the ground station to overlay multiple video streams adjusting the size to match the FOV of each stream.

I don't quite get the `SET_VIDEO_STREAM_SETTINGS` message. There is no support for ACK from the camera. If the message is lost, the ground station doesn't really have any way to tell. I'm implementing all of the above in QGC with the exception of `SET_VIDEO_STREAM_SETTINGS` until this is sorted out better.

For all the above, suggestions and criticism are welcome. More of the former :)
