### PR TITLE
Cleanup

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1617,7 +1617,7 @@
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Duration between two consecutive pictures (in seconds)</param>
         <param index="3">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="4">Capture sequence (ID to prevent double captures when a command is retransmitted, 0: unused, &gt;= 1: used)</param>
+        <param index="4">Capture sequence ID (to prevent double captures when a command is retransmitted, 0: unused, &gt;= 1: used - Only valid for single capture)</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1562,16 +1562,12 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Request storage information (STORAGE_INFORMATION). Use the command's target_component to target a specific component's storage.</description>
         <param index="1">Storage ID (0 for all, 1 for first, 2 for second, etc.)</param>
         <param index="2">0: No Action 1: Request storage information</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Format a storage medium. Once format is complete, a STORAGE_INFORMATION message is sent. Use the command's target_component to target a specific component's storage.</description>
         <param index="1">Storage ID (1 for first, 2 for second, etc.)</param>
         <param index="2">0: No action 1: Format storage</param>
@@ -4721,8 +4717,6 @@
       <field type="float" name="focusLevel">Current focus level (0.0 to 100.0, NaN if not known)</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about a storage medium.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="storage_id">Storage ID (1 for first, 2 for second, etc.)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1615,7 +1615,7 @@
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
         <description>Start image capture sequence. Camera must send CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
-        <param index="2" label="Duration" units="s">Duration between two consecutive pictures (in seconds)</param>
+        <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
         <param index="3" label="Capture Count" minValue="0">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE</param>
         <param index="4" label="Sequence Number" minValue="0">Capture sequence number starting from 1. This is only valid for single-capture (param3==1). Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted. Use 0 to ignore it.</param>
         <param index="5">Reserved (all remaining params)</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1563,14 +1563,14 @@
       </entry>
       <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
         <description>Request storage information (STORAGE_INFORMATION). Use the command's target_component to target a specific component's storage.</description>
-        <param index="1">Storage ID (0 for all, 1 for first, 2 for second, etc.)</param>
-        <param index="2">0: No Action 1: Request storage information</param>
+        <param index="1" label="Storage ID" minValue="0">Storage ID (0 for all, 1 for first, 2 for second, etc.)</param>
+        <param index="2" label="Confirm Request" minValue="0" maxValue="1">0: No Action 1: Request storage information</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
         <description>Format a storage medium. The formatting system must respond with STORAGE_INFORMATION when the operation is complete. Use the command's target_component to target a specific component's storage.</description>
-        <param index="1">Storage ID (1 for first, 2 for second, etc.)</param>
-        <param index="2">0: No action 1: Format storage</param>
+        <param index="1" label="Storage ID" minValue="0">Storage ID (1 for first, 2 for second, etc.)</param>
+        <param index="2" label="Confirm Request" minValue="0" maxValue="1">0: No action 1: Format storage</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
@@ -1615,9 +1615,9 @@
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
         <description>Start image capture sequence. Camera must send CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
-        <param index="2" units="s">Duration between two consecutive pictures (in seconds)</param>
-        <param index="3">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE</param>
-        <param index="4">Capture sequence number starting from 1. This is only valid for single-capture (param3==1). Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted. Use 0 to ignore it.</param>
+        <param index="2" label="Duration" units="s">Duration between two consecutive pictures (in seconds)</param>
+        <param index="3" label="Capture Count" minValue="0">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE</param>
+        <param index="4" label="Sequence Number" minValue="0">Capture sequence number starting from 1. This is only valid for single-capture (param3==1). Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted. Use 0 to ignore it.</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1568,7 +1568,7 @@
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
-        <description>Format a storage medium. Once format is complete, a STORAGE_INFORMATION message is sent. Use the command's target_component to target a specific component's storage.</description>
+        <description>Format a storage medium. The formatting system must respond with STORAGE_INFORMATION when the operation is complete. Use the command's target_component to target a specific component's storage.</description>
         <param index="1">Storage ID (1 for first, 2 for second, etc.)</param>
         <param index="2">0: No action 1: Format storage</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -1591,7 +1591,7 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE">
