### PR TITLE
Fix typo in MAV_CMD_DO_FOLLOW description

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -894,7 +894,7 @@
         <param index="7">Altitude</param>
       </entry>
       <entry value="32" name="MAV_CMD_DO_FOLLOW" hasLocation="false" isDestination="false">
-        <description>Being following a target</description>
+        <description>Begin following a target</description>
         <param index="1" label="System ID" minValue="0" maxValue="255" increment="1">System ID (of the FOLLOW_TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode.</param>
         <param index="2">RESERVED</param>
         <param index="3">RESERVED</param>


### PR DESCRIPTION
Found a minor typo while looking through some message definitions: I assume "_Being_ following a target" should be "_Begin_ following a target". (https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FOLLOW)

I felt it would be overkill to open an issue for this so there is no connected issue to this PR.