### PR TITLE
Clarify LINK_NODE_STATUS.tx_overflows and .rx_overflow

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3292,8 +3292,8 @@
       <field type="uint32_t" name="tx_rate" units="bytes/s">Transmit rate</field>
       <field type="uint32_t" name="rx_rate" units="bytes/s">Receive rate</field>
       <field type="uint16_t" name="rx_parse_err" units="bytes">Number of bytes that could not be parsed correctly.</field>
-      <field type="uint16_t" name="tx_overflows">Transmit buffer overflows. This number wraps around as it reaches UINT16_MAX</field>
-      <field type="uint16_t" name="rx_overflows">Receive buffer overflows. This number wraps around as it reaches UINT16_MAX</field>
+      <field type="uint16_t" name="tx_overflows" units="bytes">Transmit buffer overflows. This number wraps around as it reaches UINT16_MAX</field>
+      <field type="uint16_t" name="rx_overflows" units="bytes">Receive buffer overflows. This number wraps around as it reaches UINT16_MAX</field>
       <field type="uint32_t" name="messages_sent">Messages sent</field>
       <field type="uint32_t" name="messages_received">Messages received (estimated from counting seq)</field>
       <field type="uint32_t" name="messages_lost">Messages lost (estimated from counting seq)</field>


### PR DESCRIPTION
This PR assumes that overflows are measured in bytes. Please confirm.