### PR TITLE
MOTOR_TEST service updates to common.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1410,9 +1410,8 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-
       <entry value="209" name="MAV_CMD_DO_MOTOR_TEST" hasLocation="false" isDestination="false">
-        <description>Mission command to perform motor test.</description>
+        <description>Command to perform motor test.</description>
         <param index="1" label="Instance" minValue="1" increment="1">Motor instance number (from 1 to max number of motors on the vehicle).</param>
         <param index="2" label="Throttle Type" enum="MOTOR_TEST_THROTTLE_TYPE">Throttle type (whether the Throttle Value in param3 is a percentage, PWM value, etc.)</param>
         <param index="3" label="Throttle">Throttle value.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1410,13 +1410,14 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+
       <entry value="209" name="MAV_CMD_DO_MOTOR_TEST" hasLocation="false" isDestination="false">
         <description>Mission command to perform motor test.</description>
-        <param index="1" label="Instance" minValue="1" increment="1">Motor instance number. (from 1 to max number of motors on the vehicle)</param>
-        <param index="2" label="Throttle Type" enum="MOTOR_TEST_THROTTLE_TYPE">Throttle type.</param>
-        <param index="3" label="Throttle">Throttle.</param>
-        <param index="4" label="Timeout" units="s" minValue="0">Timeout.</param>
-        <param index="5" label="Motor Count" minValue="0" increment="1">Motor count. (number of motors to test to test in sequence, waiting for the timeout above between them; 0=1 motor, 1=1 motor, 2=2 motors...)</param>
+        <param index="1" label="Instance" minValue="1" increment="1">Motor instance number (from 1 to max number of motors on the vehicle).</param>
+        <param index="2" label="Throttle Type" enum="MOTOR_TEST_THROTTLE_TYPE">Throttle type (whether the Throttle Value in param3 is a percentage, PWM value, etc.)</param>
+        <param index="3" label="Throttle">Throttle value.</param>
+        <param index="4" label="Timeout" units="s" minValue="0">Timeout between tests that are run in sequence.</param>
+        <param index="5" label="Motor Count" minValue="0" increment="1">Motor count. Number of motors to test in sequence: 0/1=one motor, 2= two motors, etc. The Timeout (param4) is used between tests.</param>
         <param index="6" label="Test Order" enum="MOTOR_TEST_ORDER">Motor test order.</param>
         <param index="7">Empty</param>
       </entry>
@@ -3143,29 +3144,31 @@
     </enum>
     <!-- motor test type enum -->
     <enum name="MOTOR_TEST_ORDER">
+      <description>Sequence that motors are tested when using MAV_CMD_DO_MOTOR_TEST.</description>
       <entry name="MOTOR_TEST_ORDER_DEFAULT" value="0">
-        <description>default autopilot motor test method</description>
+        <description>Default autopilot motor test method.</description>
       </entry>
       <entry name="MOTOR_TEST_ORDER_SEQUENCE" value="1">
-        <description>motor numbers are specified as their index in a predefined vehicle-specific sequence</description>
+        <description>Motor numbers are specified as their index in a predefined vehicle-specific sequence.</description>
       </entry>
       <entry name="MOTOR_TEST_ORDER_BOARD" value="2">
-        <description>motor numbers are specified as the output as labeled on the board</description>
+        <description>Motor numbers are specified as the output as labeled on the board.</description>
       </entry>
     </enum>
     <!-- motor test throttle type enum -->
     <enum name="MOTOR_TEST_THROTTLE_TYPE">
+      <description>Defines how throttle value is represented in MAV_CMD_DO_MOTOR_TEST.</description>
       <entry value="0" name="MOTOR_TEST_THROTTLE_PERCENT">
-        <description>throttle as a percentage from 0 ~ 100</description>
+        <description>Throttle as a percentage (0 ~ 100)</description>
       </entry>
       <entry value="1" name="MOTOR_TEST_THROTTLE_PWM">
-        <description>throttle as an absolute PWM value (normally in range of 1000~2000)</description>
+        <description>Throttle as an absolute PWM value (normally in range of 1000~2000).</description>
       </entry>
       <entry value="2" name="MOTOR_TEST_THROTTLE_PILOT">
-        <description>throttle pass-through from pilot's transmitter</description>
+        <description>Throttle pass-through from pilot's transmitter.</description>
       </entry>
       <entry value="3" name="MOTOR_TEST_COMPASS_CAL">
-        <description>per-motor compass calibration test</description>
+        <description>Per-motor compass calibration test.</description>
       </entry>
     </enum>
     <!-- GPS_INPUT ignore flags enum -->


### PR DESCRIPTION
This adds new param metadata to motor test command. I'm hoping to clarify the operation and document the service. 

Some assumptions - can anyone confirm:
- This is a simple command protocol message MAV_CMD_DO_MOTOR_TEST. There are no other messages involved other than the ACK/NACK.
- This cannot/must not be used in missions.
- ACK is returned with progress updates, and with success and on completion. Otherwise if test can't be run or if it fails NACK returned.
- There are two modes - single motor test and sequential motor test.
  - Single motor test uses param 1 and tests just the specified motor
  - Sequence uses param 5 to indicate a count of motors to test, with sequence specified in other params.
- I assume this is expected to work such that the user either tells GCS to start one motor or a sequence of motors. The message is sent and the user watches the motors start, run etc. The GCS shows motors under test based on ACK progress, and knows when finished based on ACK complete. The GCS may report an error if test can't run, but otherwise this is just user watching the motors spin and deciding if they are happy with the order. 

Questions:
 - What if both single (param 1) and sequence (param 5) tests are specified? Which should the command respect?
- In sequence, what is the timeout? Ie I guess that test runs, motor is started and this timeout is how long the test will run for. But it could be that some feedback is expected from "somewhere" and this is timeout that says "we're not waiting for confirmation".
- If timeout is really just "motor run time" then assume this also applies to single motor test mode?
- Where is this implemented? ArduPilot, PX4?

Further comments inline!