### PR TITLE
HIGH_LATENCY2: Tidy description

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5209,7 +5209,7 @@
       <field type="uint8_t" name="epv" units="dm">Maximum error vertical position since last message</field>
       <field type="int8_t" name="temperature_air" units="degC">Air temperature from airspeed sensor</field>
       <field type="int8_t" name="climb_rate" units="dm/s">Maximum climb rate magnitude since last message</field>
-      <field type="int8_t" name="battery" units="%">Battery (percentage, -1 for DNU)</field>
+      <field type="int8_t" name="battery" units="%">Battery level (-1 if field not provided).</field>
       <field type="uint16_t" name="wp_num">Current waypoint number</field>
       <field type="uint16_t" name="failure_flags" enum="HL_FAILURE_FLAG" display="bitmask">Bitmap of failure flags.</field>
       <field type="int8_t" name="custom0">Field for custom payload.</field>


### PR DESCRIPTION
Percentage not required in description (is in units). Changed DNU to clear description of "not used"