### PR TITLE
common.xml: add AIS message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3834,6 +3834,182 @@
         <description>Format is Modern Music Markup Language (MML): https://en.wikipedia.org/wiki/Music_Macro_Language#Modern_MML.</description>
       </entry>
     </enum>
+    <!-- AIS related enums-->
+    <enum name="AIS_TYPE">
+      <description>Type of AIS vessel, enum duplicated from AIS standard, https://gpsd.gitlab.io/gpsd/AIVDM.html</description>
+      <entry value="0" name="AIS_TYPE_UNKNOWN">
+        <description>Not available (default).</description>
+      </entry>
+      <entry value="1" name="AIS_TYPE_RESERVED_1"/>
+      <entry value="2" name="AIS_TYPE_RESERVED_2"/>
+      <entry value="3" name="AIS_TYPE_RESERVED_3"/>
+      <entry value="4" name="AIS_TYPE_RESERVED_4"/>
+      <entry value="5" name="AIS_TYPE_RESERVED_5"/>
+      <entry value="6" name="AIS_TYPE_RESERVED_6"/>
+      <entry value="7" name="AIS_TYPE_RESERVED_7"/>
+      <entry value="8" name="AIS_TYPE_RESERVED_8"/>
+      <entry value="9" name="AIS_TYPE_RESERVED_9"/>
+      <entry value="10" name="AIS_TYPE_RESERVED_10"/>
+      <entry value="11" name="AIS_TYPE_RESERVED_11"/>
+      <entry value="12" name="AIS_TYPE_RESERVED_12"/>
+      <entry value="13" name="AIS_TYPE_RESERVED_13"/>
+      <entry value="14" name="AIS_TYPE_RESERVED_14"/>
+      <entry value="15" name="AIS_TYPE_RESERVED_15"/>
+      <entry value="16" name="AIS_TYPE_RESERVED_16"/>
+      <entry value="17" name="AIS_TYPE_RESERVED_17"/>
+      <entry value="18" name="AIS_TYPE_RESERVED_18"/>
+      <entry value="19" name="AIS_TYPE_RESERVED_19"/>
+      <entry value="20" name="AIS_TYPE_WIG">
+        <description>Wing In Ground effect.</description>
+      </entry>
+      <entry value="21" name="AIS_TYPE_WIG_HAZARDOUS_A"/>
+      <entry value="22" name="AIS_TYPE_WIG_HAZARDOUS_B"/>
+      <entry value="23" name="AIS_TYPE_WIG_HAZARDOUS_C"/>
+      <entry value="24" name="AIS_TYPE_WIG_HAZARDOUS_D"/>
+      <entry value="25" name="AIS_TYPE_WIG_RESERVED_1"/>
+      <entry value="26" name="AIS_TYPE_WIG_RESERVED_2"/>
+      <entry value="27" name="AIS_TYPE_WIG_RESERVED_3"/>
+      <entry value="28" name="AIS_TYPE_WIG_RESERVED_4"/>
+      <entry value="29" name="AIS_TYPE_WIG_RESERVED_5"/>
+      <entry value="30" name="AIS_TYPE_FISHING"/>
+      <entry value="31" name="AIS_TYPE_TOWING"/>
+      <entry value="32" name="AIS_TYPE_TOWING_LARGE">
+        <description>Towing: length exceeds 200m or breadth exceeds 25m.</description>
+      </entry>
+      <entry value="33" name="AIS_TYPE_DREDGING">
+        <description>Dredging or other underwater ops.</description>
+      </entry>
+      <entry value="34" name="AIS_TYPE_DIVING"/>
+      <entry value="35" name="AIS_TYPE_MILITARY"/>
+      <entry value="36" name="AIS_TYPE_SAILING"/>
+      <entry value="37" name="AIS_TYPE_PLEASURE"/>
+      <entry value="38" name="AIS_TYPE_RESERVED_20"/>
+      <entry value="39" name="AIS_TYPE_RESERVED_21"/>
+      <entry value="40" name="AIS_TYPE_HSC">
+        <description>High Speed Craft.</description>
+      </entry>
+      <entry value="41" name="AIS_TYPE_HSC_HAZARDOUS_A"/>
+      <entry value="42" name="AIS_TYPE_HSC_HAZARDOUS_B"/>
+      <entry value="43" name="AIS_TYPE_HSC_HAZARDOUS_C"/>
+      <entry value="44" name="AIS_TYPE_HSC_HAZARDOUS_D"/>
+      <entry value="45" name="AIS_TYPE_HSC_RESERVED_1"/>
+      <entry value="46" name="AIS_TYPE_HSC_RESERVED_2"/>
+      <entry value="47" name="AIS_TYPE_HSC_RESERVED_3"/>
+      <entry value="48" name="AIS_TYPE_HSC_RESERVED_4"/>
+      <entry value="49" name="AIS_TYPE_HSC_UNKNOWN"/>
+      <entry value="50" name="AIS_TYPE_PILOT"/>
+      <entry value="51" name="AIS_TYPE_SAR">
+        <description>Search And Rescue vessel.</description>
+      </entry>
+      <entry value="52" name="AIS_TYPE_TUG"/>
+      <entry value="53" name="AIS_TYPE_PORT_TENDER"/>
+      <entry value="54" name="AIS_TYPE_ANTI_POLLUTION">
+        <description>Anti-pollution equipment.</description>
+      </entry>
+      <entry value="55" name="AIS_TYPE_LAW_ENFORCEMENT"/>
+      <entry value="56" name="AIS_TYPE_SPARE_LOCAL_1"/>
+      <entry value="57" name="AIS_TYPE_SPARE_LOCAL_2"/>
+      <entry value="58" name="AIS_TYPE_MEDICAL_TRANSPORT"/>
+      <entry value="59" name="AIS_TYPE_NONECOMBATANT">
+        <description>Noncombatant ship according to RR Resolution No. 18.</description>
+      </entry>
+      <entry value="60" name="AIS_TYPE_PASSENGER"/>
+      <entry value="61" name="AIS_TYPE_PASSENGER_HAZARDOUS_A"/>
+      <entry value="62" name="AIS_TYPE_PASSENGER_HAZARDOUS_B"/>
+      <entry value="63" name="AIS_TYPE_AIS_TYPE_PASSENGER_HAZARDOUS_C"/>
+      <entry value="64" name="AIS_TYPE_PASSENGER_HAZARDOUS_D"/>
+      <entry value="65" name="AIS_TYPE_PASSENGER_RESERVED_1"/>
+      <entry value="66" name="AIS_TYPE_PASSENGER_RESERVED_2"/>
+      <entry value="67" name="AIS_TYPE_PASSENGER_RESERVED_3"/>
+      <entry value="68" name="AIS_TYPE_AIS_TYPE_PASSENGER_RESERVED_4"/>
+      <entry value="69" name="AIS_TYPE_PASSENGER_UNKNOWN"/>
+      <entry value="70" name="AIS_TYPE_CARGO"/>
+      <entry value="71" name="AIS_TYPE_CARGO_HAZARDOUS_A"/>
+      <entry value="72" name="AIS_TYPE_CARGO_HAZARDOUS_B"/>
+      <entry value="73" name="AIS_TYPE_CARGO_HAZARDOUS_C"/>
+      <entry value="74" name="AIS_TYPE_CARGO_HAZARDOUS_D"/>
+      <entry value="75" name="AIS_TYPE_CARGO_RESERVED_1"/>
+      <entry value="76" name="AIS_TYPE_CARGO_RESERVED_2"/>
+      <entry value="77" name="AIS_TYPE_CARGO_RESERVED_3"/>
+      <entry value="78" name="AIS_TYPE_CARGO_RESERVED_4"/>
+      <entry value="79" name="AIS_TYPE_CARGO_UNKNOWN"/>
+      <entry value="80" name="AIS_TYPE_TANKER"/>
+      <entry value="81" name="AIS_TYPE_TANKER_HAZARDOUS_A"/>
+      <entry value="82" name="AIS_TYPE_TANKER_HAZARDOUS_B"/>
+      <entry value="83" name="AIS_TYPE_TANKER_HAZARDOUS_C"/>
+      <entry value="84" name="AIS_TYPE_TANKER_HAZARDOUS_D"/>
+      <entry value="85" name="AIS_TYPE_TANKER_RESERVED_1"/>
+      <entry value="86" name="AIS_TYPE_TANKER_RESERVED_2"/>
+      <entry value="87" name="AIS_TYPE_TANKER_RESERVED_3"/>
+      <entry value="88" name="AIS_TYPE_TANKER_RESERVED_4"/>
+      <entry value="89" name="AIS_TYPE_TANKER_UNKNOWN"/>
+      <entry value="90" name="AIS_TYPE_OTHER"/>
+      <entry value="91" name="AIS_TYPE_OTHER_HAZARDOUS_A"/>
+      <entry value="92" name="AIS_TYPE_OTHER_HAZARDOUS_B"/>
+      <entry value="93" name="AIS_TYPE_OTHER_HAZARDOUS_C"/>
+      <entry value="94" name="AIS_TYPE_OTHER_HAZARDOUS_D"/>
+      <entry value="95" name="AIS_TYPE_OTHER_RESERVED_1"/>
+      <entry value="96" name="AIS_TYPE_OTHER_RESERVED_2"/>
+      <entry value="97" name="AIS_TYPE_OTHER_RESERVED_3"/>
+      <entry value="98" name="AIS_TYPE_OTHER_RESERVED_4"/>
+      <entry value="99" name="AIS_TYPE_OTHER_UNKNOWN"/>
+    </enum>
+    <enum name="AIS_NAV_STATUS">
+      <description>Navigational status of AIS vessel, enum duplicated from AIS standard, https://gpsd.gitlab.io/gpsd/AIVDM.html</description>
+      <entry value="0" name="UNDER_WAY">
+        <description>Under way using engine.</description>
+      </entry>
+      <entry value="1" name="AIS_NAV_ANCHORED"/>
+      <entry value="2" name="AIS_NAV_UN_COMMANDED"/>
+      <entry value="3" name="AIS_NAV_RESTRICTED_MANOEUVERABILITY"/>
+      <entry value="4" name="AIS_NAV_DRAUGHT_CONSTRAINED"/>
+      <entry value="5" name="AIS_NAV_MOORED"/>
+      <entry value="6" name="AIS_NAV_AGROUND"/>
+      <entry value="7" name="AIS_NAV_FISHING"/>
+      <entry value="8" name="AIS_NAV_SAILING"/>
+      <entry value="9" name="AIS_NAV_RESERVED_HSC"/>
+      <entry value="10" name="AIS_NAV_RESERVED_WIG"/>
+      <entry value="11" name="AIS_NAV_RESERVED_1"/>
+      <entry value="12" name="AIS_NAV_RESERVED_2"/>
+      <entry value="13" name="AIS_NAV_RESERVED_3"/>
+      <entry value="14" name="AIS_NAV_AIS_SART">
+        <description>Search And Rescue Transponder.</description>
+      </entry>
+      <entry value="15" name="AIS_NAV_UNKNOWN">
+        <description>Not available (default).</description>
+      </entry>
+    </enum>
+    <enum name="AIS_FLAGS">
+      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>These flags are used in the AIS_VESSEL.fields bitmask to indicate validity of data in the other message fields. When set, the data is valid.</description>
+      <entry value="1" name="AIS_FLAGS_POSITION_ACCURACY">
+        <description>1 = Position accuracy less than 10m, 0 = position accuracy greater than 10m.</description>
+      </entry>
+      <entry value="2" name="AIS_FLAGS_VALID_COG"/>
+      <entry value="4" name="AIS_FLAGS_VALID_VELOCITY"/>
+      <entry value="8" name="AIS_FLAGS_HIGH_VELOCITY">
+        <description>1 = Velocity over 52.5765m/s (102.2 knots)</description>
+      </entry>
+      <entry value="16" name="AIS_FLAGS_VALID_TURN_RATE"/>
+      <entry value="32" name="AIS_FLAGS_TURN_RATE_SIGN_ONLY">
+        <description>Only the sign of the returned turn rate value is valid, either greater than 5deg/30s or less than -5deg/30s</description>
+      </entry>
+      <entry value="64" name="AIS_FLAGS_VALID_DIMENSIONS"/>
+      <entry value="128" name="AIS_FLAGS_LARGE_BOW_DIMENSION">
+        <description>Distance to bow is larger than 511m</description>
+      </entry>
+      <entry value="256" name="AIS_FLAGS_LARGE_STERN_DIMENSION">
+        <description>Distance to stern is larger than 511m</description>
+      </entry>
+      <entry value="512" name="AIS_FLAGS_LARGE_PORT_DIMENSION">
+        <description>Distance to port side is larger than 63m</description>
+      </entry>
+      <entry value="1024" name="AIS_FLAGS_LARGE_STARBOARD_DIMENSION">
+        <description>Distance to starboard side is larger than 63m</description>
+      </entry>
+      <entry value="2048" name="AIS_FLAGS_VALID_CALLSIGN"/>
+      <entry value="4096" name="AIS_FLAGS_VALID_NAME"/>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">
@@ -5605,6 +5781,28 @@
       <field type="uint16_t" name="max_version">Maximum MAVLink version supported (set to the same value as version by default)</field>
       <field type="uint8_t[8]" name="spec_version_hash">The first 8 bytes (not characters printed in hex!) of the git hash.</field>
       <field type="uint8_t[8]" name="library_version_hash">The first 8 bytes (not characters printed in hex!) of the git hash.</field>
