### PR TITLE
common.xml: NMEA 0183 passthrough message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5507,6 +5507,10 @@
       <field type="uint8_t[8]" name="spec_version_hash">The first 8 bytes (not characters printed in hex!) of the git hash.</field>
       <field type="uint8_t[8]" name="library_version_hash">The first 8 bytes (not characters printed in hex!) of the git hash.</field>
     </message>
+    <message id="302" name="NMEA_PASSTHROUGH">
+      <description>Passthrough for NMEA 0183</description>
+      <field type="char[74]" name="sentence">The NMEA sentence without start character, line feed and carriage return</field>
+    </message>
     <!-- UAVCAN related messages. Please keep the range [310, 320) reserved for UAVCAN. -->
     <message id="310" name="UAVCAN_NODE_STATUS">
       <description>General status information of an UAVCAN node. Please refer to the definition of the UAVCAN message "uavcan.protocol.NodeStatus" for the background information. The UAVCAN specification is available at http://uavcan.org.</description>


### PR DESCRIPTION
This is the NMEA bit broken out from https://github.com/mavlink/mavlink/pull/1228.

I have added a nmea pass-through message, this passes the NMEA sentence as received. NMEA sentences are terminated with a * then two check sum characters, from this it will be possible to detect the end of the message.

The idea of this is that we only partly cover 2 AIS messages out of the 27 with our dedicated message. This allows other messages to be passed through if desired, in quite a lot of cases they would be messages that happen very infrequently, for example you can broadcast plain text messages or get weather reports. There is even a stay-out zone message. It seems silly to duplicate all these in mavlink so i think its better to just allow pass-through directly. This extends to all NMEA stuff, not just AIS

tldr: Over AIS we sometimes get messages that are useful for operators but not for vehicles, plain text messages and weather reports for example. It seems redundant (and a lot of work) to add duplicate mavlink messages for each AIS one. This allows us to send on to the operator as is. 