### PR TITLE
Add non NED/ENU frames for external position

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5568,7 +5568,7 @@
       <field type="float[21]" name="velocity_covariance">Row-major representation of a 6x6 velocity cross-covariance matrix upper right triangle (states: vx, vy, vz, rollspeed, pitchspeed, yawspeed; first six entries are the first ROW, next five entries are the second ROW, etc.). If unknown, assign NaN value to first element in the array.</field>
       <extensions/>
       <field type="uint8_t" name="reset_counter">Estimate reset counter. This should be incremented when the estimate resets in any of the dimensions (position, velocity, attitude, angular speed). This is designed to be used when e.g an external SLAM system detects a loop-closure and the estimate jumps.</field>
-      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Type of estimator that is providing the odometry.</field>\
+      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Type of estimator that is providing the odometry.</field>
     </message>
     <message id="332" name="TRAJECTORY_REPRESENTATION_WAYPOINTS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -857,22 +857,34 @@
         <description>Body fixed frame of reference, Z-up (x: forward, y: left, z: up).</description>
       </entry>
       <entry value="14" name="MAV_FRAME_MOCAP_NED">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FRD"/>
         <description>Odometry local coordinate frame of data given by a motion capture system, Z-down (x: north, y: east, z: down).</description>
       </entry>
       <entry value="15" name="MAV_FRAME_MOCAP_ENU">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FLU"/>
         <description>Odometry local coordinate frame of data given by a motion capture system, Z-up (x: east, y: north, z: up).</description>
       </entry>
       <entry value="16" name="MAV_FRAME_VISION_NED">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FRD"/>
         <description>Odometry local coordinate frame of data given by a vision estimation system, Z-down (x: north, y: east, z: down).</description>
       </entry>
       <entry value="17" name="MAV_FRAME_VISION_ENU">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FLU"/>
         <description>Odometry local coordinate frame of data given by a vision estimation system, Z-up (x: east, y: north, z: up).</description>
       </entry>
       <entry value="18" name="MAV_FRAME_ESTIM_NED">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FRD"/>
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-down (x: north, y: east, z: down).</description>
       </entry>
       <entry value="19" name="MAV_FRAME_ESTIM_ENU">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FLU"/>
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: east, y: noth, z: up).</description>
+      </entry>
+      <entry value="20" name="MAV_FRAME_ESTIM_FRD">
+        <description>Odometry reference coordinate frame of data given by an external estimator, Z-down, but not aligned with NED</description>
+      </entry>
+      <entry value="21" name="MAV_FRAME_ESTIM_FLU">
+        <description>Odometry reference coordinate frame of data given by an external estimator, Z-up, but not aligned with NED</description>
       </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
@@ -2818,6 +2830,12 @@
       </entry>
       <entry value="5" name="MAV_ESTIMATOR_TYPE_GPS_INS">
         <description>Estimator integrating GPS and inertial sensing.</description>
+      </entry>
+      <entry value="6" name="MAV_ESTIMATOR_TYPE_MOCAP">
+        <description>Estimate from external motion capturing system.</description>
+      </entry>
+      <entry value="7" name="MAV_ESTIMATOR_TYPE_AUTOPILOT">
+        <description>Estimator on autopilot.</description>
       </entry>
     </enum>
     <enum name="MAV_BATTERY_TYPE">
@@ -5533,6 +5551,7 @@
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="uint8_t" name="frame_id" enum="MAV_FRAME">Coordinate frame of reference for the pose data.</field>
       <field type="uint8_t" name="child_frame_id" enum="MAV_FRAME">Coordinate frame of reference for the velocity in free space (twist) data.</field>
+      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Type of estimator that is providing the odometry.</field>
       <field type="float" name="x" units="m">X Position</field>
       <field type="float" name="y" units="m">Y Position</field>
       <field type="float" name="z" units="m">Z Position</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -883,10 +883,10 @@
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: east, y: noth, z: up).</description>
       </entry>
       <entry value="20" name="MAV_FRAME_LOCAL_FRD">
-        <description>Odometry reference coordinate frame of data given by an external estimator, Z-down, not aligned with North</description>
+        <description>Forward, Right, Down coordinate frame. This is a local frame with Z-down and arbitrary F/R alignment (i.e. not aligned with NED/earth frame).</description>
       </entry>
       <entry value="21" name="MAV_FRAME_LOCAL_FLU">
-        <description>Odometry reference coordinate frame of data given by an external estimator, Z-up, not aligned with North</description>
+        <description>Forward, Left, Up coordinate frame. This is a local frame with Z-up and arbitrary F/L alignment (i.e. not aligned with ENU/earth frame).</description>
       </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
@@ -2818,6 +2818,9 @@
     </enum>
     <enum name="MAV_ESTIMATOR_TYPE">
       <description>Enumeration of estimator types</description>
