### PR TITLE
Allow defining stream type.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2952,13 +2952,13 @@
         <description>Stream is RTSP</description>
       </entry>
       <entry value="1" name="VIDEO_STREAM_TYPE_RTPUDP">
-        <description>Stream is RTP UDP (uri gives the port number)</description>
+        <description>Stream is RTP UDP (URI gives the port number)</description>
       </entry>
       <entry value="2" name="VIDEO_STREAM_TYPE_TCP_MPEG">
         <description>Stream is MPEG on TCP</description>
       </entry>
-      <entry value="3" name="VIDEO_STREAM_TYPE_MPEGTS_H264">
-        <description>Stream is h.264 on MPEG TS (uri gives the port number)</description>
+      <entry value="3" name="VIDEO_STREAM_TYPE_MPEG_TS_H264">
+        <description>Stream is h.264 on MPEG TS (URI gives the port number)</description>
       </entry>
     </enum>
     <enum name="SET_ZOOM_TYPE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2942,6 +2942,24 @@
       <entry value="2" name="VIDEO_STREAM_STATUS_FLAGS_THERMAL">
         <description>Stream is thermal imaging</description>
       </entry>
+      <entry value="4" name="VIDEO_STREAM_HAS_BASIC_ZOOM">
+        <description>Stream has basic zoom control (MAV_CMD_SET_CAMERA_ZOOM)</description>
+      </entry>
+    </enum>
+    <enum name="VIDEO_STREAM_TYPE">
+      <description>Video stream types</description>
+      <entry value="0" name="VIDEO_STREAM_TYPE_RTSP">
+        <description>Stream is RTSP</description>
+      </entry>
+      <entry value="1" name="VIDEO_STREAM_TYPE_RTPUDP">
+        <description>Stream is RTP UDP (uri gives the port number)</description>
+      </entry>
+      <entry value="2" name="VIDEO_STREAM_TYPE_TCP_MPEG">
+        <description>Stream is MPEG on TCP</description>
+      </entry>
+      <entry value="3" name="VIDEO_STREAM_TYPE_MPEGTS_H264">
+        <description>Stream is h.264 on MPEG TS (uri gives the port number)</description>
+      </entry>
     </enum>
     <enum name="SET_ZOOM_TYPE">
       <description>Zoom types for MAV_CMD_SET_CAMERA_ZOOM</description>
@@ -4783,6 +4801,7 @@
       <description>Information about video stream</description>
       <field type="uint8_t" name="stream_id">Stream ID (1 for first, 2 for second, etc.)</field>
       <field type="uint8_t" name="count">Number of streams available</field>
+      <field type="uint8_t" name="type" enum="VIDEO_STREAM_TYPE">Type of stream</field>
       <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags</field>
       <field type="float" name="framerate" units="Hz">Frame rate</field>
       <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution</field>
@@ -4790,7 +4809,7 @@
       <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
-      <field type="char[160]" name="uri">Video stream URI</field>
+      <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to)</field>
     </message>
     <message id="270" name="SET_VIDEO_STREAM_SETTINGS">
       <wip/>


### PR DESCRIPTION
This adds a field telling the GCS the type of video stream for a given stream. In most cases, you don't "set" anything. The vehicle has a fixed type of video stream and it will tell you what it is. The field allows the GCS to use a proper pipeline for receiving and rendering the video stream.

In addition, I've also added a flag telling if the stream supports zoom. As streams are decoupled from "cameras" (which have their own API), if your system has video stream with zoom support but no other "camera" feature (image/video capture, etc.), there is no way to let the GCS know the stream handles zoom.

@julianoes, another change in the structure. I'm implementing this in QGC (basic, experimental support is already in master).

Note that this is unrelated to #885 as this is only for `VIDEO_STREAM_INFORMATION` while #885 is dealing with `SET_VIDEO_STREAM_SETTINGS`, which I have no plans to implement within QGC.