### PR TITLE
COMPONENT_INFORMATION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3227,8 +3227,8 @@
     </enum>
     <enum name="COMPONENT_CAP_FLAGS">
       <description>Component capability flags (Bitmap)</description>
-      <entry value="0" name="DUMMY">
-        <description>Dummy to make generator happy.</description>
+      <entry value="0" name="COMPONENT_CAP_FLAGS_NONE">
+        <description>No flags set.</description>
       </entry>
     </enum>
   </enums>
@@ -5219,10 +5219,10 @@
       <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission. -1 means no mission active and/or no estimate available.</field>
       <field type="int32_t" name="commanded_action" units="s">Estimated time for completing the current commanded action (i.e. Go To, Takeoff, Land, etc.). -1 means no action active and/or no estimate available.</field>
     </message>
-    <message id="700" name="COMPONENT_INFORMATION">
+    <message id="385" name="COMPONENT_INFORMATION">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
-      <description>Information about a component. For camera components use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION.</description>
+      <description>Information about a component. For camera components instead use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the component vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the component model</field>
@@ -5230,7 +5230,7 @@
       <field type="uint32_t" name="hardware_version">Version of the component hardware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
       <field type="uint32_t" name="capability_flags" enum="COMPONENT_CAP_FLAGS">Bitmap of component capability flags.</field>
       <field type="uint16_t" name="component_definition_version">Component definition version (iteration)</field>
-      <field type="char[140]" name="component_definition_uri">Component definition URI (if any, otherwise only basic functions will be available).</field>
+      <field type="char[140]" name="component_definition_uri">Component definition URI (if any, otherwise only basic functions will be available). The XML format is not yet specified and work in progress. </field>
     </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1645,13 +1645,6 @@
         <param index="1" label="Tag" minValue="0" increment="1">Target tag to jump to.</param>
         <param index="2" label="Repeat" minValue="0" increment="1">Repeat count.</param>
       </entry>
-      <entry value="700" name="MAV_CMD_REQUEST_COMPONENT_INFORMATION" hasLocation="false" isDestination="false">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Request component information (COMPONENT_INFORMATION). For camera components use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION.</description>
-        <param index="1" label="Capabilities" minValue="0" maxValue="1" increment="1">0: No action 1: Request component information</param>
-        <param index="2">Reserved (all remaining params)</param>
-      </entry>      
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
@@ -3231,6 +3224,9 @@
       <entry value="2" name="PARACHUTE_RELEASE">
         <description>Release parachute.</description>
       </entry>
+    </enum>
+    <enum name="COMPONENT_CAP_FLAGS">
+      <description>Component capability flags (Bitmap)</description>
     </enum>
   </enums>
   <messages>
@@ -5232,7 +5228,7 @@
       <field type="uint32_t" name="capability_flags" enum="COMPONENT_CAP_FLAGS">Bitmap of component capability flags.</field>
       <field type="uint16_t" name="component_definition_version">Component definition version (iteration)</field>
       <field type="char[140]" name="component_definition_uri">Component definition URI (if any, otherwise only basic functions will be available).</field>
-    </message>    
+    </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3735,9 +3735,6 @@
       <entry value="2" name="COMPONENT_CAP_FLAGS_PARAM_EXT">
         <description>Component has parameters, and supports the extended parameter protocol (PARAM_EXT messages).</description>
       </entry>
-      <entry value="4" name="COMPONENT_CAP_FLAGS_FTP">
-        <description>Component supports MAVLinkFTP for downloading the component definition file.</description>
-      </entry>
     </enum>
   </enums>
   <messages>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3227,6 +3227,9 @@
     </enum>
     <enum name="COMPONENT_CAP_FLAGS">
       <description>Component capability flags (Bitmap)</description>
+      <entry value="0" name="DUMMY">
+        <description>Dummy to make generator happy.</description>
+      </entry>
     </enum>
   </enums>
   <messages>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3735,6 +3735,9 @@
       <entry value="2" name="COMPONENT_CAP_FLAGS_PARAM_EXT">
         <description>Component has parameters, and supports the extended parameter protocol (PARAM_EXT messages).</description>
       </entry>
+      <entry value="4" name="COMPONENT_CAP_FLAGS_FTP">
+        <description>Component supports MAVLinkFTP for downloading the component definition file.</description>
+      </entry>
     </enum>
   </enums>
   <messages>
