### PR TITLE
Make MAV_CMDs own section of messages with field markup

### DIFF
--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -22,8 +22,10 @@ xsl_file_name = "mavlink_to_html_table_gitbook.xsl"
 xml_message_definitions_dir_name = "../message_definitions/v1.0/"
 
 output_dir = "./messages/"
-if not os.path.exists(output_dir):
-    os.makedirs(output_dir)
+output_dir_html=output_dir+"_html/"
+if not os.path.exists(output_dir_html):
+    os.makedirs(output_dir_html)
+
 
 # File for index
 index_file_name = "README.md"
@@ -98,6 +100,8 @@ def inject_top_level_docs(input_html,filename):
     insert_text+='\n\n<span id="mav2_extension_field"></span>\n> **Note** MAVLink 2 extension fields that have been added to MAVLink 1 messages are displayed in blue.'
     style_text='\n\n<style>\ntd {\n    vertical-align:top;\n}\n</style>'
     insert_text+=style_text
+    # Include HTML in generated content
+    insert_text+='\n\n{%% include "_html/%s.html" %%}' % filename[:-4]
     input_html=insert_text+'\n\n'+input_html
     
     
@@ -126,25 +130,38 @@ for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
             prettyHTML=strip_text_before_string(prettyHTML,'<html>')
             prettyHTML = fix_content_in_tags(prettyHTML)
             
-            #Inject a heading and doc-type intro (markdown format)
-            prettyHTML = inject_top_level_docs(prettyHTML,file)
-            
             #Replace invalid file extensions (workaround for xslt)
             prettyHTML = fix_include_file_extension(prettyHTML)
 
             #Replace space markers with intentional space
             prettyHTML = fix_replace_space_marker(prettyHTML)
             
-            #Write output markdown file
-            output_file_name = file.rsplit('.',1)[0]+".md"
-            output_file_name_withdir = output_dir+output_file_name
-            print("Output filename: %s" % output_file_name)
+            #Write output html file
+            output_file_name_html = file.rsplit('.',1)[0]+".html"
 
-            with open(output_file_name_withdir, 'w') as out:
-                out.write(prettyHTML )
+            output_file_name_html_withdir = output_dir_html+output_file_name_html
+            print("Output filename (html): %s" % output_file_name_html)
+
+            with open(output_file_name_html_withdir, 'w') as out:
+                out.write(prettyHTML)
+
+
+            #Write output markdown file
+            output_file_name_md = file.rsplit('.',1)[0]+".md"
+
+            markdown_text=''
+            #Inject a heading and doc-type intro (markdown format)
+            markdown_text = inject_top_level_docs(markdown_text,file)
+
+            output_file_name_md_withdir = output_dir+output_file_name_md
+            print("Output filename (md): %s" % output_file_name_md)
+
+            with open(output_file_name_md_withdir, 'w') as out:
+                out.write(markdown_text)
+
             
             #if not file=='common.xml':
-            index_text+='\n* [%s](%s)' % (file,output_file_name)
+            index_text+='\n* [%s](%s)' % (file,output_file_name_md)
             
 #Write the index - Disabled for now.
 with open(index_file_name, 'w') as content_file:

--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -61,6 +61,12 @@ def fix_include_file_extension(input_html):
     ## Fixes up file extension .xml.md.unlikely (easier than fixing up the XSLT to strip file extensions!)
     input_html=input_html.replace('.xml.md.unlikely','.md')
     return input_html
+
+def fix_replace_space_marker(input_html):
+    ## Above we remove hidden space. I can't seem to regexp just that type of space, so use space markers in text
+    input_html=input_html.replace('xxx_space_xxx',' ')
+    return input_html
+
     
 def strip_text_before_string(original_text,strip_text):
     # Strip out all text before some string
@@ -125,6 +131,9 @@ for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
             
             #Replace invalid file extensions (workaround for xslt)
             prettyHTML = fix_include_file_extension(prettyHTML)