+    </message>
+    <message id="301" name="AIS_VESSEL">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>The location and information of an AIS vessel</description>
+      <field type="uint32_t" name="MMSI">Mobile Marine Service Identifier, 9 decimal digits</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude</field>
+      <field type="uint16_t" name="COG" units="cdeg">Course over ground</field>
+      <field type="uint16_t" name="heading" units="cdeg">True heading</field>
+      <field type="uint16_t" name="velocity" units="cm/s">Speed over ground</field>
+      <field type="int8_t" name="turn_rate" units="cdeg/s">Turn rate</field>
+      <field type="uint8_t" name="navigational_status" enum="AIS_NAV_STATUS">Navigational status</field>
+      <field type="uint8_t" name="type" enum="AIS_TYPE">Type of vessels</field>
+      <field type="uint16_t" name="dimension_bow" units="m">Distance from lat/lon location to bow</field>
+      <field type="uint16_t" name="dimension_stern" units="m">Distance from lat/lon location to stern</field>
+      <field type="uint8_t" name="dimension_port" units="m">Distance from lat/lon location to port side</field>
+      <field type="uint8_t" name="dimension_starboard" units="m">Distance from lat/lon location to starboard side</field>
+      <field type="char[7]" name="callsign">The vessel callsign</field>
+      <field type="char[20]" name="name">The vessel name</field>
+      <field type="uint16_t" name="tslc" units="s">Time since last communication in seconds</field>
+      <field type="uint16_t" name="flags" enum="AIS_FLAGS" display="bitmask">Bitmask to indicate various statuses including valid data fields</field>
     </message>
     <!-- UAVCAN related messages. Please keep the range [310, 320) reserved for UAVCAN. -->
     <message id="310" name="UAVCAN_NODE_STATUS">


