### PR TITLE
Allow bigger STATUSTEXT messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4642,9 +4642,11 @@
       <field type="int32_t" name="value">Signed integer value</field>
     </message>
     <message id="253" name="STATUSTEXT">
-      <description>Status text message. These messages are printed in yellow in the COMM console of QGroundControl. WARNING: They consume quite some bandwidth, so use only for important status and error messages. If implemented wisely, these messages are buffered on the MCU and sent only at a limited rate (e.g. 10 Hz).</description>
+      <description>Status text message. These messages should only be used for important status and error messages. Keep them concise to ensure they can be displayed by the recipient (and to reduce bandwidth). WARNING: Status updates consume significant bandwidth. They should be buffered and sent at a limited rate (e.g. 10 Hz).</description>
       <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424.</field>
-      <field type="char[50]" name="text">Status text message, without null termination character</field>
+      <field type="char[50]" name="text">Status text message, without null termination character.</field>
+      <extensions/>
+      <field type="char[204]" name="extra_text">Additional status text, without null termination character. Append to 'text' field content for display. NOTE: Not all systems support extra_text, so consider populating 'text' with sensible stand-alone content.</field>
     </message>
     <message id="254" name="DEBUG">
       <description>Send a debug value. The index is used to discriminate between values. These values show up in the plot of QGroundControl as DEBUG N.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4642,7 +4642,7 @@
       <field type="int32_t" name="value">Signed integer value</field>
     </message>
     <message id="253" name="STATUSTEXT">
-      <description>Status text message. These messages should only be used for important status and error messages. Keep them concise to ensure they can be displayed by the recipient (and to reduce bandwidth). WARNING: Status updates consume significant bandwidth. They should be buffered and sent at a limited rate (e.g. 10 Hz).</description>
+      <description>Status text message. These messages should only be used for important status and error messages (and kept concise).</description>
       <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424.</field>
       <field type="char[50]" name="text">Status text message, without null termination character.</field>
       <extensions/>


### PR DESCRIPTION
The MAVLINK1 STATUSTEXT message allows only 50 char messages, which is restrictive. While we don't want the message abused in terms of bandwidth usage and overly long strings for display in UIs, we know that if there had been the ability to have message empty-byte truncation when the message was defined, a larger number would have been specified. 

This PR adds a second (extension) field `extra_text` that can be appended to the `text` field for longer messages:
- It recommends users should craft the `text` content to be stand alone so that if used with systems that don't understand extra_text the message can still be understood.
- QGC is moved from the description as recipient could be anything - another GCS or a developer API.

The alternative was to define a new full width message. The [dev call](https://github.com/mavlink/mavlink/wiki/20181212-Dev-Meeting) proposed this approach because we assume it retains the greatest compatibility, and may encourage users to keep messages concise. We're open to a completely new message if @meee1 and @DonLakeFlyer feel strongly that is better.

@DonLakeFlyer @auturgy @WickedShell @LorenzMeier et al, thoughts?