### PR TITLE
SET_POSITION_HOME: Add frame for local coordinates

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5234,6 +5234,7 @@
       <field type="float" name="approach_z" units="m">Local Z position of the end of the approach vector. Multicopters should set this position based on their takeoff path. Grass-landing fixed wing aircraft should set it the same way as multicopters. Runway-landing fixed wing aircraft should set it to the opposite direction of the takeoff, assuming the takeoff happened from the threshold / touchdown zone.</field>
       <extensions/>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the local frame fields: x, y, z.</field>
     </message>
     <message id="244" name="MESSAGE_INTERVAL">
       <description>The interval between messages for a particular MAVLink message ID. This message is the response to the MAV_CMD_GET_MESSAGE_INTERVAL command. This interface replaces DATA_STREAM.</description>


### PR DESCRIPTION
This is an attempt to clarify how [SET_POSITION_HOME](https://mavlink.io/en/messages/common.html#SET_HOME_POSITION) should work, as discussed in 
https://github.com/mavlink/mavlink/issues/898#issuecomment-514027281

The (first) specific fix is to add field to specify frame for local coordinate values - since this could be any frame. [Note, the intention could be that a system has the concept of a default frame - effectively I opened this to find out what the thinking is]

**Question**: what should user do if they don't want to specify a local frame or global frame. Is it that if you're working in global system (ie outside) the global home will be used, and if you're working in a local system (e.g. from a VIO system) that the local system will be used - so you can and should specify both, and the irrelevant one will be ignored?