### PR TITLE
Correct MAV_TYPE entry for servo

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -168,7 +168,7 @@
       <entry value="32" name="MAV_TYPE_FLARM">
         <description>FLARM collision avoidance system</description>
       </entry>
-      <entry value="33" name="SERVO">
+      <entry value="33" name="MAV_TYPE_SERVO">
         <description>Servo</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -66,9 +66,9 @@
       </entry>
     </enum>
     <enum name="MAV_TYPE">
-      <description>MAVLINK system type. All components in a system should report this type in their HEARTBEAT.</description>
+      <description>MAVLINK component type reported in HEARTBEAT message. Flight controllers must report the type of the vehicle on which they are mounted (e.g. MAV_TYPE_OCTOROTOR). All other components must report a value appropriate for their type (e.g. a camera must use MAV_TYPE_CAMERA).</description>
       <entry value="0" name="MAV_TYPE_GENERIC">
-        <description>Generic micro air vehicle.</description>
+        <description>Generic micro air vehicle</description>
       </entry>
       <entry value="1" name="MAV_TYPE_FIXED_WING">
         <description>Fixed wing aircraft.</description>
@@ -147,10 +147,10 @@
         <description>VTOL reserved 5</description>
       </entry>
       <entry value="26" name="MAV_TYPE_GIMBAL">
-        <description>Gimbal (standalone)</description>
+        <description>Gimbal</description>
       </entry>
       <entry value="27" name="MAV_TYPE_ADSB">
-        <description>ADSB system (standalone)</description>
+        <description>ADSB system</description>
       </entry>
       <entry value="28" name="MAV_TYPE_PARAFOIL">
         <description>Steerable, nonrigid airfoil</description>
@@ -159,13 +159,16 @@
         <description>Dodecarotor</description>
       </entry>
       <entry value="30" name="MAV_TYPE_CAMERA">
-        <description>Camera (standalone)</description>
+        <description>Camera</description>
       </entry>
       <entry value="31" name="MAV_TYPE_CHARGING_STATION">
         <description>Charging station</description>
       </entry>
       <entry value="32" name="MAV_TYPE_FLARM">
-        <description>FLARM collision avoidance system (standalone)</description>
+        <description>FLARM collision avoidance system</description>
+      </entry>
+      <entry value="33" name="MAV_TYPE_SERVO">
+        <description>Servo</description>
       </entry>
     </enum>
     <enum name="MAV_MODE_FLAG">


### PR DESCRIPTION
does two simple things
1. corrects the MAV_TYPE enum entry for a servo type to MAV_TYPE_SERVO (was SERVO, which looks like an obvious mistake to me)
2. grabs the occasion and makes the MAV_TYPE enum entries in minimal.xml match those in common.xml