### PR TITLE
Video streaming is now part of the camera API

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4836,16 +4836,17 @@
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about video stream</description>
       <field type="uint8_t" name="stream_id">Video Stream ID (1 for first, 2 for second, etc.)</field>
-      <field type="uint8_t" name="count">Number of streams available</field>
-      <field type="uint8_t" name="type" enum="VIDEO_STREAM_TYPE">Type of stream</field>
-      <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags</field>
-      <field type="float" name="framerate" units="Hz">Frame rate</field>
-      <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution</field>
-      <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution</field>
-      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate</field>
-      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
-      <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
-      <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to)</field>
+      <field type="uint8_t" name="count">Number of streams available.</field>
+      <field type="uint8_t" name="type" enum="VIDEO_STREAM_TYPE">Type of stream.</field>
+      <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags.</field>
+      <field type="float" name="framerate" units="Hz">Frame rate.</field>
+      <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution.</field>
+      <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution.</field>
+      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate.</field>
+      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise.</field>
+      <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view.</field>
+      <field type="char[32]" name="name">Stream name.</field>
+      <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to).</field>
     </message>
     <message id="270" name="VIDEO_STREAM_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1619,9 +1619,9 @@
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NAN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
-        <param index="2">Duration between two consecutive pictures (in seconds)</param>
-        <param index="3">Number of images to capture total - 0 for unlimited capture</param>
-        <param index="4">Capture sequence (ID to prevent double captures when a command is retransmitted, 0: unused, &gt;= 1: used)</param>
+        <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
+        <param index="3" label="Capture Count" minValue="0">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE</param>
+        <param index="4" label="Sequence Number" minValue="0">Capture sequence number starting from 1. This is only valid for single-capture (param3 == 1). Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted. Use 0 to ignore it.</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
@@ -1632,8 +1632,8 @@
       <entry value="2002" name="MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Re-request a CAMERA_IMAGE_CAPTURE packet. Use NAN for reserved values.</description>
-        <param index="1">Sequence number for missing CAMERA_IMAGE_CAPTURE packet</param>
+        <description>Re-request a CAMERA_IMAGE_CAPTURE message. Use NaN for reserved values.</description>
+        <param index="1">Sequence number for missing CAMERA_IMAGE_CAPTURE message</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2003" name="MAV_CMD_DO_TRIGGER_CONTROL">
@@ -1644,36 +1644,35 @@
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
         <description>Starts video capture (recording). Use NAN for reserved values.</description>
-        <param index="1">Reserved (Set to 0)</param>
-        <param index="2">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency in Hz)</param>
+        <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams)</param>
+        <param index="2" label="Status Frequency" minValue="0" units="Hz">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency in Hz)</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
         <description>Stop the current video capture (recording). Use NAN for reserved values.</description>
-        <param index="1">Reserved (Set to 0)</param>
+        <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams)</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Start video streaming</description>
-        <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
+        <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved</param>
       </entry>
       <entry value="2503" name="MAV_CMD_VIDEO_STOP_STREAMING">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Stop the current video streaming</description>
-        <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
+        <description>Stop the given video stream</description>
+        <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved</param>
       </entry>
       <entry value="2504" name="MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Request video stream information (VIDEO_STREAM_INFORMATION)</description>
-        <param index="1">Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
-        <param index="2">0: No Action 1: Request video stream information</param>
-        <param index="3">Reserved (all remaining params)</param>
+        <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
+        <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2510" name="MAV_CMD_LOGGING_START">
         <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
@@ -2933,6 +2932,9 @@
       <entry value="128" name="CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS">
         <description>Camera has basic focus control (MAV_CMD_SET_CAMERA_FOCUS)</description>
       </entry>
+      <entry value="256" name="CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM">
+        <description>Camera has video streaming capabilities (use CMD_REQUEST_VIDEO_STREAM_INFORMATION for video streaming info)</description>
+      </entry>
     </enum>
     <enum name="VIDEO_STREAM_STATUS_FLAGS">
       <description>Stream status flags (Bitmap)</description>
@@ -2941,9 +2943,6 @@
       </entry>
       <entry value="2" name="VIDEO_STREAM_STATUS_FLAGS_THERMAL">
         <description>Stream is thermal imaging</description>
-      </entry>
-      <entry value="4" name="VIDEO_STREAM_HAS_BASIC_ZOOM">
-        <description>Stream has basic zoom control (MAV_CMD_SET_CAMERA_ZOOM)</description>
       </entry>
     </enum>
     <enum name="VIDEO_STREAM_TYPE">
@@ -4803,7 +4802,7 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about video stream</description>
-      <field type="uint8_t" name="stream_id">Stream ID (1 for first, 2 for second, etc.)</field>
+      <field type="uint8_t" name="stream_id">Video Stream ID (1 for first, 2 for second, etc.)</field>
       <field type="uint8_t" name="count">Number of streams available</field>
       <field type="uint8_t" name="type" enum="VIDEO_STREAM_TYPE">Type of stream</field>
       <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags</field>
