### PR TITLE
Use of uninitialised memory

### DIFF
--- a/examples/linux/mavlink_udp.c
+++ b/examples/linux/mavlink_udp.c
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
 	//struct sockaddr_in fromAddr;
 	uint8_t buf[BUFFER_LENGTH];
 	ssize_t recsize;
-	socklen_t fromlen;
+	socklen_t fromlen = sizeof(gcAddr);
 	int bytes_sent;
 	mavlink_message_t msg;
 	uint16_t len;


### PR DESCRIPTION
You're passing uninitialised memory to recvfrom() this is very bad, as this can cause the packages to be cut off.
From [man recvfrom](https://linux.die.net/man/2/recvfrom):

> The argument addrlen is a value-result argument, which the caller should initialize before the call to the size of the buffer associated with src_addr, and modified on return to indicate the actual size of the source address. The returned address is truncated if the buffer provided is too small; in this case, addrlen will return a value greater than was supplied to the call.