### PR TITLE
add waypoint type extension to TRAJECTORY_REPRESENTATION_WAYPOINT

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5077,6 +5077,7 @@
       <field type="float[5]" name="acc_z" units="m/s/s">Z-acceleration of waypoint, set to NaN if not being used</field>
       <field type="float[5]" name="pos_yaw" units="rad">Yaw angle, set to NaN if not being used</field>
       <field type="float[5]" name="vel_yaw" units="rad/s">Yaw rate, set to NaN if not being used</field>
+      <field type="uint16_t[5]" name="command" enum="MAV_CMD">Scheduled action for each waypoint, UINT16_MAX if not being used.</field>
     </message>
     <message id="333" name="TRAJECTORY_REPRESENTATION_BEZIER">
       <wip/>


### PR DESCRIPTION
This PR adds the ability to add the type associated with each waypoint e.g. land, takeoff.... 
This information is available also in the mission item however the two messages aren't synchronized in ROS.  