-        <description>Set camera running mode. Use NAN for reserved values.</description>
+        <description>Set camera running mode. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Camera mode (see CAMERA_MODE enum)</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -1599,7 +1599,7 @@
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera zoom. Returns CAMERA_SETTINGS message. Use NAN for reserved values.</description>
+        <description>Set camera zoom. Returns CAMERA_SETTINGS message. Use NaN for reserved values.</description>
         <param index="1" enum="SET_ZOOM_TYPE">Zoom type</param>
         <param index="2">Zoom value</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -1607,28 +1607,28 @@
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera focus. Returns CAMERA_SETTINGS message. Use NAN for reserved values.</description>
+        <description>Set camera focus. Returns CAMERA_SETTINGS message. Use NaN for reserved values.</description>
         <param index="1" enum="SET_FOCUS_TYPE">Focus type</param>
         <param index="2">Focus value</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
-        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NAN for reserved values.</description>
+        <description>Start image capture sequence. Camera must send CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
-        <param index="2">Duration between two consecutive pictures (in seconds)</param>
-        <param index="3">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="4">Capture sequence ID (to prevent double captures when a command is retransmitted, 0: unused, &gt;= 1: used - Only valid for single capture)</param>
+        <param index="2" units="s">Duration between two consecutive pictures (in seconds)</param>
+        <param index="3">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE</param>
+        <param index="4">Capture sequence number starting from 1. This is only valid for single-capture (param3==1). Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted. Use 0 to ignore it.</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
-        <description>Stop image capture sequence Use NAN for reserved values.</description>
+        <description>Stop image capture sequence Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2002" name="MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Re-request a CAMERA_IMAGE_CAPTURE packet. Use NAN for reserved values.</description>
+        <description>Re-request a CAMERA_IMAGE_CAPTURE packet. Use NaN for reserved values.</description>
         <param index="1">Sequence number for missing CAMERA_IMAGE_CAPTURE packet</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
@@ -1639,13 +1639,13 @@
         <param index="3">1 to pause triggering, but without switching the camera off or retracting it. -1 to ignore</param>
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
-        <description>Starts video capture (recording). Use NAN for reserved values.</description>
+        <description>Starts video capture (recording). Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency in Hz)</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
-        <description>Stop the current video capture (recording). Use NAN for reserved values.</description>
+        <description>Stop the current video capture (recording). Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
@@ -1694,12 +1694,12 @@
       <entry value="2520" name="MAV_CMD_AIRFRAME_CONFIGURATION">
         <description/>
         <param index="1">Landing gear ID (default: 0, -1 for all)</param>
-        <param index="2">Landing gear position (Down: 0, Up: 1, NAN for no change)</param>
-        <param index="3">Reserved, set to NAN</param>
-        <param index="4">Reserved, set to NAN</param>
-        <param index="5">Reserved, set to NAN</param>
-        <param index="6">Reserved, set to NAN</param>
-        <param index="7">Reserved, set to NAN</param>
+        <param index="2">Landing gear position (Down: 0, Up: 1, NaN for no change)</param>
+        <param index="3">Reserved, set to NaN</param>
+        <param index="4">Reserved, set to NaN</param>
+        <param index="5">Reserved, set to NaN</param>
+        <param index="6">Reserved, set to NaN</param>
+        <param index="7">Reserved, set to NaN</param>
       </entry>
       <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY">
         <description>Request to start/stop transmitting over the high latency telemetry</description>


### PR DESCRIPTION
Removing WIP from messages that are no longer WIP (they are now in production)

Better explaining the _Capture sequence ID_ for `MAV_CMD_IMAGE_START_CAPTURE`. If _Number of images to capture total_ is not 1, the sequence ID seems meaningless. Correct me if I'm wrong.