### PR TITLE
Manual Control add 4 more joystick axes (channels 5-8)

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3696,6 +3696,11 @@
       <field type="int16_t" name="z">Z-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a separate slider movement with maximum being 1000 and minimum being -1000 on a joystick and the thrust of a vehicle. Positive values are positive thrust, negative values are negative thrust.</field>
       <field type="int16_t" name="r">R-axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Generally corresponds to a twisting of the joystick, with counter-clockwise being 1000 and clockwise being -1000, and the yaw of a vehicle.</field>
       <field type="uint16_t" name="buttons">A bitfield corresponding to the joystick buttons' current state, 1 for pressed, 0 for released. The lowest bit corresponds to Button 1.</field>
+      <extensions/>
+      <field type="int16_t" name="chan5">axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Corresponds to movement on joystick channel 5</field>
+      <field type="int16_t" name="chan6">axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Corresponds to movement on joystick channel 6</field>
+      <field type="int16_t" name="chan7">axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Corresponds to movement on joystick channel 7</field>
+      <field type="int16_t" name="chan8">axis, normalized to the range [-1000,1000]. A value of INT16_MAX indicates that this axis is invalid. Corresponds to movement on joystick channel 8</field>
     </message>
     <message id="70" name="RC_CHANNELS_OVERRIDE">
       <description>The RAW values of the RC channels sent to the MAV to override info received from the RC radio. A value of UINT16_MAX means no change to that channel. A value of 0 means control of that channel should be released back to the RC radio. The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%. Individual receivers/transmitters might violate this specification.</description>


### PR DESCRIPTION
Proposal to extend the manual_control MAVLink message for extra channels. See [RFC 0015 - Mavlink MANUAL_CONTROL message extension PR](https://github.com/mavlink/rfcs/pull/16)