### PR TITLE
New gimbal messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -667,7 +667,7 @@
         <description>Servo #14.</description>
       </entry>
       <entry value="154" name="MAV_COMP_ID_GIMBAL">
-        <description>Gimbal #1.</description>
+        <description>Gimbal component #1.</description>
       </entry>
       <entry value="155" name="MAV_COMP_ID_LOG">
         <description>Logging component.</description>
@@ -689,19 +689,19 @@
         <description>FLARM collision alert component.</description>
       </entry>
       <entry value="171" name="MAV_COMP_ID_GIMBAL2">
-        <description>Gimbal #2.</description>
+        <description>Gimbal component #2.</description>
       </entry>
       <entry value="172" name="MAV_COMP_ID_GIMBAL3">
-        <description>Gimbal #3.</description>
+        <description>Gimbal component #3.</description>
       </entry>
       <entry value="173" name="MAV_COMP_ID_GIMBAL4">
-        <description>Gimbal #4</description>
+        <description>Gimbal component. #4</description>
       </entry>
       <entry value="174" name="MAV_COMP_ID_GIMBAL5">
-        <description>Gimbal #5.</description>
+        <description>Gimbal component #5.</description>
       </entry>
       <entry value="175" name="MAV_COMP_ID_GIMBAL6">
-        <description>Gimbal #6.</description>
+        <description>Gimbal component #6.</description>
       </entry>
       <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
         <description>Component that can generate/supply a mission flight plan (e.g. GCS or developer API).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -667,7 +667,7 @@
         <description>Servo #14.</description>
       </entry>
       <entry value="154" name="MAV_COMP_ID_GIMBAL">
-        <description>Gimbal component #1.</description>
+        <description>Gimbal #1.</description>
       </entry>
       <entry value="155" name="MAV_COMP_ID_LOG">
         <description>Logging component.</description>
@@ -689,19 +689,19 @@
         <description>FLARM collision alert component.</description>
       </entry>
       <entry value="171" name="MAV_COMP_ID_GIMBAL2">
-        <description>Gimbal component #2.</description>
+        <description>Gimbal #2.</description>
       </entry>
       <entry value="172" name="MAV_COMP_ID_GIMBAL3">
-        <description>Gimbal component #3.</description>
+        <description>Gimbal #3.</description>
       </entry>
       <entry value="173" name="MAV_COMP_ID_GIMBAL4">
-        <description>Gimbal component. #4</description>
+        <description>Gimbal #4</description>
       </entry>
       <entry value="174" name="MAV_COMP_ID_GIMBAL5">
-        <description>Gimbal component #5.</description>
+        <description>Gimbal #5.</description>
       </entry>
       <entry value="175" name="MAV_COMP_ID_GIMBAL6">
-        <description>Gimbal component #6.</description>
+        <description>Gimbal #6.</description>
       </entry>
       <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
         <description>Component that can generate/supply a mission flight plan (e.g. GCS or developer API).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6027,7 +6027,7 @@
       <description>High level message to control a gimbal's attitude. This message is to be sent to the gimbal manager (e.g. from a ground station). Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uin32t_t" enum="GIMBAL_MANAGER_FLAGS">High level gimbal manager flags to use.</field>
+      <field type="uint32_t" enum="GIMBAL_MANAGER_FLAGS">High level gimbal manager flags to use.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_MANAGER_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1004,6 +1004,27 @@
         <description>Gimbal tracks system with specified system ID</description>
       </entry>
     </enum>
+    <enum name="GIMBAL_CAP_FLAGS">
+      <description>Gimbal capability flags (Bitmap)</description>
+      <entry value="1" name="GIMBAL_CAP_FLAGS_HAS_RETRACT">
+        <description>Gimbal supports a retracted position</description>
+      </entry>
+      <entry value="2" name="GIMBAL_CAP_FLAGS_HAS_NEUTRAL">
+        <description>Gimbal supports a neutral, not-stabilized position</description>
+      </entry>
+      <entry value="4" name="GIMBAL_CAP_FLAGS_HAS_YAW_FOLLOW">
+        <description>Gimbal supports to follow a yaw angle relative to the vehicle</description>
+      </entry>
+      <entry value="8" name="GIMBAL_CAP_FLAGS_HAS_YAW_LOCK">
+        <description>Gimbal supports locking to an absolute heading</description>
+      </entry>
+      <entry value="16" name="GIMBAL_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
+        <description>Gimbal supports to point to a local position</description>
+      </entry>
+      <entry value="32" name="GIMBAL_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
+        <description>Gimbal supports to point to a global GPS position</description>
+      </entry>
+    </enum>
     <enum name="MAV_GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
       <entry value="0" name="MAV_GIMBAL_MODE_RETRACT">
@@ -5890,7 +5911,15 @@
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
     </message>
-    <message id="280" name="GIMBAL_CONTROL_ATTITUDE">
+    <message id="280" name="GIMBAL_INFORMATION">
+      <description>Information about a gimbal</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t[32]" name="vendor_name">Name of the gimbal vendor</field>
+      <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
+      <field type="uint32_t" name="firmware_version">Version of the gimbal firmware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_CAP_FLAGS">Bitmap of gimbal capability flags.</field>
+    </message>
+    <message id="281" name="GIMBAL_CONTROL_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message to control a gimbal's attitude. This message is to be sent by the autopilot to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
@@ -5904,7 +5933,7 @@
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
     </message>
-    <message id="281" name="GIMBAL_CONTROL_LOCATION_GLOBAL">
+    <message id="282" name="GIMBAL_CONTROL_LOCATION_GLOBAL">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message to control a gimbal to point to a GPS point. This message is to be sent by the autopilot to the gimbal component.</description>
@@ -5914,7 +5943,7 @@
       <field type="int32_t" name="lon" units="degE7">Longitude where gimbal should point to</field>
       <field type="int32_t" name="alt" units="mm">Altitude (MSL) where gimbal should point to</field>
     </message>
-    <message id="282" name="GIMBAL_CONTROL_LOCATION_LOCAL">
+    <message id="283" name="GIMBAL_CONTROL_LOCATION_LOCAL">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message to control a gimbal to point to a local position. This message is to be sent by the autopilot to the gimbal component.</description>
@@ -5924,7 +5953,7 @@
       <field type="float" name="y" units="m">Y position of location in the local coordinate frame NED</field>
       <field type="float" name="z" units="m">Z position of location in the local coordinate frame NED</field>
     </message>
-    <message id="283" name="GIMBAL_CONTROL_STATUS_ATTITUDE">
+    <message id="284" name="GIMBAL_CONTROL_STATUS_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message reporting the status of a gimbal. This message can be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1760,7 +1760,7 @@
       </entry>
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
-        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_ATTITUDE">This message is ambiguous and inconsistent. It has been replaced by MAV_CMD_DO_GIMBAL_ATTITUDE and MAV_CMD_DO_SET_ROI_*.</deprecated>
+        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is ambiguous and inconsistent. It has been replaced by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE and MAV_CMD_DO_SET_ROI_*.</deprecated>
         <description>Mission command to control a camera or antenna mount</description>
         <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input).</param>
         <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
@@ -1842,7 +1842,7 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT" hasLocation="false" isDestination="false">
-        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_ATTITUDE"/>
+        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE"/>
         <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
         <param index="1" label="Q1">quaternion param q1, w (1 in null-rotation)</param>
         <param index="2" label="Q2">quaternion param q2, x (0 in null-rotation)</param>
@@ -2095,7 +2095,7 @@
         <param index="1" label="Tag" minValue="0" increment="1">Target tag to jump to.</param>
         <param index="2" label="Repeat" minValue="0" increment="1">Repeat count.</param>
       </entry>
-      <entry value="1000" name="MAV_CMD_DO_GIMBAL_ATTITUDE" hasLocation="false" isDestination="false">
+      <entry value="1000" name="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>High level setpoint to be sent to a gimbal manager to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: a gimbal is never to react to this command but only the gimbal manager.</description>
@@ -2106,7 +2106,7 @@
         <param index="5" label="Gimbal mode" enum="GIMBAL_MANAGER_MODE">Gimbal controller mode.</param>
         <param index="6" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
-      <entry value="1001" name="MAV_CMD_DO_GIMBAL_TRACK_POINT" hasLocation="false" isDestination="false">
+      <entry value="1001" name="MAV_CMD_DO_GIMBAL_MANAGER_TRACK_POINT" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>If the gimbal manager supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking.</description>
@@ -2115,7 +2115,7 @@
         <param index="3" label="Point 2 x" minValue="0" maxValue="1">Pitch/tilt angular rate (positive to point up).</param>
         <param index="4" label="Point 2 y" minValue="0" maxValue="1">Yaw/pan angular rate (positive to pan to the right).</param>
       </entry>
-      <entry value="1002" name="MAV_CMD_DO_GIMBAL_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
+      <entry value="1002" name="MAV_CMD_DO_GIMBAL_MANAGER_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>If the gimbal supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), this command allows to initiate the tracking.</description>
@@ -5937,7 +5937,7 @@
       <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of log files</field>
     </message>
     <message id="265" name="MOUNT_ORIENTATION">
-      <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_ATTITUDE">This message is being replaced by MAV_CMD_DO_GIMBAL_ATTITUDE.</deprecated>
+      <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is being replaced by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE.</deprecated>
       <description>Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="roll" units="deg">Roll in global frame (set to NaN for invalid).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1722,9 +1722,9 @@
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
-        <param index="5">Latitude (deg * 1E7)</param>
-        <param index="6">Longitude (deg * 1E7)</param>
-        <param index="7">Altitude (meters)</param>
+        <param index="5" label="Latitude" units="degE7">Latitude of ROI location (deg * 1E7)</param>
+        <param index="6" label="Longitude" units="degE7">Longitude of ROI location (deg * 1E7)</param>
+        <param index="7" label="Altitude" units="m">Altitude of ROI location (meters)</param>
       </entry>
       <entry value="196" name="MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET" hasLocation="false" isDestination="false">
         <description>Sets the region of interest (ROI) to be toward next waypoint, with optional pitch/roll/yaw offset. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal device. A gimbal device is not to react to this message.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -983,7 +983,7 @@
     </enum>
     <!-- Camera Mount mode Enumeration -->
     <enum name="MAV_MOUNT_MODE">
-      <deprecated since="2019-07" replaced_by="GIMBAL_MANAGER_MODE"/>
+      <deprecated since="2019-07" replaced_by="GIMBAL_MANAGER_FLAGS"/>
       <description>Enumeration of possible mount operation modes</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
         <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
@@ -1005,123 +1005,129 @@
       </entry>
     </enum>
     <enum name="GIMBAL_CAP_FLAGS">
-      <description>Gimbal low level capability flags (Bitmap)</description>
+      <description>Gimbal low level capability flags (bitmap)</description>
       <entry value="1" name="GIMBAL_CAP_FLAGS_HAS_RETRACT">
         <description>Gimbal supports a retracted position</description>
       </entry>
       <entry value="2" name="GIMBAL_CAP_FLAGS_HAS_NEUTRAL">
         <description>Gimbal supports a horizontal, forward looking position, stabilized</description>
       </entry>
-      <entry value="4" name="GIMBAL_CAP_FLAGS_HAS_YAW_FOLLOW">
-        <description>Gimbal supports to follow a yaw angle relative to the vehicle</description>
+      <entry value="4" name="GIMBAL_CAP_FLAGS_HAS_ROLL_FOLLOW">
+        <description>Gimbal supports to follow a roll angle relative to the vehicle</description>
       </entry>
