### PR TITLE
Update RSSI values to 0-254, 255=not used

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3413,7 +3413,7 @@
       <field type="int16_t" name="chan6_scaled">RC channel 6 value scaled.</field>
       <field type="int16_t" name="chan7_scaled">RC channel 7 value scaled.</field>
       <field type="int16_t" name="chan8_scaled">RC channel 8 value scaled.</field>
-      <field type="uint8_t" name="rssi" units="%">Receive signal strength indicator. Values: [0-100], 255: invalid/unknown.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
     </message>
     <message id="35" name="RC_CHANNELS_RAW">
       <description>The RAW values of the RC channels received. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. A value of UINT16_MAX implies the channel is unused. Individual receivers/transmitters might violate this specification.</description>
@@ -3427,7 +3427,7 @@
       <field type="uint16_t" name="chan6_raw" units="us">RC channel 6 value.</field>
       <field type="uint16_t" name="chan7_raw" units="us">RC channel 7 value.</field>
       <field type="uint16_t" name="chan8_raw" units="us">RC channel 8 value.</field>
-      <field type="uint8_t" name="rssi" units="%">Receive signal strength indicator. Values: [0-100], 255: invalid/unknown.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
     </message>
     <message id="36" name="SERVO_OUTPUT_RAW">
       <description>The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.</description>
@@ -3670,7 +3670,7 @@
       <field type="uint16_t" name="chan16_raw" units="us">RC channel 16 value.</field>
       <field type="uint16_t" name="chan17_raw" units="us">RC channel 17 value.</field>
       <field type="uint16_t" name="chan18_raw" units="us">RC channel 18 value.</field>
-      <field type="uint8_t" name="rssi" units="%">Receive signal strength indicator. Values: [0-100], 255: invalid/unknown.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
     </message>
     <message id="66" name="REQUEST_DATA_STREAM">
       <deprecated since="2015-08" replaced_by="SET_MESSAGE_INTERVAL"/>
@@ -3953,7 +3953,7 @@
       <field type="uint16_t" name="chan10_raw" units="us">RC channel 10 value</field>
       <field type="uint16_t" name="chan11_raw" units="us">RC channel 11 value</field>
       <field type="uint16_t" name="chan12_raw" units="us">RC channel 12 value</field>
-      <field type="uint8_t" name="rssi">Receive signal strength indicator. Values: [0-100], 255: invalid/unknown.</field>
+      <field type="uint8_t" name="rssi">Receive signal strength indicator in device-dependent units/scale. Values: [0-254], 255: invalid/unknown.</field>
     </message>
     <message id="93" name="HIL_ACTUATOR_CONTROLS">
       <description>Sent from autopilot to simulation. Hardware in the loop control outputs (replacement for HIL_CONTROLS)</description>


### PR DESCRIPTION
Update RSSI values in  [RC_CHANNELS](https://mavlink.io/en/messages/common.html#RC_CHANNELS), [RC_CHANNELS_RAW](https://mavlink.io/en/messages/common.html#RC_CHANNELS_RAW), [RC_CHANNELS_SCALED](https://mavlink.io/en/messages/common.html#RC_CHANNELS_SCALED) to same definition discussed in #1027 (note, RADIO_STATUS already updated).

Fixes #1027

@LorenzMeier @auturgy Please confirm you are happy with this. @auturgy as discussed, this will need to be updated in both PX4 and ArduPilot.