### PR TITLE
common: Add a relative jump command

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1616,6 +1616,15 @@
         <param index="2">Focus value</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
+      <entry value="600" name="MAV_CMD_JUMP_TAG">
+        <description>Tagged jump target. Can be jumped to with MAV_CMD_DO_JUMP_TAG.</description>
+        <param index="1">Tag.</param>
+      </entry>
+      <entry value="601" name="MAV_CMD_DO_JUMP_TAG">
+        <description>Jump to the matching tag in the mission list. Repeat this action for the specified number of times. A mission should contain a single matching tag for each jump. If this is not the case then a jump to a missing tag should complete the mission, and a jump where there are multiple matching tags should always select the one with the lowest mission sequence number.</description>
+        <param index="1">Target tag to jump to.</param>
+        <param index="2">Repeat count</param>
+      </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NAN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>


### PR DESCRIPTION
This provides support for a variant of `MAV_CMD_DO_JUMP` that instead uses relative indexes. The motivation for this is when working with a complex mission a jump may make the most sense in a local contect (IE go back 4 waypoints), and having to remember to edit the jump target on the absolute command when you delete an earlier unassociated waypoint is a problem. Similarly it's not actually clear if a jump index should automatically be adjusted by a GCS in this scenario either. By allowing an explicit relative mode of jumping a user can plan for this case easily.

This could have been a flag on the existing jump command, but it was thought to be easier to drop into most GCS/UI's more easily as a seperate command, allowing a distinct visual styling. (It also allows a way to ensure that a mission uploaded that depends upon this command being relative will actuallly be interpreted as a relative command).