### PR TITLE
FOCUS_TYPE_METRES - add

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3307,7 +3307,7 @@
       </entry>
       <entry value="3" name="ZOOM_TYPE_FOCAL_LENGTH">
         <description>Zoom value/variable focal length in milimetres. Note that there is no message to get the valid zoom range of the camera, so this can type can only be used for cameras where the zoom range is known (implying that this cannot reliably be used in a GCS for an arbitrary camera)</description>
-      </entry>     
+      </entry>
     </enum>
     <enum name="SET_FOCUS_TYPE">
       <description>Focus types for MAV_CMD_SET_CAMERA_FOCUS</description>
@@ -3322,8 +3322,7 @@
       </entry>
       <entry value="3" name="FOCUS_TYPE_METERS">
         <description>Focus value in metres. Note that there is no message to get the valid focus range of the camera, so this can type can only be used for cameras where the range is known (implying that this cannot reliably be used in a GCS for an arbitrary camera).</description>
-      </entry>      
-      
+      </entry>
     </enum>
     <enum name="PARAM_ACK">
       <description>Result from a PARAM_EXT_SET message.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3305,6 +3305,9 @@
       <entry value="2" name="ZOOM_TYPE_RANGE">
         <description>Zoom value as proportion of full camera range (a value between 0.0 and 100.0)</description>
       </entry>
+      <entry value="3" name="ZOOM_TYPE_FOCAL_LENGTH">
+        <description>Zoom value/variable focal length in milimetres. Note that there is no message to get the valid zoom range of the camera, so this can type can only be used for cameras where the zoom range is known (implying that this cannot reliably be used in a GCS for an arbitrary camera)</description>
+      </entry>     
     </enum>
     <enum name="SET_FOCUS_TYPE">
       <description>Focus types for MAV_CMD_SET_CAMERA_FOCUS</description>
@@ -3317,6 +3320,10 @@
       <entry value="2" name="FOCUS_TYPE_RANGE">
         <description>Focus value as proportion of full camera focus range (a value between 0.0 and 100.0)</description>
       </entry>
+      <entry value="3" name="FOCUS_TYPE_METERS">
+        <description>Focus value in metres. Note that there is no message to get the valid focus range of the camera, so this can type can only be used for cameras where the range is known (implying that this cannot reliably be used in a GCS for an arbitrary camera).</description>
+      </entry>      
+      
     </enum>
     <enum name="PARAM_ACK">
       <description>Result from a PARAM_EXT_SET message.</description>


### PR DESCRIPTION
Add FOCUS_TYPE_METERS and ZOOM_TYPE_FOCAL_LENGTH to respective enums, as discussed in 
https://github.com/mavlink/mavlink/pull/1224#issuecomment-531091300

This does not add messages to get the focal range/zoom/etc from a camera. IMO that probably should be done - because otherwise IMO the mechanisms for setting these outside of parameters may not be worth having at all. And while I understand this could quickly get complicated, adding ranges for video and camera does not seem too scary (and addresses the 80% of likely use).

If you agree can you add range-getting messages either in their own PR or this one?