-      <entry value="8" name="GIMBAL_CAP_FLAGS_HAS_YAW_LOCK">
-        <description>Gimbal supports locking to an absolute heading</description>
+      <entry value="8" name="GIMBAL_CAP_FLAGS_HAS_ROLL_LOCK">
+        <description>Gimbal supports locking to an roll angle (generally that's the default with roll stabilized)</description>
       </entry>
-      <entry value="16" name="GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
-        <description>Gimbal supports yawing infinetely (e.g. using slip disk).</description>
+      <entry value="16" name="GIMBAL_CAP_FLAGS_HAS_PITCH_FOLLOW">
+        <description>Gimbal supports to follow a pitch angle relative to the vehicle</description>
+      </entry>
+      <entry value="32" name="GIMBAL_CAP_FLAGS_HAS_PITCH_LOCK">
+        <description>Gimbal supports locking to an pitch angle (generally that's the default with pitch stabilized)</description>
+      </entry>
+      <entry value="64" name="GIMBAL_CAP_FLAGS_HAS_YAW_FOLLOW">
+        <description>Gimbal supports to follow a yaw angle relative to the vehicle (generally that's the default)</description>
+      </entry>
+      <entry value="128" name="GIMBAL_CAP_FLAGS_HAS_YAW_LOCK">
+        <description>Gimbal supports locking to an absolute heading (often this is an option available)</description>
+      </entry>
+      <entry value="256" name="GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+        <description>Gimbal supports yawing/panning infinetely (e.g. using slip disk).</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_CAP_FLAGS">
-      <description>Gimbal high level capability flags (Bitmap)</description>
+      <description>Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_CAP_FLAGS which are identical with GIMBAL_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>
       <entry value="1" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_RETRACT">
-        <description>Gimbal supports a retracted position</description>
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_RETRACT</description>
       </entry>
       <entry value="2" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_NEUTRAL">
-        <description>Gimbal supports a horizontal, forward looking position, stabilized</description>
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_NEUTRAL</description>
       </entry>
-      <entry value="4" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_FOLLOW">
-        <description>Gimbal supports to follow a yaw angle relative to the vehicle</description>
+      <entry value="4" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_FOLLOW">
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_ROLL_FOLLOW</description>
       </entry>
-      <entry value="8" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_LOCK">
-        <description>Gimbal supports locking to an absolute heading</description>
+      <entry value="8" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_LOCK">
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_ROLL_LOCK</description>
       </entry>
-      <entry value="16" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
-        <description>Gimbal supports yawing infinetely (e.g. using slip disk).</description>
+      <entry value="16" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_FOLLOW">
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_PITCH_FOLLOW</description>
       </entry>
-      <entry value="32" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
-        <description>Gimbal supports to point to a local position</description>
+      <entry value="32" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_FOLLOW">
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_PITCH_FOLLOW</description>
       </entry>
-      <entry value="64" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
-        <description>Gimbal supports to point to a global latitude, longitude, altitude position</description>
+      <entry value="64" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_FOLLOW">
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_YAW_FOLLOW</description>
       </entry>
-      <entry value="128" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT">
-        <description>Gimbal supports tracking of a point on the camera</description>
+      <entry value="128" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_LOCK">
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_YAW_LOCK</description>
       </entry>
-      <entry value="256" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
-        <description>Gimbal supports tracking of a point on the camera</description>
+      <entry value="256" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+        <description>Based on GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW</description>
       </entry>
-      <entry value="512" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE">
-        <description>Gimbal supports pitching and yawing at an angular velocity scaled by focal length (the more zoomed in, the slower the movement).</description>
+      <entry value="65536" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
+        <description>Gimbal manager supports to point to a local position</description>
       </entry>
-      <entry value="1024" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_NUDGING">
-        <description>Gimbal supports nudging when pointing to a location or tracking</description>
+      <entry value="131072" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
+        <description>Gimbal manager supports to point to a global latitude, longitude, altitude position</description>
       </entry>
-      <entry value="2048" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_OVERRIDE">
-        <description>Gimbal supports overriding when pointing to a location or tracking</description>
+      <entry value="262144" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT">
+        <description>Gimbal manager supports tracking of a point on the camera</description>
       </entry>
-    </enum>
-    <enum name="GIMBAL_MODE">
-      <description>Enumeration of possible low level gimbal operation modes (used between gimbal manager and gimbal)</description>
-      <entry value="0" name="GIMBAL_MODE_RETRACT">
-        <description>Set to retracted safe position (no stabilization)</description>
+      <entry value="524288" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
+        <description>Gimbal manager supports tracking of a point on the camera</description>
       </entry>
-      <entry value="1" name="GIMBAL_MODE_NEUTRAL">
-        <description>Set to neutral position (horizontal, forward looking, with stabilization)</description>
+      <entry value="1048576" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE">
+        <description>Gimbal manager supports pitching and yawing at an angular velocity scaled by focal length (the more zoomed in, the slower the movement).</description>
       </entry>
-      <entry value="2" name="GIMBAL_MODE_YAW_FOLLOW">
-        <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
+      <entry value="2097152" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_NUDGING">
+        <description>Gimbal manager supports nudging when pointing to a location or tracking</description>
       </entry>
-      <entry value="3" name="GIMBAL_MODE_YAW_LOCK">
-        <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
+      <entry value="4194304" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_OVERRIDE">
+        <description>Gimbal manager supports overriding when pointing to a location or tracking</description>
       </entry>
     </enum>
-    <enum name="GIMBAL_MANAGER_MODE">
-      <description>Enumeration of high level possible gimbal operation modes</description>
-      <entry value="0" name="GIMBAL_MANAGER_MODE_NONE">
-        <description>Give up control over gimbal and let GIMBAL_CONTROL_ATTITUDE takeover again (can e.g. be used after a mission is finished)</description>
+    <enum name="GIMBAL_FLAGS">
+      <description>Flags for lower level gimbal operation.</description>
+      <entry value="1" name="GIMBAL_FLAGS_RETRACT">
+        <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
       </entry>
-      <entry value="1" name="GIMBAL_MANAGER_MODE_RETRACT">
-        <description>Set to retracted safe position (no stabilization)</description>
+      <entry value="2" name="GIMBAL_FLAGS_NEUTRAL">
+        <description>Set to neutral position (horizontal, forward looking, with stabiliziation), takes presedence over all other flags except RETRACT.</description>
       </entry>
-      <entry value="2" name="GIMBAL_MANAGER_MODE_NEUTRAL">
-        <description>Set to neutral position (horizontal, forward looking, with stabilization)</description>
+      <entry value="4" name="GIMBAL_FLAGS_ROLL_LOCK">
+        <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>
       </entry>
-      <entry value="3" name="GIMBAL_MANAGER_MODE_YAW_FOLLOW">
-        <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
+      <entry value="8" name="GIMBAL_FLAGS_PITCH_LOCK">
+        <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
       </entry>
-      <entry value="4" name="GIMBAL_MANAGER_MODE_YAW_LOCK">
-        <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
+      <entry value="16" name="GIMBAL_FLAGS_YAW_LOCK">
+        <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_FLAGS">
-      <description>Flags for gimbal high level operation.</description>
+      <description>Flags for high level gimbal manager operation The first 16 bytes are identical to the GIMBAL_FLAGS.</description>
       <entry value="1" name="GIMBAL_MANAGER_FLAGS_RETRACT">
-        <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
+        <description>Based on GIMBAL_FLAGS_RETRACT</description>
       </entry>
       <entry value="2" name="GIMBAL_MANAGER_FLAGS_NEUTRAL">
-        <description>Set to neutral position (horizontal, forward looking, with stabiliziation), takes presedence over all other flags except RETRACT.</description>
+        <description>Based on GIMBAL_FLAGS_NEUTRAL</description>
       </entry>
       <entry value="4" name="GIMBAL_MANAGER_FLAGS_ROLL_LOCK">
-        <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>
+        <description>Based on GIMBAL_FLAGS_ROLL_LOCK</description>
       </entry>
       <entry value="8" name="GIMBAL_MANAGER_FLAGS_PITCH_LOCK">
-        <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
+        <description>Based on GIMBAL_FLAGS_PITCH_LOCK</description>
       </entry>
       <entry value="16" name="GIMBAL_MANAGER_FLAGS_YAW_LOCK">
-        <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+        <description>Based on GIMBAL_FLAGS_YAW_LOCK</description>
       </entry>
-      <entry value="32" name="GIMBAL_MANAGER_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
-        <description>Scale angular velocity relative to focal length. This means the gimbal should move slower if it is zoomed in.</description>
+      <entry value="1048576" name="GIMBAL_MANAGER_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
+        <description>Scale angular velocity relative to focal length. This means the gimbal moves slower if it is zoomed in.</description>
       </entry>
-      <entry value="64" name="GIMBAL_MANAGER_FLAGS_NUDGE">
+      <entry value="2097152" name="GIMBAL_MANAGER_FLAGS_NUDGE">
         <description>Interpret attitude control on top of pointing to a location or tracking. If this flag is set, the quaternion is relative to the existing tracking angle.</description>
       </entry>
-      <entry value="128" name="GIMBAL_MANAGER_FLAGS_OVERRIDE">
-        <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_CONTROL_FLAGS_YAW_LOCK.</description>
-      </entry>
-      <entry value="256" name="GIMBAL_MANAGER_FLAGS_SCALE_BY_FOCAL_LENGTH">
-        <description>Set if the angular velocity control should be scaled by focal length (the more zoomed in the slower).</description>
+      <entry value="4194304" name="GIMBAL_MANAGER_FLAGS_OVERRIDE">
+        <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_MANAGER_FLAGS_YAW_LOCK.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
@@ -2092,7 +2098,7 @@
       <entry value="1000" name="MAV_CMD_DO_GIMBAL_ATTITUDE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>High level setpoint to be sent to a gimbal manager to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
+        <description>High level setpoint to be sent to a gimbal manager to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: a gimbal is never to react to this command but only the gimbal manager.</description>
         <param index="1" label="Tilt angular rate" units="deg/s">Tilt/pitch angular rate (positive to point up).</param>
         <param index="2" label="Pan angular rate" units="deg/s">Pan/yaw angular rate (positive to pan to the right).</param>
         <param index="3" label="Tilt angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
@@ -5931,7 +5937,7 @@
       <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of log files</field>
     </message>
     <message id="265" name="MOUNT_ORIENTATION">
-      <deprecated since="2019-07" replaced_by="GIMBAL_CONTROL_STATUS_ATTITUDE">This message is being replaced by GIMBAL_CONTROL_STATUS_ATTITUDE.</deprecated>
+      <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_ATTITUDE">This message is being replaced by MAV_CMD_DO_GIMBAL_ATTITUDE.</deprecated>
       <description>Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="roll" units="deg">Roll in global frame (set to NaN for invalid).</field>
@@ -5995,9 +6001,11 @@
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
     </message>
     <message id="280" name="GIMBAL_MANAGER_INFORMATION">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about a high level gimbal manager</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
-      <field type="uint32_t" name="flags" enum="GIMBAL_MANAGER_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
+      <field type="uint32_t" name="cap_flags" enum="GIMBAL_MANAGER_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
       <field type="uint8_t" name="gimbal_component">Gimbal component ID that this gimbal manager is responsible for.</field>
       <field type="float" name="tilt_max" units="rad">Maximum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_min" units="rad">Minimum tilt/pitch angle (positive: up, negative: down)</field>
@@ -6006,13 +6014,34 @@
       <field type="float" name="pan_min" units="rad">Minimum pan/yaw angle (positive: to the right, negative: to the left)</field>
       <field type="float" name="pan_rate_max" units="rad/s">Minimum pan/yaw angular rate (positive: to the right, negative: to the left)</field>
     </message>
-    <message id="281" name="GIMBAL_INFORMATION">
+    <message id="281" name="GIMBAL_MANAGER_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Current status about a high level gimbal manager</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_MANAGER_FLAGS">High level gimbal manager flags currently applied.</field>
+    </message>
+    <message id="282" name="GIMBAL_MANAGER_SET_ATTITUDE">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>High level message to control a gimbal's attitude. This message is to be sent to the gimbal manager (e.g. from a ground station). Angles and rates can be set to NaN according to use case.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uin32t_t" enum="GIMBAL_MANAGER_FLAGS">High level gimbal manager flags to use.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_MANAGER_FLAGS_YAW_LOCK is set)</field>
+      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
+    </message>
+    <message id="283" name="GIMBAL_INFORMATION">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about a low level gimbal</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the gimbal vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
       <field type="uint32_t" name="firmware_version">Version of the gimbal firmware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
-      <field type="uint32_t" name="flags" enum="GIMBAL_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
+      <field type="uint16_t" name="cap_flags" enum="GIMBAL_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
       <field type="float" name="tilt_max" units="rad">Maximum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_min" units="rad">Minimum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_rate_max" units="rad/s">Maximum tilt/pitch angular rate (positive: up, negative: down)</field>
@@ -6020,36 +6049,24 @@
       <field type="float" name="pan_min" units="rad">Minimum pan/yaw angle (positive: to the right, negative: to the left)</field>
       <field type="float" name="pan_rate_max" units="rad/s">Minimum pan/yaw angular rate (positive: to the right, negative: to the left)</field>
     </message>
-    <message id="282" name="GIMBAL_MANAGER_SET_ATTITUDE">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>High level message to control a gimbal's attitude. This message is to be sent to the gimbal manager (e.g. from a ground stationi). Angles and rates can be set to NaN according to use case.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="mode" enum="GIMBAL_MANAGER_MODE">High level gimbal manager mode.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
-      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
-      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
-      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
-    </message>
-    <message id="283" name="GIMBAL_SET_ATTITUDE">
+    <message id="284" name="GIMBAL_SET_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Low level message to control a gimbal's attitude. This message is to be sent from the gimbal manager to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="mode" enum="GIMBAL_MODE">Low level gimbal mode.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
+      <field type="uint16_t" name="flags" enum="GIMBAL_FLAGS">Low level gimbal flags.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
     </message>
-    <message id="284" name="GIMBAL_ATTITUDE_STATUS">
+    <message id="285" name="GIMBAL_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message reporting the status of a gimbal. This message should be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
-      <field type="uint16_t" name="mode" enum="GIMBAL_MODE">Current gimbal mode</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
+      <field type="uint16_t" name="flags" enum="GIMBAL_FLAGS">Current gimbal flags set.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1005,7 +1005,6 @@
       </entry>
     </enum>
     <enum name="MAV_GIMBAL_MODE">
-      <wip/>
       <description>Enumeration of possible gimbal operation modes</description>
       <entry value="0" name="MAV_GIMBAL_MODE_RETRACT">
         <description>Set to retracted safe position</description>
@@ -1021,7 +1020,6 @@
       </entry>
     </enum>
     <enum name="MAV_GIMBAL_CONTROL_FLAGS">
-      <wip/>
       <description>Flags for gimbal operation.</description>
       <entry value="1" name="MAV_GIMBAL_CONTROL_FLAG_RETRACT">
         <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5829,6 +5829,7 @@
       <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of log files</field>
     </message>
     <message id="265" name="MOUNT_ORIENTATION">
+      <deprecated since="2019-07" replaced_by="GIMBAL_CONTROL_STATUS_ATTITUDE">This message is being replaced by GIMBAL_CONTROL_STATUS_ATTITUDE.</deprecated>
       <description>Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="roll" units="deg">Roll in global frame (set to NaN for invalid).</field>
@@ -5897,7 +5898,7 @@
       <description>Message to control a gimbal's attitude. This message is to be sent by the autopilot to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="unit16_t" name="flags" enum="MAV_GIMBAL_CONTROL_FLAGS" display="bitmask">Gimbal control flags.</field>
+      <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_FLAGS" display="bitmask">Gimbal control flags.</field>
       <field type="float" name="roll" units="rad">Roll angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK is set, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="pitch" units="rad">Pitch angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK is set, positive tilting up, NaN to be ignored.</field>
       <field type="float" name="yaw" units="rad">Yaw angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_YAW_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_YAW_LOCK is set, positive is paning to the right, NaN to be ignored.</field>
@@ -5917,6 +5918,16 @@
       <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame NED</field>
       <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame NED</field>
       <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame NED</field>
+    </message>
+    <message id="282" name="GIMBAL_CONTROL_STATUS_ATTITUDE">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Message reporting the status of a gimbal. This message can be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
+      <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_FLAGS">Current gimbal control flags</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
+      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
+      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1130,6 +1130,33 @@
         <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_MANAGER_FLAGS_YAW_LOCK.</description>
       </entry>
     </enum>
+    <enum name="GIMBAL_DEVICE_ERROR_FLAGS">
+      <description>Gimbal device (low level) error flags (bitmap, 0 means no error)</description>
+      <entry value="1" name="GIMBAL_DEVICE_ERROR_FLAGS_AT_ROLL_LIMIT">
+        <description>Gimbal device is limited by hardware roll limit.</description>
+      </entry>
+      <entry value="2" name="GIMBAL_DEVICE_ERROR_FLAGS_AT_PITCH_LIMIT">
+        <description>Gimbal device is limited by hardware pitch limit.</description>
+      </entry>
+      <entry value="4" name="GIMBAL_DEVICE_ERROR_FLAGS_AT_YAW_LIMIT">
+        <description>Gimbal device is limited by hardware yaw limit.</description>
+      </entry>
+      <entry value="8" name="GIMBAL_DEVICE_ERROR_FLAGS_ENCODER_ERROR">
+        <description>There is an error with the gimbal encoders.</description>
+      </entry>
+      <entry value="16" name="GIMBAL_DEVICE_ERROR_FLAGS_POWER_ERROR">
+        <description>There is an error with the gimbal power source.</description>
+      </entry>
+      <entry value="32" name="GIMBAL_DEVICE_ERROR_FLAGS_MOTOR_ERROR">
+        <description>There is an error with the gimbal motor's.</description>
+      </entry>
+      <entry value="64" name="GIMBAL_DEVICE_ERROR_FLAGS_SOFTWARE_ERROR">
+        <description>There is an error with the gimbal's software.</description>
+      </entry>
+      <entry value="128" name="GIMBAL_DEVICE_ERROR_FLAGS_COMMS_ERROR">
+        <description>There is an error with the gimbal's communication.</description>
+      </entry>
+    </enum>
     <!-- UAVCAN node health enumeration -->
     <enum name="UAVCAN_NODE_HEALTH">
       <description>Generalized UAVCAN node health</description>
@@ -6071,6 +6098,7 @@
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>
+      <field type="uint32" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1033,6 +1033,12 @@
       <entry value="256" name="GIMBAL_CAP_FLAGS_HAS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
         <description>Gimbal supports turning at angular velocities relative to the focal length (the more zoomed in, the slower the movement)</description>
       </entry>
+      <entry value="512" name="GIMBAL_CAP_FLAGS_SUPPORTS_NUDGING">
+        <description>Gimbal supports nudging when pointing to a location or tracking</description>
+      </entry>
+      <entry value="1024" name="GIMBAL_CAP_FLAGS_SUPPORTS_OVERRIDE">
+        <description>Gimbal supports overriding when pointing to a location or tracking</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
@@ -1068,6 +1074,12 @@
       </entry>
       <entry value="32" name="GIMBAL_CONTROL_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
         <description>Scale angular velocity relative to focal length. This means the gimbal should move slower if it is zoomed in.</description>
+      </entry>
+      <entry value="64" name="GIMBAL_CONTROL_FLAGS_NUDGE">
+        <description>Interpret attitude control on top of pointing to a location or tracking. If this flag is set, the quaternion is relative to the existing tracking angle.</description>
+      </entry>
+      <entry value="128" name="GIMBAL_CONTROL_FLAGS_OVERRIDE">
+        <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_CONTROL_FLAGS_YAW_LOCK.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1121,7 +1121,7 @@
         <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_CONTROL_FLAGS_YAW_LOCK.</description>
       </entry>
       <entry value="256" name="GIMBAL_CONTROL_FLAGS_SCALE_BY_FOCAL_LENGTH">
-        <description>Set if the angular velocity control should be scaled by focal length (the more zoomed in the slower). This requires GIMBAL_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE.</description>
+        <description>Set if the angular velocity control should be scaled by focal length (the more zoomed in the slower).</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1747,8 +1747,9 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="198" name="MAV_CMD_DO_SET_ROI_SYSID">
-        <description>Mount tracks system with specified system ID. Determination of target vehicle position may be done with GLOBAL_POSITION_INT or any other means.</description>
+        <description>Mount tracks system with specified system ID. Determination of target vehicle position may be done with GLOBAL_POSITION_INT or any other means. This command can be sent to a gimbal manager but not to a gimbal device. A gimbal device is not to react to this message.</description>
         <param index="1" label="System ID" minValue="1" maxValue="255" increment="1">sysid</param>
+        <param index="2" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="200" name="MAV_CMD_DO_CONTROL_VIDEO" hasLocation="false" isDestination="false">
         <description>Control onboard camera system.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5926,9 +5926,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_FLAGS" display="bitmask">Gimbal control flags.</field>
-      <field type="float" name="roll" units="rad">Roll angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK is set, positive is banking to the right, NaN to be ignored.</field>
-      <field type="float" name="pitch" units="rad">Pitch angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK is set, positive tilting up, NaN to be ignored.</field>
-      <field type="float" name="yaw" units="rad">Yaw angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_YAW_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_YAW_LOCK is set, positive is paning to the right, NaN to be ignored.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1988,11 +1988,13 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
-        <param index="1" units="rad" minValue="-1.57" maxValue="1.57">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
-        <param index="2" units="rad" minValue="-3.14" maxValue="3.14">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
-        <param index="3" units="rad/s">Pitch/tilt angular rate (positive to point up).</param>
-        <param index="4" units="rad/s">Yaw/pan angular rate (positive to pan to the right).</param>
-        <param index="5" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
+        <param index="1" units="rad">Roll angle relative to world horizon (positive to turn to the right).</param>
+        <param index="2" units="rad">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
+        <param index="3" units="rad">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+        <param index="4" units="rad/s">Roll angular rate (positive to turn to the right).</param>
+        <param index="5" units="rad/s">Pitch/tilt angular rate (positive to point up).</param>
+        <param index="6" units="rad/s">Yaw/pan angular rate (positive to pan to the right).</param>
+        <param index="7" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1051,8 +1051,8 @@
       <entry value="16" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_FOLLOW">
         <description>Based on GIMBAL_CAP_FLAGS_HAS_PITCH_FOLLOW</description>
       </entry>
-      <entry value="32" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_FOLLOW">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_PITCH_FOLLOW</description>
+      <entry value="32" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_LOCK">
+        <description>Based on GIMBAL_CAP_FLAGS_HAS_PITCH_LOCK</description>
       </entry>
       <entry value="64" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_FOLLOW">
         <description>Based on GIMBAL_CAP_FLAGS_HAS_YAW_FOLLOW</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1004,64 +1004,64 @@
         <description>Gimbal tracks system with specified system ID</description>
       </entry>
     </enum>
-    <enum name="GIMBAL_CAP_FLAGS">
-      <description>Gimbal low level capability flags (bitmap)</description>
-      <entry value="1" name="GIMBAL_CAP_FLAGS_HAS_RETRACT">
-        <description>Gimbal supports a retracted position</description>
+    <enum name="GIMBAL_DEVICE_CAP_FLAGS">
+      <description>Gimbal device (low level) capability flags (bitmap)</description>
+      <entry value="1" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT">
+        <description>Gimbal device supports a retracted position</description>
       </entry>
-      <entry value="2" name="GIMBAL_CAP_FLAGS_HAS_NEUTRAL">
-        <description>Gimbal supports a horizontal, forward looking position, stabilized</description>
+      <entry value="2" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_NEUTRAL">
+        <description>Gimbal device supports a horizontal, forward looking position, stabilized</description>
       </entry>
-      <entry value="4" name="GIMBAL_CAP_FLAGS_HAS_ROLL_FOLLOW">
-        <description>Gimbal supports to follow a roll angle relative to the vehicle</description>
+      <entry value="4" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_FOLLOW">
+        <description>Gimbal device supports to follow a roll angle relative to the vehicle</description>
       </entry>
-      <entry value="8" name="GIMBAL_CAP_FLAGS_HAS_ROLL_LOCK">
-        <description>Gimbal supports locking to an roll angle (generally that's the default with roll stabilized)</description>
+      <entry value="8" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_LOCK">
+        <description>Gimbal device supports locking to an roll angle (generally that's the default with roll stabilized)</description>
       </entry>
-      <entry value="16" name="GIMBAL_CAP_FLAGS_HAS_PITCH_FOLLOW">
-        <description>Gimbal supports to follow a pitch angle relative to the vehicle</description>
+      <entry value="16" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_FOLLOW">
+        <description>Gimbal device supports to follow a pitch angle relative to the vehicle</description>
       </entry>
-      <entry value="32" name="GIMBAL_CAP_FLAGS_HAS_PITCH_LOCK">
-        <description>Gimbal supports locking to an pitch angle (generally that's the default with pitch stabilized)</description>
+      <entry value="32" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_LOCK">
+        <description>Gimbal device supports locking to an pitch angle (generally that's the default with pitch stabilized)</description>
       </entry>
-      <entry value="64" name="GIMBAL_CAP_FLAGS_HAS_YAW_FOLLOW">
-        <description>Gimbal supports to follow a yaw angle relative to the vehicle (generally that's the default)</description>
+      <entry value="64" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW">
+        <description>Gimbal device supports to follow a yaw angle relative to the vehicle (generally that's the default)</description>
       </entry>
-      <entry value="128" name="GIMBAL_CAP_FLAGS_HAS_YAW_LOCK">
-        <description>Gimbal supports locking to an absolute heading (often this is an option available)</description>
+      <entry value="128" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK">
+        <description>Gimbal device supports locking to an absolute heading (often this is an option available)</description>
       </entry>
-      <entry value="256" name="GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
-        <description>Gimbal supports yawing/panning infinetely (e.g. using slip disk).</description>
+      <entry value="256" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+        <description>Gimbal device supports yawing/panning infinetely (e.g. using slip disk).</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_CAP_FLAGS">
-      <description>Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_CAP_FLAGS which are identical with GIMBAL_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>
+      <description>Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_DEVICE_CAP_FLAGS which are identical with GIMBAL_DEVICE_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>
       <entry value="1" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_RETRACT">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_RETRACT</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT</description>
       </entry>
       <entry value="2" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_NEUTRAL">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_NEUTRAL</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_NEUTRAL</description>
       </entry>
       <entry value="4" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_FOLLOW">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_ROLL_FOLLOW</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_FOLLOW</description>
       </entry>
       <entry value="8" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_LOCK">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_ROLL_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_LOCK</description>
       </entry>
       <entry value="16" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_FOLLOW">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_PITCH_FOLLOW</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_FOLLOW</description>
       </entry>
       <entry value="32" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_LOCK">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_PITCH_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_LOCK</description>
       </entry>
       <entry value="64" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_FOLLOW">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_YAW_FOLLOW</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW</description>
       </entry>
       <entry value="128" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_LOCK">
-        <description>Based on GIMBAL_CAP_FLAGS_HAS_YAW_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK</description>
       </entry>
       <entry value="256" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
-        <description>Based on GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW</description>
       </entry>
       <entry value="65536" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
         <description>Gimbal manager supports to point to a local position</description>
@@ -1085,40 +1085,40 @@
         <description>Gimbal manager supports overriding when pointing to a location or tracking</description>
       </entry>
     </enum>
-    <enum name="GIMBAL_FLAGS">
-      <description>Flags for lower level gimbal operation.</description>
-      <entry value="1" name="GIMBAL_FLAGS_RETRACT">
+    <enum name="GIMBAL_DEVICE_FLAGS">
+      <description>Flags for gimbal device (lower level) operation.</description>
+      <entry value="1" name="GIMBAL_DEVICE_FLAGS_RETRACT">
         <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
       </entry>
-      <entry value="2" name="GIMBAL_FLAGS_NEUTRAL">
+      <entry value="2" name="GIMBAL_DEVICE_FLAGS_NEUTRAL">
         <description>Set to neutral position (horizontal, forward looking, with stabiliziation), takes presedence over all other flags except RETRACT.</description>
       </entry>
-      <entry value="4" name="GIMBAL_FLAGS_ROLL_LOCK">
+      <entry value="4" name="GIMBAL_DEVICE_FLAGS_ROLL_LOCK">
         <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>
       </entry>
-      <entry value="8" name="GIMBAL_FLAGS_PITCH_LOCK">
+      <entry value="8" name="GIMBAL_DEVICE_FLAGS_PITCH_LOCK">
         <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
       </entry>
-      <entry value="16" name="GIMBAL_FLAGS_YAW_LOCK">
+      <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_FLAGS">
-      <description>Flags for high level gimbal manager operation The first 16 bytes are identical to the GIMBAL_FLAGS.</description>
+      <description>Flags for high level gimbal manager operation The first 16 bytes are identical to the GIMBAL_DEVICE_FLAGS.</description>
       <entry value="1" name="GIMBAL_MANAGER_FLAGS_RETRACT">
-        <description>Based on GIMBAL_FLAGS_RETRACT</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_RETRACT</description>
       </entry>
       <entry value="2" name="GIMBAL_MANAGER_FLAGS_NEUTRAL">
-        <description>Based on GIMBAL_FLAGS_NEUTRAL</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_NEUTRAL</description>
       </entry>
       <entry value="4" name="GIMBAL_MANAGER_FLAGS_ROLL_LOCK">
-        <description>Based on GIMBAL_FLAGS_ROLL_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_ROLL_LOCK</description>
       </entry>
       <entry value="8" name="GIMBAL_MANAGER_FLAGS_PITCH_LOCK">
-        <description>Based on GIMBAL_FLAGS_PITCH_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_PITCH_LOCK</description>
       </entry>
       <entry value="16" name="GIMBAL_MANAGER_FLAGS_YAW_LOCK">
-        <description>Based on GIMBAL_FLAGS_YAW_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_YAW_LOCK</description>
       </entry>
       <entry value="1048576" name="GIMBAL_MANAGER_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
         <description>Scale angular velocity relative to focal length. This means the gimbal moves slower if it is zoomed in.</description>
@@ -6033,7 +6033,7 @@
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
     </message>
-    <message id="283" name="GIMBAL_INFORMATION">
+    <message id="283" name="GIMBAL_DEVICE_INFORMATION">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about a low level gimbal</description>
@@ -6041,7 +6041,7 @@
       <field type="uint8_t[32]" name="vendor_name">Name of the gimbal vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
       <field type="uint32_t" name="firmware_version">Version of the gimbal firmware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
-      <field type="uint16_t" name="cap_flags" enum="GIMBAL_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
+      <field type="uint16_t" name="cap_flags" enum="GIMBAL_DEVICE_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
       <field type="float" name="tilt_max" units="rad">Maximum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_min" units="rad">Minimum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_rate_max" units="rad/s">Maximum tilt/pitch angular rate (positive: up, negative: down)</field>
@@ -6049,24 +6049,24 @@
       <field type="float" name="pan_min" units="rad">Minimum pan/yaw angle (positive: to the right, negative: to the left)</field>
       <field type="float" name="pan_rate_max" units="rad/s">Minimum pan/yaw angular rate (positive: to the right, negative: to the left)</field>
     </message>
-    <message id="284" name="GIMBAL_SET_ATTITUDE">
+    <message id="284" name="GIMBAL_DEVICE_SET_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Low level message to control a gimbal's attitude. This message is to be sent from the gimbal manager to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
+      <description>Low level message to control a gimbal device's attitude. This message is to be sent from the gimbal manager to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="flags" enum="GIMBAL_FLAGS">Low level gimbal flags.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_FLAGS_YAW_LOCK is set)</field>
+      <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
     </message>
-    <message id="285" name="GIMBAL_ATTITUDE_STATUS">
+    <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message reporting the status of a gimbal. This message should be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
-      <field type="uint16_t" name="flags" enum="GIMBAL_FLAGS">Current gimbal flags set.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_FLAGS_YAW_LOCK is set)</field>
+      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
+      <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1055,7 +1055,7 @@
         <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
       </entry>
       <entry value="16" name="MAV_GIMBAL_CONTROL_CAP_FLAG_YAW_LOCK">
-        <description>Lock yaw angle to absolute angle relative to North (not relative to drone).</description>
+        <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
@@ -5926,8 +5926,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_CAP_FLAGS" display="bitmask">Gimbal control flags.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation). The frame is specified by the field q_frame.</field>
-      <field type="uint8_t" name="q_frame">Input frame of Quaternion. 0: Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle), 1: Earth frame with the x-axis pointing North (yaw absolute). </field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag MAV_GIMBAL_CONTROL_CAP_FLAG_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
@@ -5957,7 +5956,7 @@
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message reporting the status of a gimbal. This message can be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
       <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_CAP_FLAGS">Current gimbal control flags</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag MAV_GIMBAL_CONTROL_CAP_FLAG_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1692,7 +1692,7 @@
         <param index="7" label="Yaw Offset">yaw offset from next waypoint, positive panning to the right</param>
       </entry>
       <entry value="197" name="MAV_CMD_DO_SET_ROI_NONE" hasLocation="false" isDestination="false">
-        <description>Cancels any previous ROI command returning the vehicle/sensors to default flight characteristics. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message.</description>
+        <description>Cancels any previous ROI command returning the vehicle/sensors to default flight characteristics. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message. After this command the gimbal manager should go back to manual input if available, and otherwise assume a neutral position.</description>
         <param index="1" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -983,7 +983,7 @@
     </enum>
     <!-- Camera Mount mode Enumeration -->
     <enum name="MAV_MOUNT_MODE">
-      <deprecated since="2019-07" replaced_by="MAV_GIMBAL_MODE"/>
+      <deprecated since="2019-07" replaced_by="GIMBAL_MODE"/>
       <description>Enumeration of possible mount operation modes</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
         <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
@@ -1025,36 +1025,36 @@
         <description>Gimbal supports to point to a global GPS position</description>
       </entry>
     </enum>
-    <enum name="MAV_GIMBAL_MODE">
+    <enum name="GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
-      <entry value="0" name="MAV_GIMBAL_MODE_RETRACT">
+      <entry value="0" name="GIMBAL_MODE_RETRACT">
         <description>Set to retracted safe position (no stabilization)</description>
       </entry>
-      <entry value="1" name="MAV_GIMBAL_MODE_NEUTRAL">
+      <entry value="1" name="GIMBAL_MODE_NEUTRAL">
         <description>Set to neutral position (horizontal, forward looking, with stabilization)</description>
       </entry>
-      <entry value="2" name="MAV_GIMBAL_MODE_YAW_FOLLOW">
+      <entry value="2" name="GIMBAL_MODE_YAW_FOLLOW">
         <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
       </entry>
-      <entry value="3" name="MAV_GIMBAL_MODE_YAW_LOCK">
+      <entry value="3" name="GIMBAL_MODE_YAW_LOCK">
         <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
       </entry>
     </enum>
-    <enum name="MAV_GIMBAL_CONTROL_CAP_FLAGS">
+    <enum name="GIMBAL_CONTROL_FLAGS">
       <description>Flags for gimbal operation.</description>
-      <entry value="1" name="MAV_GIMBAL_CONTROL_CAP_FLAG_RETRACT">
+      <entry value="1" name="GIMBAL_CONTROL_FLAGS_RETRACT">
         <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
       </entry>
-      <entry value="2" name="MAV_GIMBAL_CONTROL_CAP_FLAG_NEUTRAL">
+      <entry value="2" name="GIMBAL_CONTROL_FLAGS_NEUTRAL">
         <description>Set to neutral position (horizontal, forward looking, with stabiliziation), takes presedence over all other flags except RETRACT.</description>
       </entry>
-      <entry value="4" name="MAV_GIMBAL_CONTROL_CAP_FLAG_ROLL_LOCK">
+      <entry value="4" name="GIMBAL_CONTROL_FLAGS_ROLL_LOCK">
         <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>
       </entry>
-      <entry value="8" name="MAV_GIMBAL_CONTROL_CAP_FLAG_PITCH_LOCK">
+      <entry value="8" name="GIMBAL_CONTROL_FLAGS_PITCH_LOCK">
         <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
       </entry>
-      <entry value="16" name="MAV_GIMBAL_CONTROL_CAP_FLAG_YAW_LOCK">
+      <entry value="16" name="GIMBAL_CONTROL_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
     </enum>
@@ -2027,7 +2027,7 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
-        <param index="1" label="Gimbal mode" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
+        <param index="1" label="Gimbal mode" enum="GIMBAL_MODE">Gimbal mode.</param>
         <param index="2" label="Roll angle" units="deg" minValue="-180" maxValue="180">Roll angle relative to world horizon (positive to turn to the right).</param>
         <param index="3" label="Pitch angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
         <param index="4" label="Yaw angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
@@ -5925,8 +5925,8 @@
       <description>Message to control a gimbal's attitude. This message is to be sent by the autopilot to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_CAP_FLAGS" display="bitmask">Gimbal control flags.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag MAV_GIMBAL_CONTROL_CAP_FLAG_YAW_LOCK is set)</field>
+      <field type="uint16_t" name="flags" enum="GIMBAL_CONTROL_FLAGS" display="bitmask">Gimbal control flags.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
@@ -5955,8 +5955,8 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message reporting the status of a gimbal. This message can be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
-      <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_CAP_FLAGS">Current gimbal control flags</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag MAV_GIMBAL_CONTROL_CAP_FLAG_YAW_LOCK is set)</field>
+      <field type="uint16_t" name="flags" enum="GIMBAL_CONTROL_FLAGS">Current gimbal control flags</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1024,6 +1024,12 @@
       <entry value="32" name="GIMBAL_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
         <description>Gimbal supports to point to a global latitude, longitude, altitude position</description>
       </entry>
+      <entry value="64" name="GIMBAL_CAP_FLAGS_HAS_TRACKING_POINT">
+        <description>Gimbal supports tracking of a point on the camera</description>
+      </entry>
+      <entry value="128" name="GIMBAL_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
+        <description>Gimbal supports tracking of a point on the camera</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
@@ -2034,6 +2040,24 @@
         <param index="5" label="Roll angle" units="deg" minValue="-180" maxValue="180">Roll angle relative to world horizon (positive to turn to the right).</param>
         <param index="6" label="Pitch angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
         <param index="7" label="Yaw angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+      </entry>
+      <entry value="1001" name="MAV_CMD_DO_GIMBAL_TRACK_POINT" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>If the gimbal supports visual tracking (GIMBAL_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking.</description>
+        <param index="1" label="Point 1 x" minValue="0" maxValue="1">Point to track.</param>
+        <param index="2" label="Point 1 y" minValue="0" maxValue="1">Roll angular rate (positive to turn to the right).</param>
+        <param index="3" label="Point 2 x" minValue="0" maxValue="1">Pitch/tilt angular rate (positive to point up).</param>
+        <param index="4" label="Point 2 y" minValue="0" maxValue="1">Yaw/pan angular rate (positive to pan to the right).</param>
+      </entry>
+      <entry value="1002" name="MAV_CMD_DO_GIMBAL_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>If the gimbal supports visual tracking (GIMBAL_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), this command allows to initiate the tracking.</description>
+        <param index="1" label="Top left corner x" minValue="0" maxValue="1">Top left corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
+        <param index="2" label="Top left corner y" minValue="0" maxValue="1">Top left corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
+        <param index="3" label="Bottom right corner x" minValue="0" maxValue="1">Bottom right corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
+        <param index="4" label="Bottom right corner y" minValue="0" maxValue="1">Bottom right corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -983,7 +983,7 @@
     </enum>
     <!-- Camera Mount mode Enumeration -->
     <enum name="MAV_MOUNT_MODE">
-      <deprecated since="2019-07" replaced_by="GIMBAL_MANAGER_FLAGS"/>
+      <deprecated since="2020-01" replaced_by="GIMBAL_MANAGER_FLAGS"/>
       <description>Enumeration of possible mount operation modes</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
         <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
@@ -1760,7 +1760,7 @@
       </entry>
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
-        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is ambiguous and inconsistent. It has been replaced by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE and MAV_CMD_DO_SET_ROI_*.</deprecated>
+        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is ambiguous and inconsistent. It has been replaced by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE and MAV_CMD_DO_SET_ROI_*.</deprecated>
         <description>Mission command to control a camera or antenna mount</description>
         <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input).</param>
         <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
@@ -1842,7 +1842,7 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT" hasLocation="false" isDestination="false">
-        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE"/>
+        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE"/>
         <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
         <param index="1" label="Q1">quaternion param q1, w (1 in null-rotation)</param>
         <param index="2" label="Q2">quaternion param q2, x (0 in null-rotation)</param>
@@ -5937,7 +5937,7 @@
       <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of log files</field>
     </message>
     <message id="265" name="MOUNT_ORIENTATION">
-      <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is being replaced by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE.</deprecated>
+      <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is being replaced by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE.</deprecated>
       <description>Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="roll" units="deg">Roll in global frame (set to NaN for invalid).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5882,9 +5882,9 @@
       <field type="float" name="pitch" units="rad">Pitch in global frame, positive is tilting up (NaN to be ignored).</field>
       <field type="float" name="yaw_relative" units="rad">Yaw relative to vehicle, -pi to pi, positive to the right, required for MAV_GIMBAL_MODE_FOLLOW (NaN to be ignored).</field>
       <field type="float" name="yaw_absolute" units="rad">Yaw absolute, 0 is North, -pi to pi, positive to the right, required for MAV_GIMBAL_MODE_LOCK mode (NaN to be ignored).</field>
-      <field type="float" name="rollspeed" units="rad/s">Roll angular speed (NaN to be ignored).</field>
-      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed (NaN to be ignored).</field>
-      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed (NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN to be ignored).</field>
     </message>
     <message id="281" name="GIMBAL_CONTROL_LOCATION">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1010,7 +1010,7 @@
         <description>Gimbal supports a retracted position</description>
       </entry>
       <entry value="2" name="GIMBAL_CAP_FLAGS_HAS_NEUTRAL">
-        <description>Gimbal supports a neutral, not-stabilized position</description>
+        <description>Gimbal supports a horizontal, forward looking position, stabilized</description>
       </entry>
       <entry value="4" name="GIMBAL_CAP_FLAGS_HAS_YAW_FOLLOW">
         <description>Gimbal supports to follow a yaw angle relative to the vehicle</description>
@@ -1031,7 +1031,7 @@
         <description>Set to retracted safe position (no stabilization)</description>
       </entry>
       <entry value="1" name="MAV_GIMBAL_MODE_NEUTRAL">
-        <description>Set to neutral position (horizontal, forward looking, no stabilization)</description>
+        <description>Set to neutral position (horizontal, forward looking, with stabilization)</description>
       </entry>
       <entry value="2" name="MAV_GIMBAL_MODE_YAW_FOLLOW">
         <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
@@ -1046,7 +1046,7 @@
         <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
       </entry>
       <entry value="2" name="MAV_GIMBAL_CONTROL_FLAG_NEUTRAL">
-        <description>Set to neutral position (horizontal, forward looking, no stabiliziation), takes presedence over all other flags except RETRACT.</description>
+        <description>Set to neutral position (horizontal, forward looking, with stabiliziation), takes presedence over all other flags except RETRACT.</description>
       </entry>
       <entry value="4" name="MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK">
         <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1033,8 +1033,8 @@
       <entry value="8" name="MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK">
         <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
       </entry>
-      <entry value="16" name="MAV_GIMBAL_CONTROL_FLAT_YAW_LOCK">
-        <description>Lock yaw angle to absolute angle relative to North (not relative to drone). This is a choice based on GIMBAL_MODE.</description>
+      <entry value="16" name="MAV_GIMBAL_CONTROL_FLAG_YAW_LOCK">
+        <description>Lock yaw angle to absolute angle relative to North (not relative to drone).</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1012,77 +1012,95 @@
       <entry value="2" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_NEUTRAL">
         <description>Gimbal device supports a horizontal, forward looking position, stabilized</description>
       </entry>
-      <entry value="4" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_FOLLOW">
+      <entry value="4" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_AXIS">
+        <description>Gimbal device supports rotating around roll axis.</description>
+      </entry>
+      <entry value="8" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_FOLLOW">
         <description>Gimbal device supports to follow a roll angle relative to the vehicle</description>
       </entry>
-      <entry value="8" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_LOCK">
+      <entry value="16" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_LOCK">
         <description>Gimbal device supports locking to an roll angle (generally that's the default with roll stabilized)</description>
       </entry>
-      <entry value="16" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_FOLLOW">
+      <entry value="32" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_AXIS">
+        <description>Gimbal device supports rotating around pitch axis.</description>
+      </entry>
+      <entry value="64" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_FOLLOW">
         <description>Gimbal device supports to follow a pitch angle relative to the vehicle</description>
       </entry>
-      <entry value="32" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_LOCK">
+      <entry value="128" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_LOCK">
         <description>Gimbal device supports locking to an pitch angle (generally that's the default with pitch stabilized)</description>
       </entry>
-      <entry value="64" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW">
+      <entry value="256" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_AXIS">
+        <description>Gimbal device supports rotating around yaw axis.</description>
+      </entry>
+      <entry value="512" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW">
         <description>Gimbal device supports to follow a yaw angle relative to the vehicle (generally that's the default)</description>
       </entry>
-      <entry value="128" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK">
+      <entry value="1024" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK">
         <description>Gimbal device supports locking to an absolute heading (often this is an option available)</description>
       </entry>
-      <entry value="256" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+      <entry value="2048" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
         <description>Gimbal device supports yawing/panning infinetely (e.g. using slip disk).</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_CAP_FLAGS">
       <description>Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_DEVICE_CAP_FLAGS which are identical with GIMBAL_DEVICE_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>
       <entry value="1" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_RETRACT">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT.</description>
       </entry>
       <entry value="2" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_NEUTRAL">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_NEUTRAL</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_NEUTRAL.</description>
       </entry>
-      <entry value="4" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_FOLLOW">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_FOLLOW</description>
+      <entry value="4" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_AXIS">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_AXIS.</description>
       </entry>
-      <entry value="8" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_LOCK">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_LOCK</description>
+      <entry value="8" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_FOLLOW">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_FOLLOW.</description>
       </entry>
-      <entry value="16" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_FOLLOW">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_FOLLOW</description>
+      <entry value="16" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_ROLL_LOCK">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_ROLL_LOCK.</description>
       </entry>
-      <entry value="32" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_LOCK">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_LOCK</description>
+      <entry value="32" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_AXIS">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_AXIS.</description>
       </entry>
-      <entry value="64" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_FOLLOW">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW</description>
+      <entry value="64" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_FOLLOW">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_FOLLOW.</description>
       </entry>
-      <entry value="128" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_LOCK">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK</description>
+      <entry value="128" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_PITCH_LOCK">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_PITCH_LOCK.</description>
       </entry>
-      <entry value="256" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
-        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW</description>
+      <entry value="256" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_AXIS">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_AXIS.</description>
+      </entry>
+      <entry value="512" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_FOLLOW">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_FOLLOW.</description>
+      </entry>
+      <entry value="1024" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_LOCK">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK.</description>
+      </entry>
+      <entry value="2048" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW.</description>
       </entry>
       <entry value="65536" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
-        <description>Gimbal manager supports to point to a local position</description>
+        <description>Gimbal manager supports to point to a local position.</description>
       </entry>
       <entry value="131072" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
-        <description>Gimbal manager supports to point to a global latitude, longitude, altitude position</description>
+        <description>Gimbal manager supports to point to a global latitude, longitude, altitude position.</description>
       </entry>
       <entry value="262144" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT">
-        <description>Gimbal manager supports tracking of a point on the camera</description>
+        <description>Gimbal manager supports tracking of a point on the camera.</description>
       </entry>
       <entry value="524288" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
-        <description>Gimbal manager supports tracking of a point on the camera</description>
+        <description>Gimbal manager supports tracking of a point on the camera.</description>
       </entry>
       <entry value="1048576" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE">
         <description>Gimbal manager supports pitching and yawing at an angular velocity scaled by focal length (the more zoomed in, the slower the movement).</description>
       </entry>
       <entry value="2097152" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_NUDGING">
-        <description>Gimbal manager supports nudging when pointing to a location or tracking</description>
+        <description>Gimbal manager supports nudging when pointing to a location or tracking.</description>
       </entry>
       <entry value="4194304" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_OVERRIDE">
-        <description>Gimbal manager supports overriding when pointing to a location or tracking</description>
+        <description>Gimbal manager supports overriding when pointing to a location or tracking.</description>
       </entry>
     </enum>
     <enum name="GIMBAL_DEVICE_FLAGS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1007,10 +1007,10 @@
     <enum name="MAV_GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
       <entry value="0" name="MAV_GIMBAL_MODE_RETRACT">
-        <description>Set to retracted safe position</description>
+        <description>Set to retracted safe position (no stabilization)</description>
       </entry>
-      <entry value="1" name="MAV_GIMBAL_MODE_DEFAULT">
-        <description>Set to neutral (default) position</description>
+      <entry value="1" name="MAV_GIMBAL_MODE_NEUTRAL">
+        <description>Set to neutral position (horizontal, forward looking, no stabilization)</description>
       </entry>
       <entry value="2" name="MAV_GIMBAL_MODE_YAW_FOLLOW">
         <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
@@ -1025,7 +1025,7 @@
         <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
       </entry>
       <entry value="2" name="MAV_GIMBAL_CONTROL_FLAG_NEUTRAL">
-        <description>Set to neutral position (no stabiliziation), takes presedence over all other flags except RETRACT.</description>
+        <description>Set to neutral position (horizontal, forward looking, no stabiliziation), takes presedence over all other flags except RETRACT.</description>
       </entry>
       <entry value="4" name="MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK">
         <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2006,13 +2006,13 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
-        <param index="1" units="deg">Roll angle relative to world horizon (positive to turn to the right).</param>
-        <param index="2" units="deg">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
-        <param index="3" units="deg">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
-        <param index="4" units="deg/s">Roll angular rate (positive to turn to the right).</param>
-        <param index="5" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
-        <param index="6" units="deg/s">Yaw/pan angular rate (positive to pan to the right).</param>
-        <param index="7" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
+        <param index="1" label="Roll angle" units="deg">Roll angle relative to world horizon (positive to turn to the right).</param>
+        <param index="2" label="Pitch angle" units="deg">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
+        <param index="3" label="Yaw angle" units="deg">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+        <param index="4" label="Roll angular rate" units="deg/s">Roll angular rate (positive to turn to the right).</param>
+        <param index="5" label="Pitch angular rate" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
+        <param index="6" label="Yaw angular rate" units="deg/s">Yaw/pan angular rate (positive to pan to the right).</param>
+        <param index="7" label="" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2109,7 +2109,7 @@
       <entry value="1001" name="MAV_CMD_DO_GIMBAL_MANAGER_TRACK_POINT" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>If the gimbal manager supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking.</description>
+        <description>If the gimbal manager supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking. Such a tracking gimbal manager would usually be an integrated camera/gimbal, or alternatively a companion computer connected to a camera.</description>
         <param index="1" label="Point x" minValue="0" maxValue="1">Point to track x value.</param>
         <param index="2" label="Point y" minValue="0" maxValue="1">Point to track y value.</param>
         <param index="7" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
@@ -2117,7 +2117,7 @@
       <entry value="1002" name="MAV_CMD_DO_GIMBAL_MANAGER_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>If the gimbal supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), this command allows to initiate the tracking.</description>
+        <description>If the gimbal supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), this command allows to initiate the tracking. Such a tracking gimbal manager would usually be an integrated camera/gimbal, or alternatively a companion computer connected to a camera.</description>
         <param index="1" label="Top left corner x" minValue="0" maxValue="1">Top left corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
         <param index="2" label="Top left corner y" minValue="0" maxValue="1">Top left corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
         <param index="3" label="Bottom right corner x" minValue="0" maxValue="1">Bottom right corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5926,7 +5926,8 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_CAP_FLAGS" display="bitmask">Gimbal control flags.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation). The frame is specified by the field q_frame.</field>
+      <field type="uint8_t" name="q_frame">Input frame of Quaternion. 0: Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle), 1: Earth frame with the x-axis pointing North (yaw absolute). </field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5999,10 +5999,12 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint32_t" name="flags" enum="GIMBAL_CONTROLLER_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
       <field type="uint8_t" name="gimbal_component">Gimbal component ID that this gimbal controller is responsible for.</field>
-      <field type="float" name="pitch_max" units="rad">Maximum pitch angle (positive: up, negative: down)</field>
-      <field type="float" name="pitch_min" units="rad">Minimum pitch angle (positive: up, negative: down)</field>
-      <field type="float" name="yaw_max" units="rad">Maximum yaw angle (positive: to the right, negative: to the left)</field>
-      <field type="float" name="yaw_min" units="rad">Minimum yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="tilt_max" units="rad">Maximum tilt/pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="tilt_min" units="rad">Minimum tilt/pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="tilt_rate_max" units="rad/s">Maximum tilt/pitch angular rate (positive: up, negative: down)</field>
+      <field type="float" name="pan_max" units="rad">Maximum pan/yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="pan_min" units="rad">Minimum pan/yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="pan_rate_max" units="rad/s">Minimum pan/yaw angular rate (positive: to the right, negative: to the left)</field>
     </message>
     <message id="281" name="GIMBAL_INFORMATION">
       <description>Information about a low level gimbal</description>
@@ -6011,10 +6013,12 @@
       <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
       <field type="uint32_t" name="firmware_version">Version of the gimbal firmware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
       <field type="uint32_t" name="flags" enum="GIMBAL_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
-      <field type="float" name="pitch_max" units="rad">Maximum pitch angle (positive: up, negative: down)</field>
-      <field type="float" name="pitch_min" units="rad">Minimum pitch angle (positive: up, negative: down)</field>
-      <field type="float" name="yaw_max" units="rad">Maximum yaw angle (positive: to the right, negative: to the left)</field>
-      <field type="float" name="yaw_min" units="rad">Minimum yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="tilt_max" units="rad">Maximum tilt/pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="tilt_min" units="rad">Minimum tilt/pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="tilt_rate_max" units="rad/s">Maximum tilt/pitch angular rate (positive: up, negative: down)</field>
+      <field type="float" name="pan_max" units="rad">Maximum pan/yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="pan_min" units="rad">Minimum pan/yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="pan_rate_max" units="rad/s">Minimum pan/yaw angular rate (positive: to the right, negative: to the left)</field>
     </message>
     <message id="282" name="GIMBAL_CONTROLLER_SET_ATTITUDE">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6049,7 +6049,7 @@
     <message id="280" name="GIMBAL_MANAGER_INFORMATION">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Information about a high level gimbal manager</description>
+      <description>Information about a high level gimbal manager. This message should be requested by a ground station using MAV_CMD_REQUEST_MESSAGE.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint32_t" name="cap_flags" enum="GIMBAL_MANAGER_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
       <field type="uint8_t" name="gimbal_component">Gimbal component ID that this gimbal manager is responsible for.</field>
@@ -6063,7 +6063,7 @@
     <message id="281" name="GIMBAL_MANAGER_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Current status about a high level gimbal manager</description>
+      <description>Current status about a high level gimbal manager. This message should be broadcast at a low regular rate (e.g. 5Hz).</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint32_t" name="flags" enum="GIMBAL_MANAGER_FLAGS">High level gimbal manager flags currently applied.</field>
     </message>
@@ -6083,7 +6083,7 @@
     <message id="283" name="GIMBAL_DEVICE_INFORMATION">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Information about a low level gimbal</description>
+      <description>Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the gimbal vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
@@ -6112,7 +6112,7 @@
     <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
+      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right). This message should be broadcast at a low regular rate (e.g. 10Hz).</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6083,7 +6083,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set, set all fields to NaN if only angular velocity should be used)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6059,6 +6059,7 @@
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
+      <field type="float" name="feed_forward_angular_velocity_z" units="rad/s">Feed forward Z component of angular velocity, positive is yawing to the right, NaN to be ignored. This field is only needed if the gimbal manager is not the autopilot itself. It allows the autopilot to send the feed forward yaw setpoint when it is actively yawing. It can then be passed on by the gimbal manager to a gimbal device.</field>
     </message>
     <message id="283" name="GIMBAL_DEVICE_INFORMATION">
       <wip/>
@@ -6087,6 +6088,7 @@
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
+      <field type="float" name="feed_forward_angular_velocity_z" units="rad/s">Feed forward Z component of angular velocity, positive is yawing to the right, NaN to be ignored. This is to indicate if the autopilot is actively yawing.</field>
     </message>
     <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -983,7 +983,8 @@
     </enum>
     <!-- Camera Mount mode Enumeration -->
     <enum name="MAV_MOUNT_MODE">
-      <description>Enumeration of possible mount operation modes</description>
+      <deprecated since="2019-07" replaced_by="MAV_GIMBAL_MODE"/>
+      <description>Enumeration of possible mount operation modes (deprecated, replaced by MAV_GIMBAL_MODE)</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
         <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
       </entry>
@@ -1001,6 +1002,21 @@
       </entry>
       <entry value="5" name="MAV_MOUNT_MODE_SYSID_TARGET">
         <description>Gimbal tracks system with specified system ID</description>
+      </entry>
+    </enum>
+    <enum name="MAV_GIMBAL_MODE">
+      <description>Enumeration of possible gimbal operation modes</description>
+      <entry value="0" name="MAV_GIMBAL_MODE_RETRACT">
+        <description>Retracted safe position</description>
+      </entry>
+      <entry value="1" name="MAV_GIMBAL_MODE_DEFAULT">
+        <description>Neutral (default) position.</description>
+      </entry>
+      <entry value="2" name="MAV_GIMBAL_MODE_FOLLOW">
+        <description>Use Follow mode (this mode should follows the heading of the vehicle with some dampening).</description>
+      </entry>
+      <entry value="3" name="MAV_GIMBAL_MODE_LOCK">
+        <description>Use Lock mode (this mode should lock to heading ignoring the vehicle heading as much as possible).</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
@@ -1633,6 +1649,7 @@
       </entry>
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
+        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_ATTITUDE">This message is ambiguous and inconsistent and therefore replaced by MAV_CMD_DO_GIMBAL_ATTITUDE and MAV_CMD_DO_SET_ROI_*.</deprecated>
         <description>Mission command to control a camera or antenna mount</description>
         <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input).</param>
         <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
@@ -1714,6 +1731,7 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT" hasLocation="false" isDestination="false">
+        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_ATTITUDE"/>
         <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
         <param index="1" label="Q1">quaternion param q1, w (1 in null-rotation)</param>
         <param index="2" label="Q2">quaternion param q2, x (0 in null-rotation)</param>
@@ -1965,6 +1983,16 @@
         <description>Jump to the matching tag in the mission list. Repeat this action for the specified number of times. A mission should contain a single matching tag for each jump. If this is not the case then a jump to a missing tag should complete the mission, and a jump where there are multiple matching tags should always select the one with the lowest mission sequence number.</description>
         <param index="1" label="Tag" minValue="0" increment="1">Target tag to jump to.</param>
         <param index="2" label="Repeat" minValue="0" increment="1">Repeat count.</param>
+      </entry>
+      <entry value="1000" name="MAV_CMD_DO_GIMBAL_ATTITUDE" hasLocation="false" isDestination="false">
+        <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset.</description>
+        <param index="1">Pitch/tilt angle relative to world horizon (+90 to -90 degrees, negative is to tilt down, positive to tilt up).</param>
+        <param index="2">Yaw/pan angle (-180 to 180 degrees, positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+        <param index="3">Pitch/tilt angular rate (degrees/second, positive to point up).</param>
+        <param index="4">Yaw/pan angular rate (degrees/second, positive to pan to the right).</param>
+        <param index="5" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
+        <param index="6">Reserved.</param>
+        <param index="7">Reserved.</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1042,6 +1042,9 @@
       <entry value="2048" name="GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
         <description>Gimbal supports yawing infinetely (e.g. using slip disk).</description>
       </entry>
+      <entry value="4096" name="GIMBAL_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE">
+        <description>Gimbal supports pitching and yawing at an angular velocity scaled by focal length (the more zoomed in, the slower the movement).</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
@@ -1092,6 +1095,9 @@
       </entry>
       <entry value="512" name="GIMBAL_CONTROL_FLAGS_SOURCE_GCS">
         <description>Set if the input source for the gimbal attitude control is a GCS.</description>
+      </entry>
+      <entry value="1024" name="GIMBAL_CONTROL_FLAGS_SCALE_BY_FOCAL_LENGTH">
+        <description>Set if the angular velocity control should be scaled by focal length (the more zoomed in the slower). This requires GIMBAL_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1087,6 +1087,12 @@
       <entry value="128" name="GIMBAL_CONTROL_FLAGS_OVERRIDE">
         <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_CONTROL_FLAGS_YAW_LOCK.</description>
       </entry>
+      <entry value="256" name="GIMBAL_CONTROL_FLAGS_SOURCE_RC">
+        <description>Set if the input source for the gimbal attitude control is RC.</description>
+      </entry>
+      <entry value="512" name="GIMBAL_CONTROL_FLAGS_SOURCE_GCS">
+        <description>Set if the input source for the gimbal attitude control is a GCS.</description>
+      </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
     <enum name="UAVCAN_NODE_HEALTH">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1005,6 +1005,7 @@
       </entry>
     </enum>
     <enum name="MAV_GIMBAL_MODE">
+      <wip/>
       <description>Enumeration of possible gimbal operation modes</description>
       <entry value="0" name="MAV_GIMBAL_MODE_RETRACT">
         <description>Set to retracted safe position</description>
@@ -1012,11 +1013,30 @@
       <entry value="1" name="MAV_GIMBAL_MODE_DEFAULT">
         <description>Set to neutral (default) position</description>
       </entry>
-      <entry value="2" name="MAV_GIMBAL_MODE_FOLLOW">
-        <description>Use Heading Follow mode (this follows the heading of the vehicle with some smoothing)</description>
+      <entry value="2" name="MAV_GIMBAL_MODE_YAW_FOLLOW">
+        <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
       </entry>
-      <entry value="3" name="MAV_GIMBAL_MODE_LOCK">
-        <description>Use Lock mode (this mode locks to a certain direction ignoring the vehicle heading as much as possible)</description>
+      <entry value="3" name="MAV_GIMBAL_MODE_YAW_LOCK">
+        <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_GIMBAL_CONTROL_FLAGS">
+      <wip/>
+      <description>Flags for gimbal operation.</description>
+      <entry value="1" name="MAV_GIMBAL_CONTROL_FLAG_RETRACT">
+        <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
+      </entry>
+      <entry value="2" name="MAV_GIMBAL_CONTROL_FLAG_NEUTRAL">
+        <description>Set to neutral position (no stabiliziation), takes presedence over all other flags except RETRACT.</description>
+      </entry>
+      <entry value="4" name="MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK">
+        <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>
+      </entry>
+      <entry value="8" name="MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK">
+        <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
+      </entry>
+      <entry value="16" name="MAV_GIMBAL_CONTROL_FLAT_YAW_LOCK">
+        <description>Lock yaw angle to absolute angle relative to North (not relative to drone). This is a choice based on GIMBAL_MODE.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
@@ -5877,14 +5897,13 @@
       <description>Message to control a gimbal's attitude. This message is to be sent by the autopilot to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="mode" enum="MAV_GIMBAL_MODE">Gimbal mode.</field>
-      <field type="float" name="roll" units="rad">Roll in global frame, positive is tilt to the right (NaN to be ignored).</field>
-      <field type="float" name="pitch" units="rad">Pitch in global frame, positive is tilting up (NaN to be ignored).</field>
-      <field type="float" name="yaw_relative" units="rad">Yaw relative to vehicle, -pi to pi, positive to the right, required for MAV_GIMBAL_MODE_FOLLOW (NaN to be ignored).</field>
-      <field type="float" name="yaw_absolute" units="rad">Yaw absolute, 0 is North, -pi to pi, positive to the right, required for MAV_GIMBAL_MODE_LOCK mode (NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN to be ignored).</field>
-      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN to be ignored).</field>
+      <field type="unit16_t" name="flags" enum="MAV_GIMBAL_CONTROL_FLAGS" display="bitmask">Gimbal control flags.</field>
+      <field type="float" name="roll" units="rad">Roll angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK is set, positive is banking to the right, NaN to be ignored.</field>
+      <field type="float" name="pitch" units="rad">Pitch angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK is set, positive tilting up, NaN to be ignored.</field>
+      <field type="float" name="yaw" units="rad">Yaw angle, relative to vehicle frame if MAV_GIMBAL_CONTROL_FLAG_YAW_LOCK is not set, in absolute world frame if MAV_GIMBAL_CONTROL_FLAG_YAW_LOCK is set, positive is paning to the right, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
     </message>
     <message id="281" name="GIMBAL_CONTROL_LOCATION">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1988,12 +1988,12 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
-        <param index="1" units="rad">Roll angle relative to world horizon (positive to turn to the right).</param>
-        <param index="2" units="rad">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
-        <param index="3" units="rad">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
-        <param index="4" units="rad/s">Roll angular rate (positive to turn to the right).</param>
-        <param index="5" units="rad/s">Pitch/tilt angular rate (positive to point up).</param>
-        <param index="6" units="rad/s">Yaw/pan angular rate (positive to pan to the right).</param>
+        <param index="1" units="deg">Roll angle relative to world horizon (positive to turn to the right).</param>
+        <param index="2" units="deg">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
+        <param index="3" units="deg">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+        <param index="4" units="deg/s">Roll angular rate (positive to turn to the right).</param>
+        <param index="5" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
+        <param index="6" units="deg/s">Yaw/pan angular rate (positive to pan to the right).</param>
         <param index="7" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1042,16 +1042,19 @@
     </enum>
     <enum name="GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
-      <entry value="0" name="GIMBAL_MODE_RETRACT">
+      <entry value="0" name="GIMBAL_MODE_NONE">
+        <description>Give up control over gimbal and let GIMBAL_CONTROL_ATTITUDE takeover again (can e.g. be used after a mission is finished)</description>
+      </entry>
+      <entry value="1" name="GIMBAL_MODE_RETRACT">
         <description>Set to retracted safe position (no stabilization)</description>
       </entry>
-      <entry value="1" name="GIMBAL_MODE_NEUTRAL">
+      <entry value="2" name="GIMBAL_MODE_NEUTRAL">
         <description>Set to neutral position (horizontal, forward looking, with stabilization)</description>
       </entry>
-      <entry value="2" name="GIMBAL_MODE_YAW_FOLLOW">
+      <entry value="3" name="GIMBAL_MODE_YAW_FOLLOW">
         <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
       </entry>
-      <entry value="3" name="GIMBAL_MODE_YAW_LOCK">
+      <entry value="4" name="GIMBAL_MODE_YAW_LOCK">
         <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2027,13 +2027,13 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
-        <param index="1" label="Roll angle" units="deg">Roll angle relative to world horizon (positive to turn to the right).</param>
-        <param index="2" label="Pitch angle" units="deg">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
-        <param index="3" label="Yaw angle" units="deg">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
-        <param index="4" label="Roll angular rate" units="deg/s">Roll angular rate (positive to turn to the right).</param>
-        <param index="5" label="Pitch angular rate" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
-        <param index="6" label="Yaw angular rate" units="deg/s">Yaw/pan angular rate (positive to pan to the right).</param>
-        <param index="7" label="" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
+        <param index="1" label="Gimbal mode" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
+        <param index="2" label="Roll angle" units="deg" minValue="-180" maxValue="180">Roll angle relative to world horizon (positive to turn to the right).</param>
+        <param index="3" label="Pitch angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
+        <param index="4" label="Yaw angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+        <param index="5" label="Roll angular rate" units="deg/s">Roll angular rate (positive to turn to the right).</param>
+        <param index="6" label="Pitch angular rate" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
+        <param index="7" label="Yaw angular rate" units="deg/s">Yaw/pan angular rate (positive to pan to the right).</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6099,7 +6099,7 @@
     <message id="284" name="GIMBAL_DEVICE_SET_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Low level message to control a gimbal device's attitude. This message is to be sent from the gimbal manager to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
+      <description>Low level message to control a gimbal device's attitude. This message is to be sent from the gimbal manager to the gimbal device component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
@@ -6112,7 +6112,7 @@
     <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right). This message should be broadcast at a low regular rate (e.g. 10Hz).</description>
+      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal device component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right). This message should be broadcast at a low regular rate (e.g. 10Hz).</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6065,6 +6065,7 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1677,9 +1677,9 @@
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
-        <param index="5">Latitude</param>
-        <param index="6">Longitude</param>
-        <param index="7">Altitude</param>
+        <param index="5">Latitude (deg * 1E7)</param>
+        <param index="6">Longitude (deg * 1E7)</param>
+        <param index="7">Altitude (meters)</param>
       </entry>
       <entry value="196" name="MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET" hasLocation="false" isDestination="false">
         <description>Sets the region of interest (ROI) to be toward next waypoint, with optional pitch/roll/yaw offset. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message.</description>
@@ -1687,9 +1687,9 @@
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
-        <param index="5" label="Pitch Offset">pitch offset from next waypoint</param>
-        <param index="6" label="Roll Offset">roll offset from next waypoint</param>
-        <param index="7" label="Yaw Offset">yaw offset from next waypoint</param>
+        <param index="5" label="Pitch Offset">Pitch offset from next waypoint, positive tilting up</param>
+        <param index="6" label="Roll Offset">roll offset from next waypoint, positive banking to the right</param>
+        <param index="7" label="Yaw Offset">yaw offset from next waypoint, positive panning to the right</param>
       </entry>
       <entry value="197" name="MAV_CMD_DO_SET_ROI_NONE" hasLocation="false" isDestination="false">
         <description>Cancels any previous ROI command returning the vehicle/sensors to default flight characteristics. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -984,7 +984,7 @@
     <!-- Camera Mount mode Enumeration -->
     <enum name="MAV_MOUNT_MODE">
       <deprecated since="2020-01" replaced_by="GIMBAL_MANAGER_FLAGS"/>
-      <description>Enumeration of possible mount operation modes</description>
+      <description>Enumeration of possible mount operation modes. This message is used by obsolete/deprecated gimbal messages.</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
         <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1030,6 +1030,9 @@
       <entry value="128" name="GIMBAL_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
         <description>Gimbal supports tracking of a point on the camera</description>
       </entry>
+      <entry value="256" name="GIMBAL_CAP_FLAGS_HAS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
+        <description>Gimbal supports turning at angular velocities relative to the focal length (the more zoomed in, the slower the movement)</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
@@ -1062,6 +1065,9 @@
       </entry>
       <entry value="16" name="GIMBAL_CONTROL_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+      </entry>
+      <entry value="32" name="GIMBAL_CONTROL_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
+        <description>Scale angular velocity relative to focal length. This means the gimbal should move slower if it is zoomed in.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5966,6 +5966,10 @@
       <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
       <field type="uint32_t" name="firmware_version">Version of the gimbal firmware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
       <field type="uint32_t" name="flags" enum="GIMBAL_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
+      <field type="float" name="pitch_max" units="rad">Maximum pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="pitch_min" units="rad">Minimum pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="yaw_max" units="rad">Maximum yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="yaw_min" units="rad">Minimum yaw angle (positive: to the right, negative: to the left)</field>
     </message>
     <message id="281" name="GIMBAL_CONTROL_ATTITUDE">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1040,21 +1040,21 @@
         <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
       </entry>
     </enum>
-    <enum name="MAV_GIMBAL_CONTROL_FLAGS">
+    <enum name="MAV_GIMBAL_CONTROL_CAP_FLAGS">
       <description>Flags for gimbal operation.</description>
-      <entry value="1" name="MAV_GIMBAL_CONTROL_FLAG_RETRACT">
+      <entry value="1" name="MAV_GIMBAL_CONTROL_CAP_FLAG_RETRACT">
         <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
       </entry>
-      <entry value="2" name="MAV_GIMBAL_CONTROL_FLAG_NEUTRAL">
+      <entry value="2" name="MAV_GIMBAL_CONTROL_CAP_FLAG_NEUTRAL">
         <description>Set to neutral position (horizontal, forward looking, with stabiliziation), takes presedence over all other flags except RETRACT.</description>
       </entry>
-      <entry value="4" name="MAV_GIMBAL_CONTROL_FLAG_ROLL_LOCK">
+      <entry value="4" name="MAV_GIMBAL_CONTROL_CAP_FLAG_ROLL_LOCK">
         <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>
       </entry>
-      <entry value="8" name="MAV_GIMBAL_CONTROL_FLAG_PITCH_LOCK">
+      <entry value="8" name="MAV_GIMBAL_CONTROL_CAP_FLAG_PITCH_LOCK">
         <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
       </entry>
-      <entry value="16" name="MAV_GIMBAL_CONTROL_FLAG_YAW_LOCK">
+      <entry value="16" name="MAV_GIMBAL_CONTROL_CAP_FLAG_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone).</description>
       </entry>
     </enum>
@@ -5925,7 +5925,7 @@
       <description>Message to control a gimbal's attitude. This message is to be sent by the autopilot to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_FLAGS" display="bitmask">Gimbal control flags.</field>
+      <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_CAP_FLAGS" display="bitmask">Gimbal control flags.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
@@ -5955,7 +5955,7 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message reporting the status of a gimbal. This message can be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
-      <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_FLAGS">Current gimbal control flags</field>
+      <field type="uint16_t" name="flags" enum="MAV_GIMBAL_CONTROL_CAP_FLAGS">Current gimbal control flags</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -984,7 +984,7 @@
     <!-- Camera Mount mode Enumeration -->
     <enum name="MAV_MOUNT_MODE">
       <deprecated since="2019-07" replaced_by="MAV_GIMBAL_MODE"/>
-      <description>Enumeration of possible mount operation modes (deprecated, replaced by MAV_GIMBAL_MODE)</description>
+      <description>Enumeration of possible mount operation modes</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
         <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
       </entry>
@@ -1007,16 +1007,16 @@
     <enum name="MAV_GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>
       <entry value="0" name="MAV_GIMBAL_MODE_RETRACT">
-        <description>Retracted safe position</description>
+        <description>Set to retracted safe position</description>
       </entry>
       <entry value="1" name="MAV_GIMBAL_MODE_DEFAULT">
-        <description>Neutral (default) position.</description>
+        <description>Set to neutral (default) position</description>
       </entry>
       <entry value="2" name="MAV_GIMBAL_MODE_FOLLOW">
-        <description>Use Follow mode (this mode should follows the heading of the vehicle with some dampening).</description>
+        <description>Use Heading Follow mode (this follows the heading of the vehicle with some smoothing)</description>
       </entry>
       <entry value="3" name="MAV_GIMBAL_MODE_LOCK">
-        <description>Use Lock mode (this mode should lock to heading ignoring the vehicle heading as much as possible).</description>
+        <description>Use Lock mode (this mode locks to a certain direction ignoring the vehicle heading as much as possible)</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
@@ -1649,7 +1649,7 @@
       </entry>
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
-        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_ATTITUDE">This message is ambiguous and inconsistent and therefore replaced by MAV_CMD_DO_GIMBAL_ATTITUDE and MAV_CMD_DO_SET_ROI_*.</deprecated>
+        <deprecated since="2019-07" replaced_by="MAV_CMD_DO_GIMBAL_ATTITUDE">This message is ambiguous and inconsistent. It has been replaced by MAV_CMD_DO_GIMBAL_ATTITUDE and MAV_CMD_DO_SET_ROI_*.</deprecated>
         <description>Mission command to control a camera or antenna mount</description>
         <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input).</param>
         <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
@@ -1985,14 +1985,14 @@
         <param index="2" label="Repeat" minValue="0" increment="1">Repeat count.</param>
       </entry>
       <entry value="1000" name="MAV_CMD_DO_GIMBAL_ATTITUDE" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
-        <param index="1">Pitch/tilt angle relative to world horizon (+90 to -90 degrees, negative is to tilt down, positive to tilt up).</param>
-        <param index="2">Yaw/pan angle (-180 to 180 degrees, positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
-        <param index="3">Pitch/tilt angular rate (degrees/second, positive to point up).</param>
-        <param index="4">Yaw/pan angular rate (degrees/second, positive to pan to the right).</param>
+        <param index="1" units="rad" minValue="-1.57" maxValue="1.57">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
+        <param index="2" units="rad" minValue="-3.14" maxValue="3.14">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+        <param index="3" units="rad/s">Pitch/tilt angular rate (positive to point up).</param>
+        <param index="4" units="rad/s">Yaw/pan angular rate (positive to pan to the right).</param>
         <param index="5" enum="MAV_GIMBAL_MODE">Gimbal mode.</param>
-        <param index="6">Reserved.</param>
-        <param index="7">Reserved.</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
@@ -5876,13 +5876,13 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="mode" enum="MAV_GIMBAL_MODE">Gimbal mode.</field>
-      <field type="float" name="roll" units="rad">Roll in global frame, positive is tilt to the right (set to NaN for not set).</field>
-      <field type="float" name="pitch" units="rad">Pitch in global frame, positive is tilting up (set to NaN for not set).</field>
-      <field type="float" name="yaw_relative" units="rad">Yaw relative to vehicle, required for MAV_GIMBAL_MODE_FOLLOW (set to NaN for not set).</field>
-      <field type="float" name="yaw_absolute" units="rad">Yaw absolute, 0 is North, -pi to pi, positive to the right, required for MAV_GIMBAL_MODE_LOCK mode (set to NaN for not set).</field>
-      <field type="float" name="rollspeed" units="rad/s">Roll angular speed (NaN for not set).</field>
-      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed (NaN for not set).</field>
-      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed (NaN for not set).</field>
+      <field type="float" name="roll" units="rad">Roll in global frame, positive is tilt to the right (NaN to be ignored).</field>
+      <field type="float" name="pitch" units="rad">Pitch in global frame, positive is tilting up (NaN to be ignored).</field>
+      <field type="float" name="yaw_relative" units="rad">Yaw relative to vehicle, -pi to pi, positive to the right, required for MAV_GIMBAL_MODE_FOLLOW (NaN to be ignored).</field>
+      <field type="float" name="yaw_absolute" units="rad">Yaw absolute, 0 is North, -pi to pi, positive to the right, required for MAV_GIMBAL_MODE_LOCK mode (NaN to be ignored).</field>
+      <field type="float" name="rollspeed" units="rad/s">Roll angular speed (NaN to be ignored).</field>
+      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed (NaN to be ignored).</field>
+      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed (NaN to be ignored).</field>
     </message>
     <message id="281" name="GIMBAL_CONTROL_LOCATION">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2068,7 +2068,7 @@
       <entry value="1000" name="MAV_CMD_DO_GIMBAL_ATTITUDE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
+        <description>Setpoint to be sent to a gimbal to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
         <param index="1" label="Gimbal mode" enum="GIMBAL_MODE">Gimbal mode.</param>
         <param index="2" label="Roll angular rate" units="deg/s">Roll angular rate (positive to turn to the right).</param>
         <param index="3" label="Pitch angular rate" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
@@ -5986,7 +5986,7 @@
     <message id="281" name="GIMBAL_CONTROL_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message to control a gimbal's attitude. This message is to be sent by the autopilot to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
+      <description>Message to control a gimbal's attitude. This message is to be sent to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_CONTROL_FLAGS" display="bitmask">Gimbal control flags.</field>
@@ -5998,7 +5998,7 @@
     <message id="282" name="GIMBAL_CONTROL_LOCATION_GLOBAL">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message to control a gimbal to point to a GPS point. This message is to be sent by the autopilot to the gimbal component.</description>
+      <description>Message to control a gimbal to point to a GPS point. This message is to be sent to the gimbal component.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="int32_t" name="lat" units="degE7">Latitude where gimbal should point to</field>
@@ -6008,7 +6008,7 @@
     <message id="283" name="GIMBAL_CONTROL_LOCATION_LOCAL">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message to control a gimbal to point to a local position. This message is to be sent by the autopilot to the gimbal component.</description>
+      <description>Message to control a gimbal to point to a local position. This message is to be sent to the gimbal component.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="float" name="x" units="m">X position of location in the local coordinate frame NED</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -983,7 +983,7 @@
     </enum>
     <!-- Camera Mount mode Enumeration -->
     <enum name="MAV_MOUNT_MODE">
-      <deprecated since="2019-07" replaced_by="GIMBAL_CONTROLLER_MODE"/>
+      <deprecated since="2019-07" replaced_by="GIMBAL_MANAGER_MODE"/>
       <description>Enumeration of possible mount operation modes</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
         <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
@@ -1022,47 +1022,47 @@
         <description>Gimbal supports yawing infinetely (e.g. using slip disk).</description>
       </entry>
     </enum>
-    <enum name="GIMBAL_CONTROLLER_CAP_FLAGS">
+    <enum name="GIMBAL_MANAGER_CAP_FLAGS">
       <description>Gimbal high level capability flags (Bitmap)</description>
-      <entry value="1" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_RETRACT">
+      <entry value="1" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_RETRACT">
         <description>Gimbal supports a retracted position</description>
       </entry>
-      <entry value="2" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_NEUTRAL">
+      <entry value="2" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_NEUTRAL">
         <description>Gimbal supports a horizontal, forward looking position, stabilized</description>
       </entry>
-      <entry value="4" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_YAW_FOLLOW">
+      <entry value="4" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_FOLLOW">
         <description>Gimbal supports to follow a yaw angle relative to the vehicle</description>
       </entry>
-      <entry value="8" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_YAW_LOCK">
+      <entry value="8" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_LOCK">
         <description>Gimbal supports locking to an absolute heading</description>
       </entry>
-      <entry value="16" name="GIMBAL_CONTROLLER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+      <entry value="16" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
         <description>Gimbal supports yawing infinetely (e.g. using slip disk).</description>
       </entry>
-      <entry value="32" name="GIMBAL_CONTROLLER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
+      <entry value="32" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
         <description>Gimbal supports to point to a local position</description>
       </entry>
-      <entry value="64" name="GIMBAL_CONTROLLER_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
+      <entry value="64" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
         <description>Gimbal supports to point to a global latitude, longitude, altitude position</description>
       </entry>
-      <entry value="128" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_TRACKING_POINT">
+      <entry value="128" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT">
         <description>Gimbal supports tracking of a point on the camera</description>
       </entry>
-      <entry value="256" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
+      <entry value="256" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
         <description>Gimbal supports tracking of a point on the camera</description>
       </entry>
-      <entry value="512" name="GIMBAL_CONTROLLER_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE">
+      <entry value="512" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE">
         <description>Gimbal supports pitching and yawing at an angular velocity scaled by focal length (the more zoomed in, the slower the movement).</description>
       </entry>
-      <entry value="1024" name="GIMBAL_CONTROLLER_CAP_FLAGS_SUPPORTS_NUDGING">
+      <entry value="1024" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_NUDGING">
         <description>Gimbal supports nudging when pointing to a location or tracking</description>
       </entry>
-      <entry value="2048" name="GIMBAL_CONTROLLER_CAP_FLAGS_SUPPORTS_OVERRIDE">
+      <entry value="2048" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_OVERRIDE">
         <description>Gimbal supports overriding when pointing to a location or tracking</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MODE">
-      <description>Enumeration of possible low level gimbal operation modes (used between gimbal controller and gimbal)</description>
+      <description>Enumeration of possible low level gimbal operation modes (used between gimbal manager and gimbal)</description>
       <entry value="0" name="GIMBAL_MODE_RETRACT">
         <description>Set to retracted safe position (no stabilization)</description>
       </entry>
@@ -1076,51 +1076,51 @@
         <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
       </entry>
     </enum>
-    <enum name="GIMBAL_CONTROLLER_MODE">
+    <enum name="GIMBAL_MANAGER_MODE">
       <description>Enumeration of high level possible gimbal operation modes</description>
-      <entry value="0" name="GIMBAL_CONTROLLER_MODE_NONE">
+      <entry value="0" name="GIMBAL_MANAGER_MODE_NONE">
         <description>Give up control over gimbal and let GIMBAL_CONTROL_ATTITUDE takeover again (can e.g. be used after a mission is finished)</description>
       </entry>
-      <entry value="1" name="GIMBAL_CONTROLLER_MODE_RETRACT">
+      <entry value="1" name="GIMBAL_MANAGER_MODE_RETRACT">
         <description>Set to retracted safe position (no stabilization)</description>
       </entry>
-      <entry value="2" name="GIMBAL_CONTROLLER_MODE_NEUTRAL">
+      <entry value="2" name="GIMBAL_MANAGER_MODE_NEUTRAL">
         <description>Set to neutral position (horizontal, forward looking, with stabilization)</description>
       </entry>
-      <entry value="3" name="GIMBAL_CONTROLLER_MODE_YAW_FOLLOW">
+      <entry value="3" name="GIMBAL_MANAGER_MODE_YAW_FOLLOW">
         <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
       </entry>
-      <entry value="4" name="GIMBAL_CONTROLLER_MODE_YAW_LOCK">
+      <entry value="4" name="GIMBAL_MANAGER_MODE_YAW_LOCK">
         <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
       </entry>
     </enum>
-    <enum name="GIMBAL_CONTROLLER_FLAGS">
+    <enum name="GIMBAL_MANAGER_FLAGS">
       <description>Flags for gimbal high level operation.</description>
-      <entry value="1" name="GIMBAL_CONTROL_FLAGS_RETRACT">
+      <entry value="1" name="GIMBAL_MANAGER_FLAGS_RETRACT">
         <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
       </entry>
-      <entry value="2" name="GIMBAL_CONTROL_FLAGS_NEUTRAL">
+      <entry value="2" name="GIMBAL_MANAGER_FLAGS_NEUTRAL">
         <description>Set to neutral position (horizontal, forward looking, with stabiliziation), takes presedence over all other flags except RETRACT.</description>
       </entry>
-      <entry value="4" name="GIMBAL_CONTROL_FLAGS_ROLL_LOCK">
+      <entry value="4" name="GIMBAL_MANAGER_FLAGS_ROLL_LOCK">
         <description>Lock roll angle to absolute angle relative to horizon (not relative to drone). This is generally the default with a stabilizing gimbal.</description>
       </entry>
-      <entry value="8" name="GIMBAL_CONTROL_FLAGS_PITCH_LOCK">
+      <entry value="8" name="GIMBAL_MANAGER_FLAGS_PITCH_LOCK">
         <description>Lock pitch angle to absolute angle relative to horizon (not relative to drone). This is generally the default.</description>
       </entry>
-      <entry value="16" name="GIMBAL_CONTROL_FLAGS_YAW_LOCK">
+      <entry value="16" name="GIMBAL_MANAGER_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
-      <entry value="32" name="GIMBAL_CONTROL_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
+      <entry value="32" name="GIMBAL_MANAGER_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
         <description>Scale angular velocity relative to focal length. This means the gimbal should move slower if it is zoomed in.</description>
       </entry>
-      <entry value="64" name="GIMBAL_CONTROL_FLAGS_NUDGE">
+      <entry value="64" name="GIMBAL_MANAGER_FLAGS_NUDGE">
         <description>Interpret attitude control on top of pointing to a location or tracking. If this flag is set, the quaternion is relative to the existing tracking angle.</description>
       </entry>
-      <entry value="128" name="GIMBAL_CONTROL_FLAGS_OVERRIDE">
+      <entry value="128" name="GIMBAL_MANAGER_FLAGS_OVERRIDE">
         <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_CONTROL_FLAGS_YAW_LOCK.</description>
       </entry>
-      <entry value="256" name="GIMBAL_CONTROL_FLAGS_SCALE_BY_FOCAL_LENGTH">
+      <entry value="256" name="GIMBAL_MANAGER_FLAGS_SCALE_BY_FOCAL_LENGTH">
         <description>Set if the angular velocity control should be scaled by focal length (the more zoomed in the slower).</description>
       </entry>
     </enum>
@@ -2092,18 +2092,18 @@
       <entry value="1000" name="MAV_CMD_DO_GIMBAL_ATTITUDE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>High level setpoint to be sent to a gimbal controller to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
+        <description>High level setpoint to be sent to a gimbal manager to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
         <param index="1" label="Tilt angular rate" units="deg/s">Tilt/pitch angular rate (positive to point up).</param>
         <param index="2" label="Pan angular rate" units="deg/s">Pan/yaw angular rate (positive to pan to the right).</param>
         <param index="3" label="Tilt angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
         <param index="4" label="Pan angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
-        <param index="5" label="Gimbal mode" enum="GIMBAL_CONTROLLER_MODE">Gimbal controller mode.</param>
+        <param index="5" label="Gimbal mode" enum="GIMBAL_MANAGER_MODE">Gimbal controller mode.</param>
         <param index="6" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="1001" name="MAV_CMD_DO_GIMBAL_TRACK_POINT" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>If the gimbal controller supports visual tracking (GIMBAL_CONTROLLER_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking.</description>
+        <description>If the gimbal manager supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking.</description>
         <param index="1" label="Point 1 x" minValue="0" maxValue="1">Point to track.</param>
         <param index="2" label="Point 1 y" minValue="0" maxValue="1">Roll angular rate (positive to turn to the right).</param>
         <param index="3" label="Point 2 x" minValue="0" maxValue="1">Pitch/tilt angular rate (positive to point up).</param>
@@ -2112,7 +2112,7 @@
       <entry value="1002" name="MAV_CMD_DO_GIMBAL_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>If the gimbal supports visual tracking (GIMBAL_CONTROLLER_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), this command allows to initiate the tracking.</description>
+        <description>If the gimbal supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), this command allows to initiate the tracking.</description>
         <param index="1" label="Top left corner x" minValue="0" maxValue="1">Top left corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
         <param index="2" label="Top left corner y" minValue="0" maxValue="1">Top left corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
         <param index="3" label="Bottom right corner x" minValue="0" maxValue="1">Bottom right corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
@@ -5994,11 +5994,11 @@
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
     </message>
-    <message id="280" name="GIMBAL_CONTROLLER_INFORMATION">
-      <description>Information about a high level gimbal controller</description>
+    <message id="280" name="GIMBAL_MANAGER_INFORMATION">
+      <description>Information about a high level gimbal manager</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
-      <field type="uint32_t" name="flags" enum="GIMBAL_CONTROLLER_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
-      <field type="uint8_t" name="gimbal_component">Gimbal component ID that this gimbal controller is responsible for.</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_MANAGER_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
+      <field type="uint8_t" name="gimbal_component">Gimbal component ID that this gimbal manager is responsible for.</field>
       <field type="float" name="tilt_max" units="rad">Maximum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_min" units="rad">Minimum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_rate_max" units="rad/s">Maximum tilt/pitch angular rate (positive: up, negative: down)</field>
@@ -6020,13 +6020,13 @@
       <field type="float" name="pan_min" units="rad">Minimum pan/yaw angle (positive: to the right, negative: to the left)</field>
       <field type="float" name="pan_rate_max" units="rad/s">Minimum pan/yaw angular rate (positive: to the right, negative: to the left)</field>
     </message>
-    <message id="282" name="GIMBAL_CONTROLLER_SET_ATTITUDE">
+    <message id="282" name="GIMBAL_MANAGER_SET_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>High level message to control a gimbal's attitude. This message is to be sent to the gimbal controller (e.g. from a ground stationi). Angles and rates can be set to NaN according to use case.</description>
+      <description>High level message to control a gimbal's attitude. This message is to be sent to the gimbal manager (e.g. from a ground stationi). Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="mode" enum="GIMBAL_CONTROLLER_MODE">High level gimbal controller mode.</field>
+      <field type="uint16_t" name="mode" enum="GIMBAL_MANAGER_MODE">High level gimbal manager mode.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
@@ -6035,7 +6035,7 @@
     <message id="283" name="GIMBAL_SET_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Low level message to control a gimbal's attitude. This message is to be sent from the gimbal controller to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
+      <description>Low level message to control a gimbal's attitude. This message is to be sent from the gimbal manager to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="mode" enum="GIMBAL_MODE">Low level gimbal mode.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6098,7 +6098,7 @@
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>
-      <field type="uint32" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
+      <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5904,20 +5904,27 @@
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
     </message>
-    <message id="281" name="GIMBAL_CONTROL_LOCATION">
+    <message id="281" name="GIMBAL_CONTROL_LOCATION_GLOBAL">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message to control a gimbal to point to a GPS point or local position. This can be used for a GPS position if x, y, z are set to NaN or a local position if lat, lon, alt are set to 0. This message is to be sent by the autopilot to the gimbal component.</description>
+      <description>Message to control a gimbal to point to a GPS point. This message is to be sent by the autopilot to the gimbal component.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="int32_t" name="lat" units="degE7">Latitude where gimbal should point to</field>
       <field type="int32_t" name="lon" units="degE7">Longitude where gimbal should point to</field>
       <field type="int32_t" name="alt" units="mm">Altitude (MSL) where gimbal should point to</field>
-      <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame NED</field>
-      <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame NED</field>
-      <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame NED</field>
     </message>
-    <message id="282" name="GIMBAL_CONTROL_STATUS_ATTITUDE">
+    <message id="282" name="GIMBAL_CONTROL_LOCATION_LOCAL">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Message to control a gimbal to point to a local position. This message is to be sent by the autopilot to the gimbal component.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="float" name="x" units="m">X position of location in the local coordinate frame NED</field>
+      <field type="float" name="y" units="m">Y position of location in the local coordinate frame NED</field>
+      <field type="float" name="z" units="m">Z position of location in the local coordinate frame NED</field>
+    </message>
+    <message id="283" name="GIMBAL_CONTROL_STATUS_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message reporting the status of a gimbal. This message can be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1358,7 +1358,7 @@
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>
-        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
         <param index="1" label="ROI Mode" enum="MAV_ROI">Region of interest mode.</param>
         <param index="2" label="WP Index" minValue="0" increment="1">Waypoint index/ target ID. (see MAV_ROI enum)</param>
         <param index="3" label="ROI Index" minValue="0" increment="1">ROI index (allows a vehicle to manage multiple ROI's)</param>
@@ -1717,7 +1717,7 @@
       </entry>
       <entry value="201" name="MAV_CMD_DO_SET_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>
-        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
+        <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
         <param index="1" label="ROI Mode" enum="MAV_ROI">Region of interest mode.</param>
         <param index="2" label="WP Index" minValue="0" increment="1">Waypoint index/ target ID (depends on param 1).</param>
         <param index="3" label="ROI Index" minValue="0" increment="1">Region of interest index. (allows a vehicle to manage multiple ROI's)</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1760,7 +1760,7 @@
       </entry>
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
-        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is ambiguous and inconsistent. It has been replaced by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE and MAV_CMD_DO_SET_ROI_*.</deprecated>
+        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is ambiguous and inconsistent. It has been superseded by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE and MAV_CMD_DO_SET_ROI_*. The message can still be used to communicate with legacy gimbals implementing it.</deprecated>
         <description>Mission command to control a camera or antenna mount</description>
         <param index="1">pitch depending on mount mode (degrees or degrees/second depending on pitch input).</param>
         <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
@@ -5937,7 +5937,7 @@
       <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of log files</field>
     </message>
     <message id="265" name="MOUNT_ORIENTATION">
-      <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is being replaced by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE.</deprecated>
+      <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is being superseded by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE. The message can still be used to communicate with legacy gimbals implementing it.</deprecated>
       <description>Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="roll" units="deg">Roll in global frame (set to NaN for invalid).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1722,9 +1722,9 @@
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
-        <param index="5" label="Latitude" units="degE7">Latitude of ROI location (deg * 1E7)</param>
-        <param index="6" label="Longitude" units="degE7">Longitude of ROI location (deg * 1E7)</param>
-        <param index="7" label="Altitude" units="m">Altitude of ROI location (meters)</param>
+        <param index="5" label="Latitude" units="degE7">Latitude of ROI location</param>
+        <param index="6" label="Longitude" units="degE7">Longitude of ROI location</param>
+        <param index="7" label="Altitude" units="m">Altitude of ROI location</param>
       </entry>
       <entry value="196" name="MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET" hasLocation="false" isDestination="false">
         <description>Sets the region of interest (ROI) to be toward next waypoint, with optional pitch/roll/yaw offset. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal device. A gimbal device is not to react to this message.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1022,7 +1022,7 @@
         <description>Gimbal supports to point to a local position</description>
       </entry>
       <entry value="32" name="GIMBAL_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
-        <description>Gimbal supports to point to a global GPS position</description>
+        <description>Gimbal supports to point to a global latitude, longitude, altitude position</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MODE">
@@ -2028,12 +2028,12 @@
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
         <param index="1" label="Gimbal mode" enum="GIMBAL_MODE">Gimbal mode.</param>
-        <param index="2" label="Roll angle" units="deg" minValue="-180" maxValue="180">Roll angle relative to world horizon (positive to turn to the right).</param>
-        <param index="3" label="Pitch angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
-        <param index="4" label="Yaw angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
-        <param index="5" label="Roll angular rate" units="deg/s">Roll angular rate (positive to turn to the right).</param>
-        <param index="6" label="Pitch angular rate" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
-        <param index="7" label="Yaw angular rate" units="deg/s">Yaw/pan angular rate (positive to pan to the right).</param>
+        <param index="2" label="Roll angular rate" units="deg/s">Roll angular rate (positive to turn to the right).</param>
+        <param index="3" label="Pitch angular rate" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
+        <param index="4" label="Yaw angular rate" units="deg/s">Yaw/pan angular rate (positive to pan to the right).</param>
+        <param index="5" label="Roll angle" units="deg" minValue="-180" maxValue="180">Roll angle relative to world horizon (positive to turn to the right).</param>
+        <param index="6" label="Pitch angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
+        <param index="7" label="Yaw angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
@@ -5917,7 +5917,7 @@
       <field type="uint8_t[32]" name="vendor_name">Name of the gimbal vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
       <field type="uint32_t" name="firmware_version">Version of the gimbal firmware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
-      <field type="uint32_t" name="flags" enum="GIMBAL_CAP_FLAGS">Bitmap of gimbal capability flags.</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
     </message>
     <message id="281" name="GIMBAL_CONTROL_ATTITUDE">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1039,6 +1039,9 @@
       <entry value="1024" name="GIMBAL_CAP_FLAGS_SUPPORTS_OVERRIDE">
         <description>Gimbal supports overriding when pointing to a location or tracking</description>
       </entry>
+      <entry value="2048" name="GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+        <description>Gimbal supports yawing infinetely (e.g. using slip disk).</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MODE">
       <description>Enumeration of possible gimbal operation modes</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5893,9 +5893,9 @@
       <field type="int32_t" name="lat" units="degE7">Latitude where gimbal should point to</field>
       <field type="int32_t" name="lon" units="degE7">Longitude where gimbal should point to</field>
       <field type="int32_t" name="alt" units="mm">Altitude (MSL) where gimbal should point to</field>
-      <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame</field>
-      <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame</field>
-      <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame</field>
+      <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame NED</field>
+      <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame NED</field>
+      <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame NED</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1717,8 +1717,8 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="195" name="MAV_CMD_DO_SET_ROI_LOCATION" hasLocation="true" isDestination="false">
-        <description>Sets the region of interest (ROI) to a location. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message.</description>
-        <param index="1" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
+        <description>Sets the region of interest (ROI) to a location. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal device. A gimbal is not to react to this message.</description>
+        <param index="1" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. (Send command multiple times for more than one but not all gimbals.)</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -1727,8 +1727,8 @@
         <param index="7">Altitude (meters)</param>
       </entry>
       <entry value="196" name="MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET" hasLocation="false" isDestination="false">
-        <description>Sets the region of interest (ROI) to be toward next waypoint, with optional pitch/roll/yaw offset. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message.</description>
-        <param index="1" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
+        <description>Sets the region of interest (ROI) to be toward next waypoint, with optional pitch/roll/yaw offset. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal device. A gimbal device is not to react to this message.</description>
+        <param index="1" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. (Send command multiple times for more than one but not all gimbals.)</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -1737,8 +1737,8 @@
         <param index="7" label="Yaw Offset">yaw offset from next waypoint, positive panning to the right</param>
       </entry>
       <entry value="197" name="MAV_CMD_DO_SET_ROI_NONE" hasLocation="false" isDestination="false">
-        <description>Cancels any previous ROI command returning the vehicle/sensors to default flight characteristics. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message. After this command the gimbal manager should go back to manual input if available, and otherwise assume a neutral position.</description>
-        <param index="1" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
+        <description>Cancels any previous ROI command returning the vehicle/sensors to default flight characteristics. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal device. A gimbal device is not to react to this message. After this command the gimbal manager should go back to manual input if available, and otherwise assume a neutral position.</description>
+        <param index="1" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. (Send command multiple times for more than one but not all gimbals.)</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -2149,7 +2149,7 @@
         <param index="3" label="Tilt angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
         <param index="4" label="Pan angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
         <param index="5" label="Gimbal manager flags" enum="GIMBAL_MANAGER_FLAGS">Gimbal manager flags to use.</param>
-        <param index="7" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
+        <param index="7" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="1001" name="MAV_CMD_DO_GIMBAL_MANAGER_TRACK_POINT" hasLocation="false" isDestination="false">
         <wip/>
@@ -2157,7 +2157,7 @@
         <description>If the gimbal manager supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking. Such a tracking gimbal manager would usually be an integrated camera/gimbal, or alternatively a companion computer connected to a camera.</description>
         <param index="1" label="Point x" minValue="0" maxValue="1">Point to track x value.</param>
         <param index="2" label="Point y" minValue="0" maxValue="1">Point to track y value.</param>
-        <param index="7" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
+        <param index="7" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="1002" name="MAV_CMD_DO_GIMBAL_MANAGER_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
         <wip/>
@@ -2167,7 +2167,7 @@
         <param index="2" label="Top left corner y" minValue="0" maxValue="1">Top left corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
         <param index="3" label="Bottom right corner x" minValue="0" maxValue="1">Bottom right corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
         <param index="4" label="Bottom right corner y" minValue="0" maxValue="1">Bottom right corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
-        <param index="7" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
+        <param index="7" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -983,7 +983,7 @@
     </enum>
     <!-- Camera Mount mode Enumeration -->
     <enum name="MAV_MOUNT_MODE">
-      <deprecated since="2019-07" replaced_by="GIMBAL_MODE"/>
+      <deprecated since="2019-07" replaced_by="GIMBAL_CONTROLLER_MODE"/>
       <description>Enumeration of possible mount operation modes</description>
       <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
         <description>Load and keep safe position (Roll,Pitch,Yaw) from permant memory and stop stabilization</description>
@@ -1005,7 +1005,7 @@
       </entry>
     </enum>
     <enum name="GIMBAL_CAP_FLAGS">
-      <description>Gimbal capability flags (Bitmap)</description>
+      <description>Gimbal low level capability flags (Bitmap)</description>
       <entry value="1" name="GIMBAL_CAP_FLAGS_HAS_RETRACT">
         <description>Gimbal supports a retracted position</description>
       </entry>
@@ -1018,54 +1018,84 @@
       <entry value="8" name="GIMBAL_CAP_FLAGS_HAS_YAW_LOCK">
         <description>Gimbal supports locking to an absolute heading</description>
       </entry>
-      <entry value="16" name="GIMBAL_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
-        <description>Gimbal supports to point to a local position</description>
-      </entry>
-      <entry value="32" name="GIMBAL_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
-        <description>Gimbal supports to point to a global latitude, longitude, altitude position</description>
-      </entry>
-      <entry value="64" name="GIMBAL_CAP_FLAGS_HAS_TRACKING_POINT">
-        <description>Gimbal supports tracking of a point on the camera</description>
-      </entry>
-      <entry value="128" name="GIMBAL_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
-        <description>Gimbal supports tracking of a point on the camera</description>
-      </entry>
-      <entry value="256" name="GIMBAL_CAP_FLAGS_HAS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
-        <description>Gimbal supports turning at angular velocities relative to the focal length (the more zoomed in, the slower the movement)</description>
-      </entry>
-      <entry value="512" name="GIMBAL_CAP_FLAGS_SUPPORTS_NUDGING">
-        <description>Gimbal supports nudging when pointing to a location or tracking</description>
-      </entry>
-      <entry value="1024" name="GIMBAL_CAP_FLAGS_SUPPORTS_OVERRIDE">
-        <description>Gimbal supports overriding when pointing to a location or tracking</description>
-      </entry>
-      <entry value="2048" name="GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+      <entry value="16" name="GIMBAL_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
         <description>Gimbal supports yawing infinetely (e.g. using slip disk).</description>
       </entry>
-      <entry value="4096" name="GIMBAL_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE">
+    </enum>
+    <enum name="GIMBAL_CONTROLLER_CAP_FLAGS">
+      <description>Gimbal high level capability flags (Bitmap)</description>
+      <entry value="1" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_RETRACT">
+        <description>Gimbal supports a retracted position</description>
+      </entry>
+      <entry value="2" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_NEUTRAL">
+        <description>Gimbal supports a horizontal, forward looking position, stabilized</description>
+      </entry>
+      <entry value="4" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_YAW_FOLLOW">
+        <description>Gimbal supports to follow a yaw angle relative to the vehicle</description>
+      </entry>
+      <entry value="8" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_YAW_LOCK">
+        <description>Gimbal supports locking to an absolute heading</description>
+      </entry>
+      <entry value="16" name="GIMBAL_CONTROLLER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
+        <description>Gimbal supports yawing infinetely (e.g. using slip disk).</description>
+      </entry>
+      <entry value="32" name="GIMBAL_CONTROLLER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
+        <description>Gimbal supports to point to a local position</description>
+      </entry>
+      <entry value="64" name="GIMBAL_CONTROLLER_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
+        <description>Gimbal supports to point to a global latitude, longitude, altitude position</description>
+      </entry>
+      <entry value="128" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_TRACKING_POINT">
+        <description>Gimbal supports tracking of a point on the camera</description>
+      </entry>
+      <entry value="256" name="GIMBAL_CONTROLLER_CAP_FLAGS_HAS_TRACKING_RECTANGLE">
+        <description>Gimbal supports tracking of a point on the camera</description>
+      </entry>
+      <entry value="512" name="GIMBAL_CONTROLLER_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE">
         <description>Gimbal supports pitching and yawing at an angular velocity scaled by focal length (the more zoomed in, the slower the movement).</description>
+      </entry>
+      <entry value="1024" name="GIMBAL_CONTROLLER_CAP_FLAGS_SUPPORTS_NUDGING">
+        <description>Gimbal supports nudging when pointing to a location or tracking</description>
+      </entry>
+      <entry value="2048" name="GIMBAL_CONTROLLER_CAP_FLAGS_SUPPORTS_OVERRIDE">
+        <description>Gimbal supports overriding when pointing to a location or tracking</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MODE">
-      <description>Enumeration of possible gimbal operation modes</description>
-      <entry value="0" name="GIMBAL_MODE_NONE">
-        <description>Give up control over gimbal and let GIMBAL_CONTROL_ATTITUDE takeover again (can e.g. be used after a mission is finished)</description>
-      </entry>
-      <entry value="1" name="GIMBAL_MODE_RETRACT">
+      <description>Enumeration of possible low level gimbal operation modes (used between gimbal controller and gimbal)</description>
+      <entry value="0" name="GIMBAL_MODE_RETRACT">
         <description>Set to retracted safe position (no stabilization)</description>
       </entry>
-      <entry value="2" name="GIMBAL_MODE_NEUTRAL">
+      <entry value="1" name="GIMBAL_MODE_NEUTRAL">
         <description>Set to neutral position (horizontal, forward looking, with stabilization)</description>
       </entry>
-      <entry value="3" name="GIMBAL_MODE_YAW_FOLLOW">
+      <entry value="2" name="GIMBAL_MODE_YAW_FOLLOW">
         <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
       </entry>
-      <entry value="4" name="GIMBAL_MODE_YAW_LOCK">
+      <entry value="3" name="GIMBAL_MODE_YAW_LOCK">
         <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
       </entry>
     </enum>
-    <enum name="GIMBAL_CONTROL_FLAGS">
-      <description>Flags for gimbal operation.</description>
+    <enum name="GIMBAL_CONTROLLER_MODE">
+      <description>Enumeration of high level possible gimbal operation modes</description>
+      <entry value="0" name="GIMBAL_CONTROLLER_MODE_NONE">
+        <description>Give up control over gimbal and let GIMBAL_CONTROL_ATTITUDE takeover again (can e.g. be used after a mission is finished)</description>
+      </entry>
+      <entry value="1" name="GIMBAL_CONTROLLER_MODE_RETRACT">
+        <description>Set to retracted safe position (no stabilization)</description>
+      </entry>
+      <entry value="2" name="GIMBAL_CONTROLLER_MODE_NEUTRAL">
+        <description>Set to neutral position (horizontal, forward looking, with stabilization)</description>
+      </entry>
+      <entry value="3" name="GIMBAL_CONTROLLER_MODE_YAW_FOLLOW">
+        <description>Normal gimbal operation: stabilizing and following yaw relative to vehicle.</description>
+      </entry>
+      <entry value="4" name="GIMBAL_CONTROLLER_MODE_YAW_LOCK">
+        <description>Normal gimbal operation: stabilizing and locking yaw to absolute heading.</description>
+      </entry>
+    </enum>
+    <enum name="GIMBAL_CONTROLLER_FLAGS">
+      <description>Flags for gimbal high level operation.</description>
       <entry value="1" name="GIMBAL_CONTROL_FLAGS_RETRACT">
         <description>Set to retracted safe position (no stabilization), takes presedence over all other flags.</description>
       </entry>
@@ -1090,13 +1120,7 @@
       <entry value="128" name="GIMBAL_CONTROL_FLAGS_OVERRIDE">
         <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_CONTROL_FLAGS_YAW_LOCK.</description>
       </entry>
-      <entry value="256" name="GIMBAL_CONTROL_FLAGS_SOURCE_RC">
-        <description>Set if the input source for the gimbal attitude control is RC.</description>
-      </entry>
-      <entry value="512" name="GIMBAL_CONTROL_FLAGS_SOURCE_GCS">
-        <description>Set if the input source for the gimbal attitude control is a GCS.</description>
-      </entry>
-      <entry value="1024" name="GIMBAL_CONTROL_FLAGS_SCALE_BY_FOCAL_LENGTH">
+      <entry value="256" name="GIMBAL_CONTROL_FLAGS_SCALE_BY_FOCAL_LENGTH">
         <description>Set if the angular velocity control should be scaled by focal length (the more zoomed in the slower). This requires GIMBAL_CAP_FLAGS_SUPPORTS_FOCAL_LENGTH_SCALE.</description>
       </entry>
     </enum>
@@ -2068,19 +2092,18 @@
       <entry value="1000" name="MAV_CMD_DO_GIMBAL_ATTITUDE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Setpoint to be sent to a gimbal to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
-        <param index="1" label="Gimbal mode" enum="GIMBAL_MODE">Gimbal mode.</param>
-        <param index="2" label="Roll angular rate" units="deg/s">Roll angular rate (positive to turn to the right).</param>
-        <param index="3" label="Pitch angular rate" units="deg/s">Pitch/tilt angular rate (positive to point up).</param>
-        <param index="4" label="Yaw angular rate" units="deg/s">Yaw/pan angular rate (positive to pan to the right).</param>
-        <param index="5" label="Roll angle" units="deg" minValue="-180" maxValue="180">Roll angle relative to world horizon (positive to turn to the right).</param>
-        <param index="6" label="Pitch angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
-        <param index="7" label="Yaw angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+        <description>High level setpoint to be sent to a gimbal controller to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
+        <param index="1" label="Tilt angular rate" units="deg/s">Tilt/pitch angular rate (positive to point up).</param>
+        <param index="2" label="Pan angular rate" units="deg/s">Pan/yaw angular rate (positive to pan to the right).</param>
+        <param index="3" label="Tilt angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
+        <param index="4" label="Pan angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
+        <param index="5" label="Gimbal mode" enum="GIMBAL_CONTROLLER_MODE">Gimbal controller mode.</param>
+        <param index="6" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="1001" name="MAV_CMD_DO_GIMBAL_TRACK_POINT" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>If the gimbal supports visual tracking (GIMBAL_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking.</description>
+        <description>If the gimbal controller supports visual tracking (GIMBAL_CONTROLLER_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking.</description>
         <param index="1" label="Point 1 x" minValue="0" maxValue="1">Point to track.</param>
         <param index="2" label="Point 1 y" minValue="0" maxValue="1">Roll angular rate (positive to turn to the right).</param>
         <param index="3" label="Point 2 x" minValue="0" maxValue="1">Pitch/tilt angular rate (positive to point up).</param>
@@ -2089,7 +2112,7 @@
       <entry value="1002" name="MAV_CMD_DO_GIMBAL_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>If the gimbal supports visual tracking (GIMBAL_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), this command allows to initiate the tracking.</description>
+        <description>If the gimbal supports visual tracking (GIMBAL_CONTROLLER_CAP_FLAGS_HAS_TRACKING_RECTANGLE is set), this command allows to initiate the tracking.</description>
         <param index="1" label="Top left corner x" minValue="0" maxValue="1">Top left corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
         <param index="2" label="Top left corner y" minValue="0" maxValue="1">Top left corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
         <param index="3" label="Bottom right corner x" minValue="0" maxValue="1">Bottom right corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
@@ -5971,8 +5994,18 @@
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
     </message>
-    <message id="280" name="GIMBAL_INFORMATION">
-      <description>Information about a gimbal</description>
+    <message id="280" name="GIMBAL_CONTROLLER_INFORMATION">
+      <description>Information about a high level gimbal controller</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_CONTROLLER_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
+      <field type="uint8_t" name="gimbal_component">Gimbal component ID that this gimbal controller is responsible for.</field>
+      <field type="float" name="pitch_max" units="rad">Maximum pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="pitch_min" units="rad">Minimum pitch angle (positive: up, negative: down)</field>
+      <field type="float" name="yaw_max" units="rad">Maximum yaw angle (positive: to the right, negative: to the left)</field>
+      <field type="float" name="yaw_min" units="rad">Minimum yaw angle (positive: to the right, negative: to the left)</field>
+    </message>
+    <message id="281" name="GIMBAL_INFORMATION">
+      <description>Information about a low level gimbal</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the gimbal vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
@@ -5983,43 +6016,35 @@
       <field type="float" name="yaw_max" units="rad">Maximum yaw angle (positive: to the right, negative: to the left)</field>
       <field type="float" name="yaw_min" units="rad">Minimum yaw angle (positive: to the right, negative: to the left)</field>
     </message>
-    <message id="281" name="GIMBAL_CONTROL_ATTITUDE">
+    <message id="282" name="GIMBAL_CONTROLLER_SET_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message to control a gimbal's attitude. This message is to be sent to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
+      <description>High level message to control a gimbal's attitude. This message is to be sent to the gimbal controller (e.g. from a ground stationi). Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="flags" enum="GIMBAL_CONTROL_FLAGS" display="bitmask">Gimbal control flags.</field>
+      <field type="uint16_t" name="mode" enum="GIMBAL_CONTROLLER_MODE">High level gimbal controller mode.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
     </message>
-    <message id="282" name="GIMBAL_CONTROL_LOCATION_GLOBAL">
+    <message id="283" name="GIMBAL_SET_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message to control a gimbal to point to a GPS point. This message is to be sent to the gimbal component.</description>
+      <description>Low level message to control a gimbal's attitude. This message is to be sent from the gimbal controller to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="int32_t" name="lat" units="degE7">Latitude where gimbal should point to</field>
-      <field type="int32_t" name="lon" units="degE7">Longitude where gimbal should point to</field>
-      <field type="int32_t" name="alt" units="mm">Altitude (MSL) where gimbal should point to</field>
+      <field type="uint16_t" name="mode" enum="GIMBAL_MODE">Low level gimbal mode.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
+      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
     </message>
-    <message id="283" name="GIMBAL_CONTROL_LOCATION_LOCAL">
+    <message id="284" name="GIMBAL_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message to control a gimbal to point to a local position. This message is to be sent to the gimbal component.</description>
-      <field type="uint8_t" name="target_system">System ID</field>
-      <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="float" name="x" units="m">X position of location in the local coordinate frame NED</field>
-      <field type="float" name="y" units="m">Y position of location in the local coordinate frame NED</field>
-      <field type="float" name="z" units="m">Z position of location in the local coordinate frame NED</field>
-    </message>
-    <message id="284" name="GIMBAL_CONTROL_STATUS_ATTITUDE">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message reporting the status of a gimbal. This message can be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
-      <field type="uint16_t" name="flags" enum="GIMBAL_CONTROL_FLAGS">Current gimbal control flags</field>
+      <description>Message reporting the status of a gimbal. This message should be broadcasted by a gimbal component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right).</description>
+      <field type="uint16_t" name="mode" enum="GIMBAL_MODE">Current gimbal mode</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_CONTROL_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1985,7 +1985,7 @@
         <param index="2" label="Repeat" minValue="0" increment="1">Repeat count.</param>
       </entry>
       <entry value="1000" name="MAV_CMD_DO_GIMBAL_ATTITUDE" hasLocation="false" isDestination="false">
-        <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset.</description>
+        <description>Setpoint to be sent to autopilot to set a gimbal attitude. It is possible to set combinations of the values below. E.g. an angle as well as a desired angular rate can be used to get to this angle at a certain angular rate, or an angular rate only will result in continuous turning. NaN is to be used to signal unset. Note: this command is only used between ground station and autopilot or as part of missions but never directly to a gimbal. To communicate with a gimbal the messages GIMBAL_CONTROL_* are to be used.</description>
         <param index="1">Pitch/tilt angle relative to world horizon (+90 to -90 degrees, negative is to tilt down, positive to tilt up).</param>
         <param index="2">Yaw/pan angle (-180 to 180 degrees, positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
         <param index="3">Pitch/tilt angular rate (degrees/second, positive to point up).</param>
@@ -5868,6 +5868,34 @@
       <field type="uint32_t" name="bitrate" units="bits/s">Bit rate</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise</field>
       <field type="uint16_t" name="hfov" units="deg">Horizontal Field of view</field>
+    </message>
+    <message id="280" name="GIMBAL_CONTROL_ATTITUDE">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Message to control a gimbal's attitude. This message is to be sent by the autopilot to the gimbal component. Angles and rates can be set to NaN according to use case.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="mode" enum="MAV_GIMBAL_MODE">Gimbal mode.</field>
+      <field type="float" name="roll" units="rad">Roll in global frame, positive is tilt to the right (set to NaN for not set).</field>
+      <field type="float" name="pitch" units="rad">Pitch in global frame, positive is tilting up (set to NaN for not set).</field>
+      <field type="float" name="yaw_relative" units="rad">Yaw relative to vehicle, required for MAV_GIMBAL_MODE_FOLLOW (set to NaN for not set).</field>
+      <field type="float" name="yaw_absolute" units="rad">Yaw absolute, 0 is North, -pi to pi, positive to the right, required for MAV_GIMBAL_MODE_LOCK mode (set to NaN for not set).</field>
+      <field type="float" name="rollspeed" units="rad/s">Roll angular speed (NaN for not set).</field>
+      <field type="float" name="pitchspeed" units="rad/s">Pitch angular speed (NaN for not set).</field>
+      <field type="float" name="yawspeed" units="rad/s">Yaw angular speed (NaN for not set).</field>
+    </message>
+    <message id="281" name="GIMBAL_CONTROL_LOCATION">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Message to control a gimbal to point to a GPS point or local position. This can be used for a GPS position if x, y, z are set to NaN or a local position if lat, lon, alt are set to 0. This message is to be sent by the autopilot to the gimbal component.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude where gimbal should point to</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude where gimbal should point to</field>
+      <field type="int32_t" name="alt" units="mm">Altitude (MSL) where gimbal should point to</field>
+      <field type="float" name="x" units="m">Local X position of this position in the local coordinate frame</field>
+      <field type="float" name="y" units="m">Local Y position of this position in the local coordinate frame</field>
+      <field type="float" name="z" units="m">Local Z position of this position in the local coordinate frame</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6078,7 +6078,6 @@
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
-      <field type="float" name="feed_forward_angular_velocity_z" units="rad/s">Feed forward Z component of angular velocity, positive is yawing to the right, NaN to be ignored. This field is only needed if the gimbal manager is not the autopilot itself. It allows the autopilot to send the feed forward yaw setpoint when it is actively yawing. It can then be passed on by the gimbal manager to a gimbal device.</field>
     </message>
     <message id="283" name="GIMBAL_DEVICE_INFORMATION">
       <wip/>
@@ -6107,7 +6106,6 @@
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
-      <field type="float" name="feed_forward_angular_velocity_z" units="rad/s">Feed forward Z component of angular velocity, positive is yawing to the right, NaN to be ignored. This is to indicate if the autopilot is actively yawing.</field>
     </message>
     <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
       <wip/>
@@ -6120,6 +6118,21 @@
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>
       <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
+    </message>
+    <message id="286" name="AUTOPILOT_STATE_FOR_GIMBAL_DEVICE">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Low level message containing autopilot state relevant for a gimbal device. This message is to be sent from the gimbal manager to the gimbal device component. The data of this message server for the gimbal's estimator corrections in particular horizon compensation, as well as the autopilot's control intention e.g. feed forward angular control in z-axis.</description>
+      <field type="uint64_t" name="time_boot_us" units="us">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="float[4]" name="q">Quaternion components of autopilot attitude: w, x, y, z (1 0 0 0 is the null-rotation, Hamiltonian convention).</field>
+      <field type="uint32_t" name="q_estimated_delay_us" units="us">Estimated delay of the attitude data.</field>
+      <field type="float" name="vx" units="m/s">X Speed in NED (North, East, Down).</field>
+      <field type="float" name="vy" units="m/s">Y Speed in NED (North, East, Down).</field>
+      <field type="float" name="vz" units="m/s">Z Speed in NED (North, East, Down).</field>
+      <field type="uint32_t" name="v_estimated_delay_us" units="us">Estimated delay of the speed data.</field>
+      <field type="float" name="feed_forward_angular_velocity_z" units="rad/s">Feed forward Z component of angular velocity, positive is yawing to the right, NaN to be ignored. This is to indicate if the autopilot is actively yawing.</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1672,8 +1672,8 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="195" name="MAV_CMD_DO_SET_ROI_LOCATION" hasLocation="true" isDestination="false">
-        <description>Sets the region of interest (ROI) to a location. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
-        <param index="1">Empty</param>
+        <description>Sets the region of interest (ROI) to a location. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message.</description>
+        <param index="1" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -1682,8 +1682,8 @@
         <param index="7">Altitude</param>
       </entry>
       <entry value="196" name="MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET" hasLocation="false" isDestination="false">
-        <description>Sets the region of interest (ROI) to be toward next waypoint, with optional pitch/roll/yaw offset. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
-        <param index="1">Empty</param>
+        <description>Sets the region of interest (ROI) to be toward next waypoint, with optional pitch/roll/yaw offset. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message.</description>
+        <param index="1" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -1692,8 +1692,8 @@
         <param index="7" label="Yaw Offset">yaw offset from next waypoint</param>
       </entry>
       <entry value="197" name="MAV_CMD_DO_SET_ROI_NONE" hasLocation="false" isDestination="false">
-        <description>Cancels any previous ROI command returning the vehicle/sensors to default flight characteristics. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>
-        <param index="1">Empty</param>
+        <description>Cancels any previous ROI command returning the vehicle/sensors to default flight characteristics. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras. This command can be sent to a gimbal manager but not to a gimbal. A gimbal is not to react to this message.</description>
+        <param index="1" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -2103,17 +2103,16 @@
         <param index="2" label="Pan angular rate" units="deg/s">Pan/yaw angular rate (positive to pan to the right).</param>
         <param index="3" label="Tilt angle" units="deg" minValue="-180" maxValue="180">Pitch/tilt angle relative to world horizon (negative is to tilt down, positive to tilt up).</param>
         <param index="4" label="Pan angle" units="deg" minValue="-180" maxValue="180">Yaw/pan angle (positive is pan to the right, relative to vehicle for PAN mode, absolute to North for HOLD mode) </param>
-        <param index="5" label="Gimbal mode" enum="GIMBAL_MANAGER_MODE">Gimbal controller mode.</param>
-        <param index="6" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
+        <param index="5" label="Gimbal manager flags" enum="GIMBAL_MANAGER_FLAGS">Gimbal manager flags to use.</param>
+        <param index="7" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="1001" name="MAV_CMD_DO_GIMBAL_MANAGER_TRACK_POINT" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>If the gimbal manager supports visual tracking (GIMBAL_MANAGER_CAP_FLAGS_HAS_TRACKING_POINT is set), this command allows to initiate the tracking.</description>
-        <param index="1" label="Point 1 x" minValue="0" maxValue="1">Point to track.</param>
-        <param index="2" label="Point 1 y" minValue="0" maxValue="1">Roll angular rate (positive to turn to the right).</param>
-        <param index="3" label="Point 2 x" minValue="0" maxValue="1">Pitch/tilt angular rate (positive to point up).</param>
-        <param index="4" label="Point 2 y" minValue="0" maxValue="1">Yaw/pan angular rate (positive to pan to the right).</param>
+        <param index="1" label="Point x" minValue="0" maxValue="1">Point to track x value.</param>
+        <param index="2" label="Point y" minValue="0" maxValue="1">Point to track y value.</param>
+        <param index="7" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="1002" name="MAV_CMD_DO_GIMBAL_MANAGER_TRACK_RECTANGLE" hasLocation="false" isDestination="false">
         <wip/>
@@ -2123,6 +2122,7 @@
         <param index="2" label="Top left corner y" minValue="0" maxValue="1">Top left corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
         <param index="3" label="Bottom right corner x" minValue="0" maxValue="1">Bottom right corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
         <param index="4" label="Bottom right corner y" minValue="0" maxValue="1">Bottom right corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
+        <param index="7" label="Gimbal ID">Component ID of gimbal to address, 0 for all gimbal components. (Send command multiple times for more than one but not all gimbals.)</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6027,7 +6027,7 @@
       <description>High level message to control a gimbal's attitude. This message is to be sent to the gimbal manager (e.g. from a ground station). Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint32_t" enum="GIMBAL_MANAGER_FLAGS">High level gimbal manager flags to use.</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_MANAGER_FLAGS">High level gimbal manager flags to use.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_MANAGER_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>


### PR DESCRIPTION
This is the follow up to the [discussion on the dev call](https://github.com/mavlink/mavlink/wiki/20190515-Dev-Meeting#call-1) where the overall opinion was to deprecate the existing mount/gimbal messages and come up with a new/consistent set.

I also had further helpful discussions with @olliw42, for details see #1130 and #1135.

**This PR/proposal has evolved quite a bit over time. There is a [document for the high level description](https://docs.google.com/document/d/16pekKRXLN2FhlL9YNFP983cjfBKAsDwN0gOSks8USo4/edit?usp=sharing).**