### PR TITLE
script: skip pymavlink install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  
+
+cache: pip
+
 matrix:
   include:
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libxml2-dev libxml2-utils
+
+install:
+  - pip install -U future lxml
+
 script:
   - ./scripts/test.sh
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -61,13 +61,3 @@ then
 fi
 cd "$SRC_DIR/pymavlink/generator/javascript" && npm test
 
-# Run tests
-echo $sep
-echo "QUATERNION TEST"
-echo $sep
-cd "$SRC_DIR"
-pymavlink/tests/test_quaternion.py
-echo "ROTMAT TEST"
-echo $sep
-pymavlink/tests/test_rotmat.py
-echo PASS

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,21 +16,6 @@ cd "$SRC_DIR"
 ./scripts/format_xml.sh -c
 echo PASS
 
-# install
-echo $sep
-echo "PYMAVLINK INSTALL"
-echo $sep
-cd "$SRC_DIR"
-
-user_arg="--user"
-if [ "$TRAVIS" = true ] || [ "$CI" = true ]
-then
-	user_arg=""
-fi
-pip install $user_arg -r pymavlink/requirements.txt
-cd "$SRC_DIR/pymavlink"
-python setup.py build install $user_arg
-
 generate_mavlink() {
     echo $sep
     echo "GENERATING MAVLINK " \
@@ -38,7 +23,7 @@ generate_mavlink() {
     echo "DEFINITION : " "$msg_def"
     echo $sep
     outdir="/tmp/mavlink_${wire_protocol}_${lang}"
-    mavgen.py --lang="${lang}" \
+    pymavlink/tools/mavgen.py --lang="${lang}" \
 	    --wire-protocol "${wire_protocol}" \
 	    --strict-units \
 	    --output="${outdir}" "${msg_def}"


### PR DESCRIPTION
skip useless pymavlink installation.
Pymavink already get its autotest.
Moreover this prevent failure without message when .xml aren't valid as pymavlink try to build then for install.
At least, it allow docker build to use much small image as pymavlink gcc dependency isn't need anymore (save a lot of space, so that is greener ! ;-P )