### PR TITLE
Add OpenDroneID messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3470,6 +3470,8 @@
       </entry>
       <entry value="2" name="MAV_ODID_LOCATION_SRC_FIXED">
         <description>The location of the remote pilot is a fixed location.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3226,6 +3226,247 @@
         <description>Release parachute.</description>
       </entry>
     </enum>
+    <enum name="MAV_ODID_IDTYPE">
+      <entry value="0" name="MAV_ODID_IDTYPE_NONE">
+        <description>No type defined.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_IDTYPE_SERIAL_NUMBER">
+        <description>Manufacturer Serial Number (ANSI/CTA-2063 format).</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_IDTYPE_CAA_ASSIGNED_ID">
+        <description>CAA (Civil Aviation Authority) assigned ID. Format: [ICAO Country Code].[CAA Assigned ID]</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_IDTYPE_UTM_ASSIGNED_ID">
+        <description>UTM (Unmanned Traffic Management) assigned ID (UUID RFC4122).</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_UATYPE">
+      <entry value="0" name="MAV_ODID_UATYPE_NONE">
+        <description>No UA (Unmanned Aircraft) type defined.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_UATYPE_AEROPLANE">
+        <description>Aeroplane/Airplane.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_UATYPE_ROTORCRAFT">
+        <description>Rotorcraft (including Multirotor).</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_UATYPE_GYROPLANE">
+        <description>Gyroplane.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_UATYPE_VTOL">
+        <description>VTOL (Vertical Take-Off and Landing). Fixed wing aircraft that can take off vertically.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_UATYPE_ORNITHOPTER">
+        <description>Ornithopter.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_UATYPE_GLIDER">
+        <description>Glider.</description>
+      </entry>
+      <entry value="7" name="MAV_ODID_UATYPE_KITE">
+        <description>Kite.</description>
+      </entry>
+      <entry value="8" name="MAV_ODID_UATYPE_FREE_BALLOON">
+        <description>Free Balloon.</description>
+      </entry>
+      <entry value="9" name="MAV_ODID_UATYPE_CAPTIVE_BALLOON">
+        <description>Captive Balloon.</description>
+      </entry>
+      <entry value="10" name="MAV_ODID_UATYPE_AIRSHIP">
+        <description>Airship.</description>
+      </entry>
+      <entry value="11" name="MAV_ODID_UATYPE_FREE_FALL_PARACHUTE">
+        <description>Free Fall/Parachute.</description>
+      </entry>
+      <entry value="12" name="MAV_ODID_UATYPE_ROCKET">
+        <description>Rocket.</description>
+      </entry>
+      <entry value="13" name="MAV_ODID_UATYPE_GROUND_OBSTACLE">
+        <description>Ground Obstacle.</description>
+      </entry>
+      <entry value="14" name="MAV_ODID_UATYPE_RESERVED">
+        <description>Reserved.</description>
+      </entry>
+      <entry value="15" name="MAV_ODID_UATYPE_OTHER">
+        <description>Other type of aircraft not listed earlier.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_STATUS">
+      <entry value="0" name="MAV_ODID_STATUS_UNDECLARED">
+        <description>The status of the (UA) Unmanned Aircraft is undefined.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_STATUS_GROUND">
+        <description>The UA is on the ground.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_STATUS_AIRBORNE">
+        <description>The UA is in the air.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_HEIGHT_REF">
+      <entry value="0" name="MAV_ODID_HEIGHT_REF_OVER_TAKEOFF">
+        <description>The height field is relative to the take-off location.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_HEIGHT_REF_OVER_GROUND">
+        <description>The height field is relative to ground.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_HOR_ACC">
+      <entry value="0" name="MAV_ODID_HOR_ACC_UNKNOWN">
+        <description>The horizontal accuracy is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_HOR_ACC_10NM">
+        <description>The horizontal accuracy is smaller than 10 Nautical Miles.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_HOR_ACC_4NM">
+        <description>The horizontal accuracy is smaller than 4 Nautical Miles.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_HOR_ACC_2NM">
+        <description>The horizontal accuracy is smaller than 2 Nautical Miles.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_HOR_ACC_1NM">
+        <description>The horizontal accuracy is smaller than 1 Nautical Miles.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_HOR_ACC_0_5NM">
+        <description>The horizontal accuracy is smaller than 0.5 Nautical Miles.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_HOR_ACC_0_3NM">
+        <description>The horizontal accuracy is smaller than 0.3 Nautical Miles.</description>
+      </entry>
+      <entry value="7" name="MAV_ODID_HOR_ACC_0_1NM">
+        <description>The horizontal accuracy is smaller than 0.1 Nautical Miles.</description>
+      </entry>
+      <entry value="8" name="MAV_ODID_HOR_ACC_0_05NM">
+        <description>The horizontal accuracy is smaller than 0.05 Nautical Miles.</description>
+      </entry>
+      <entry value="9" name="MAV_ODID_HOR_ACC_30_METER">
+        <description>The horizontal accuracy is smaller than 30 meter.</description>
+      </entry>
+      <entry value="10" name="MAV_ODID_HOR_ACC_10_METER">
+        <description>The horizontal accuracy is smaller than 10 meter.</description>
+      </entry>
+      <entry value="11" name="MAV_ODID_HOR_ACC_3_METER">
+        <description>The horizontal accuracy is smaller than 3 meter.</description>
+      </entry>
+      <entry value="12" name="MAV_ODID_HOR_ACC_1_METER">
+        <description>The horizontal accuracy is smaller than 1 meter.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_VER_ACC">
+      <entry value="0" name="MAV_ODID_VER_ACC_UNKNOWN">
+        <description>The vertical accuracy is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_VER_ACC_150_METER">
+        <description>The vertical accuracy is smaller than 150 meter.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_VER_ACC_45_METER">
+        <description>The vertical accuracy is smaller than 45 meter.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_VER_ACC_25_METER">
+        <description>The vertical accuracy is smaller than 25 meter.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_VER_ACC_10_METER">
+        <description>The vertical accuracy is smaller than 10 meter.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_VER_ACC_3_METER">
+        <description>The vertical accuracy is smaller than 3 meter.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_VER_ACC_1_METER">
+        <description>The vertical accuracy is smaller than 1 meter.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_SPEED_ACC">
+      <entry value="0" name="MAV_ODID_SPEED_ACC_UNKNOWN">
+        <description>The speed accuracy is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_SPEED_ACC_10_METER_PER_SECOND">
+        <description>The speed accuracy is smaller than 10 meter per second.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_SPEED_ACC_3_METER_PER_SECOND">
+        <description>The speed accuracy is smaller than 3 meter per second.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_SPEED_ACC_1_METER_PER_SECOND">
+        <description>The speed accuracy is smaller than 1 meter per second.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_SPEED_ACC_0_3_METER_PER_SECOND">
+        <description>The speed accuracy is smaller than 0.3 meter per second.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_TIME_ACC">
+      <entry value="0" name="MAV_ODID_TIME_ACC_UNKNOWN">
+        <description>The timestamp accuracy is unknown.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_TIME_ACC_0_1_SECOND">
+        <description>The timestamp accuracy is smaller than 0.1 second.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_TIME_ACC_0_2_SECOND">
+        <description>The timestamp accuracy is smaller than 0.2 second.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_TIME_ACC_0_3_SECOND">
+        <description>The timestamp accuracy is smaller than 0.3 second.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_TIME_ACC_0_4_SECOND">
+        <description>The timestamp accuracy is smaller than 0.4 second.</description>
+      </entry>
+      <entry value="5" name="MAV_ODID_TIME_ACC_0_5_SECOND">
+        <description>The timestamp accuracy is smaller than 0.5 second.</description>
+      </entry>
+      <entry value="6" name="MAV_ODID_TIME_ACC_0_6_SECOND">
+        <description>The timestamp accuracy is smaller than 0.6 second.</description>
+      </entry>
+      <entry value="7" name="MAV_ODID_TIME_ACC_0_7_SECOND">
+        <description>The timestamp accuracy is smaller than 0.7 second.</description>
+      </entry>
+      <entry value="8" name="MAV_ODID_TIME_ACC_0_8_SECOND">
+        <description>The timestamp accuracy is smaller than 0.8 second.</description>
+      </entry>
+      <entry value="9" name="MAV_ODID_TIME_ACC_0_9_SECOND">
+        <description>The timestamp accuracy is smaller than 0.9 second.</description>
+      </entry>
+      <entry value="10" name="MAV_ODID_TIME_ACC_1_0_SECOND">
+        <description>The timestamp accuracy is smaller than 1.0 second.</description>
+      </entry>
+      <entry value="11" name="MAV_ODID_TIME_ACC_1_1_SECOND">
+        <description>The timestamp accuracy is smaller than 1.1 second.</description>
+      </entry>
+      <entry value="12" name="MAV_ODID_TIME_ACC_1_2_SECOND">
+        <description>The timestamp accuracy is smaller than 1.2 second.</description>
+      </entry>
+      <entry value="13" name="MAV_ODID_TIME_ACC_1_3_SECOND">
+        <description>The timestamp accuracy is smaller than 1.3 second.</description>
+      </entry>
+      <entry value="14" name="MAV_ODID_TIME_ACC_1_4_SECOND">
+        <description>The timestamp accuracy is smaller than 1.4 second.</description>
+      </entry>
+      <entry value="15" name="MAV_ODID_TIME_ACC_1_5_SECOND">
+        <description>The timestamp accuracy is smaller than 1.5 second.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_AUTH">
+      <entry value="0" name="MAV_ODID_AUTH_NONE">
+        <description>No authentication type is specified.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_AUTH_MPUID">
+        <description>Manufacturer Programmed Unique ID.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_DESC_TYPE">
+      <entry value="0" name="MAV_ODID_DESC_TYPE_TEXT">
+        <description>Free-form text description of the purpose of the flight.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_DESC_TYPE_REMOTE_PILOT_ID">
+        <description>Remote pilot ID as assigned by the Civil Aviation Authority.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_LOCATION_SRC">
+      <entry value="0" name="MAV_ODID_LOCATION_SRC_TAKEOFF">
+        <description>The location of the remote pilot is the same as the take-off location.</description>
+      </entry>
+      <entry value="1" name="MAV_ODID_LOCATION_SRC_LIVE_GNSS">
+        <description>The location of the remote pilot is based on live GNSS data.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_LOCATION_SRC_FIXED">
+        <description>The location of the remote pilot is a fixed location.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">
@@ -5220,6 +5461,62 @@
       <field type="uint64_t" name="time_usec" units="us">Timestamp (synced to UNIX time or since system boot).</field>
       <field type="uint8_t" name="count">Number of wheels reported.</field>
       <field type="double[16]" name="distance" units="m">Distance reported by individual wheel encoders. Forward rotations increase values, reverse rotations decrease them. Not all wheels will necessarily have wheel encoders; the mapping of encoders to wheel positions must be agreed/understood by the endpoints.</field>