+      <entry value="0" name="MAV_ESTIMATOR_TYPE_UNKNOWN">
+        <description>Unknown type of the estimator.</description>
+      </entry>
       <entry value="1" name="MAV_ESTIMATOR_TYPE_NAIVE">
         <description>This is a naive estimator without any real covariance feedback.</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2834,11 +2834,11 @@
       <entry value="6" name="MAV_ESTIMATOR_TYPE_MOCAP">
         <description>Estimate from external motion capturing system.</description>
       </entry>
-      <entry value="7" name="MAV_ESTIMATOR_TYPE_AUTOPILOT">
-        <description>Estimator on autopilot.</description>
-      </entry>
       <entry value="7" name="MAV_ESTIMATOR_TYPE_LIDAR">
         <description>Estimator based on lidar sensor input.</description>
+      </entry>
+      <entry value="8" name="MAV_ESTIMATOR_TYPE_AUTOPILOT">
+        <description>Estimator on autopilot.</description>
       </entry>
     </enum>
     <enum name="MAV_BATTERY_TYPE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -880,10 +880,10 @@
         <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FLU"/>
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: east, y: noth, z: up).</description>
       </entry>
-      <entry value="20" name="MAV_FRAME_ESTIM_FRD">
+      <entry value="20" name="MAV_FRAME_LOCAL_FRD">
         <description>Odometry reference coordinate frame of data given by an external estimator, Z-down, but not aligned with NED</description>
       </entry>
-      <entry value="21" name="MAV_FRAME_ESTIM_FLU">
+      <entry value="21" name="MAV_FRAME_LOCAL_FLU">
         <description>Odometry reference coordinate frame of data given by an external estimator, Z-up, but not aligned with NED</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3853,7 +3853,7 @@
       <field type="int16_t" name="zmag" units="mgauss">Z Magnetic field</field>
     </message>
     <message id="27" name="RAW_IMU">
-      <description>The RAW IMU readings for the usual 9DOF sensor setup. This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
+      <description>The RAW IMU readings for a 9DOF sensor, which is identified by the id (default IMU1). This message should always contain the true raw values without any scaling to allow data capture and system debugging.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="int16_t" name="xacc">X acceleration (raw)</field>
       <field type="int16_t" name="yacc">Y acceleration (raw)</field>
@@ -3864,6 +3864,8 @@
       <field type="int16_t" name="xmag">X Magnetic field (raw)</field>
       <field type="int16_t" name="ymag">Y Magnetic field (raw)</field>
       <field type="int16_t" name="zmag">Z Magnetic field (raw)</field>
+      <extensions/>
+      <field type="uint8_t" name="id">Id. Ids are numbered from 0 and map to IMUs numbered from 1 (e.g. IMU1 will have a message with id=0)</field>
     </message>
     <message id="28" name="RAW_PRESSURE">
       <description>The RAW pressure readings for the typical setup of one absolute pressure and one differential pressure sensor. The sensor values should be the raw, UNSCALED ADC values.</description>
@@ -4574,6 +4576,8 @@
       <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
       <field type="float" name="temperature" units="degC">Temperature</field>
       <field type="uint16_t" name="fields_updated" display="bitmask">Bitmap for fields that have updated since last message, bit 0 = xacc, bit 12: temperature</field>
+      <extensions/>
+      <field type="uint8_t" name="id">Id. Ids are numbered from 0 and map to IMUs numbered from 1 (e.g. IMU1 will have a message with id=0)</field>
     </message>
     <message id="106" name="OPTICAL_FLOW_RAD">
       <description>Optical flow from an angular rate flow sensor (e.g. PX4FLOW or mouse sensor)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -839,9 +839,11 @@
         <description>Offset to the current local frame. Anything expressed in this frame should be added to the current local frame position.</description>
       </entry>
       <entry value="8" name="MAV_FRAME_BODY_NED">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_BODY_FRD"/>
         <description>Setpoint in body NED frame. This makes sense if all position control is externalized - e.g. useful to command 2 m/s^2 acceleration to the right.</description>
       </entry>
       <entry value="9" name="MAV_FRAME_BODY_OFFSET_NED">
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_BODY_FRD"/>
         <description>Offset in body NED frame. This makes sense if adding setpoints to the current flight path, to avoid an obstacle - e.g. useful to command 2 m/s^2 acceleration to the east.</description>
       </entry>
       <entry value="10" name="MAV_FRAME_GLOBAL_TERRAIN_ALT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -881,10 +881,10 @@
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: east, y: noth, z: up).</description>
       </entry>
       <entry value="20" name="MAV_FRAME_LOCAL_FRD">