@@ -4814,20 +4813,6 @@
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
       <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to)</field>
-    </message>
-    <message id="270" name="SET_VIDEO_STREAM_SETTINGS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message that sets video stream settings</description>
-      <field type="uint8_t" name="target_system">system ID of the target</field>
-      <field type="uint8_t" name="target_component">component ID of the target</field>
-      <field type="uint8_t" name="camera_id">Stream ID (1 for first, 2 for second, etc.)</field>
-      <field type="float" name="framerate" units="Hz">Frame rate (set to -1 for highest framerate possible)</field>
-      <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution (set to -1 for highest resolution possible)</field>
-      <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution (set to -1 for highest resolution possible)</field>
-      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate (set to -1 for auto)</field>
-      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
-      <field type="char[160]" name="uri">Video stream URI (mostly for UDP/RTP)</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1603,7 +1603,7 @@
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera zoom. Returns CAMERA_SETTINGS message. Use NaN for reserved values.</description>
+        <description>Set camera zoom. Camera must respond with a CAMERA_SETTINGS message (on success). Use NaN for reserved values.</description>
         <param index="1" enum="CAMERA_ZOOM_TYPE">Zoom type</param>
         <param index="2">Zoom value. The range of valid values depend on the zoom type.</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -1611,7 +1611,7 @@
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera focus. Returns CAMERA_SETTINGS message. Use NaN for reserved values.</description>
+        <description>Set camera focus. Camera must respond with a CAMERA_SETTINGS message (on success). Use NaN for reserved values.</description>
         <param index="1" enum="SET_FOCUS_TYPE">Focus type</param>
         <param index="2">Focus value</param>
         <param index="3">Reserved (all remaining params)</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1674,6 +1674,13 @@
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
+      <entry value="2505" name="MAV_CMD_REQUEST_VIDEO_STREAM_STATUS">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Request video stream status (VIDEO_STREAM_STATUS)</description>
+        <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
       <entry value="2510" name="MAV_CMD_LOGGING_START">
         <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
         <param index="1">Format: 0: ULog</param>
@@ -4813,6 +4820,19 @@
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
       <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to)</field>
+    </message>
+    <message id="270" name="VIDEO_STREAM_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Information about the status of a video stream.</description>
+      <field type="uint8_t" name="stream_id">Video Stream ID (1 for first, 2 for second, etc.)</field>
+      <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags</field>
+      <field type="float" name="framerate" units="Hz">Frame rate</field>
+      <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution</field>
+      <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution</field>
+      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second</field>
+      <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
+      <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1595,7 +1595,7 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE">
-        <description>Set camera running mode. Use NAN for reserved values. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
+        <description>Set camera running mode. Use NaN for reserved values. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Camera mode (see CAMERA_MODE enum)</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -1603,7 +1603,7 @@
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera zoom. Returns CAMERA_SETTINGS message. Use NAN for reserved values.</description>
+        <description>Set camera zoom. Returns CAMERA_SETTINGS message. Use NaN for reserved values.</description>
         <param index="1" enum="SET_ZOOM_TYPE">Zoom type</param>
         <param index="2">Zoom value</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -1611,7 +1611,7 @@
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera focus. Returns CAMERA_SETTINGS message. Use NAN for reserved values.</description>
+        <description>Set camera focus. Returns CAMERA_SETTINGS message. Use NaN for reserved values.</description>
         <param index="1" enum="SET_FOCUS_TYPE">Focus type</param>
         <param index="2">Focus value</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -1626,7 +1626,7 @@
         <param index="2">Repeat count</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
-        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NAN for reserved values.</description>
+        <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
         <param index="3" label="Capture Count" minValue="0">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE</param>
@@ -1634,7 +1634,7 @@
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
-        <description>Stop image capture sequence Use NAN for reserved values.</description>
+        <description>Stop image capture sequence Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
@@ -1652,13 +1652,13 @@
         <param index="3">1 to pause triggering, but without switching the camera off or retracting it. -1 to ignore</param>
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE">
-        <description>Starts video capture (recording). Use NAN for reserved values.</description>
+        <description>Starts video capture (recording). Use NaN for reserved values.</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams)</param>
         <param index="2" label="Status Frequency" minValue="0" units="Hz">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency in Hz)</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
-        <description>Stop the current video capture (recording). Use NAN for reserved values.</description>
+        <description>Stop the current video capture (recording). Use NaN for reserved values.</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams)</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
@@ -1713,12 +1713,12 @@
       <entry value="2520" name="MAV_CMD_AIRFRAME_CONFIGURATION">
         <description/>
         <param index="1">Landing gear ID (default: 0, -1 for all)</param>
