### PR TITLE
FOCUS_TYPE_RANGE: Typo

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3300,7 +3300,7 @@
         <description>Continuous focus up/down until stopped (-1 for focusing in, 1 for focusing out towards infinity, 0 to stop focusing)</description>
       </entry>
       <entry value="2" name="FOCUS_TYPE_RANGE">
-        <description>Zoom value as proportion of full camera range (a value between 0.0 and 100.0)</description>
+        <description>Focus value as proportion of full camera focus range (a value between 0.0 and 100.0)</description>
       </entry>
     </enum>
     <enum name="PARAM_ACK">


### PR DESCRIPTION
@dogmaphobic:
I think this was a typo. Can you confirm?

In addition, in https://groups.google.com/forum/#!msg/mavlink/9KrPARAMe1c/LRW6IPBHBAAJ there is a question:

> I would like to pass the focus distance in meters to the camera. But would this be focus type number 2, or maybe a new one?

My take is that we don't support this. Do we want to?