### PR TITLE
Add MAV_MISSION_OPERATION_CANCELLED

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2187,51 +2187,54 @@
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">
-      <description>result in a MAVLink mission ack</description>
+      <description>Result of mission operation (in a MISSION_ACK message).</description>
       <entry value="0" name="MAV_MISSION_ACCEPTED">
         <description>mission accepted OK</description>
       </entry>
       <entry value="1" name="MAV_MISSION_ERROR">
-        <description>generic error / not accepting mission commands at all right now</description>
+        <description>Generic error / not accepting mission commands at all right now.</description>
       </entry>
       <entry value="2" name="MAV_MISSION_UNSUPPORTED_FRAME">
-        <description>coordinate frame is not supported</description>
+        <description>Coordinate frame is not supported.</description>
       </entry>
       <entry value="3" name="MAV_MISSION_UNSUPPORTED">
-        <description>command is not supported</description>
+        <description>Command is not supported.</description>
       </entry>
       <entry value="4" name="MAV_MISSION_NO_SPACE">
-        <description>mission item exceeds storage space</description>
+        <description>Mission item exceeds storage space.</description>
       </entry>
       <entry value="5" name="MAV_MISSION_INVALID">
-        <description>one of the parameters has an invalid value</description>
+        <description>One of the parameters has an invalid value.</description>
       </entry>
       <entry value="6" name="MAV_MISSION_INVALID_PARAM1">
-        <description>param1 has an invalid value</description>
+        <description>param1 has an invalid value.</description>
       </entry>
       <entry value="7" name="MAV_MISSION_INVALID_PARAM2">
-        <description>param2 has an invalid value</description>
+        <description>param2 has an invalid value.</description>
       </entry>
       <entry value="8" name="MAV_MISSION_INVALID_PARAM3">
-        <description>param3 has an invalid value</description>
+        <description>param3 has an invalid value.</description>
       </entry>
       <entry value="9" name="MAV_MISSION_INVALID_PARAM4">
-        <description>param4 has an invalid value</description>
+        <description>param4 has an invalid value.</description>
       </entry>
       <entry value="10" name="MAV_MISSION_INVALID_PARAM5_X">
-        <description>x/param5 has an invalid value</description>
+        <description>param5 (x) has an invalid value.</description>
       </entry>
       <entry value="11" name="MAV_MISSION_INVALID_PARAM6_Y">
-        <description>y/param6 has an invalid value</description>
+        <description>param6 (y) has an invalid value.</description>
       </entry>
       <entry value="12" name="MAV_MISSION_INVALID_PARAM7">
-        <description>param7 has an invalid value</description>
+        <description>param7 has an invalid value.</description>
       </entry>
       <entry value="13" name="MAV_MISSION_INVALID_SEQUENCE">
-        <description>received waypoint out of sequence</description>
+        <description>Mission item recieved out of sequence</description>
       </entry>
       <entry value="14" name="MAV_MISSION_DENIED">
-        <description>not accepting any mission commands from this communication partner</description>
+        <description>Not accepting any mission commands from this communication partner.</description>
+      </entry>
+      <entry value="15" name="MAV_MISSION_OPERATION_CANCELLED">
+        <description>Current mission operation cancelled.</description>
       </entry>
     </enum>
     <enum name="MAV_SEVERITY">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2228,7 +2228,7 @@
         <description>param7 has an invalid value.</description>
       </entry>
       <entry value="13" name="MAV_MISSION_INVALID_SEQUENCE">
-        <description>Mission item recieved out of sequence</description>
+        <description>Mission item received out of sequence</description>
       </entry>
       <entry value="14" name="MAV_MISSION_DENIED">
         <description>Not accepting any mission commands from this communication partner.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2234,7 +2234,7 @@
         <description>Not accepting any mission commands from this communication partner.</description>
       </entry>
       <entry value="15" name="MAV_MISSION_OPERATION_CANCELLED">
-        <description>Current mission operation cancelled.</description>
+        <description>Current mission operation cancelled (e.g. mission upload, mission download).</description>
       </entry>
     </enum>
     <enum name="MAV_SEVERITY">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2219,13 +2219,13 @@
         <description>param4 has an invalid value.</description>
       </entry>
       <entry value="10" name="MAV_MISSION_INVALID_PARAM5_X">
-        <description>param5 (x) has an invalid value.</description>
+        <description>x / param5 has an invalid value.</description>
       </entry>
       <entry value="11" name="MAV_MISSION_INVALID_PARAM6_Y">
-        <description>param6 (y) has an invalid value.</description>
+        <description>y / param6 has an invalid value.</description>
       </entry>
       <entry value="12" name="MAV_MISSION_INVALID_PARAM7">
-        <description>param7 has an invalid value.</description>
+        <description>z / param7 has an invalid value.</description>
       </entry>
       <entry value="13" name="MAV_MISSION_INVALID_SEQUENCE">
         <description>Mission item received out of sequence</description>


### PR DESCRIPTION
This adds MAV_MISSION_OPERATION_CANCELLED to allow a system to report that the current operation has been cancelled. This might be returned as a response to any request.
I've tidied up the rest of the enum text too. 

Note, this is irrelevant to ArduPilot which does not support cancellation (just times out). It is relevant to PX4 and other systems, which will otherwise return a spurious error.