### PR TITLE
Add component ID for a TUNNEL node

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -736,6 +736,10 @@
       <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
         <description>Component to bridge to UART (i.e. from UDP).</description>
       </entry>
+      </entry>
+      <entry value="242" name="MAV_COMP_ID_TUNNEL_NODE">
+        <description>Component handling TUNNEL messages (e.g. vendor specific GUI of a component).</description>
+      </entry>
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
         <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID.</deprecated>
         <description>Component for handling system messages (e.g. to ARM, takeoff, etc.).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -736,7 +736,6 @@
       <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
         <description>Component to bridge to UART (i.e. from UDP).</description>
       </entry>
-      </entry>
       <entry value="242" name="MAV_COMP_ID_TUNNEL_NODE">
         <description>Component handling TUNNEL messages (e.g. vendor specific GUI of a component).</description>
       </entry>


### PR DESCRIPTION
adds a default component ID for a tunnel communication partner node.

For the rational pl see https://github.com/mavlink/mavlink/issues/1225#issuecomment-529074833.