+
+            #Replace space markers with intentional space
+            prettyHTML = fix_replace_space_marker(prettyHTML)
             
             #Write output markdown file
             output_file_name = file.rsplit('.',1)[0]+".md"

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -145,11 +145,12 @@
          <xsl:when test="@enum">
             <br /><strong>Possible values:</strong> <xsl:value-of select="@enum" />
          </xsl:when>
-         <xsl:when test="@minValue or @maxValue or @increment">
-           <br /><strong>Values:</strong> 
-           <xsl:if test='@minValue'><xsl:value-of select="@minValue" /> (min), </xsl:if>
-           <xsl:if test='@maxValue'><xsl:value-of select="@maxValue" /> (max), </xsl:if>
-           <xsl:if test='@increment'><xsl:value-of select="@increment" /> (increment) </xsl:if>
+         <xsl:when test="@minValue or @maxValue or @increment or @units">
+           <br /><strong>Values:</strong>
+           <xsl:if test='@units'><em>units:</em> <xsl:value-of select="@minValue" />, </xsl:if>
+           <xsl:if test='@minValue'><em>min:</em><xsl:value-of select="@minValue" />, </xsl:if>
+           <xsl:if test='@maxValue'><em>max:</em><xsl:value-of select="@maxValue" />, </xsl:if>
+           <xsl:if test='@increment'><em>increment:</em><xsl:value-of select="@increment" /></xsl:if>
          </xsl:when>
        </xsl:choose>
 

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -131,7 +131,7 @@
 <xsl:template match="//param">
    <tr>
    <td></td>
-   <td>Mission Param #<xsl:value-of select="@index" /></td> <!-- mission_param -->
+   <td>Param #<xsl:value-of select="@index" /></td> <!-- mission_param -->
    <td><xsl:value-of select="." /></td> <!-- mavlink_comment -->
    </tr>
 </xsl:template>

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -24,7 +24,9 @@
     <xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute>
     #<xsl:value-of select="@id" />
    </a>
-  )</h3> 
+  )</h3>
+   <xsl:apply-templates select="wip" />
+   <xsl:apply-templates select="deprecated" />
    <p> <!-- description -->
      <xsl:if test='@id > 255'><strong>(MAVLink 2) </strong></xsl:if>
      <xsl:value-of select="description" /></p>
@@ -50,6 +52,7 @@
   </tbody>
   </table>
 </xsl:template>
+
 
 <xsl:template match="//field">
    <tr> <!-- mavlink_field -->
@@ -92,7 +95,7 @@
      <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
      <a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute>
      <xsl:value-of select="@name" /></a></h3>
-
+   <xsl:apply-templates select="deprecated" />  
    <p><xsl:value-of select="description" /></p> <!-- description -->
    <table class="sortable">
    <thead>
@@ -111,8 +114,11 @@
 <xsl:template match="//entry">
    <tr id="{@name}"> <!-- mavlink_field -->
    <td><xsl:value-of select="@value" /></td>  <!-- mavlink_type -->
-   <td><a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute>
-   <xsl:value-of select="@name" /></a></td> <!-- mavlink_name -->
+   <td>
+      <a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute><xsl:value-of select="@name" /></a> 
+      <xsl:apply-templates select="deprecated" />
+      <xsl:apply-templates select="wip" />
+   </td> <!-- mavlink_name -->
    <td><xsl:value-of select="description" /></td> <!-- mavlink_comment -->
    </tr>
 <xsl:if test='param'>
@@ -135,6 +141,19 @@
    <td><xsl:value-of select="." /></td> <!-- mavlink_comment -->
    </tr>
 </xsl:template>
+
+<xsl:template match="//wip">
+  <p style="color:red"><strong>WORK IN PROGRESS:</strong> Do not use message in stable production environments (it may change).</p>
+</xsl:template>
+
+<xsl:template match="//deprecated">
+  <p style="color:red"><strong>DEPRECATED: </strong> Replaced by <xsl:value-of select="@replaced_by" /> (<xsl:value-of select="@since" />).
+  <xsl:if test='.'>
+    <xsl:value-of select="." />
+  </xsl:if>
+</p>
+</xsl:template>
+
 
 
 </xsl:stylesheet>

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -8,8 +8,13 @@
 
 <xsl:template match="//enums">
    <h2>MAVLink Type Enumerations</h2>