-        <description>Odometry reference coordinate frame of data given by an external estimator, Z-down, but not aligned with NED</description>
+        <description>Odometry reference coordinate frame of data given by an external estimator, Z-down, not aligned with North</description>
       </entry>
       <entry value="21" name="MAV_FRAME_LOCAL_FLU">
-        <description>Odometry reference coordinate frame of data given by an external estimator, Z-up, but not aligned with NED</description>
+        <description>Odometry reference coordinate frame of data given by an external estimator, Z-up, not aligned with North</description>
       </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
@@ -2836,6 +2836,9 @@
       </entry>
       <entry value="7" name="MAV_ESTIMATOR_TYPE_AUTOPILOT">
         <description>Estimator on autopilot.</description>
+      </entry>
+      <entry value="7" name="MAV_ESTIMATOR_TYPE_LIDAR">
+        <description>Estimator based on lidar sensor input.</description>
       </entry>
     </enum>
     <enum name="MAV_BATTERY_TYPE">
@@ -5551,7 +5554,6 @@
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
       <field type="uint8_t" name="frame_id" enum="MAV_FRAME">Coordinate frame of reference for the pose data.</field>
       <field type="uint8_t" name="child_frame_id" enum="MAV_FRAME">Coordinate frame of reference for the velocity in free space (twist) data.</field>
-      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Type of estimator that is providing the odometry.</field>
       <field type="float" name="x" units="m">X Position</field>
       <field type="float" name="y" units="m">Y Position</field>
       <field type="float" name="z" units="m">Z Position</field>
@@ -5566,6 +5568,7 @@
       <field type="float[21]" name="velocity_covariance">Row-major representation of a 6x6 velocity cross-covariance matrix upper right triangle (states: vx, vy, vz, rollspeed, pitchspeed, yawspeed; first six entries are the first ROW, next five entries are the second ROW, etc.). If unknown, assign NaN value to first element in the array.</field>
       <extensions/>
       <field type="uint8_t" name="reset_counter">Estimate reset counter. This should be incremented when the estimate resets in any of the dimensions (position, velocity, attitude, angular speed). This is designed to be used when e.g an external SLAM system detects a loop-closure and the estimate jumps.</field>
+      <field type="uint8_t" name="estimator_type" enum="MAV_ESTIMATOR_TYPE">Type of estimator that is providing the odometry.</field>\
     </message>
     <message id="332" name="TRAJECTORY_REPRESENTATION_WAYPOINTS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -857,27 +857,27 @@
         <description>Body fixed frame of reference, Z-up (x: forward, y: left, z: up).</description>
       </entry>
       <entry value="14" name="MAV_FRAME_MOCAP_NED">
-        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FRD"/>
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_LOCAL_FRD"/>
         <description>Odometry local coordinate frame of data given by a motion capture system, Z-down (x: north, y: east, z: down).</description>
       </entry>
       <entry value="15" name="MAV_FRAME_MOCAP_ENU">
-        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FLU"/>
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_LOCAL_FLU"/>
         <description>Odometry local coordinate frame of data given by a motion capture system, Z-up (x: east, y: north, z: up).</description>
       </entry>
       <entry value="16" name="MAV_FRAME_VISION_NED">
-        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FRD"/>
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_LOCAL_FRD"/>
         <description>Odometry local coordinate frame of data given by a vision estimation system, Z-down (x: north, y: east, z: down).</description>
       </entry>
       <entry value="17" name="MAV_FRAME_VISION_ENU">
-        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FLU"/>
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_LOCAL_FLU"/>
         <description>Odometry local coordinate frame of data given by a vision estimation system, Z-up (x: east, y: north, z: up).</description>
       </entry>
       <entry value="18" name="MAV_FRAME_ESTIM_NED">
-        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FRD"/>
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_LOCAL_FRD"/>
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-down (x: north, y: east, z: down).</description>
       </entry>
       <entry value="19" name="MAV_FRAME_ESTIM_ENU">
-        <deprecated since="2019-08" replaced_by="MAV_FRAME_ESTIM_FLU"/>
+        <deprecated since="2019-08" replaced_by="MAV_FRAME_LOCAL_FLU"/>
         <description>Odometry local coordinate frame of data given by an estimator running onboard the vehicle, Z-up (x: east, y: noth, z: up).</description>
       </entry>
       <entry value="20" name="MAV_FRAME_LOCAL_FRD">


### PR DESCRIPTION
External pose as well as odometry information is almost never aligned with
earth's north and east directions. This adds a two new frames that are labeled with
FRD and FLU. With this we get rid of the ambigious usage of ENU and NED.
Additionally, this commit reduced the number of frames for external pose/odometry information.
The source for the information is now handled by an additional field in the odometry message.
The estimator type is extended to cover mocap and autopilot (fcu).
@TSC21 @mhkabir 