### PR TITLE
SERVO_OUTPUT_RAW et al port mapping clarification

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3375,7 +3375,7 @@
     <message id="34" name="RC_CHANNELS_SCALED">
       <description>The scaled values of the RC channels received: (-100%) -10000, (0%) 0, (100%) 10000. Channels that are inactive should be set to UINT16_MAX.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
-      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX.</field>
       <field type="int16_t" name="chan1_scaled">RC channel 1 value scaled.</field>
       <field type="int16_t" name="chan2_scaled">RC channel 2 value scaled.</field>
       <field type="int16_t" name="chan3_scaled">RC channel 3 value scaled.</field>
@@ -3389,7 +3389,7 @@
     <message id="35" name="RC_CHANNELS_RAW">
       <description>The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. A value of UINT16_MAX implies the channel is unused. Individual receivers/transmitters might violate this specification.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
-      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows for more than 8 servos.</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX.</field>
       <field type="uint16_t" name="chan1_raw" units="us">RC channel 1 value.</field>
       <field type="uint16_t" name="chan2_raw" units="us">RC channel 2 value.</field>
       <field type="uint16_t" name="chan3_raw" units="us">RC channel 3 value.</field>
@@ -3403,7 +3403,7 @@
     <message id="36" name="SERVO_OUTPUT_RAW">
       <description>The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.</description>
       <field type="uint32_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
-      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.</field>
+      <field type="uint8_t" name="port">Servo output port (set of 8 outputs = 1 port). Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX.</field>
       <field type="uint16_t" name="servo1_raw" units="us">Servo output 1 value</field>
       <field type="uint16_t" name="servo2_raw" units="us">Servo output 2 value</field>
       <field type="uint16_t" name="servo3_raw" units="us">Servo output 3 value</field>


### PR DESCRIPTION
This updates description of the port field used to differentiate between "banks of servos/channels" in RC_CHANNELS_SCALED, RC_CHANNELS_RAW, SERVO_OUTPUT_RAW to recommend particular values for the known ports on Pixhawk. It does not attempt to define for other systems.

Specifically 
- it removes the comment "Most MAVs will just use one, but this allows for more than 8 servos." (not necessarily true, but only the bit "allows for more than 8 servos potentially useful".
- Adds "Flight stacks running on Pixhawk should use: 0 = MAIN, 1 = AUX." - I think common for PX4 and ArduPilot

OK @auturgy @bkueng ?