-   <xsl:apply-templates />
+   <xsl:apply-templates select="enum[@name!='MAV_CMD']" />
+
+   <h2>MAVLink Commands (MAV_CMD)</h2>
+   <xsl:apply-templates select="enum[@name='MAV_CMD']" mode="params"/>
 </xsl:template>
+
+
 
 <xsl:template match="//messages">
    <h2>MAVLink Messages</h2>
@@ -90,6 +95,7 @@
    <p>This file has protocol dialect: <xsl:value-of select="." />.</p>
 </xsl:template>
 
+
 <xsl:template match="//enum">
    <h3> <!-- mavlink_message_name -->
      <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
@@ -111,6 +117,44 @@
   </table>
 </xsl:template>
 
+
+<xsl:template match="//enum" mode="params">
+   <p><xsl:value-of select="description" /> </p>
+   <xsl:apply-templates select="entry" mode="params" />
+</xsl:template>
+
+
+<xsl:template match="//entry" mode="params">
+   <h3 id="{@name}"><xsl:value-of select="@name" /> (<a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute><xsl:value-of select="@value" /></a>)</h3>
+      <xsl:apply-templates select="deprecated" />
+      <xsl:apply-templates select="wip" />
+      <p><xsl:value-of select="description" /> </p> <!-- mavlink_comment -->
+
+
+   <table class="sortable">
+   <thead>
+   <tr> <!-- mavlink_field_header -->
+      <th>Param</th>
+      <th>Description</th>
+
+      <xsl:if test='*/@enum or */@minValue or */@maxValue or */@increment'>
+        <th>Values</th>
+      </xsl:if>
+
+     <xsl:if test='*/@units'>
+       <th>Units</th>
+     </xsl:if>
+
+   </tr>
+   </thead>
+   <tbody>
+    <xsl:apply-templates select="param" mode="params" /> 
+   </tbody>
+  </table>
+
+</xsl:template>
+
+
 <xsl:template match="//entry">
    <tr id="{@name}"> <!-- mavlink_field -->
    <td><xsl:value-of select="@value" /></td>  <!-- mavlink_type -->
@@ -121,6 +165,8 @@
    </td> <!-- mavlink_name -->
    <td><xsl:value-of select="description" /></td> <!-- mavlink_comment -->
    </tr>
+
+
 <xsl:if test='param'>
    <tr>
      <td></td>
@@ -130,9 +176,49 @@
     <td colspan="3"><br /></td>
    </tr>
 </xsl:if>
-   
-
 </xsl:template>
+
+
+
+<xsl:template match="//param" mode="params">
+    <tr>
+        <td><xsl:value-of select="@index" /> </td> <!-- mission_param -->
+
+        <td><xsl:value-of select="." />
+         <xsl:if test='@label or @decimalPlaces'><br /><strong>GCS display settings:</strong>
+            <xsl:if test='@label'><em>Label:</em> <xsl:value-of select="@label" />, </xsl:if>
+            <xsl:if test='@decimalPlaces'><em>decimalPlaces:</em> <xsl:value-of select="@decimalPlaces" /></xsl:if>
+         </xsl:if>
+        </td>
+
+
+   <xsl:if test='../*/@enum or ../*/@minValue or ../*/@maxValue or ../*/@increment'>
+     <td>
+      <xsl:choose>
+         <xsl:when test="@enum">
+           <xsl:value-of select="@enum" />
+         </xsl:when>
+         <xsl:when test="@minValue or @maxValue or @increment ">
+           <xsl:if test='@minValue'><em>min:</em><xsl:value-of select="@minValue" /><xsl:text>xxx_space_xxx</xsl:text></xsl:if>
+           <xsl:if test='@maxValue'><em>max:</em><xsl:value-of select="@maxValue" /><xsl:text>xxx_space_xxx</xsl:text></xsl:if>
+           <xsl:if test='@increment'><em>increment:</em><xsl:value-of select="@increment" /></xsl:if>
+         </xsl:when>
+      </xsl:choose>
+  </td>
+   </xsl:if>
+
+
+   <xsl:if test='../*/@units'>
+     <td><xsl:value-of select="@units" /></td> <!-- mavlink_units -->
+   </xsl:if>
+     
+
+       
+   </tr>
+</xsl:template>
+
+
+
 
 <xsl:template match="//param">
    <tr>
