### PR TITLE
Remove tests on Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.5"
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
Fixes #1051

Tests are failing on Python 3.3 due to lxml dependency no longer supporting that version. IMO 3.3 is a legacy test platform superseded by Python 3.5 - there is no real need to continue to support it. 