### PR TITLE
Adding an enum to storage info.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -763,8 +763,8 @@
       <entry value="2" name="STORAGE_STATUS_READY">
         <description>Storage present and ready.</description>
       </entry>
-      <entry value="3" name="STORAGE_STATUS_NONE">
-        <description>Storage should be ignored.</description>
+      <entry value="3" name="STORAGE_STATUS_NOT_SUPPORTED">
+        <description>Camera does not supply storage status information. Capacity information in STORAGE_INFORMATION fields will be ignored.</description>
       </entry>
     </enum>
     <!-- The MAV_CMD enum entries describe either: -->
@@ -4824,12 +4824,12 @@
       <field type="float" name="focusLevel">Current focus level (0.0 to 100.0, NaN if not known)</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
-      <description>Information about a storage medium. This message is sent in response to a request or whenever the status of the storage changes.</description>
+      <description>Information about a storage medium. This message is sent in response to a request and whenever the status of the storage changes (STORAGE_STATUS).</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="storage_id">Storage ID (1 for first, 2 for second, etc.)</field>
       <field type="uint8_t" name="storage_count">Number of storage devices</field>
       <field type="uint8_t" name="status" enum="STORAGE_STATUS">Status of storage</field>
-      <field type="float" name="total_capacity" units="MiB">Total capacity.</field>
+      <field type="float" name="total_capacity" units="MiB">Total capacity. If storage is not ready (STORAGE_STATUS_READY) value will be ignored.</field>
       <field type="float" name="used_capacity" units="MiB">Used capacity.</field>
       <field type="float" name="available_capacity" units="MiB">Available storage capacity.</field>
       <field type="float" name="read_speed" units="MiB/s">Read speed.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4830,8 +4830,8 @@
       <field type="uint8_t" name="storage_count">Number of storage devices</field>
       <field type="uint8_t" name="status" enum="STORAGE_STATUS">Status of storage</field>
       <field type="float" name="total_capacity" units="MiB">Total capacity. If storage is not ready (STORAGE_STATUS_READY) value will be ignored.</field>
-      <field type="float" name="used_capacity" units="MiB">Used capacity.</field>
-      <field type="float" name="available_capacity" units="MiB">Available storage capacity.</field>
+      <field type="float" name="used_capacity" units="MiB">Used capacity. If storage is not ready (STORAGE_STATUS_READY) value will be ignored.</field>
+      <field type="float" name="available_capacity" units="MiB">Available storage capacity. If storage is not ready (STORAGE_STATUS_READY) value will be ignored.</field>
       <field type="float" name="read_speed" units="MiB/s">Read speed.</field>
       <field type="float" name="write_speed" units="MiB/s">Write speed.</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -752,6 +752,21 @@
         <description>The node is no longer available online.</description>
       </entry>
     </enum>
+    <enum name="STORAGE_STATUS">
+      <description>Flags to indicate the status of camera storage.</description>
+      <entry value="0" name="STORAGE_STATUS_EMPTY">
+        <description>Storage is missing (no microSD card loaded for example.)</description>
+      </entry>
+      <entry value="1" name="STORAGE_STATUS_UNFORMATTED">
+        <description>Storage present but unformatted.</description>
+      </entry>
+      <entry value="2" name="STORAGE_STATUS_READY">
+        <description>Storage present and ready.</description>
+      </entry>
+      <entry value="3" name="STORAGE_STATUS_NONE">
+        <description>Storage should be ignored.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM and MISSION_ITEM_INT messages) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -4809,11 +4824,11 @@
       <field type="float" name="focusLevel">Current focus level (0.0 to 100.0, NaN if not known)</field>
     </message>
     <message id="261" name="STORAGE_INFORMATION">
-      <description>Information about a storage medium.</description>
+      <description>Information about a storage medium. This message is sent in response to a request or whenever the status of the storage changes.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="storage_id">Storage ID (1 for first, 2 for second, etc.)</field>
       <field type="uint8_t" name="storage_count">Number of storage devices</field>
-      <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
+      <field type="uint8_t" name="status" enum="STORAGE_STATUS">Status of storage</field>
       <field type="float" name="total_capacity" units="MiB">Total capacity.</field>
       <field type="float" name="used_capacity" units="MiB">Used capacity.</field>
       <field type="float" name="available_capacity" units="MiB">Available storage capacity.</field>


### PR DESCRIPTION
Following a [conversation here](https://github.com/mavlink/qgroundcontrol/issues/7434), I've added an enum to indicate the status of the (camera) storage. One more status was added: ~**None**~ **Not Supported**. That indicates that storage should be ignored (the camera is capable of functioning without it).

I've also added a description telling this message is not only sent in response to a request but also whenever the status of the storage changes. This is for notifying the GS of events such as microSD card inserted/removed, storage formatted, etc.