### PR TITLE
Markup reserved values with NaN default values

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2222,7 +2222,7 @@
         <param index="3" label="Pause" minValue="-1" maxValue="1" increment="2">1 to pause triggering, but without switching the camera off or retracting it. -1 to ignore</param>
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE" hasLocation="false" isDestination="false">
-        <description>Starts video capture (recording).</description>      
+        <description>Starts video capture (recording).</description>
         <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams)</param>
         <param index="2" label="Status Frequency" minValue="0" units="Hz">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency)</param>
         <param index="3" reserved="True" default="NaN"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1598,9 +1598,9 @@
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE">
         <description>Set camera running mode. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
         <param index="2" enum="CAMERA_MODE">Camera mode</param>
-        <param index="3" reserved="True" default="NaN" />
-        <param index="4" reserved="True" default="NaN" />
-        <param index="7" reserved="True" default="NaN" />
+        <param index="3" reserved="True" default="NaN"/>
+        <param index="4" reserved="True" default="NaN"/>
+        <param index="7" reserved="True" default="NaN"/>
       </entry>
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
         <wip/>
@@ -1608,9 +1608,9 @@
         <description>Set camera zoom. Camera must respond with a CAMERA_SETTINGS message (on success).</description>
         <param index="1" enum="CAMERA_ZOOM_TYPE">Zoom type</param>
         <param index="2">Zoom value. The range of valid values depend on the zoom type.</param>
-        <param index="3" reserved="True" default="NaN" />
-        <param index="4" reserved="True" default="NaN" />
-        <param index="7" reserved="True" default="NaN" />
+        <param index="3" reserved="True" default="NaN"/>
+        <param index="4" reserved="True" default="NaN"/>
+        <param index="7" reserved="True" default="NaN"/>
       </entry>
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
         <wip/>
@@ -1618,9 +1618,9 @@
         <description>Set camera focus. Camera must respond with a CAMERA_SETTINGS message (on success).</description>
         <param index="1" enum="SET_FOCUS_TYPE">Focus type</param>
         <param index="2">Focus value</param>
-        <param index="3" reserved="True" default="NaN" />
-        <param index="4" reserved="True" default="NaN" />
-        <param index="7" reserved="True" default="NaN" />
+        <param index="3" reserved="True" default="NaN"/>
+        <param index="4" reserved="True" default="NaN"/>
+        <param index="7" reserved="True" default="NaN"/>
       </entry>
       <entry value="600" name="MAV_CMD_JUMP_TAG">
         <description>Tagged jump target. Can be jumped to with MAV_CMD_DO_JUMP_TAG.</description>
@@ -1641,20 +1641,20 @@
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
         <description>Stop image capture sequence.</description>
-        <param index="2" reserved="True" default="NaN" />
-        <param index="3" reserved="True" default="NaN" />
-        <param index="4" reserved="True" default="NaN" />
-        <param index="7" reserved="True" default="NaN" />
+        <param index="2" reserved="True" default="NaN"/>
+        <param index="3" reserved="True" default="NaN"/>
+        <param index="4" reserved="True" default="NaN"/>
+        <param index="7" reserved="True" default="NaN"/>
       </entry>
       <entry value="2002" name="MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Re-request a CAMERA_IMAGE_CAPTURE message.</description>
         <param index="1">Sequence number for missing CAMERA_IMAGE_CAPTURE message</param>
-        <param index="2" reserved="True" default="NaN" />
-        <param index="3" reserved="True" default="NaN" />
-        <param index="4" reserved="True" default="NaN" />
-        <param index="7" reserved="True" default="NaN" />
+        <param index="2" reserved="True" default="NaN"/>
+        <param index="3" reserved="True" default="NaN"/>
+        <param index="4" reserved="True" default="NaN"/>
+        <param index="7" reserved="True" default="NaN"/>
       </entry>
       <entry value="2003" name="MAV_CMD_DO_TRIGGER_CONTROL">
         <description>Enable or disable on-board camera triggering system.</description>
