### PR TITLE
LINK_NODE_STATUS.rx_parse_err: Clarify units

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3291,7 +3291,7 @@
       <field type="uint8_t" name="rx_buf" units="%">Remaining free receive buffer space</field>
       <field type="uint32_t" name="tx_rate" units="bytes/s">Transmit rate</field>
       <field type="uint32_t" name="rx_rate" units="bytes/s">Receive rate</field>
-      <field type="uint16_t" name="rx_parse_err">Number of bytes that could not be parsed correctly</field>
+      <field type="uint16_t" name="rx_parse_err" units="bytes">Number of bytes that could not be parsed correctly.</field>
       <field type="uint16_t" name="tx_overflows">Transmit buffer overflows. This number wraps around as it reaches UINT16_MAX</field>
       <field type="uint16_t" name="rx_overflows">Receive buffer overflows. This number wraps around as it reaches UINT16_MAX</field>
       <field type="uint32_t" name="messages_sent">Messages sent</field>


### PR DESCRIPTION
Units were missing. These are clearly bytes, so I will self merge.