### PR TITLE
OPTICAL_FLOW.flow_comp_m_(x/y) units to m/s

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4026,8 +4026,8 @@
       <field type="uint8_t" name="sensor_id">Sensor ID</field>
       <field type="int16_t" name="flow_x" units="dpix">Flow in x-sensor direction</field>
       <field type="int16_t" name="flow_y" units="dpix">Flow in y-sensor direction</field>
-      <field type="float" name="flow_comp_m_x" units="m">Flow in x-sensor direction, angular-speed compensated</field>
-      <field type="float" name="flow_comp_m_y" units="m">Flow in y-sensor direction, angular-speed compensated</field>
+      <field type="float" name="flow_comp_m_x" units="m/s">Flow in x-sensor direction, angular-speed compensated</field>
+      <field type="float" name="flow_comp_m_y" units="m/s">Flow in y-sensor direction, angular-speed compensated</field>
       <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
       <field type="float" name="ground_distance" units="m">Ground distance. Positive value: distance known. Negative value: Unknown distance</field>
       <extensions/>


### PR DESCRIPTION
Fixes #1187

As stated by @jlecoeur the `OPTICAL_FLOW.flow_comp_m_x` and `flow_comp_m_y` must either be velocity units or an integration time unit is required so that flow can be determined from these. Given there is no such integration unit it is very likely that people are assuming m/s OR that it is not being used. Either way, the "best" fix is to clarify m/s.

Still waiting for confirmation on linked item from @auturgy.