### PR TITLE
Add ISBD_LINK_STATUS in common

### DIFF
--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -270,16 +270,5 @@
       <field type="uint8_t" name="sinr_ecio">SINR (LTE) or ECIO (WCDMA) as reported by modem (unconverted)</field>
       <field type="uint8_t" name="rsrq">RSRQ (LTE only) as reported by modem (unconverted)</field>
     </message>
-    <message id="214" name="SATCOM_LINK_STATUS">
-      <description>Status of the SatCom link</description>
-      <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
-      <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session</field>
-      <field type="uint16_t" name="failed_sessions">Number of failed sessions</field>
-      <field type="uint16_t" name="successful_sessions">Number of successful sessions</field>
-      <field type="uint8_t" name="signal_quality">Signal quality</field>
-      <field type="uint8_t" name="ring_pending">Ring call pending</field>
-      <field type="uint8_t" name="tx_session_pending">Transmission session pending</field>
-      <field type="uint8_t" name="rx_session_pending">Receiving session pending</field>
-    </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5101,6 +5101,17 @@
       <field type="uint16_t" name="lac">Location area code. If unknown, set to: 0</field>
       <field type="uint32_t" name="cid">Cell ID. If unknown, set to: UINT32_MAX</field>
     </message>
+    <message id="335" name="ISBD_LINK_STATUS">
+      <description>Status of the Iridium SBD link</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
+      <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session</field>
+      <field type="uint16_t" name="failed_sessions">Number of failed sbd sessions</field>
+      <field type="uint16_t" name="successful_sessions">Number of successful sbd sessions</field>
+      <field type="uint8_t" name="signal_quality">Signal quality</field>
+      <field type="uint8_t" name="ring_pending">Ring call pending</field>
+      <field type="uint8_t" name="tx_session_pending">Transmission session pending</field>
+      <field type="uint8_t" name="rx_session_pending">Receiving session pending</field>
+    </message>
     <message id="340" name="UTM_GLOBAL_POSITION">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5102,15 +5102,15 @@
       <field type="uint32_t" name="cid">Cell ID. If unknown, set to: UINT32_MAX</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
-      <description>Status of the Iridium SBD link</description>
-      <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
-      <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session</field>
-      <field type="uint16_t" name="failed_sessions">Number of failed sbd sessions</field>
-      <field type="uint16_t" name="successful_sessions">Number of successful sbd sessions</field>
-      <field type="uint8_t" name="signal_quality">Signal quality</field>
-      <field type="uint8_t" name="ring_pending">Ring call pending</field>
-      <field type="uint8_t" name="tx_session_pending">Transmission session pending</field>
-      <field type="uint8_t" name="rx_session_pending">Receiving session pending</field>
+      <description>Status of the Iridium SBD link.</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
+      <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session. The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
+      <field type="uint16_t" name="failed_sessions">Number of failed SBD sessions.</field>
+      <field type="uint16_t" name="successful_sessions">Number of successful SBD sessions.</field>
+      <field type="uint8_t" name="signal_quality">Signal quality equal to the number of bars displayed on the ISU signal strength indicator. Range is 0 to 5, where 0 indicates no signal and 5 indicates maximum signal strength.</field>
+      <field type="uint8_t" name="ring_pending">1: Ring call pending, 0: No call pending.</field>
+      <field type="uint8_t" name="tx_session_pending">1: Transmission session pending, 0: No transmission session pending.</field>
+      <field type="uint8_t" name="rx_session_pending">1: Receiving session pending, 0: No receiving session pending.</field>
     </message>
     <message id="340" name="UTM_GLOBAL_POSITION">
       <wip/>


### PR DESCRIPTION
Based on the comments on  [PR #1106](https://github.com/mavlink/mavlink/pull/1106) I:

- renamed the SATCOM_LINK_STATUS to ISBD_LINK_STATUS (ISBD = Iridium Short Burst Data)
- gave it an id in the MAVLink2 range

I think it would be nice to have this message in common because it would represent the status of the iridiumsbd driver which is in pixhawk master and thus potentially be helpful for other people outside ASL.
However, I am open to suggestions and if you think it should not be in common we can leave it in the ASLUAV dialect.