### PR TITLE
Add highlighting of item type

### DIFF
--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -7,17 +7,19 @@
 </xsl:template>
 
 <xsl:template match="//enums">
-   <h2>MAVLink Type Enumerations</h2>
+   <h2 id="enums">MAVLink Type Enumerations</h2>
    <xsl:apply-templates select="enum[@name!='MAV_CMD']" />
 
-   <h2>MAVLink Commands (MAV_CMD)</h2>
+   <h2 id="mav_commands">MAVLink Commands (MAV_CMD)</h2>
+   <blockquote class="alert alert-info clearfix"><strong class="fa fa-2x fa-edit"></strong><p>MAVLink commands (MAV_CMD) and messages are different! These commands define the values of up to 7 parameters that are packaged INSIDE specific messages used in the Mission Protocol and Command Protocol. Use commands for actions in missions or if you need acknowledgment and/or retry logic from a request. Otherwise use messages.</p></blockquote>
    <xsl:apply-templates select="enum[@name='MAV_CMD']" mode="params"/>
+
 </xsl:template>
 
 
 
 <xsl:template match="//messages">
-   <h2>MAVLink Messages</h2>
+   <h2 id="messages">MAVLink Messages</h2>
    <xsl:apply-templates />
 </xsl:template>
 
@@ -32,7 +34,7 @@
   )</h3>
    <xsl:apply-templates select="wip" />
    <xsl:apply-templates select="deprecated" />
-   <p> <!-- description -->
+   <p> <!-- description --><a href="#messages">[Message]</a>
      <xsl:if test='@id > 255'><strong>(MAVLink 2) </strong></xsl:if>
      <xsl:value-of select="description" /></p>
    <table class="sortable">
@@ -97,12 +99,12 @@
 
 
 <xsl:template match="//enum">
-   <h3> <!-- mavlink_message_name -->
+   <h3> <!-- mavlink_enum_name -->
      <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
      <a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute>
      <xsl:value-of select="@name" /></a></h3>
    <xsl:apply-templates select="deprecated" />  
-   <p><xsl:value-of select="description" /></p> <!-- description -->
+   <p><a href="#enums">[Enum]</a><xsl:value-of select="description" /></p> <!-- description -->
    <table class="sortable">
    <thead>
    <tr> <!-- mavlink_field_header -->
@@ -128,7 +130,7 @@
    <h3 id="{@name}"><xsl:value-of select="@name" /> (<a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute><xsl:value-of select="@value" /></a>)</h3>
       <xsl:apply-templates select="deprecated" />
       <xsl:apply-templates select="wip" />
-      <p><xsl:value-of select="description" /> </p> <!-- mavlink_comment -->
+      <p><a href="#mav_commands">[Command]</a><xsl:value-of select="description" /> </p> <!-- mavlink_comment -->
 
 
    <table class="sortable">


### PR DESCRIPTION
Fixes #1191

Adds links at start of body text which makes it easier to tell that something is a command or message.

![image](https://user-images.githubusercontent.com/5368500/62340957-c29c8b00-b524-11e9-89f5-afafcb20aca6.png)

If you click the link, you get taken to the top of the section. For commands you get some advisory text that explains that commands are not messages (the note below):

![image](https://user-images.githubusercontent.com/5368500/62521527-30252000-b873-11e9-8907-d17d7f9fc1e8.png)


