### PR TITLE
Clarify VFR_HUD.airspeed is IAS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3655,13 +3655,13 @@
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
     </message>
     <message id="74" name="VFR_HUD">
-      <description>Metrics typically displayed on a HUD for fixed wing aircraft</description>
-      <field type="float" name="airspeed" units="m/s">Current airspeed</field>
-      <field type="float" name="groundspeed" units="m/s">Current ground speed</field>
-      <field type="int16_t" name="heading" units="deg">Current heading in degrees, in compass units (0..360, 0=north)</field>
-      <field type="uint16_t" name="throttle" units="%">Current throttle setting in integer percent, 0 to 100</field>
-      <field type="float" name="alt" units="m">Current altitude (MSL)</field>
-      <field type="float" name="climb" units="m/s">Current climb rate</field>
+      <description>Metrics typically displayed on a HUD for fixed wing aircraft.</description>
+      <field type="float" name="airspeed" units="m/s">Current indicated airspeed (IAS).</field>
+      <field type="float" name="groundspeed" units="m/s">Current ground speed.</field>
+      <field type="int16_t" name="heading" units="deg">Current heading (0-360, 0=north).</field>
+      <field type="uint16_t" name="throttle" units="%">Current throttle setting (0 to 100).</field>
+      <field type="float" name="alt" units="m">Current altitude (MSL).</field>
+      <field type="float" name="climb" units="m/s">Current climb rate.</field>
     </message>
     <message id="75" name="COMMAND_INT">
       <description>Message encoding a command with parameters as scaled integers. Scaling depends on the actual command value.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3658,7 +3658,7 @@
       <description>Metrics typically displayed on a HUD for fixed wing aircraft.</description>
       <field type="float" name="airspeed" units="m/s">Current indicated airspeed (IAS).</field>
       <field type="float" name="groundspeed" units="m/s">Current ground speed.</field>
-      <field type="int16_t" name="heading" units="deg">Current heading (0-360, 0=north).</field>
+      <field type="int16_t" name="heading" units="deg">Current heading in compass units (0-360, 0=north).</field>
       <field type="uint16_t" name="throttle" units="%">Current throttle setting (0 to 100).</field>
       <field type="float" name="alt" units="m">Current altitude (MSL).</field>
       <field type="float" name="climb" units="m/s">Current climb rate.</field>


### PR DESCRIPTION
Discussion originates in https://github.com/mavlink/mavlink/issues/929#issuecomment-446777948.

The airspeed in the HUD could be true airspeed, indicated airspeed, airspeed setpoint, etc etc. This clarifies that it is "indicated airspeed". This is definitely the case for ArduPilot, and I THINK it is also the case for PX4 (@dagar ?)

In addition, minor tidy removes units information from descriptions.