### PR TITLE
Clarify how MAV_TYPE should be used.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -67,6 +67,7 @@
       </entry>
     </enum>
     <enum name="MAV_TYPE">
+      <description>MAVLINK system type. All components in a system should report this type in their HEARTBEAT.</description>
       <entry value="0" name="MAV_TYPE_GENERIC">
         <description>Generic micro air vehicle.</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3002,8 +3002,8 @@
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">
-      <description>The heartbeat message shows that a system is present and responding. The type of the MAV and Autopilot hardware allow the receiving system to treat further messages from this system appropriate (e.g. by laying out the user interface based on the autopilot).</description>
-      <field type="uint8_t" name="type" enum="MAV_TYPE">Type of the MAV (quadrotor, helicopter, etc.)</field>
+      <description>The heartbeat message shows that a system or component is present and responding. The type and autopilot fields (along with the message component id), allow the receiving system to treat further messages from this system appropriately (e.g. by laying out the user interface based on the autopilot).</description>
+      <field type="uint8_t" name="type" enum="MAV_TYPE">Type of the system (quadrotor, helicopter, etc.). Components use the same type as their associated system.</field>
       <field type="uint8_t" name="autopilot" enum="MAV_AUTOPILOT">Autopilot type / class.</field>
       <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>


### PR DESCRIPTION
This clarifies how [MAV_TYPE](https://mavlink.io/en/messages/common.html#MAV_TYPE) should be used for systems and components. 

This is "controversial" because 
- the [HEARTBEAT](https://mavlink.io/en/messages/common.html#MAV_TYPE) message currently only talks about systems, not components.
- it means some of the definitions are wrong and should have been addressed via component ids.

Specifically:
- `MAV_TYPE` should be used to identify a particular type of system (vehicle)
- All components of a vehicle would have this same type.
- Components that need separate addressing should use the correct MAV_COMPONENT id.

Notes:
* The usage reflects how QGroundControl works
* This means that the following definitions are wrong because "Onboard" components must use the system MAV_TYPE.
  - [MAV_TYPE_GIMBAL](https://mavlink.io/en/messages/common.html#MAV_TYPE_GIMBAL) - Onboard gimbal
  - [MAV_TYPE_ADSB](https://mavlink.io/en/messages/common.html#MAV_TYPE_ADSB) - Onboard ADSB peripheral
  - [MAV_TYPE_FLARM](https://mavlink.io/en/messages/common.html#MAV_TYPE_FLARM) - Onboard FLARM collision avoidance system
  - The above should either be deprecated/removed, or descriptions should be modified to reflect that the systems are "standalone" or offboard.
* [MAV_TYPE_CAMERA](https://mavlink.io/en/messages/common.html#MAV_TYPE_CAMERA) - Camera - this is correct if it is used for a standalone camera with its own system id.
* Possible alternative is that `HEARTBEAT` should use `MAV_TYPE` for component. This would then force new component things to have both a new MAV_TYPE and a new MAV_COMPONENT. I don't think this was the original intent.

