### PR TITLE
Redefine MAV_TYPE_ FLARM CAMERA and ADSB as standalone

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -151,7 +151,7 @@
         <description>Onboard gimbal</description>
       </entry>
       <entry value="27" name="MAV_TYPE_ADSB">
-        <description>Onboard ADSB peripheral</description>
+        <description>ADSB system (standalone)</description>
       </entry>
       <entry value="28" name="MAV_TYPE_PARAFOIL">
         <description>Steerable, nonrigid airfoil</description>
@@ -160,13 +160,13 @@
         <description>Dodecarotor</description>
       </entry>
       <entry value="30" name="MAV_TYPE_CAMERA">
-        <description>Camera</description>
+        <description>Camera (standalone)</description>
       </entry>
       <entry value="31" name="MAV_TYPE_CHARGING_STATION">
         <description>Charging station</description>
       </entry>
       <entry value="32" name="MAV_TYPE_FLARM">
-        <description>Onboard FLARM collision avoidance system</description>
+        <description>FLARM collision avoidance system (standalone)</description>
       </entry>
     </enum>
     <enum name="FIRMWARE_VERSION_TYPE">


### PR DESCRIPTION
Follows on from https://github.com/mavlink/mavlink/pull/1022

MAV_TYPES refer to standalone systems, and are consistent across all components in a system. This clarifies the the FLARM, ADSB and CAMERA types are for standalone systems, not these items as components of an onboard system. 