### PR TITLE
add additional component_id fields for obstacle avoidance and VIO

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -465,6 +465,12 @@
       <entry value="195" name="MAV_COMP_ID_PATHPLANNER">
         <description/>
       </entry>
+      <entry value="196" name="MAV_COMP_ID_OBSTACLE_AVOIDANCE">
+        <description/>
+      </entry>
+      <entry value="197" name="MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY">
+        <description/>
+      </entry>
       <entry value="200" name="MAV_COMP_ID_IMU">
         <description/>
       </entry>


### PR DESCRIPTION
To monitor individual processes on the companion computer, the component ID enum has to be extended to include the process types which should be monitored over the heartbeat meassage.