### PR TITLE
Add a constant to MAV_AUTOPILOT for a COEX Pelican charging station

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -65,6 +65,9 @@
       <entry value="19" name="MAV_AUTOPILOT_AIRRAILS">
         <description>AirRails - http://uaventure.com</description>
       </entry>
+      <entry value="20" name="MAV_AUTOPILOT_COEX_CS">
+        <description>COEX Pelican charging station - http://copterexpress.com/pelican</description>
+      </entry>
     </enum>
     <enum name="MAV_TYPE">
       <description>MAVLINK system type. All components in a system should report this type in their HEARTBEAT.</description>


### PR DESCRIPTION
COEX develops a MAVLink-compatible charging station which is configurable through QGroundControl. For a better integration we need a MAV_AUTOPILOT constant for our project instead of using MAV_AUTOPILOT_GENERIC.