### PR TITLE
Reserving component IDs for private components

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -377,6 +377,232 @@
       <entry value="1" name="MAV_COMP_ID_AUTOPILOT1">
         <description>System flight controller component ("autopilot"). Only one autopilot is expected in a particular system.</description>
       </entry>
+      <!-- Component ids from 25-99 are reserved for private OEM component definitions (and may be incompatible with other private components). Note that if this range is later reduced, higher ids will be reallocated first. -->
+      <entry value="25" name="MAV_COMP_ID_USER1">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="26" name="MAV_COMP_ID_USER2">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="27" name="MAV_COMP_ID_USER3">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="28" name="MAV_COMP_ID_USER4">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="29" name="MAV_COMP_ID_USER5">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="30" name="MAV_COMP_ID_USER6">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="31" name="MAV_COMP_ID_USER7">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="32" name="MAV_COMP_ID_USER8">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="33" name="MAV_COMP_ID_USER9">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="34" name="MAV_COMP_ID_USER10">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="35" name="MAV_COMP_ID_USER11">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="36" name="MAV_COMP_ID_USER12">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="37" name="MAV_COMP_ID_USER13">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="38" name="MAV_COMP_ID_USER14">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="39" name="MAV_COMP_ID_USER15">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="40" name="MAV_COMP_ID_USE16">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="41" name="MAV_COMP_ID_USER17">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="42" name="MAV_COMP_ID_USER18">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="43" name="MAV_COMP_ID_USER19">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="44" name="MAV_COMP_ID_USER20">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="45" name="MAV_COMP_ID_USER21">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="46" name="MAV_COMP_ID_USER22">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="47" name="MAV_COMP_ID_USER23">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="48" name="MAV_COMP_ID_USER24">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="49" name="MAV_COMP_ID_USER25">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="50" name="MAV_COMP_ID_USER26">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="51" name="MAV_COMP_ID_USER27">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="52" name="MAV_COMP_ID_USER28">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="53" name="MAV_COMP_ID_USER29">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="54" name="MAV_COMP_ID_USER30">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="55" name="MAV_COMP_ID_USER31">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="56" name="MAV_COMP_ID_USER32">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="57" name="MAV_COMP_ID_USER33">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="58" name="MAV_COMP_ID_USER34">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="59" name="MAV_COMP_ID_USER35">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="60" name="MAV_COMP_ID_USER36">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="61" name="MAV_COMP_ID_USER37">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="62" name="MAV_COMP_ID_USER38">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="63" name="MAV_COMP_ID_USER39">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="64" name="MAV_COMP_ID_USER40">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="65" name="MAV_COMP_ID_USER41">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="66" name="MAV_COMP_ID_USER42">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="67" name="MAV_COMP_ID_USER43">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="68" name="MAV_COMP_ID_USER44">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="69" name="MAV_COMP_ID_USER45">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="70" name="MAV_COMP_ID_USER46">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="71" name="MAV_COMP_ID_USER47">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="72" name="MAV_COMP_ID_USER48">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="73" name="MAV_COMP_ID_USER49">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="74" name="MAV_COMP_ID_USER50">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="75" name="MAV_COMP_ID_USER51">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="76" name="MAV_COMP_ID_USER52">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="77" name="MAV_COMP_ID_USER53">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="78" name="MAV_COMP_ID_USER54">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="79" name="MAV_COMP_ID_USER55">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="80" name="MAV_COMP_ID_USER56">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="81" name="MAV_COMP_ID_USER57">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="82" name="MAV_COMP_ID_USER58">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="83" name="MAV_COMP_ID_USER59">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="84" name="MAV_COMP_ID_USER60">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="85" name="MAV_COMP_ID_USER61">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="86" name="MAV_COMP_ID_USER62">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="87" name="MAV_COMP_ID_USER63">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="88" name="MAV_COMP_ID_USER64">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="89" name="MAV_COMP_ID_USER65">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="90" name="MAV_COMP_ID_USER66">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="91" name="MAV_COMP_ID_USER67">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="92" name="MAV_COMP_ID_USER68">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="93" name="MAV_COMP_ID_USER69">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="94" name="MAV_COMP_ID_USER70">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="95" name="MAV_COMP_ID_USER71">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="96" name="MAV_COMP_ID_USER72">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="97" name="MAV_COMP_ID_USER73">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="98" name="MAV_COMP_ID_USER74">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="99" name="MAV_COMP_ID_USER75">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
       <entry value="100" name="MAV_COMP_ID_CAMERA">
         <description>Camera #1.</description>
       </entry>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -261,6 +261,232 @@
       <entry value="1" name="MAV_COMP_ID_AUTOPILOT1">
         <description>System flight controller component ("autopilot"). Only one autopilot is expected in a particular system.</description>
       </entry>
