### PR TITLE
Follow up PR for UTM_GLOBAL_POSITION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4886,9 +4886,9 @@
       <field type="int32_t" name="next_lat" units="degE7">Next waypoint, latitude (WGS84)</field>
       <field type="int32_t" name="next_lon" units="degE7">Next waypoint, longitude (WGS84)</field>
       <field type="int32_t" name="next_alt" units="mm">Next waypoint, altitude (WGS84)</field>
-      <field type="uint16_t" name="update_rate">Seconds * 1E2 until next update. Set to 0 if unknown or in data driven mode.</field>
+      <field type="uint16_t" name="update_rate" units="cs">Time until next update. Set to 0 if unknown or in data driven mode.</field>
       <field type="uint8_t" name="flight_state" enum="UTM_FLIGHT_STATE">Flight state</field>
-      <field type="uint8_t" name="flags" enum="UTM_DATA_AVAIL_FLAGS">Bitwise OR combination of the data available flags.</field>
+      <field type="uint8_t" name="flags" enum="UTM_DATA_AVAIL_FLAGS" display="bitmask">Bitwise OR combination of the data available flags.</field>
     </message>
     <message id="350" name="DEBUG_FLOAT_ARRAY">
       <description>Large debug/prototyping array. The message uses the maximum available payload for data. The array_id and name fields are used to discriminate between messages in code and in user interfaces (respectively). Do not use in production code.</description>


### PR DESCRIPTION
There have been requested changes open from #1009. This is the follow up PR to address them as well.

- Add centisecond as unit to update_rate field
- Add missing display tag

Related to ArduPilot/pymavlink#242