### PR TITLE
Reserving part of the component ID range for private components.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -378,6 +378,7 @@
       <entry value="1" name="MAV_COMP_ID_AUTOPILOT1">
         <description>System flight controller component ("autopilot"). Only one autopilot is expected in a particular system.</description>
       </entry>
+      <!-- Component ids from 25-99 are reserved for private OEM component definitions; components in this range may be incompatible with other private components. -->
       <entry value="100" name="MAV_COMP_ID_CAMERA">
         <description>Camera #1.</description>
       </entry>


### PR DESCRIPTION
Per https://github.com/mavlink/qgroundcontrol/issues/7049#issuecomment-447726922 (apologies for the delay in actioning this), I propose the C25-C99 range be reserved for private component definitions. A quick look at the existing definition files indicates this should not cause any conflicts.

To clarify, the definition of 'private components' is essentially "things which can be incompatible with other private components". This should exclude anything which is sold as a component to the general public. In Aeronavics' case, we have a number of avionics components, both physical and logical, which don't match any of the existing definitions, are important to us, but would be meaningless to other people if they were taking up address space in the public definitions.