+      <!-- Component ids from 25-99 are reserved for private OEM component definitions (and may be incompatible with other private components). Note that if this range is later reduced, higher ids will be reallocated first. -->
+      <entry value="25" name="MAV_COMP_ID_USER1">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="26" name="MAV_COMP_ID_USER2">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="27" name="MAV_COMP_ID_USER3">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="28" name="MAV_COMP_ID_USER4">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="29" name="MAV_COMP_ID_USER5">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="30" name="MAV_COMP_ID_USER6">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="31" name="MAV_COMP_ID_USER7">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="32" name="MAV_COMP_ID_USER8">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="33" name="MAV_COMP_ID_USER9">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="34" name="MAV_COMP_ID_USER10">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="35" name="MAV_COMP_ID_USER11">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="36" name="MAV_COMP_ID_USER12">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="37" name="MAV_COMP_ID_USER13">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="38" name="MAV_COMP_ID_USER14">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="39" name="MAV_COMP_ID_USER15">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="40" name="MAV_COMP_ID_USE16">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="41" name="MAV_COMP_ID_USER17">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="42" name="MAV_COMP_ID_USER18">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="43" name="MAV_COMP_ID_USER19">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="44" name="MAV_COMP_ID_USER20">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="45" name="MAV_COMP_ID_USER21">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="46" name="MAV_COMP_ID_USER22">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="47" name="MAV_COMP_ID_USER23">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="48" name="MAV_COMP_ID_USER24">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="49" name="MAV_COMP_ID_USER25">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="50" name="MAV_COMP_ID_USER26">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="51" name="MAV_COMP_ID_USER27">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="52" name="MAV_COMP_ID_USER28">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="53" name="MAV_COMP_ID_USER29">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="54" name="MAV_COMP_ID_USER30">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="55" name="MAV_COMP_ID_USER31">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="56" name="MAV_COMP_ID_USER32">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="57" name="MAV_COMP_ID_USER33">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="58" name="MAV_COMP_ID_USER34">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="59" name="MAV_COMP_ID_USER35">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="60" name="MAV_COMP_ID_USER36">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="61" name="MAV_COMP_ID_USER37">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="62" name="MAV_COMP_ID_USER38">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="63" name="MAV_COMP_ID_USER39">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="64" name="MAV_COMP_ID_USER40">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="65" name="MAV_COMP_ID_USER41">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="66" name="MAV_COMP_ID_USER42">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="67" name="MAV_COMP_ID_USER43">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="68" name="MAV_COMP_ID_USER44">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="69" name="MAV_COMP_ID_USER45">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="70" name="MAV_COMP_ID_USER46">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="71" name="MAV_COMP_ID_USER47">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="72" name="MAV_COMP_ID_USER48">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="73" name="MAV_COMP_ID_USER49">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="74" name="MAV_COMP_ID_USER50">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="75" name="MAV_COMP_ID_USER51">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="76" name="MAV_COMP_ID_USER52">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="77" name="MAV_COMP_ID_USER53">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="78" name="MAV_COMP_ID_USER54">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="79" name="MAV_COMP_ID_USER55">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="80" name="MAV_COMP_ID_USER56">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="81" name="MAV_COMP_ID_USER57">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="82" name="MAV_COMP_ID_USER58">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="83" name="MAV_COMP_ID_USER59">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="84" name="MAV_COMP_ID_USER60">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="85" name="MAV_COMP_ID_USER61">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="86" name="MAV_COMP_ID_USER62">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="87" name="MAV_COMP_ID_USER63">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="88" name="MAV_COMP_ID_USER64">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="89" name="MAV_COMP_ID_USER65">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="90" name="MAV_COMP_ID_USER66">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="91" name="MAV_COMP_ID_USER67">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="92" name="MAV_COMP_ID_USER68">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="93" name="MAV_COMP_ID_USER69">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="94" name="MAV_COMP_ID_USER70">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="95" name="MAV_COMP_ID_USER71">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="96" name="MAV_COMP_ID_USER72">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="97" name="MAV_COMP_ID_USER73">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="98" name="MAV_COMP_ID_USER74">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
+      <entry value="99" name="MAV_COMP_ID_USER75">
+        <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
+      </entry>
       <entry value="100" name="MAV_COMP_ID_CAMERA">
         <description>Camera #1.</description>
       </entry>


### PR DESCRIPTION
@edwinhayes @auturgy This replaces #1077 with an actual range of components in both common.xml and minimal.xml. Using individual IDs ensures that the range can't be used by accident in the same library build as common.xml or minimal.xml.

I'm OK to merge this. Any final thoughts?