### PR TITLE
Add MAV_BATTERY_CHARGE_STATE_CHARGING

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2603,7 +2603,7 @@
       </entry>
     </enum>
     <enum name="MAV_BATTERY_CHARGE_STATE">
-      <description>Enumeration for low battery states.</description>
+      <description>Enumeration for battery charge states.</description>
       <entry value="0" name="MAV_BATTERY_CHARGE_STATE_UNDEFINED">
         <description>Low battery state is not provided</description>
       </entry>
@@ -2624,6 +2624,9 @@
       </entry>
       <entry value="6" name="MAV_BATTERY_CHARGE_STATE_UNHEALTHY">
         <description>Battery is diagnosed to be defective or an error occurred, usage is discouraged / prohibited.</description>
+      </entry>
+      <entry value="7" name="MAV_BATTERY_CHARGE_STATE_CHARGING">
+        <description>Battery is charging.</description>
       </entry>
     </enum>
     <enum name="MAV_VTOL_STATE">


### PR DESCRIPTION
I propose adding a charging state of the battery.

This enum value would be useful for systems with automatic charging stations.