### PR TITLE
MAV_CMDs - put param labels next to index

### DIFF
--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -134,7 +134,7 @@
    <table class="sortable">
    <thead>
    <tr> <!-- mavlink_field_header -->
-      <th>Param</th>
+      <th>Param (:Label)</th>
       <th>Description</th>
 
       <xsl:if test='*/@enum or */@minValue or */@maxValue or */@increment'>
@@ -182,10 +182,12 @@
 
 <xsl:template match="//param" mode="params">
     <tr>
-        <td><xsl:value-of select="@index" /> </td> <!-- mission_param -->
+        <td><xsl:value-of select="@index" /> 
+        <xsl:if test='@label'>: <xsl:value-of select="@label" /></xsl:if>
+        </td> <!-- mission_param -->
 
         <td><xsl:value-of select="." />
-         <xsl:if test='@label or @decimalPlaces'><br /><strong>GCS display settings:</strong>
+         <xsl:if test='@decimalPlaces'><br /><strong>GCS display settings:</strong>
             <xsl:if test='@label'><em>Label:</em> <xsl:value-of select="@label" />, </xsl:if>
             <xsl:if test='@decimalPlaces'><em>decimalPlaces:</em> <xsl:value-of select="@decimalPlaces" /></xsl:if>
          </xsl:if>


### PR DESCRIPTION
This moves the param lablels next to the index, if they exist. This is much more readable, and helps users see what the index is for. 

![image](https://user-images.githubusercontent.com/5368500/62341744-c382ec00-b527-11e9-99c3-4f699e237750.png)

The old way is below. In this case all "GCS display hints" are displayed together. 

![image](https://user-images.githubusercontent.com/5368500/62341724-ad752b80-b527-11e9-9e58-fe5748bdbf2b.png)
