### PR TITLE
Revert DISTANCE_SENSOR.covariance

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4307,7 +4307,7 @@
       <field type="uint8_t" name="type" enum="MAV_DISTANCE_SENSOR">Type of distance sensor.</field>
       <field type="uint8_t" name="id">Onboard ID of the sensor</field>
       <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces. downward-facing: ROTATION_PITCH_270, upward-facing: ROTATION_PITCH_90, backward-facing: ROTATION_PITCH_180, forward-facing: ROTATION_NONE, left-facing: ROTATION_YAW_90, right-facing: ROTATION_YAW_270</field>
-      <field type="uint8_t" name="covariance" units="cm^2">Measurement variance in centimeters^2. 0 for unknown / invalid readings</field>
+      <field type="uint8_t" name="covariance" units="cm">Measurement covariance. 0 for unknown / invalid readings</field>
       <extensions/>
       <field type="float" name="horizontal_fov" units="rad">Horizontal Field of View (angle) where the distance measurement is valid and the field of view is known. Otherwise this is set to 0.</field>
       <field type="float" name="vertical_fov" units="rad">Vertical Field of View (angle) where the distance measurement is valid and the field of view is known. Otherwise this is set to 0.</field>


### PR DESCRIPTION
As discussed in https://github.com/mavlink/mavlink/pull/917#issuecomment-460896776 the DISTANCE_SENSOR.covariance variable need to be reverted.

Fixing this up properly should be done in https://github.com/mavlink/mavlink/pull/1047