### PR TITLE
Common.xml:Add STATUSTEXT2 message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5012,6 +5012,11 @@
       <field type="int32_t" name="y">Y coordinate of center point.  Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
       <field type="float" name="z" units="m">Altitude of center point. Coordinate system depends on frame field.</field>
     </message>
+    <message id="365" name="STATUSTEXT2">
+      <description>Status text message (use only for important status and error messages). While the full message payload may be used for status text, we recommend that updates be kept concise. Note: The message is intended as a less restrictive replacement for STATUSTEXT.</description>
+      <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424.</field>
+      <field type="char[254]" name="text">Status text message, without null termination character.</field>
+    </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>


### PR DESCRIPTION
Adds STATUSTEXT2 message that allows full width status text, as I believe was suggested in dev meeting: https://github.com/mavlink/mavlink/pull/1038#issuecomment-452848604.

Note: 
- This uses a MAVLink2 id - assume no need to try find a MAVLink 1 id?
- Is the name OK? Could be STATUSTEXT_LONG or STATUS_TEXT_2 etc.
- I have stated *Note: The message is intended as a less restrictive replacement for STATUSTEXT.* My assumption being that systems will update to the new message. Systems that need to communicate specifically with MAVLink 1 devices would use STATUSTEXT.