-        <param index="2">Landing gear position (Down: 0, Up: 1, NAN for no change)</param>
-        <param index="3">Reserved, set to NAN</param>
-        <param index="4">Reserved, set to NAN</param>
-        <param index="5">Reserved, set to NAN</param>
-        <param index="6">Reserved, set to NAN</param>
-        <param index="7">Reserved, set to NAN</param>
+        <param index="2">Landing gear position (Down: 0, Up: 1, NaN for no change)</param>
+        <param index="3">Reserved, set to NaN</param>
+        <param index="4">Reserved, set to NaN</param>
+        <param index="5">Reserved, set to NaN</param>
+        <param index="6">Reserved, set to NaN</param>
+        <param index="7">Reserved, set to NaN</param>
       </entry>
       <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY">
         <description>Request to start/stop transmitting over the high latency telemetry</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1597,15 +1597,15 @@
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE">
         <description>Set camera running mode. Use NaN for reserved values. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
         <param index="1">Reserved (Set to 0)</param>
-        <param index="2">Camera mode (see CAMERA_MODE enum)</param>
+        <param index="2" enum="CAMERA_MODE">Camera mode</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Set camera zoom. Returns CAMERA_SETTINGS message. Use NaN for reserved values.</description>
-        <param index="1" enum="SET_ZOOM_TYPE">Zoom type</param>
-        <param index="2">Zoom value</param>
+        <param index="1" enum="CAMERA_ZOOM_TYPE">Zoom type</param>
+        <param index="2">Zoom value. The range of valid values depend on the zoom type.</param>
         <param index="3">Reserved (all remaining params)</param>
       </entry>
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
@@ -1629,7 +1629,7 @@
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
-        <param index="3" label="Capture Count" minValue="0">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE</param>
+        <param index="3" label="Capture Count" minValue="0">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
         <param index="4" label="Sequence Number" minValue="0">Capture sequence number starting from 1. This is only valid for single-capture (param3 == 1). Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted. Use 0 to ignore it.</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
@@ -2979,7 +2979,7 @@
         <description>Stream is h.264 on MPEG TS (URI gives the port number)</description>
       </entry>
     </enum>
-    <enum name="SET_ZOOM_TYPE">
+    <enum name="CAMERA_ZOOM_TYPE">
       <description>Zoom types for MAV_CMD_SET_CAMERA_ZOOM</description>
       <entry value="0" name="ZOOM_TYPE_STEP">
         <description>Zoom one step increment (-1 for wide, 1 for tele)</description>
@@ -4842,7 +4842,7 @@
       <field type="float" name="framerate" units="Hz">Frame rate</field>
       <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution</field>
       <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution</field>
-      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second</field>
+      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
       <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to)</field>
@@ -4856,7 +4856,7 @@
       <field type="float" name="framerate" units="Hz">Frame rate</field>
       <field type="uint16_t" name="resolution_h" units="pix">Horizontal resolution</field>
       <field type="uint16_t" name="resolution_v" units="pix">Vertical resolution</field>
-      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second</field>
+      <field type="uint32_t" name="bitrate" units="bits/s">Bit rate</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1595,7 +1595,7 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE">
-        <description>Set camera running mode. Use NAN for reserved values.</description>
+        <description>Set camera running mode. Use NAN for reserved values. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2">Camera mode (see CAMERA_MODE enum)</param>
         <param index="3">Reserved (all remaining params)</param>
@@ -2952,7 +2952,7 @@
         <description>Camera has basic focus control (MAV_CMD_SET_CAMERA_FOCUS)</description>
       </entry>
       <entry value="256" name="CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM">
-        <description>Camera has video streaming capabilities (use CMD_REQUEST_VIDEO_STREAM_INFORMATION for video streaming info)</description>
+        <description>Camera has video streaming capabilities (use MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION for video streaming info)</description>
       </entry>
     </enum>
     <enum name="VIDEO_STREAM_STATUS_FLAGS">


### PR DESCRIPTION
I've moved the video streaming commands and messages into the fold of the camera API. What that means is that now a "camera component" is responsible for video streaming handling. The existing video streaming commands and messages are somewhat the same but now they are targeted to a camera component ID.

If a camera supports video streaming, it tells you by settings `CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM` in its capabilities flag. When the GCS detects this flag, it will send a `MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION` command to the camera. From then on, all video streaming discovery and setup is done automatically.

A vehicle may contain 0 to many cameras (the total will depend on component ID availability as each camera has its own component ID). Each camera may contain up to 255 video streams (the value 0 is used for _all cameras_ whenever a stream ID is used).

Video streaming is inherently passive. That is, the GCS queries the camera for the video stream configuration and it then builds an appropriate pipeline to receive it. If your camera allows changing video streaming settings, you must use the `PARAM_EXT_XXX` set of commands (and a camera definition file exposing the parameters). The GCS will then present these parameters (along with their options) to the user.

Needless to say, this all needs to be documented within the camera API documentation.

* Make video streaming as part of the camera API
* Removed the `SET_VIDEO_STREAM_SETTINGS` command
* Added video stream status (request and response)

Also changed all instances of _NAN_ to _NaN_ for consistency.
