### PR TITLE
Tunnel message: add length field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5727,7 +5727,8 @@
       <field type="uint8_t" name="target_system">System ID (can be 0 for broadcast, but this is discouraged)</field>
       <field type="uint8_t" name="target_component">Component ID (can be 0 for broadcast, but this is discouraged)</field>
       <field type="uint16_t" name="payload_type" enum="MAV_TUNNEL_PAYLOAD_TYPE">A code that identifies the content of the payload (0 for unknown, which is the default). If this code is less than 32768, it is a 'registered' payload type and the corresponding code should be added to the MAV_TUNNEL_PAYLOAD_TYPE enum, and the entry possibly to https://github.com/mavlink/mavlink/tunnel-message-payload-types.xml. Software creators can register blocks of types as needed. Codes greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
-      <field type="uint8_t[128]" name="payload">Variable length payload. The payload length is defined by the remaining message length when subtracting the header and other fields. The entire content of this block is opaque unless you understand the encoding specified by payload_type.</field>
+      <field type="uint8_t" name="payload_len">Length of the data transported in payload</field>
+      <field type="uint8_t[128]" name="payload">Variable length payload. The payload length is defined by payload_len. The entire content of this block is opaque unless you understand the encoding specified by payload_type.</field>
     </message>
     <message id="390" name="ONBOARD_COMPUTER_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5727,8 +5727,8 @@
       <field type="uint8_t" name="target_system">System ID (can be 0 for broadcast, but this is discouraged)</field>
       <field type="uint8_t" name="target_component">Component ID (can be 0 for broadcast, but this is discouraged)</field>
       <field type="uint16_t" name="payload_type" enum="MAV_TUNNEL_PAYLOAD_TYPE">A code that identifies the content of the payload (0 for unknown, which is the default). If this code is less than 32768, it is a 'registered' payload type and the corresponding code should be added to the MAV_TUNNEL_PAYLOAD_TYPE enum, and the entry possibly to https://github.com/mavlink/mavlink/tunnel-message-payload-types.xml. Software creators can register blocks of types as needed. Codes greater than 32767 are considered local experiments and should not be checked in to any widely distributed codebase.</field>
-      <field type="uint8_t" name="payload_len">Length of the data transported in payload</field>
-      <field type="uint8_t[128]" name="payload">Variable length payload. The payload length is defined by payload_len. The entire content of this block is opaque unless you understand the encoding specified by payload_type.</field>
+      <field type="uint8_t" name="payload_length">Length of the data transported in payload</field>
+      <field type="uint8_t[128]" name="payload">Variable length payload. The payload length is defined by payload_length. The entire content of this block is opaque unless you understand the encoding specified by payload_type.</field>
     </message>
     <message id="390" name="ONBOARD_COMPUTER_STATUS">
       <wip/>


### PR DESCRIPTION
addresses #1220

EDITED (HamishW). The tunnel message is WIP, and Ollie is the person who championed it and is first implementer. This change makes sense and is not affecting stable messages.

EDIT (OlliW): Thx for the edit! I should have realized that it's important info that changing the message now won't do damage.