@@ -165,11 +251,11 @@
 </xsl:template>
 
 <xsl:template match="//wip">
-  <p style="color:red"><strong>WORK IN PROGRESS:</strong> Do not use message in stable production environments (it may change).</p>
+  <p style="color:red"><strong>WORK IN PROGRESS:</strong><xsl:text>xxx_space_xxx</xsl:text>Do not use in stable production environments (it may change).</p>
 </xsl:template>
 
 <xsl:template match="//deprecated">
-  <p style="color:red"><strong>DEPRECATED: </strong> Replaced by <xsl:value-of select="@replaced_by" /> (<xsl:value-of select="@since" />).
+  <p style="color:red"><strong>DEPRECATED:</strong><xsl:text>xxx_space_xxx</xsl:text>Replaced by <xsl:value-of select="@replaced_by" /> (<xsl:value-of select="@since" />).
   <xsl:if test='.'>
     <xsl:value-of select="." />
   </xsl:if>

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -138,7 +138,28 @@
    <tr>
    <td></td>
    <td>Param #<xsl:value-of select="@index" /></td> <!-- mission_param -->
-   <td><xsl:value-of select="." /></td> <!-- mavlink_comment -->
+   <td>
+       <xsl:value-of select="." />
+
+       <xsl:choose>
+         <xsl:when test="@enum">
+            <br /><strong>Possible values:</strong> <xsl:value-of select="@enum" />
+         </xsl:when>
+         <xsl:when test="@minValue or @maxValue or @increment">
+           <br /><strong>Values:</strong> 
+           <xsl:if test='@minValue'><xsl:value-of select="@minValue" /> (min), </xsl:if>
+           <xsl:if test='@maxValue'><xsl:value-of select="@maxValue" /> (max), </xsl:if>
+           <xsl:if test='@increment'><xsl:value-of select="@increment" /> (increment) </xsl:if>
+         </xsl:when>
+       </xsl:choose>
+
+       <xsl:if test='@label or @decimalPlaces'><br /><strong>GCS display settings:</strong>
+           <xsl:if test='@label'><em>Label:</em> <xsl:value-of select="@label" />, </xsl:if>
+           <xsl:if test='@decimalPlaces'><em>decimalPlaces:</em> <xsl:value-of select="@decimalPlaces" /></xsl:if>
+       </xsl:if>
+
+
+   </td> <!-- mavlink_comment -->
    </tr>
 </xsl:template>
 


### PR DESCRIPTION
Enum schema now allows params to have markup like fields that define possible values, units, and display hints to GCS - e.g.: enum value, max/min/increment, units, label, display with X decimal points.

There is no really clean way to display all these fields in the current layout (see https://github.com/mavlink/mavlink/pull/1019 for best shot).

This PR does two things.
1. It splits MAV_CMD into its own group as a peer of messages and enums
![image](https://user-images.githubusercontent.com/5368500/48309599-42b74500-e5d2-11e8-851e-d44208be9c5d.png)
2. It mimics the message format to allow columns for units and values.
![image](https://user-images.githubusercontent.com/5368500/48309623-7abe8800-e5d2-11e8-97f4-74a12632aa3c.png)
But these are only displayed if the fields are defined. If not, it looks like:
![image](https://user-images.githubusercontent.com/5368500/48309635-9d50a100-e5d2-11e8-914a-b047a66e227c.png)

The only question is where should label and decimal point fields go. I have currently put them in the description because those two don't matter to all users (they mostly matter to GCS authors).
Is that good?

You can play with this here:
https://hamishwillee.gitbooks.io/ham_mavdevguide/content/v/just_messages/en/messages/common.html