@@ -1666,17 +1666,17 @@
         <description>Starts video capture (recording). Use NaN for reserved values.</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams)</param>
         <param index="2" label="Status Frequency" minValue="0" units="Hz">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency in Hz)</param>
-        <param index="3" reserved="True" default="NaN" />
-        <param index="4" reserved="True" default="NaN" />
-        <param index="7" reserved="True" default="NaN" />
+        <param index="3" reserved="True" default="NaN"/>
+        <param index="4" reserved="True" default="NaN"/>
+        <param index="7" reserved="True" default="NaN"/>
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
         <description>Stop the current video capture (recording).</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams)</param>
-        <param index="2" reserved="True" default="NaN" />
-        <param index="3" reserved="True" default="NaN" />
-        <param index="4" reserved="True" default="NaN" />
-        <param index="7" reserved="True" default="NaN" />
+        <param index="2" reserved="True" default="NaN"/>
+        <param index="3" reserved="True" default="NaN"/>
+        <param index="4" reserved="True" default="NaN"/>
+        <param index="7" reserved="True" default="NaN"/>
       </entry>
       <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING">
         <wip/>
@@ -1726,12 +1726,12 @@
         <description/>
         <param index="1">Landing gear ID (default: 0, -1 for all)</param>
         <param index="2">Landing gear position (Down: 0, Up: 1, NaN for no change)</param>
-        <param index="2" reserved="True" default="NaN" />
-        <param index="3" reserved="True" default="NaN" />
-        <param index="4" reserved="True" default="NaN" />
+        <param index="2" reserved="True" default="NaN"/>
+        <param index="3" reserved="True" default="NaN"/>
+        <param index="4" reserved="True" default="NaN"/>
         <param index="5">Reserved, set to NaN</param>
         <param index="6">Reserved, set to NaN</param>
-        <param index="7" reserved="True" default="NaN" />
+        <param index="7" reserved="True" default="NaN"/>
       </entry>
       <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY">
         <description>Request to start/stop transmitting over the high latency telemetry</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1596,26 +1596,31 @@
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE">
-        <description>Set camera running mode. Use NaN for reserved values. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
-        <param index="1">Reserved (Set to 0)</param>
+        <description>Set camera running mode. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
         <param index="2" enum="CAMERA_MODE">Camera mode</param>
-        <param index="3">Reserved (all remaining params)</param>
+        <param index="3" reserved="True" default="NaN" />
+        <param index="4" reserved="True" default="NaN" />
+        <param index="7" reserved="True" default="NaN" />
       </entry>
       <entry value="531" name="MAV_CMD_SET_CAMERA_ZOOM">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera zoom. Camera must respond with a CAMERA_SETTINGS message (on success). Use NaN for reserved values.</description>
+        <description>Set camera zoom. Camera must respond with a CAMERA_SETTINGS message (on success).</description>
         <param index="1" enum="CAMERA_ZOOM_TYPE">Zoom type</param>
         <param index="2">Zoom value. The range of valid values depend on the zoom type.</param>
-        <param index="3">Reserved (all remaining params)</param>
+        <param index="3" reserved="True" default="NaN" />
+        <param index="4" reserved="True" default="NaN" />
+        <param index="7" reserved="True" default="NaN" />
       </entry>
       <entry value="532" name="MAV_CMD_SET_CAMERA_FOCUS">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Set camera focus. Camera must respond with a CAMERA_SETTINGS message (on success). Use NaN for reserved values.</description>
+        <description>Set camera focus. Camera must respond with a CAMERA_SETTINGS message (on success).</description>
         <param index="1" enum="SET_FOCUS_TYPE">Focus type</param>
         <param index="2">Focus value</param>
-        <param index="3">Reserved (all remaining params)</param>
+        <param index="3" reserved="True" default="NaN" />
+        <param index="4" reserved="True" default="NaN" />
+        <param index="7" reserved="True" default="NaN" />
       </entry>
       <entry value="600" name="MAV_CMD_JUMP_TAG">
         <description>Tagged jump target. Can be jumped to with MAV_CMD_DO_JUMP_TAG.</description>
