### PR TITLE
Gimbal Component IDs for Gimbal #2 to #6

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -667,7 +667,7 @@
         <description>Servo #14.</description>
       </entry>
       <entry value="154" name="MAV_COMP_ID_GIMBAL">
-        <description>Gimbal component.</description>
+        <description>Gimbal #1.</description>
       </entry>
       <entry value="155" name="MAV_COMP_ID_LOG">
         <description>Logging component.</description>
@@ -688,6 +688,21 @@
       <entry value="160" name="MAV_COMP_ID_FLARM">
         <description>FLARM collision alert component.</description>
       </entry>
+      <entry value="171" name="MAV_COMP_ID_GIMBAL2">
+        <description>Gimbal #2.</description>
+      </entry>
+      <entry value="172" name="MAV_COMP_ID_GIMBAL3">
+        <description>Gimbal #3.</description>
+      </entry>
+      <entry value="173" name="MAV_COMP_ID_GIMBAL4">
+        <description>Gimbal #4</description>
+      </entry>
+      <entry value="174" name="MAV_COMP_ID_GIMBAL5">
+        <description>Gimbal #5.</description>
+      </entry>
+      <entry value="175" name="MAV_COMP_ID_GIMBAL6">
+        <description>Gimbal #6.</description>
+      </entry>      
       <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
         <description>Component that can generate/supply a mission flight plan (e.g. GCS or developer API).</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -702,7 +702,7 @@
       </entry>
       <entry value="175" name="MAV_COMP_ID_GIMBAL6">
         <description>Gimbal #6.</description>
-      </entry>      
+      </entry>
       <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
         <description>Component that can generate/supply a mission flight plan (e.g. GCS or developer API).</description>
       </entry>


### PR DESCRIPTION
adding component IDs for gimbal #2 to #6 is part of the PR [New gimbal messages](https://github.com/mavlink/mavlink/pull/1174), #1174, which however will very likely take some more time to be finalized and merged. 

It would be useful to have these additional gimbal component IDs being defined ASAP, so they could be used ASAP, hence this PR which takes that part out of #1174.