### PR TITLE
MAV_CMD_NAV_VTOL_TAKEOFF - add param metadata

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -939,11 +939,11 @@
         <param index="7">Altitude/Z of goal</param>
       </entry>
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF">
-        <description>Takeoff from ground using VTOL mode including transition to forward flight.</description>
+        <description>Takeoff from ground using VTOL mode, and transition to forward flight with specified heading.</description>
         <param index="1">Empty</param>
-        <param index="2">Front transition heading, see VTOL_TRANSITION_HEADING enum.</param>
+        <param index="2" label="Transition Heading" enum="VTOL_TRANSITION_HEADING">Front transition heading.</param>
         <param index="3">Empty</param>
-        <param index="4">Yaw angle in degrees. NaN for unchanged.</param>
+        <param index="4" label="Yaw Angle" units="deg">Yaw angle in degrees. NaN for unchanged.</param>
         <param index="5">Latitude</param>
         <param index="6">Longitude</param>
         <param index="7">Altitude</param>


### PR DESCRIPTION
This further improves #1066, adding param metadata that can help GCS better structure UI.

@amilcarlucas Have I missed anything?