### PR TITLE
common: add ACCELERATION message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5036,6 +5036,13 @@
       <field type="uint16_t" name="lac">Location area code. If unknown, set to: 0</field>
       <field type="uint32_t" name="cid">Cell ID. If unknown, set to: UINT32_MAX</field>
     </message>
+    <message id="335" name="ACCELERATION">
+      <description>Linear acceleration in the local coordinate system.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
+      <field type="float" name="ax" units="m/s/s">X acceleration</field>
+      <field type="float" name="ay" units="m/s/s">Y acceleration</field>
+      <field type="float" name="az" units="m/s/s">Z acceleration</field>
+    </message>
     <message id="340" name="UTM_GLOBAL_POSITION">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->


### PR DESCRIPTION
Common messages set totally lacks the vehicle acceleration data report. And the only message consisting it, `LOCAL_POSITION_NED_COV` was [refused](https://github.com/PX4/Firmware/pull/11081#issuecomment-449159099) by PX4, as its large size, as one of the reasons.

But this data is useful for the estimator debugging. It’s important to know, what the estimator thinks of the vehicle accelerations in the local coordinate frame, to figure out, why the estimated velocity and position acts one or other way.

This PR proposes adding very small and simple message with the accelerations data (as they were computed/considered by the estimator).

@mhkabir, @TSC21