### PR TITLE
Opaque Tunnel message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -666,11 +666,6 @@
         <description/>
       </entry>
     </enum>
-    <enum name="MAV_TUNNEL_PAYLOAD_TYPE">
-      <entry value="0" name="MAV_TUNNEL_PAYLOAD_TYPE_UNKNOWN">
-        <description>Encoding of payload unknwon.</description>
-      </entry>
-    </enum>
     <!-- fenced mode enums -->
     <enum name="FENCE_ACTION">
       <entry value="0" name="FENCE_ACTION_NONE">
@@ -3229,6 +3224,11 @@
       </entry>
       <entry value="2" name="PARACHUTE_RELEASE">
         <description>Release parachute.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_TUNNEL_PAYLOAD_TYPE">
+      <entry value="0" name="MAV_TUNNEL_PAYLOAD_TYPE_UNKNOWN">
+        <description>Encoding of payload unknown.</description>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5219,7 +5219,9 @@
       <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission. -1 means no mission active and/or no estimate available.</field>
       <field type="int32_t" name="commanded_action" units="s">Estimated time for completing the current commanded action (i.e. Go To, Takeoff, Land, etc.). -1 means no action active and/or no estimate available.</field>
     </message>
-    <message id="701" name="TUNNEL">
+    <message id="385" name="TUNNEL">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Message for transporting "arbitrary" variable-length data from one component to another (broadcast is not forbidden, but discouraged). The encoding of the data is usually extension specific, i.e. determined by the source, and is usually not documented as part of the mavlink specification.</description>
       <field type="uint8_t" name="target_system">System ID (can be 0 for broadcast, but this is discouraged)</field>
       <field type="uint8_t" name="target_component">Component ID (can be 0 for broadcast, but this is discouraged)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -666,6 +666,11 @@
         <description/>
       </entry>
     </enum>
+    <enum name="MAV_TUNNEL_PAYLOAD_TYPE">
+      <entry value="0" name="MAV_TUNNEL_PAYLOAD_TYPE_UNKNOWN">
+        <description>Encoding of payload unknwon.</description>
+      </entry>
+    </enum>
     <!-- fenced mode enums -->
     <enum name="FENCE_ACTION">
       <entry value="0" name="FENCE_ACTION_NONE">
@@ -5213,6 +5218,13 @@
       <field type="int32_t" name="mission_next_item" units="s">Estimated time for reaching/completing the currently active mission item. -1 means no time estimate available.</field>
       <field type="int32_t" name="mission_end" units="s">Estimated time for completing the current mission. -1 means no mission active and/or no estimate available.</field>
       <field type="int32_t" name="commanded_action" units="s">Estimated time for completing the current commanded action (i.e. Go To, Takeoff, Land, etc.). -1 means no action active and/or no estimate available.</field>
+    </message>
+    <message id="701" name="TUNNEL">
+      <description>Message for transporting "arbitrary" variable-length data from one component to another (broadcast is not forbidden, but discouraged). The encoding of the data is usually extension specific, i.e. determined by the source, and is usually not documented as part of the mavlink specification.</description>
+      <field type="uint8_t" name="target_system">System ID (can be 0 for broadcast, but this is discouraged)</field>
+      <field type="uint8_t" name="target_component">Component ID (can be 0 for broadcast, but this is discouraged)</field>
+      <field type="uint16_t" name="payload_type" enum="MAV_TUNNEL_PAYLOAD_TYPE">A code that identifies the content of the payload (0 for unknown, which is the default). If this code is less than 32768, it is a 'registered' payload type and the corresponding code should be added to the MAV_TUNNEL_PAYLOAD_TYPE enum, and the entry possibly to https://github.com/mavlink/mavlink/tunnel-message-payload-types.xml. Software creators can register blocks of types as needed. Codes greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
+      <field type="uint8_t[128]" name="payload">Variable length payload. The payload length is defined by the remaining message length when subtracting the header and other fields. The entire content of this block is opaque unless you understand the encoding specified by payload_type.</field>
     </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">


### PR DESCRIPTION
MAVlink message which allows a component to send specific, non-standardized data to another component. Addresses #1159 (Proposal for an opaque, tunnel message). 

In comparison to the proposal and/or the V2_EXTENSION message, I've made some changes:

* broadcast is not forbidden, but should be discouraged and not the normal use case
* I removed the target_network field, simply because I don't know what its use would be. If there is some use, it of course could/should be added,.
* I've changed the handling of the code for the encoding, i.e. payload_type, somewhat. Fundamentally only a registered number is required, so I've made it an enum. This also makes coding for implementers simpler since the enum is then already in the header ready to use. Since there is no example it isn't totally clear to me how the .xml was planned to work. I suspect that the intention was to not only use it for registering a value but also to have some xml markup to describe the structure of the data. This however would require specifying the markup, which I think would be better done at a later stage, since it's not really fundamental to bringing in the tunnel message. Similar so for the exact procedures of accepting/adding new payload types; can be discussed any time later. I suggest a friendly non-strict acceptance procedure, which minimally could consist of accepting a new code to the enum. The associated .xml is then more the "code-holder"'s responsibility.
* I've reduced the payload size to 128 bytes. I do not really see any advantage of a large payload size, and the smaller size can help implementations on not so powerful microprocessors. For comparison, the UAVCAN tunnel message has a payload size of 60, which works very well as much as I can tell from experience. (so, if you ask me the payload size could also be reduced to 64...).

One point which isn't clear to me is if there should be some payload_length field or not. The approach here is taken from `V2_EXTENSION` and `FILE_TRANSFER_PROTOCOL`, but I note that there are several messages in common.xml  with non-string variable-length data which DO have an explicit length field, e.g. `LOGGING_DATA`, `LOGGING_DATA_ACKED` (which are also MAvlink2). Hopefully someone could clarify.

This is of course open for discussion. Not sure I should have marked it as WIP.

BTW, I chose a message id of 701 without any reason. Please suggest what a more reasonable choice would be.
