### PR TITLE
Add MAV_CMD_REQUEST_MESSAGE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1541,6 +1541,10 @@
         <param index="1">The MAVLink message ID</param>
         <param index="2">The interval between two messages, in microseconds. Set to -1 to disable and 0 to request default rate.</param>
       </entry>
+      <entry value="512" name="MAV_CMD_REQUEST_MESSAGE">
+        <description>Request target system(s) respond with a specified message. This is a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL.</description>
+        <param index="1">The MAVLink message ID of the requested message.</param>
+      </entry>
       <entry value="519" name="MAV_CMD_REQUEST_PROTOCOL_VERSION">
         <description>Request MAVLink protocol version compatibility</description>
         <param index="1">1: Request supported protocol versions by all nodes on the network</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1542,7 +1542,7 @@
         <param index="2">The interval between two messages, in microseconds. Set to -1 to disable and 0 to request default rate.</param>
       </entry>
       <entry value="512" name="MAV_CMD_REQUEST_MESSAGE">
-        <description>Request target system(s) respond with a specified message. This is a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL.</description>
+        <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).</description>
         <param index="1">The MAVLink message ID of the requested message.</param>
         <param index="2">Index id (if appropriate). The use of this parameter (if any), must be defined in the requested message.</param>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1544,6 +1544,7 @@
       <entry value="512" name="MAV_CMD_REQUEST_MESSAGE">
         <description>Request target system(s) respond with a specified message. This is a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL.</description>
         <param index="1">The MAVLink message ID of the requested message.</param>
+        <param index="2">Index id (if appropriate). The use of this parameter (if any), must be defined in the requested message.</param>
       </entry>
       <entry value="519" name="MAV_CMD_REQUEST_PROTOCOL_VERSION">
         <description>Request MAVLink protocol version compatibility</description>


### PR DESCRIPTION
This adds a mavlink command to request a particular message back from a system (as suggested by @peterbarker here: https://github.com/mavlink/mavlink/pull/1073#discussion_r254929733). This is intended to request information that is occasionally needed/doesn't need to be streamed. It is like a one-shot version of MAV_CMD_SET_MESSAGE_INTERVAL.

Alternative is to update MAV_CMD_SET_MESSAGE_INTERVAL with a new parameter that does the same thing - but I don't think that is as clean.