### PR TITLE
Document signs for DO_MOUNT_CONTROL

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -700,21 +700,21 @@
     </enum>
     <!-- Camera Mount mode enumeration -->
     <enum name="MAV_MOUNT_MODE">
-      <description>Enumeration of possible mount operation modes</description>
+      <description>Enumeration of camera mount operation modes.</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
-        <description>Load and keep safe position (Roll, Pitch, Yaw) from permanent memory and stop stabilization</description>
+        <description>Retract to safe position and stop stabilization. Use Roll, Pitch, Yaw from MAV_CMD_DO_MOUNT_CONTROL message (if NaN use gimbal defaults).</description>
       </entry>
       <entry value="1" name="MAV_MOUNT_MODE_NEUTRAL">
-        <description>Load and keep neutral position (Roll, Pitch, Yaw) from permanent memory</description>
+        <description>Move to neutral position and stop stabilization. Use Roll, Pitch, Yaw from MAV_CMD_DO_MOUNT_CONTROL message (if NaN use gimbal defaults)</description>
       </entry>
       <entry value="2" name="MAV_MOUNT_MODE_MAVLINK_TARGETING">
         <description>Load neutral position and start MAVLink Roll, Pitch, Yaw control with stabilization</description>
       </entry>
       <entry value="3" name="MAV_MOUNT_MODE_RC_TARGETING">
-        <description>Load neutral position and start RC Roll, Pitch, Yaw control with stabilization</description>
+        <description>Move to neutral position and start RC Roll, Pitch, Yaw control with stabilization</description>
       </entry>
       <entry value="4" name="MAV_MOUNT_MODE_GPS_POINT">
-        <description>Load neutral position and start to point to Lat, Lon, Alt</description>
+        <description>Move to neutral position and start to point to Lat, Lon, Alt</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1311,9 +1311,9 @@
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
         <description>Mission command to control a camera or antenna mount</description>
-        <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input).</param>
-        <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
-        <param index="3">yaw depending on mount mode (degrees or degrees/second depending on yaw input).</param>
+        <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input, positive to point up, negative to point down).</param>
+        <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input, positive to tilt to the right).</param>
+        <param index="3">yaw depending on mount mode (degrees or degrees/second depending on yaw input, positive to turn to the right).</param>
         <param index="4" label="Altitude" units="m">altitude depending on mount mode.</param>
         <param index="5">latitude in degrees * 1E7, set if appropriate mount mode.</param>
         <param index="6">longitude in degrees * 1E7, set if appropriate mount mode.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1310,13 +1310,13 @@
       </entry>
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
-        <description>Mission command to control a camera or antenna mount</description>
-        <param index="1">Pitch in degrees or degrees/second depending on pitch input (positive to point up, negative to point down), use according to mount mode.</param>
-        <param index="2">Roll in degrees or degrees/second depending on roll input (positive to tilt to the right), use according to mount mode.</param>
-        <param index="3">Yaw in degrees or degrees/second depending on yaw input (positive to turn to the right), use according to mount mode.</param>
-        <param index="4" label="Altitude" units="m">Altitude use according to mount mode.</param>
-        <param index="5">Latitude in degrees * 1E7, set if appropriate mount mode.</param>
-        <param index="6">Longitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <description>Mission command to control a camera or antenna mount. How/whether params 1 to 6 are used is defined by the mount mode (param7). </description>
+        <param index="1" label="Pitch">Pitch (positive to point up, negative to point down). The units and frame depend on the mount configuration pitch input setting, MAV_CMD_MOUNT_CONFIGURE.param6: degrees for body and absolute angle frame, and degrees/second for angular rate.</param>
+        <param index="2" label="Roll">Roll (positive to tilt to the right, negative to tilt left). The units and frame depend on the mount configuration roll input setting, MAV_CMD_MOUNT_CONFIGURE.param5: degrees for body and absolute angle frame, and degrees/second for angular rate.</param>
+        <param index="3" label="Yaw">Yaw (positive to turn to the right, negative to turn left). The units and frame depend on the mount configuration roll input setting, MAV_CMD_MOUNT_CONFIGURE.param7: degrees for body and absolute angle frame, and degrees/second for angular rate.</param>
+        <param index="4" label="Altitude" units="m">Altitude.</param>
+        <param index="5" label="Latitude" units="degE7">Latitude.</param>
+        <param index="6"  label="Longitude" units="degE7">Longitude.</param>
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -698,23 +698,23 @@
         <description>Breached fence boundary</description>
       </entry>
     </enum>
-    <!-- Camera Mount mode Enumeration -->
+    <!-- Camera Mount mode enumeration -->
     <enum name="MAV_MOUNT_MODE">
       <description>Enumeration of possible mount operation modes</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
-        <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
+        <description>Load and keep safe position (Roll, Pitch, Yaw) from permanent memory and stop stabilization</description>
       </entry>
       <entry value="1" name="MAV_MOUNT_MODE_NEUTRAL">
-        <description>Load and keep neutral position (Roll,Pitch,Yaw) from permanent memory.</description>
+        <description>Load and keep neutral position (Roll, Pitch, Yaw) from permanent memory</description>
       </entry>
       <entry value="2" name="MAV_MOUNT_MODE_MAVLINK_TARGETING">
-        <description>Load neutral position and start MAVLink Roll,Pitch,Yaw control with stabilization</description>
+        <description>Load neutral position and start MAVLink Roll, Pitch, Yaw control with stabilization</description>
       </entry>
       <entry value="3" name="MAV_MOUNT_MODE_RC_TARGETING">
-        <description>Load neutral position and start RC Roll,Pitch,Yaw control with stabilization</description>
+        <description>Load neutral position and start RC Roll, Pitch, Yaw control with stabilization</description>
       </entry>
       <entry value="4" name="MAV_MOUNT_MODE_GPS_POINT">
-        <description>Load neutral position and start to point to Lat,Lon,Alt</description>
+        <description>Load neutral position and start to point to Lat, Lon, Alt</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1311,12 +1311,12 @@
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
         <description>Mission command to control a camera or antenna mount</description>
-        <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input, positive to point up, negative to point down).</param>
-        <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input, positive to tilt to the right).</param>
-        <param index="3">yaw depending on mount mode (degrees or degrees/second depending on yaw input, positive to turn to the right).</param>
-        <param index="4" label="Altitude" units="m">altitude depending on mount mode.</param>
-        <param index="5">latitude in degrees * 1E7, set if appropriate mount mode.</param>
-        <param index="6">longitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="1">Pitch in degrees or degrees/second depending on pitch input (positive to point up, negative to point down), use according to mount mode.</param>
+        <param index="2">Roll in degrees or degrees/second depending on roll input (positive to tilt to the right), use according to mount mode.</param>
+        <param index="3">Yaw in degrees or degrees/second depending on yaw input (positive to turn to the right), use according to mount mode.</param>
+        <param index="4" label="Altitude" units="m">Altitude use according to mount mode.</param>
+        <param index="5">Latitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="6">Longitude in degrees * 1E7, set if appropriate mount mode.</param>
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">


### PR DESCRIPTION
It was not specified what the signs of the gimbal attitude controls were. This is an attempt to document it. The angles should be consistent with the setpoints used for aircraft in NED as common in MAVLink.