+    </message>
+    <message id="12900" name="OPEN_DRONE_ID_BASIC_ID">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Basic ID message.</description>
+      <field type="uint8_t" name="id_type" enum="MAV_ODID_IDTYPE">Indicates the format for the uas_id field of this message.</field>
+      <field type="uint8_t" name="ua_type" enum="MAV_ODID_UATYPE">Indicates the type of UA (Unmanned Aircraft).</field>
+      <field type="uint8_t[20]" name="uas_id">UAS ID following the format specified by id_type. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <message id="12901" name="OPEN_DRONE_ID_LOCATION">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Location message. The float data types are 32-bit IEEE 754. The Location message provides the location, altitude, direction and speed of the aircraft.</description>
+      <field type="uint8_t" name="status" enum="MAV_ODID_STATUS">Indicates whether the Unmanned Aircraft is on the ground or in the air.</field>
+      <field type="uint16_t" name="direction" units="cdeg">Direction over ground (not heading, but direction of movement) in degrees * 100: 0.0 - 359.99 degrees.</field>
+      <field type="uint16_t" name="speed_horizontal" units="cm/s">Ground speed.</field>
+      <field type="int16_t" name="speed_vertical" units="cm/s">The vertical speed. Up is positive.</field>
+      <field type="int32_t" name="latitude" units="degE7">Current latitude of the UA.</field>
+      <field type="int32_t" name="longitude" units="degE7">Current longitude of the UA.</field>
+      <field type="float" name="altitude_barometric" units="m">The altitude calculated from the barometric pressue. Reference is against 29.92inHg or 1013.2mb.</field>
+      <field type="float" name="altitude_geodetic" units="m">The geodetic altitude as defined by WGS84.</field>
+      <field type="uint8_t" name="height_reference" enum="MAV_ODID_HEIGHT_REF">Indicates the reference point for the height field.</field>
+      <field type="float" name="height" units="m">The current height of the UA above the take-off location or the ground as indicated by height_reference.</field>
+      <field type="uint8_t" name="horizontal_accuracy" enum="MAV_ODID_HOR_ACC">The accuracy of the horizontal position.</field>
+      <field type="uint8_t" name="vertical_accuracy" enum="MAV_ODID_VER_ACC">The accuracy of the vertical position.</field>
+      <field type="uint8_t" name="barometer_accuracy" enum="MAV_ODID_VER_ACC">The accuracy of the barometric altitude.</field>
+      <field type="uint8_t" name="speed_accuracy" enum="MAV_ODID_SPEED_ACC">The accuracy of the horizontal and vertical speed.</field>
+      <field type="float" name="timestamp" units="s">Seconds after the full hour. Typically the GPS outputs a time of week value in milliseconds. That value can be easily converted for this field using ((float) (time_week_ms % (60*60*1000))) / 1000.</field>
+      <field type="uint8_t" name="timestamp_accuracy" enum="MAV_ODID_TIME_ACC">The accuracy of the timestamps.</field>
+    </message>
+    <message id="12902" name="OPEN_DRONE_ID_AUTHENTICATION">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Authentication message. The Authentication Message defines a field that can provide a means of authenticity for the identity of the UAS (Unmanned Aircraft System) sending the message.</description>
+      <field type="uint8_t" name="authentication_type" enum="MAV_ODID_AUTH">Indicates the type of authentication.</field>
+      <field type="uint8_t" name="data_page">Allowed range is 0 - 15.</field>
+      <field type="uint8_t[23]" name="authentication_data">Opaque authentication data. Sixteen pages are supported for a total of 16 * 23 = 368 bytes. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <message id="12903" name="OPEN_DRONE_ID_SELFID">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Self-ID message. The Self-ID Message is an opportunity for the Remote Pilot to (optionally) declare their identity and purpose of the flight. This message can provide additional information that could reduce the threat profile of a UA flying in a particular area or manner.</description>
+      <field type="uint8_t" name="description_type" enum="MAV_ODID_DESC_TYPE">Indicates the type of the description field.</field>
+      <field type="char[23]" name="description">Text description or numeric value expressed as ASCII characters. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <message id="12904" name="OPEN_DRONE_ID_SYSTEM">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID System message. The System Message contains general system information including the remote pilot location and possible aircraft group information.</description>
+      <field type="uint8_t" name="flags" enum="MAV_ODID_LOCATION_SRC">Specifies the location source for the remote pilot location.</field>
+      <field type="int32_t" name="remote_pilot_latitude" units="degE7">Latitude of the remote pilot.</field>
+      <field type="int32_t" name="remote_pilot_longitude" units="degE7">Longitude of the remote pilot.</field>
+      <field type="uint16_t" name="group_count">Number of aircraft in group or formation (default 0).</field>
+      <field type="uint16_t" name="group_radius" units="m">Radius of cylindrical area of group or formation (default 0).</field>
+      <field type="float" name="group_ceiling" units="m">Group Operations Ceiling relative to WGS84.</field>
+      <field type="float" name="group_floor" units="m">Group Operations Floor relative to WGS84.</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Add five new Mavlink messages to match the content of the
Open Drone ID messages.

This will make it easy to transmit the relevant data for
Open Drone ID implementations, instead of sending
multiple Mavlink messages that only partly contains the
necessary data fields.

See also https://github.com/opendroneid/opendroneid-core-c

Signed-off-by: Soren Friis <soren.friis@intel.com>