### PR TITLE
SCALED_IMUn: x,y,zmag units from mT to mgauss

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3619,9 +3619,9 @@
       <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis</field>
       <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis</field>
       <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis</field>
-      <field type="int16_t" name="xmag" units="mT">X Magnetic field</field>
-      <field type="int16_t" name="ymag" units="mT">Y Magnetic field</field>
-      <field type="int16_t" name="zmag" units="mT">Z Magnetic field</field>
+      <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
+      <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
+      <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
     </message>
     <message id="27" name="RAW_IMU">
       <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
@@ -4490,9 +4490,9 @@
       <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis</field>
       <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis</field>
       <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis</field>
-      <field type="int16_t" name="xmag" units="mT">X Magnetic field</field>
-      <field type="int16_t" name="ymag" units="mT">Y Magnetic field</field>
-      <field type="int16_t" name="zmag" units="mT">Z Magnetic field</field>
+      <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
+      <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
+      <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
     </message>
     <message id="117" name="LOG_REQUEST_LIST">
       <description>Request a list of available logs. On some systems calling this may stop on-board logging until LOG_REQUEST_END is called.</description>
@@ -4612,9 +4612,9 @@
       <field type="int16_t" name="xgyro" units="mrad/s">Angular speed around X axis</field>
       <field type="int16_t" name="ygyro" units="mrad/s">Angular speed around Y axis</field>
       <field type="int16_t" name="zgyro" units="mrad/s">Angular speed around Z axis</field>
-      <field type="int16_t" name="xmag" units="mT">X Magnetic field</field>
-      <field type="int16_t" name="ymag" units="mT">Y Magnetic field</field>
-      <field type="int16_t" name="zmag" units="mT">Z Magnetic field</field>
+      <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
+      <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
+      <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
     </message>
     <message id="130" name="DATA_TRANSMISSION_HANDSHAKE">
       <description>Handshake message to initiate, control and stop image streaming when using the Image Transmission Protocol: https://mavlink.io/en/services/image_transmission.html.</description>


### PR DESCRIPTION
Fixes #1179

Original unit of mT not usable for this purpose - any measured field would be of order of  0.065[mT], so would be rounded to zero. 
This changes to mgauss, which provides a value range of  (-2000 to + 2000) for common sensors. We could use nT as well as it is an SI unit but decided to use mgauss because it is a well understood unit that is used internally by ArduPilot already. The argument that nT give better resolution is true in theory, but in practise that resolution unlikely to be visible given likely noise.

@auturgy @julianoes As discussed in dev meeting. You OK to merge?