@@ -5766,7 +5769,7 @@
     <message id="395" name="COMPONENT_INFORMATION">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
-      <description>Information about a component. For camera components instead use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION. Components including GCSes must support requests of this message via MAV_CMD_REQUEST_MESSAGE.</description>
+      <description>Information about a component. For camera components instead use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION. Components including GCSes should consider supporting requests of this message via MAV_CMD_REQUEST_MESSAGE.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the component vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the component model</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3229,7 +3229,7 @@
     <enum name="COMPONENT_CAP_FLAGS">
       <description>Component capability flags (Bitmap)</description>
       <entry value="0" name="COMPONENT_CAP_FLAGS_NONE">
-        <description>No flags set.</description>
+        <description>No flags set. (do not use this flag, it will eventually be removed)</description>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3703,8 +3703,11 @@
     </enum>
     <enum name="COMPONENT_CAP_FLAGS">
       <description>Component capability flags (Bitmap)</description>
-      <entry value="0" name="COMPONENT_CAP_FLAGS_NONE">
-        <description>No flags set. (do not use this flag, it will eventually be removed)</description>
+      <entry value="1" name="COMPONENT_CAP_FLAGS_PARAM">
+        <description>Component has parameters, and supports the parameter protocol (PARAM messages).</description>
+      </entry>
+      <entry value="2" name="COMPONENT_CAP_FLAGS_PARAM_EXT">
+        <description>Component has parameters, and supports the extended parameter protocol (PARAM_EXT messages).</description>
       </entry>
     </enum>
   </enums>
@@ -5711,7 +5714,7 @@
     <message id="390" name="COMPONENT_INFORMATION">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
-      <description>Information about a component. For camera components instead use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION.</description>
+      <description>Information about a component. For camera components instead use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION. Components including GCSes must support requests of this message via MAV_CMD_REQUEST_MESSAGE.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the component vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the component model</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1645,6 +1645,13 @@
         <param index="1" label="Tag" minValue="0" increment="1">Target tag to jump to.</param>
         <param index="2" label="Repeat" minValue="0" increment="1">Repeat count.</param>
       </entry>
+      <entry value="700" name="MAV_CMD_REQUEST_COMPONENT_INFORMATION" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Request component information (COMPONENT_INFORMATION). For camera components use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION.</description>
+        <param index="1" label="Capabilities" minValue="0" maxValue="1" increment="1">0: No action 1: Request component information</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>      
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
@@ -5213,6 +5220,19 @@
       <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission. -1 means no mission active and/or no estimate available.</field>
       <field type="int32_t" name="commanded_action" units="s">Estimated time for completing the current commanded action (i.e. Go To, Takeoff, Land, etc.). -1 means no action active and/or no estimate available.</field>
     </message>
+    <message id="700" name="COMPONENT_INFORMATION">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Information about a component. For camera components use CAMERA_INFORMATION, and for autopilots use AUTOPILOT_VERSION.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t[32]" name="vendor_name">Name of the component vendor</field>
+      <field type="uint8_t[32]" name="model_name">Name of the component model</field>
+      <field type="uint32_t" name="firmware_version">Version of the component firmware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
+      <field type="uint32_t" name="hardware_version">Version of the component hardware (v &lt;&lt; 24 &amp; 0xff = Dev, v &lt;&lt; 16 &amp; 0xff = Patch, v &lt;&lt; 8 &amp; 0xff = Minor, v &amp; 0xff = Major)</field>
+      <field type="uint32_t" name="capability_flags" enum="COMPONENT_CAP_FLAGS">Bitmap of component capability flags.</field>
+      <field type="uint16_t" name="component_definition_version">Component definition version (iteration)</field>
+      <field type="char[140]" name="component_definition_uri">Component definition URI (if any, otherwise only basic functions will be available).</field>
+    </message>    
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>


### PR DESCRIPTION
- MAV_CMD_REQUEST_COMPONENT_INFORMATION added, mirrors MAV_CMD_REQUEST_CAMERA_INFORMATION
- COMPONENT_INFORMATION message added, mirrors CAMERA_INFORMATION to a large extend, but has also a hardware version field. COMPONENT_CAP_FLAGS are currently not defined.
- both were given the tentative ids 700