@@ -1635,16 +1640,21 @@
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
-        <description>Stop image capture sequence Use NaN for reserved values.</description>
-        <param index="1">Reserved (Set to 0)</param>
-        <param index="2">Reserved (all remaining params)</param>
+        <description>Stop image capture sequence.</description>
+        <param index="2" reserved="True" default="NaN" />
+        <param index="3" reserved="True" default="NaN" />
+        <param index="4" reserved="True" default="NaN" />
+        <param index="7" reserved="True" default="NaN" />
       </entry>
       <entry value="2002" name="MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Re-request a CAMERA_IMAGE_CAPTURE message. Use NaN for reserved values.</description>
+        <description>Re-request a CAMERA_IMAGE_CAPTURE message.</description>
         <param index="1">Sequence number for missing CAMERA_IMAGE_CAPTURE message</param>
-        <param index="2">Reserved (all remaining params)</param>
+        <param index="2" reserved="True" default="NaN" />
+        <param index="3" reserved="True" default="NaN" />
+        <param index="4" reserved="True" default="NaN" />
+        <param index="7" reserved="True" default="NaN" />
       </entry>
       <entry value="2003" name="MAV_CMD_DO_TRIGGER_CONTROL">
         <description>Enable or disable on-board camera triggering system.</description>
@@ -1656,40 +1666,41 @@
         <description>Starts video capture (recording). Use NaN for reserved values.</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams)</param>
         <param index="2" label="Status Frequency" minValue="0" units="Hz">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency in Hz)</param>
-        <param index="3">Reserved (all remaining params)</param>
+        <param index="3" reserved="True" default="NaN" />
+        <param index="4" reserved="True" default="NaN" />
+        <param index="7" reserved="True" default="NaN" />
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
-        <description>Stop the current video capture (recording). Use NaN for reserved values.</description>
+        <description>Stop the current video capture (recording).</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams)</param>
-        <param index="2">Reserved (all remaining params)</param>
+        <param index="2" reserved="True" default="NaN" />
+        <param index="3" reserved="True" default="NaN" />
+        <param index="4" reserved="True" default="NaN" />
+        <param index="7" reserved="True" default="NaN" />
       </entry>
       <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Start video streaming</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
-        <param index="2">Reserved</param>
       </entry>
       <entry value="2503" name="MAV_CMD_VIDEO_STOP_STREAMING">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Stop the given video stream</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
-        <param index="2">Reserved</param>
       </entry>
       <entry value="2504" name="MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Request video stream information (VIDEO_STREAM_INFORMATION)</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
-        <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2505" name="MAV_CMD_REQUEST_VIDEO_STREAM_STATUS">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Request video stream status (VIDEO_STREAM_STATUS)</description>
         <param index="1" label="Stream ID" minValue="0">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
-        <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2510" name="MAV_CMD_LOGGING_START">
         <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
@@ -1715,11 +1726,12 @@
         <description/>
         <param index="1">Landing gear ID (default: 0, -1 for all)</param>
         <param index="2">Landing gear position (Down: 0, Up: 1, NaN for no change)</param>
-        <param index="3">Reserved, set to NaN</param>
-        <param index="4">Reserved, set to NaN</param>
+        <param index="2" reserved="True" default="NaN" />
+        <param index="3" reserved="True" default="NaN" />
+        <param index="4" reserved="True" default="NaN" />
         <param index="5">Reserved, set to NaN</param>
         <param index="6">Reserved, set to NaN</param>
-        <param index="7">Reserved, set to NaN</param>
+        <param index="7" reserved="True" default="NaN" />
       </entry>
       <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY">
         <description>Request to start/stop transmitting over the high latency telemetry</description>


### PR DESCRIPTION
There was previously no formal way to markup reserved parameters and define their default. The definition is now such that:
- if you omit a parameter then it is considered reserved with a default of zero
- you can mark up a parameter as reserved with a default of NaN using: `<param index="3" reserved="True" default="NaN" />`

This PR updates the small number of params that previously just stated "all params are NaN".

Note, params 5,6 also marked as reserved/NAN. This means the message can ONLY be sent in the float variant of the command, because obviously you can't have a NaN in an int field.