### PR TITLE
Fixed typo

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2866,7 +2866,7 @@
         <description>Craft is mildly concerned about this threat</description>
       </entry>
       <entry value="2" name="MAV_COLLISION_THREAT_LEVEL_HIGH">
-        <description>Craft is panicing, and may take actions to avoid threat</description>
+        <description>Craft is panicking, and may take actions to avoid threat</description>
       </entry>
     </enum>
     <enum name="MAV_COLLISION_SRC">


### PR DESCRIPTION
Minor modification to MAV_COLLISION_THREAT_LEVEL_HIGH message description.
-Fixed typo panicing -> panicking