### PR TITLE
Allow IMU's to convey their temperature

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3877,6 +3877,8 @@
       <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
       <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
       <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
+      <extensions/>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature, 0 indicates that the IMU does not provide the temperature, if the IMU is actually at 0C, then a value of 1 should be sent.</field>
     </message>
     <message id="27" name="RAW_IMU">
       <description>The RAW IMU readings for a 9DOF sensor, which is identified by the id (default IMU1). This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
@@ -3892,6 +3894,7 @@
       <field type="int16_t" name="zmag">Z Magnetic field (raw)</field>
       <extensions/>
       <field type="uint8_t" name="id">Id. Ids are numbered from 0 and map to IMUs numbered from 1 (e.g. IMU1 will have a message with id=0)</field>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature, 0 indicates that the IMU does not provide the temperature, if the IMU is actually at 0C, then a value of 1 should be sent.</field>
     </message>
     <message id="28" name="RAW_PRESSURE">
       <description>The RAW pressure readings for the typical setup of one absolute pressure and one differential pressure sensor. The sensor values should be the raw, UNSCALED ADC values.</description>
@@ -4752,6 +4755,8 @@
       <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
       <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
       <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
+      <extensions/>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature, 0 indicates that the IMU does not provide the temperature, if the IMU is actually at 0C, then a value of 1 should be sent.</field>
     </message>
     <message id="117" name="LOG_REQUEST_LIST">
       <description>Request a list of available logs. On some systems calling this may stop on-board logging until LOG_REQUEST_END is called.</description>
@@ -4874,6 +4879,8 @@
       <field type="int16_t" name="xmag" units="mgauss">X Magnetic field</field>
       <field type="int16_t" name="ymag" units="mgauss">Y Magnetic field</field>
       <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
+      <extensions/>
+      <field type="int16_t" name="temperature" units="cdegC">Temperature, 0 indicates that the IMU does not provide the temperature, if the IMU is actually at 0C, then a value of 1 should be sent.</field>
     </message>
     <message id="130" name="DATA_TRANSMISSION_HANDSHAKE">
       <description>Handshake message to initiate, control and stop image streaming when using the Image Transmission Protocol: https://mavlink.io/en/services/image_transmission.html.</description>


### PR DESCRIPTION
This is useful information for the GCS and safety reasons. The main question I have is do we want a DNU value for this? (IE `INT16_MIN`) The downside to using a DNU is that if you don't have the extension you get 0, which is inband. We could also just declare 0 to be the DNU, and if you send a value of 0, then just add 1 to it, and accept the slight error.