### PR TITLE
Document recording time within CAMERA_CAPTURE_STATUS message.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6051,7 +6051,7 @@
       <field type="uint8_t" name="image_status">Current status of image capturing (0: idle, 1: capture in progress, 2: interval set but idle, 3: interval set and capture in progress)</field>
       <field type="uint8_t" name="video_status">Current status of video capturing (0: idle, 1: capture in progress)</field>
       <field type="float" name="image_interval" units="s">Image capture interval</field>
-      <field type="uint32_t" name="recording_time_ms" units="ms">Time since recording started</field>
+      <field type="uint32_t" name="recording_time_ms" units="ms">Time since recording started. Set to 0 if not supported (GCS to compute recording time on its own.)</field>
       <field type="float" name="available_capacity" units="MiB">Available storage capacity.</field>
       <extensions/>
       <field type="int32_t" name="image_count">Total number of images captured ('forever', or until reset using MAV_CMD_STORAGE_FORMAT).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6051,7 +6051,7 @@
       <field type="uint8_t" name="image_status">Current status of image capturing (0: idle, 1: capture in progress, 2: interval set but idle, 3: interval set and capture in progress)</field>
       <field type="uint8_t" name="video_status">Current status of video capturing (0: idle, 1: capture in progress)</field>
       <field type="float" name="image_interval" units="s">Image capture interval</field>
-      <field type="uint32_t" name="recording_time_ms" units="ms">Time since recording started. Set to 0 if not supported (GCS to compute recording time on its own.)</field>
+      <field type="uint32_t" name="recording_time_ms" units="ms">Elapsed time since recording started (0: Not supported/available). A GCS should compute recording time and use non-zero values of this field to correct any discrepancy.</field>
       <field type="float" name="available_capacity" units="MiB">Available storage capacity.</field>
       <extensions/>
       <field type="int32_t" name="image_count">Total number of images captured ('forever', or until reset using MAV_CMD_STORAGE_FORMAT).</field>


### PR DESCRIPTION
If the camera does not keep track of recording time (or doesn't know it), set the `recording_time_ms` field to 0. The `CAMERA_CAPTURE_STATUS` is only sent periodically so the GCS keeps track of recording time on its own any way. But when the camera does support reporting of the recording time, the GCS will update its internal timer to reflect what the camera tells it.