### PR TITLE
common: improve description of VTOL_TAKEOFF cmd

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -939,7 +939,7 @@
         <param index="7">Altitude/Z of goal</param>
       </entry>
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
-        <description>Takeoff from ground using VTOL mode</description>
+        <description>Takeoff from ground using VTOL mode including transition to forward flight.</description>
         <param index="1">Empty</param>
         <param index="2">Front transition heading, see VTOL_TRANSITION_HEADING enum.</param>
         <param index="3">Empty</param>


### PR DESCRIPTION
I learned today that the VTOL takeoff command includes the transition to forward flight. Let's document that.