### PR TITLE
Register 10 tunnel payload codes for STorM32

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3500,6 +3500,36 @@
       <entry value="0" name="MAV_TUNNEL_PAYLOAD_TYPE_UNKNOWN">
         <description>Encoding of payload unknown.</description>
       </entry>
+      <entry value="200" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED0">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="201" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED1">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="202" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED2">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="203" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED3">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="204" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED4">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="205" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED5">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="206" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED6">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="207" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED7">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="208" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED8">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
+      <entry value="209" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED9">
+        <description>Registered for STorM32 gimbal controller.</description>
+      </entry>
     </enum>
     <enum name="MAV_ODID_IDTYPE">
       <entry value="0" name="MAV_ODID_IDTYPE_NONE">


### PR DESCRIPTION
kindly asks to register 10 tunnel payload codes for the STorM32 gimbal controller project.

Follows the suggested rules for registration outlined here: https://github.com/mavlink/mavlink/issues/1225#issuecomment-529075395

<strike>In contrast to the suggested rules, which suggest a default block of 25 codes, I here ask for only 10 codes. Main reason is that I don't want to blow up the documentation web page with a that long enum. </strike> EDIT: default size was settled to 10