### PR DESCRIPTION
This adds a AIS message and the relevant enums. This message is an attempt to cover the two most common AIS messages. Position reports and Static and Voyage Related Data, see: https://gpsd.gitlab.io/gpsd/AIVDM.html 

I have attempted to only include the information from these messages that would be useful, there is quite a bit left out, such as vessel destination and ETA. I have, for the most part left the values in the units they arrive in over AIS, ie knots not m/s (could easily be persuaded to change this). I have added bits to the flags enum for magic values. For example in AIS turn rate is quite complex: 
- 0 = not turning
- 1…126 = turning right at up to 708 degrees per minute or higher
- 1…-126 = turning left at up to 708 degrees per minute or higher
- 127 = turning right at more than 5deg/30s (No TI available)
- -127 = turning left at more than 5deg/30s (No TI available)
- 128 (80 hex) indicates no turn information available (default)

I have replaced the magic values with bits in the AIS_FLAGS bit-mask. 

Also the type and navigation status enums are copyed directly from the AIS standards, not sure if there is a better way?

I have also added a nmea pass-through message, this passes the NMEA sentence as received. Note that they are a maximum of 74 characters long, could be shorter, I'm not sure if i should have a length field also?

The idea of this is that we only partly cover 2 AIS messages out of the 27 with our dedicated message. This allows other messages to be passed through if desired, in quite a lot of cases they would be messages that happen very infrequently, for example you can broadcast plain text messages or get weather reports. There is even a stay-out zone message. It seems silly to duplicate all these in mavlink so i think its better to just allow pass-through directly. This extends to all NMEA stuff, not just AIS
