### PR TITLE
Add SATCOM_LINK_STATUS status to ASLUAV

### DIFF
--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -270,5 +270,16 @@
       <field type="uint8_t" name="sinr_ecio">SINR (LTE) or ECIO (WCDMA) as reported by modem (unconverted)</field>
       <field type="uint8_t" name="rsrq">RSRQ (LTE only) as reported by modem (unconverted)</field>
     </message>
+    <message id="214" name="SATCOM_LINK_STATUS">
+      <description>Status of the SatCom link</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
+      <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session</field>
+      <field type="uint16_t" name="failed_sessions"> Number of failed sessions </field>
+      <field type="uint16_t" name="successful_sessions"> Number of successful sessions </field>
+      <field type="uint8_t" name="signal_quality"> Signal quality </field>
+      <field type="uint8_t" name="ring_pending"> Ring call pending </field>
+      <field type="uint8_t" name="tx_session_pending"> Transmission session pending </field>
+      <field type="uint8_t" name="rx_session_pending"> Receiving session pending </field>
+    </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -274,12 +274,12 @@
       <description>Status of the SatCom link</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
       <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session</field>
-      <field type="uint16_t" name="failed_sessions"> Number of failed sessions </field>
-      <field type="uint16_t" name="successful_sessions"> Number of successful sessions </field>
-      <field type="uint8_t" name="signal_quality"> Signal quality </field>
-      <field type="uint8_t" name="ring_pending"> Ring call pending </field>
-      <field type="uint8_t" name="tx_session_pending"> Transmission session pending </field>
-      <field type="uint8_t" name="rx_session_pending"> Receiving session pending </field>
+      <field type="uint16_t" name="failed_sessions">Number of failed sessions</field>
+      <field type="uint16_t" name="successful_sessions">Number of successful sessions</field>
+      <field type="uint8_t" name="signal_quality">Signal quality</field>
+      <field type="uint8_t" name="ring_pending">Ring call pending</field>
+      <field type="uint8_t" name="tx_session_pending">Transmission session pending</field>
+      <field type="uint8_t" name="rx_session_pending">Receiving session pending</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Add a message to transmit the useful information about the status of the SatCom link.

Currently this is only added to ASLUAV because we need to merge it quickly. However, if such a message would be useful for others we could add it as a v2 message to common.