### PR TITLE
Deprecate DO_MOUNT_CONTROL_QUAT

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1391,7 +1391,8 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT" hasLocation="false" isDestination="false">
-        <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
+        <deprecated since="2019-05" replaced_by="MAV_CMD_DO_MOUNT_CONTROL"/>
+        <description>(Deprecated) mission command to control a camera or antenna mount, using a quaternion as reference.</description>
         <param index="1" label="Q1">quaternion param q1, w (1 in null-rotation)</param>
         <param index="2" label="Q2">quaternion param q2, x (0 in null-rotation)</param>
         <param index="3" label="Q3">quaternion param q3, y (0 in null-rotation)</param>


### PR DESCRIPTION
The command `DO_MOUNT_CONTROL_QUAT` was added to the spec without need and presumably without ever being implemented by neither gimbal manufacturers nor autopilot software stacks.

In my opinion it is not needed and only creates confusion.

@LorenzMeier you added this in 2014 in this commit, do you have an opinion?
https://github.com/mavlink/mavlink/commit/7d527ff474dd7e4f0ccb9982498e7954e3190597

