### PR TITLE
Remove SET_VIDEO_STREAM_SETTINGS from Common.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4815,20 +4815,7 @@
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
       <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to)</field>
     </message>
-    <message id="270" name="SET_VIDEO_STREAM_SETTINGS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message that sets video stream settings</description>
-      <field type="uint8_t" name="target_system">system ID of the target</field>
-      <field type="uint8_t" name="target_component">component ID of the target</field>
-      <field type="uint8_t" name="camera_id">Stream ID (1 for first, 2 for second, etc.)</field>
-      <field type="float" name="framerate" units="Hz">Frame rate (set to -1 for highest framerate possible)</field>
-      <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution (set to -1 for highest resolution possible)</field>
-      <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution (set to -1 for highest resolution possible)</field>
-      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate (set to -1 for auto)</field>
-      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
-      <field type="char[160]" name="uri">Video stream URI (mostly for UDP/RTP)</field>
-    </message>
+    <!-- id="270" is free: formerly used for SET_VIDEO_STREAM_SETTINGS -->
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>
       <field type="char[32]" name="ssid">Name of Wi-Fi network (SSID). Leave it blank to leave it unchanged.</field>


### PR DESCRIPTION
Proposal is to delete the wip message `SET_VIDEO_STREAM_SETTINGS`. 

Discussion is in https://github.com/mavlink/mavlink/pull/885#issuecomment-451292906 but essentially goes that video streams (in their basic forms) are a passive system. You query what there is and you react to it accordingly. 

The set command does not make sense because there is no way to know *what* to set. It isn't really a common interface, and there are better ways this might be done. 

The message has a number of other problems, but since it isn't used by anyone and is still wip, suggestion is to remove it. 

IF this is accepted we can close https://github.com/mavlink/mavlink/pull/885