### PR TITLE
Update OpenDroneId messages to match version 0.8 of the specification

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3768,8 +3768,17 @@
       <entry value="0" name="MAV_ODID_AUTH_TYPE_NONE">
         <description>No authentication type is specified.</description>
       </entry>
-      <entry value="1" name="MAV_ODID_AUTH_TYPE_MPUID">
-        <description>Manufacturer Programmed Unique ID.</description>
+      <entry value="1" name="MAV_ODID_AUTH_TYPE_UAS_ID_SIGNATURE">
+        <description>Signature for the UAS (Unmanned Aircraft System) ID.</description>
+      </entry>
+      <entry value="2" name="MAV_ODID_AUTH_TYPE_OPERATOR_ID_SIGNATURE">
+        <description>Signature for the Operator ID.</description>
+      </entry>
+      <entry value="3" name="MAV_ODID_AUTH_TYPE_MESSAGE_SET_SIGNATURE">
+        <description>Signature for the entire message set.</description>
+      </entry>
+      <entry value="4" name="MAV_ODID_AUTH_TYPE_NETWORK_REMOTE_ID">
+        <description>Authentication is provided by Network Remote ID.</description>
       </entry>
     </enum>
     <enum name="MAV_ODID_DESC_TYPE">
@@ -5870,10 +5879,13 @@
     <message id="12902" name="OPEN_DRONE_ID_AUTHENTICATION">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
-      <description>Data for filling the OpenDroneID Authentication message. The Authentication Message defines a field that can provide a means of authenticity for the identity of the UAS (Unmanned Aircraft System) sending the message.</description>
+      <description>Data for filling the OpenDroneID Authentication message. The Authentication Message defines a field that can provide a means of authenticity for the identity of the UAS (Unmanned Aircraft System). The Authentication message can have two different formats. Five data pages are supported. For data page 0, the fields PageCount, Length and TimeStamp are present and AuthData is only 17 bytes. For data page 1 through 4, PageCount,Length and TimeStamp are not present and the size of AuthData is 23 bytes.</description>
       <field type="uint8_t" name="authentication_type" enum="MAV_ODID_AUTH_TYPE">Indicates the type of authentication.</field>
-      <field type="uint8_t" name="data_page">Allowed range is 0 - 15.</field>
-      <field type="uint8_t[23]" name="authentication_data">Opaque authentication data. Sixteen pages are supported for a total of 16 * 23 = 368 bytes. Shall be filled with nulls in the unused portion of the field.</field>
+      <field type="uint8_t" name="data_page">Allowed range is 0 - 4.</field>
+      <field type="uint8_t" name="page_count">This field is only present for page 0. Allowed range is 0 - 5.</field>
+      <field type="uint8_t" name="length" units="bytes">This field is only present for page 0. Total bytes of authentication_data from all data pages. Allowed range is 0 - 109 (17 + 23*4).</field>
+      <field type="uint32_t" name="timestamp" units="s">This field is only present for page 0. 32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.</field>
+      <field type="uint8_t[23]" name="authentication_data">Opaque authentication data. For page 0, the size is only 17 bytes. For other pages, the size is 23 bytes. Shall be filled with nulls in the unused portion of the field.</field>
     </message>
     <message id="12903" name="OPEN_DRONE_ID_SELF_ID">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5839,22 +5839,22 @@
       <description>Data for filling the OpenDroneID Basic ID message.</description>
       <field type="uint8_t" name="id_type" enum="MAV_ODID_ID_TYPE">Indicates the format for the uas_id field of this message.</field>
       <field type="uint8_t" name="ua_type" enum="MAV_ODID_UA_TYPE">Indicates the type of UA (Unmanned Aircraft).</field>
-      <field type="uint8_t[20]" name="uas_id">UAS ID following the format specified by id_type. Shall be filled with nulls in the unused portion of the field.</field>
+      <field type="uint8_t[20]" name="uas_id">UAS (Unmanned Aircraft System) ID following the format specified by id_type. Shall be filled with nulls in the unused portion of the field.</field>
     </message>
     <message id="12901" name="OPEN_DRONE_ID_LOCATION">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID Location message. The float data types are 32-bit IEEE 754. The Location message provides the location, altitude, direction and speed of the aircraft.</description>
       <field type="uint8_t" name="status" enum="MAV_ODID_STATUS">Indicates whether the Unmanned Aircraft is on the ground or in the air.</field>
-      <field type="uint16_t" name="direction" units="cdeg">Direction over ground (not heading, but direction of movement) in degrees * 100: 0.0 - 359.99 degrees.</field>
-      <field type="uint16_t" name="speed_horizontal" units="cm/s">Ground speed.</field>
-      <field type="int16_t" name="speed_vertical" units="cm/s">The vertical speed. Up is positive.</field>
-      <field type="int32_t" name="latitude" units="degE7">Current latitude of the UA.</field>
-      <field type="int32_t" name="longitude" units="degE7">Current longitude of the UA.</field>
-      <field type="float" name="altitude_barometric" units="m">The altitude calculated from the barometric pressue. Reference is against 29.92inHg or 1013.2mb.</field>
-      <field type="float" name="altitude_geodetic" units="m">The geodetic altitude as defined by WGS84.</field>
+      <field type="uint16_t" name="direction" units="cdeg">Direction over ground (not heading, but direction of movement) in degrees * 100: 0.0 - 359.99 degrees. If unknown: 361.00 degrees.</field>
+      <field type="uint16_t" name="speed_horizontal" units="cm/s">Ground speed. Positive only. If unknown: 255.00 m/s. If speed is larger than 254.25 m/s, use 254.25 m/s.</field>
+      <field type="int16_t" name="speed_vertical" units="cm/s">The vertical speed. Up is positive. If unknown: 63.00 m/s. If speed is larger than 62.00 m/s, use 62.00 m/s.</field>
+      <field type="int32_t" name="latitude" units="degE7">Current latitude of the UA (Unmanned Aircraft). If unknown: 0 deg (both Lat/Lon).</field>
+      <field type="int32_t" name="longitude" units="degE7">Current longitude of the UA (Unmanned Aircraft). If unknown: 0 deg (both Lat/Lon).</field>
+      <field type="float" name="altitude_barometric" units="m">The altitude calculated from the barometric pressue. Reference is against 29.92inHg or 1013.2mb. If unknown: -1000 m.</field>
+      <field type="float" name="altitude_geodetic" units="m">The geodetic altitude as defined by WGS84. If unknown: -1000 m.</field>
       <field type="uint8_t" name="height_reference" enum="MAV_ODID_HEIGHT_REF">Indicates the reference point for the height field.</field>
-      <field type="float" name="height" units="m">The current height of the UA above the take-off location or the ground as indicated by height_reference.</field>
+      <field type="float" name="height" units="m">The current height of the UA (Unmanned Aircraft) above the take-off location or the ground as indicated by height_reference. If unknown: -1000 m.</field>
       <field type="uint8_t" name="horizontal_accuracy" enum="MAV_ODID_HOR_ACC">The accuracy of the horizontal position.</field>
       <field type="uint8_t" name="vertical_accuracy" enum="MAV_ODID_VER_ACC">The accuracy of the vertical position.</field>
       <field type="uint8_t" name="barometer_accuracy" enum="MAV_ODID_VER_ACC">The accuracy of the barometric altitude.</field>
@@ -5882,12 +5882,12 @@
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID System message. The System Message contains general system information including the remote pilot location and possible aircraft group information.</description>
       <field type="uint8_t" name="flags" enum="MAV_ODID_LOCATION_SRC">Specifies the location source for the remote pilot location.</field>
-      <field type="int32_t" name="remote_pilot_latitude" units="degE7">Latitude of the remote pilot.</field>
-      <field type="int32_t" name="remote_pilot_longitude" units="degE7">Longitude of the remote pilot.</field>
-      <field type="uint16_t" name="group_count">Number of aircraft in group or formation (default 0).</field>
-      <field type="uint16_t" name="group_radius" units="m">Radius of cylindrical area of group or formation (default 0).</field>
-      <field type="float" name="group_ceiling" units="m">Group Operations Ceiling relative to WGS84.</field>
-      <field type="float" name="group_floor" units="m">Group Operations Floor relative to WGS84.</field>
+      <field type="int32_t" name="remote_pilot_latitude" units="degE7">Latitude of the remote pilot. If unknown: 0 deg (both Lat/Lon).</field>
+      <field type="int32_t" name="remote_pilot_longitude" units="degE7">Longitude of the remote pilot. If unknown: 0 deg (both Lat/Lon).</field>
+      <field type="uint16_t" name="area_count">Number of aircraft in the area, group or formation (default 1).</field>
+      <field type="uint16_t" name="area_radius" units="m">Radius of the cylindrical area of the group or formation (default 0).</field>
+      <field type="float" name="area_ceiling" units="m">Area Operations Ceiling relative to WGS84. If unknown: -1000 m.</field>
+      <field type="float" name="area_floor" units="m">Area Operations Floor relative to WGS84. If unknown: -1000 m.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3550,67 +3550,67 @@
         <description>Registered for STorM32 gimbal controller.</description>
       </entry>
     </enum>
-    <enum name="MAV_ODID_IDTYPE">
-      <entry value="0" name="MAV_ODID_IDTYPE_NONE">
+    <enum name="MAV_ODID_ID_TYPE">
+      <entry value="0" name="MAV_ODID_ID_TYPE_NONE">
         <description>No type defined.</description>
       </entry>
-      <entry value="1" name="MAV_ODID_IDTYPE_SERIAL_NUMBER">
+      <entry value="1" name="MAV_ODID_ID_TYPE_SERIAL_NUMBER">
         <description>Manufacturer Serial Number (ANSI/CTA-2063 format).</description>
       </entry>
-      <entry value="2" name="MAV_ODID_IDTYPE_CAA_ASSIGNED_ID">
-        <description>CAA (Civil Aviation Authority) assigned ID. Format: [ICAO Country Code].[CAA Assigned ID]</description>
+      <entry value="2" name="MAV_ODID_ID_TYPE_CAA_REGISTRATION_ID">
+        <description>CAA (Civil Aviation Authority) registered ID. Format: [ICAO Country Code].[CAA Assigned ID]</description>
       </entry>
-      <entry value="3" name="MAV_ODID_IDTYPE_UTM_ASSIGNED_ID">
-        <description>UTM (Unmanned Traffic Management) assigned ID (UUID RFC4122).</description>
+      <entry value="3" name="MAV_ODID_ID_TYPE_UTM_ASSIGNED_UUID">
+        <description>UTM (Unmanned Traffic Management) assigned UUID (RFC4122).</description>
       </entry>
     </enum>
-    <enum name="MAV_ODID_UATYPE">
-      <entry value="0" name="MAV_ODID_UATYPE_NONE">
+    <enum name="MAV_ODID_UA_TYPE">
+      <entry value="0" name="MAV_ODID_UA_TYPE_NONE">
         <description>No UA (Unmanned Aircraft) type defined.</description>
       </entry>
-      <entry value="1" name="MAV_ODID_UATYPE_AEROPLANE">
-        <description>Aeroplane/Airplane.</description>
+      <entry value="1" name="MAV_ODID_UA_TYPE_AEROPLANE">
+        <description>Aeroplane/Airplane. Fixed wing.</description>
       </entry>
-      <entry value="2" name="MAV_ODID_UATYPE_ROTORCRAFT">
+      <entry value="2" name="MAV_ODID_UA_TYPE_ROTORCRAFT">
         <description>Rotorcraft (including Multirotor).</description>
       </entry>
-      <entry value="3" name="MAV_ODID_UATYPE_GYROPLANE">
+      <entry value="3" name="MAV_ODID_UA_TYPE_GYROPLANE">
         <description>Gyroplane.</description>
       </entry>
-      <entry value="4" name="MAV_ODID_UATYPE_VTOL">
+      <entry value="4" name="MAV_ODID_UA_TYPE_VTOL">
         <description>VTOL (Vertical Take-Off and Landing). Fixed wing aircraft that can take off vertically.</description>
       </entry>
-      <entry value="5" name="MAV_ODID_UATYPE_ORNITHOPTER">
+      <entry value="5" name="MAV_ODID_UA_TYPE_ORNITHOPTER">
         <description>Ornithopter.</description>
       </entry>
-      <entry value="6" name="MAV_ODID_UATYPE_GLIDER">
+      <entry value="6" name="MAV_ODID_UA_TYPE_GLIDER">
         <description>Glider.</description>
       </entry>
-      <entry value="7" name="MAV_ODID_UATYPE_KITE">
+      <entry value="7" name="MAV_ODID_UA_TYPE_KITE">
         <description>Kite.</description>
       </entry>
-      <entry value="8" name="MAV_ODID_UATYPE_FREE_BALLOON">
+      <entry value="8" name="MAV_ODID_UA_TYPE_FREE_BALLOON">
         <description>Free Balloon.</description>
       </entry>
-      <entry value="9" name="MAV_ODID_UATYPE_CAPTIVE_BALLOON">
+      <entry value="9" name="MAV_ODID_UA_TYPE_CAPTIVE_BALLOON">
         <description>Captive Balloon.</description>
       </entry>
-      <entry value="10" name="MAV_ODID_UATYPE_AIRSHIP">
-        <description>Airship.</description>
+      <entry value="10" name="MAV_ODID_UA_TYPE_AIRSHIP">
+        <description>Airship. E.g. a blimp.</description>
       </entry>
-      <entry value="11" name="MAV_ODID_UATYPE_FREE_FALL_PARACHUTE">
+      <entry value="11" name="MAV_ODID_UA_TYPE_FREE_FALL_PARACHUTE">
         <description>Free Fall/Parachute.</description>
       </entry>
-      <entry value="12" name="MAV_ODID_UATYPE_ROCKET">
+      <entry value="12" name="MAV_ODID_UA_TYPE_ROCKET">
         <description>Rocket.</description>
       </entry>
-      <entry value="13" name="MAV_ODID_UATYPE_GROUND_OBSTACLE">
+      <entry value="13" name="MAV_ODID_UA_TYPE_TETHERED_POWERED_AIRCRAFT">
+        <description>Tethered powered aircraft.</description>
+      </entry>
+      <entry value="14" name="MAV_ODID_UA_TYPE_GROUND_OBSTACLE">
         <description>Ground Obstacle.</description>
       </entry>
-      <entry value="14" name="MAV_ODID_UATYPE_RESERVED">
-        <description>Reserved.</description>
-      </entry>
-      <entry value="15" name="MAV_ODID_UATYPE_OTHER">
+      <entry value="15" name="MAV_ODID_UA_TYPE_OTHER">
         <description>Other type of aircraft not listed earlier.</description>
       </entry>
     </enum>
@@ -3638,28 +3638,28 @@
         <description>The horizontal accuracy is unknown.</description>
       </entry>
       <entry value="1" name="MAV_ODID_HOR_ACC_10NM">
-        <description>The horizontal accuracy is smaller than 10 Nautical Miles.</description>
+        <description>The horizontal accuracy is smaller than 10 Nautical Miles. 18.52 km.</description>
       </entry>
       <entry value="2" name="MAV_ODID_HOR_ACC_4NM">
-        <description>The horizontal accuracy is smaller than 4 Nautical Miles.</description>
+        <description>The horizontal accuracy is smaller than 4 Nautical Miles. 7.408 km.</description>
       </entry>
       <entry value="3" name="MAV_ODID_HOR_ACC_2NM">
-        <description>The horizontal accuracy is smaller than 2 Nautical Miles.</description>
+        <description>The horizontal accuracy is smaller than 2 Nautical Miles. 3.704 km.</description>
       </entry>
       <entry value="4" name="MAV_ODID_HOR_ACC_1NM">
-        <description>The horizontal accuracy is smaller than 1 Nautical Miles.</description>
+        <description>The horizontal accuracy is smaller than 1 Nautical Miles. 1.852 km.</description>
       </entry>
       <entry value="5" name="MAV_ODID_HOR_ACC_0_5NM">
-        <description>The horizontal accuracy is smaller than 0.5 Nautical Miles.</description>
+        <description>The horizontal accuracy is smaller than 0.5 Nautical Miles. 926 m.</description>
       </entry>
       <entry value="6" name="MAV_ODID_HOR_ACC_0_3NM">
-        <description>The horizontal accuracy is smaller than 0.3 Nautical Miles.</description>
+        <description>The horizontal accuracy is smaller than 0.3 Nautical Miles. 555.6 m.</description>
       </entry>
       <entry value="7" name="MAV_ODID_HOR_ACC_0_1NM">
-        <description>The horizontal accuracy is smaller than 0.1 Nautical Miles.</description>
+        <description>The horizontal accuracy is smaller than 0.1 Nautical Miles. 185.2 m.</description>
       </entry>
       <entry value="8" name="MAV_ODID_HOR_ACC_0_05NM">
-        <description>The horizontal accuracy is smaller than 0.05 Nautical Miles.</description>
+        <description>The horizontal accuracy is smaller than 0.05 Nautical Miles. 92.6 m.</description>
       </entry>
       <entry value="9" name="MAV_ODID_HOR_ACC_30_METER">
         <description>The horizontal accuracy is smaller than 30 meter.</description>
@@ -3701,17 +3701,17 @@
       <entry value="0" name="MAV_ODID_SPEED_ACC_UNKNOWN">
         <description>The speed accuracy is unknown.</description>
       </entry>
-      <entry value="1" name="MAV_ODID_SPEED_ACC_10_METER_PER_SECOND">
-        <description>The speed accuracy is smaller than 10 meter per second.</description>
+      <entry value="1" name="MAV_ODID_SPEED_ACC_10_METERS_PER_SECOND">
+        <description>The speed accuracy is smaller than 10 meters per second.</description>
       </entry>
-      <entry value="2" name="MAV_ODID_SPEED_ACC_3_METER_PER_SECOND">
-        <description>The speed accuracy is smaller than 3 meter per second.</description>
+      <entry value="2" name="MAV_ODID_SPEED_ACC_3_METERS_PER_SECOND">
+        <description>The speed accuracy is smaller than 3 meters per second.</description>
       </entry>
-      <entry value="3" name="MAV_ODID_SPEED_ACC_1_METER_PER_SECOND">
-        <description>The speed accuracy is smaller than 1 meter per second.</description>
+      <entry value="3" name="MAV_ODID_SPEED_ACC_1_METERS_PER_SECOND">
+        <description>The speed accuracy is smaller than 1 meters per second.</description>
       </entry>
-      <entry value="4" name="MAV_ODID_SPEED_ACC_0_3_METER_PER_SECOND">
-        <description>The speed accuracy is smaller than 0.3 meter per second.</description>
+      <entry value="4" name="MAV_ODID_SPEED_ACC_0_3_METERS_PER_SECOND">
+        <description>The speed accuracy is smaller than 0.3 meters per second.</description>
       </entry>
     </enum>
     <enum name="MAV_ODID_TIME_ACC">
@@ -3764,20 +3764,17 @@
         <description>The timestamp accuracy is smaller than 1.5 second.</description>
       </entry>
     </enum>
-    <enum name="MAV_ODID_AUTH">
-      <entry value="0" name="MAV_ODID_AUTH_NONE">
+    <enum name="MAV_ODID_AUTH_TYPE">
+      <entry value="0" name="MAV_ODID_AUTH_TYPE_NONE">
         <description>No authentication type is specified.</description>
       </entry>
-      <entry value="1" name="MAV_ODID_AUTH_MPUID">
+      <entry value="1" name="MAV_ODID_AUTH_TYPE_MPUID">
         <description>Manufacturer Programmed Unique ID.</description>
       </entry>
     </enum>
     <enum name="MAV_ODID_DESC_TYPE">
       <entry value="0" name="MAV_ODID_DESC_TYPE_TEXT">
         <description>Free-form text description of the purpose of the flight.</description>
-      </entry>
-      <entry value="1" name="MAV_ODID_DESC_TYPE_REMOTE_PILOT_ID">
-        <description>Remote pilot ID as assigned by the Civil Aviation Authority.</description>
       </entry>
     </enum>
     <enum name="MAV_ODID_LOCATION_SRC">
@@ -5840,8 +5837,8 @@
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID Basic ID message.</description>
-      <field type="uint8_t" name="id_type" enum="MAV_ODID_IDTYPE">Indicates the format for the uas_id field of this message.</field>
-      <field type="uint8_t" name="ua_type" enum="MAV_ODID_UATYPE">Indicates the type of UA (Unmanned Aircraft).</field>
+      <field type="uint8_t" name="id_type" enum="MAV_ODID_ID_TYPE">Indicates the format for the uas_id field of this message.</field>
+      <field type="uint8_t" name="ua_type" enum="MAV_ODID_UA_TYPE">Indicates the type of UA (Unmanned Aircraft).</field>
       <field type="uint8_t[20]" name="uas_id">UAS ID following the format specified by id_type. Shall be filled with nulls in the unused portion of the field.</field>
     </message>
     <message id="12901" name="OPEN_DRONE_ID_LOCATION">
@@ -5869,7 +5866,7 @@
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID Authentication message. The Authentication Message defines a field that can provide a means of authenticity for the identity of the UAS (Unmanned Aircraft System) sending the message.</description>
-      <field type="uint8_t" name="authentication_type" enum="MAV_ODID_AUTH">Indicates the type of authentication.</field>
+      <field type="uint8_t" name="authentication_type" enum="MAV_ODID_AUTH_TYPE">Indicates the type of authentication.</field>
       <field type="uint8_t" name="data_page">Allowed range is 0 - 15.</field>
       <field type="uint8_t[23]" name="authentication_data">Opaque authentication data. Sixteen pages are supported for a total of 16 * 23 = 368 bytes. Shall be filled with nulls in the unused portion of the field.</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3558,7 +3558,7 @@
         <description>Manufacturer Serial Number (ANSI/CTA-2063 format).</description>
       </entry>
       <entry value="2" name="MAV_ODID_ID_TYPE_CAA_REGISTRATION_ID">
-        <description>CAA (Civil Aviation Authority) registered ID. Format: [ICAO Country Code].[CAA Assigned ID]</description>
+        <description>CAA (Civil Aviation Authority) registered ID. Format: [ICAO Country Code].[CAA Assigned ID].</description>
       </entry>
       <entry value="3" name="MAV_ODID_ID_TYPE_UTM_ASSIGNED_UUID">
         <description>UTM (Unmanned Traffic Management) assigned UUID (RFC4122).</description>
@@ -3779,13 +3779,18 @@
     </enum>
     <enum name="MAV_ODID_LOCATION_SRC">
       <entry value="0" name="MAV_ODID_LOCATION_SRC_TAKEOFF">
-        <description>The location of the remote pilot is the same as the take-off location.</description>
+        <description>The location of the operator is the same as the take-off location.</description>
       </entry>
       <entry value="1" name="MAV_ODID_LOCATION_SRC_LIVE_GNSS">
-        <description>The location of the remote pilot is based on live GNSS data.</description>
+        <description>The location of the operator is based on live GNSS data.</description>
       </entry>
       <entry value="2" name="MAV_ODID_LOCATION_SRC_FIXED">
-        <description>The location of the remote pilot is a fixed location.</description>
+        <description>The location of the operator is a fixed location.</description>
+      </entry>
+    </enum>
+    <enum name="MAV_ODID_OPERATOR_ID_TYPE">
+      <entry value="0" name="MAV_ODID_OPERATOR_ID_TYPE_CAA">
+        <description>CAA (Civil Aviation Authority) registered operator ID.</description>
       </entry>
     </enum>
   </enums>
@@ -5836,7 +5841,7 @@
     <message id="12900" name="OPEN_DRONE_ID_BASIC_ID">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
-      <description>Data for filling the OpenDroneID Basic ID message.</description>
+      <description>Data for filling the OpenDroneID Basic ID message. This and the below messages are primarily meant for feeding data to/from an OpenDroneID implementation. E.g. https://github.com/opendroneid/opendroneid-core-c</description>
       <field type="uint8_t" name="id_type" enum="MAV_ODID_ID_TYPE">Indicates the format for the uas_id field of this message.</field>
       <field type="uint8_t" name="ua_type" enum="MAV_ODID_UA_TYPE">Indicates the type of UA (Unmanned Aircraft).</field>
       <field type="uint8_t[20]" name="uas_id">UAS (Unmanned Aircraft System) ID following the format specified by id_type. Shall be filled with nulls in the unused portion of the field.</field>
@@ -5870,24 +5875,31 @@
       <field type="uint8_t" name="data_page">Allowed range is 0 - 15.</field>
       <field type="uint8_t[23]" name="authentication_data">Opaque authentication data. Sixteen pages are supported for a total of 16 * 23 = 368 bytes. Shall be filled with nulls in the unused portion of the field.</field>
     </message>
-    <message id="12903" name="OPEN_DRONE_ID_SELFID">
+    <message id="12903" name="OPEN_DRONE_ID_SELF_ID">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
-      <description>Data for filling the OpenDroneID Self-ID message. The Self-ID Message is an opportunity for the Remote Pilot to (optionally) declare their identity and purpose of the flight. This message can provide additional information that could reduce the threat profile of a UA flying in a particular area or manner.</description>
+      <description>Data for filling the OpenDroneID Self ID message. The Self ID Message is an opportunity for the operator to (optionally) declare their identity and purpose of the flight. This message can provide additional information that could reduce the threat profile of a UA (Unmanned Aircraft) flying in a particular area or manner.</description>
       <field type="uint8_t" name="description_type" enum="MAV_ODID_DESC_TYPE">Indicates the type of the description field.</field>
       <field type="char[23]" name="description">Text description or numeric value expressed as ASCII characters. Shall be filled with nulls in the unused portion of the field.</field>
     </message>
     <message id="12904" name="OPEN_DRONE_ID_SYSTEM">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
-      <description>Data for filling the OpenDroneID System message. The System Message contains general system information including the remote pilot location and possible aircraft group information.</description>
-      <field type="uint8_t" name="flags" enum="MAV_ODID_LOCATION_SRC">Specifies the location source for the remote pilot location.</field>
-      <field type="int32_t" name="remote_pilot_latitude" units="degE7">Latitude of the remote pilot. If unknown: 0 deg (both Lat/Lon).</field>
-      <field type="int32_t" name="remote_pilot_longitude" units="degE7">Longitude of the remote pilot. If unknown: 0 deg (both Lat/Lon).</field>
+      <description>Data for filling the OpenDroneID System message. The System Message contains general system information including the operator location and possible aircraft group information.</description>
+      <field type="uint8_t" name="flags" enum="MAV_ODID_LOCATION_SRC">Specifies the location source for the operator location.</field>
+      <field type="int32_t" name="operator_latitude" units="degE7">Latitude of the operator. If unknown: 0 deg (both Lat/Lon).</field>
+      <field type="int32_t" name="operator_longitude" units="degE7">Longitude of the operator. If unknown: 0 deg (both Lat/Lon).</field>
       <field type="uint16_t" name="area_count">Number of aircraft in the area, group or formation (default 1).</field>
       <field type="uint16_t" name="area_radius" units="m">Radius of the cylindrical area of the group or formation (default 0).</field>
       <field type="float" name="area_ceiling" units="m">Area Operations Ceiling relative to WGS84. If unknown: -1000 m.</field>
       <field type="float" name="area_floor" units="m">Area Operations Floor relative to WGS84. If unknown: -1000 m.</field>
+    </message>
+    <message id="12905" name="OPEN_DRONE_ID_OPERATOR_ID">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Data for filling the OpenDroneID Operator ID message, which contains the CAA (Civil Aviation Authority) issued operator ID.</description>
+      <field type="uint8_t" name="operator_id_type" enum="MAV_ODID_OPERATOR_ID_TYPE">Indicates the type of the operator_id field.</field>
+      <field type="char[20]" name="operator_id">Text description or numeric value expressed as ASCII characters. Shall be filled with nulls in the unused portion of the field.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5849,7 +5849,7 @@
     </message>
     <message id="12900" name="OPEN_DRONE_ID_BASIC_ID">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID Basic ID message. This and the below messages are primarily meant for feeding data to/from an OpenDroneID implementation. E.g. https://github.com/opendroneid/opendroneid-core-c</description>
       <field type="uint8_t" name="id_type" enum="MAV_ODID_ID_TYPE">Indicates the format for the uas_id field of this message.</field>
       <field type="uint8_t" name="ua_type" enum="MAV_ODID_UA_TYPE">Indicates the type of UA (Unmanned Aircraft).</field>
@@ -5857,7 +5857,7 @@
     </message>
     <message id="12901" name="OPEN_DRONE_ID_LOCATION">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID Location message. The float data types are 32-bit IEEE 754. The Location message provides the location, altitude, direction and speed of the aircraft.</description>
       <field type="uint8_t" name="status" enum="MAV_ODID_STATUS">Indicates whether the Unmanned Aircraft is on the ground or in the air.</field>
       <field type="uint16_t" name="direction" units="cdeg">Direction over ground (not heading, but direction of movement) in degrees * 100: 0.0 - 359.99 degrees. If unknown: 361.00 degrees.</field>
@@ -5878,7 +5878,7 @@
     </message>
     <message id="12902" name="OPEN_DRONE_ID_AUTHENTICATION">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID Authentication message. The Authentication Message defines a field that can provide a means of authenticity for the identity of the UAS (Unmanned Aircraft System). The Authentication message can have two different formats. Five data pages are supported. For data page 0, the fields PageCount, Length and TimeStamp are present and AuthData is only 17 bytes. For data page 1 through 4, PageCount,Length and TimeStamp are not present and the size of AuthData is 23 bytes.</description>
       <field type="uint8_t" name="authentication_type" enum="MAV_ODID_AUTH_TYPE">Indicates the type of authentication.</field>
       <field type="uint8_t" name="data_page">Allowed range is 0 - 4.</field>
@@ -5889,14 +5889,14 @@
     </message>
     <message id="12903" name="OPEN_DRONE_ID_SELF_ID">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID Self ID message. The Self ID Message is an opportunity for the operator to (optionally) declare their identity and purpose of the flight. This message can provide additional information that could reduce the threat profile of a UA (Unmanned Aircraft) flying in a particular area or manner.</description>
       <field type="uint8_t" name="description_type" enum="MAV_ODID_DESC_TYPE">Indicates the type of the description field.</field>
       <field type="char[23]" name="description">Text description or numeric value expressed as ASCII characters. Shall be filled with nulls in the unused portion of the field.</field>
     </message>
     <message id="12904" name="OPEN_DRONE_ID_SYSTEM">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID System message. The System Message contains general system information including the operator location and possible aircraft group information.</description>
       <field type="uint8_t" name="flags" enum="MAV_ODID_LOCATION_SRC">Specifies the location source for the operator location.</field>
       <field type="int32_t" name="operator_latitude" units="degE7">Latitude of the operator. If unknown: 0 deg (both Lat/Lon).</field>
@@ -5908,10 +5908,19 @@
     </message>
     <message id="12905" name="OPEN_DRONE_ID_OPERATOR_ID">
       <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
       <description>Data for filling the OpenDroneID Operator ID message, which contains the CAA (Civil Aviation Authority) issued operator ID.</description>
       <field type="uint8_t" name="operator_id_type" enum="MAV_ODID_OPERATOR_ID_TYPE">Indicates the type of the operator_id field.</field>
       <field type="char[20]" name="operator_id">Text description or numeric value expressed as ASCII characters. Shall be filled with nulls in the unused portion of the field.</field>
+    </message>
+    <!-- The message ids 12906 - 12914 are reserved for OpenDroneID. -->
+    <message id="12915" name="OPEN_DRONE_ID_MESSAGE_PACK">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change, and should NOT be used in stable production environments -->
+      <description>An OpenDroneID message pack is a container for multiple encoded OpenDroneID messages (i.e. not in the format given for the above messages descriptions but after encoding into the compressed OpenDroneID byte format). Used e.g. when transmitting on Bluetooth 5.0 Long Range/Extended Advertising or on WiFi Neighbor Aware Networking.</description>
+      <field type="uint8_t" name="single_message_size" units="bytes">This field must currently always be equal to 25 bytes, since all encoded OpenDroneID messages are specificed to have this length.</field>
+      <field type="uint8_t" name="msg_pack_size">Number of encoded messages in the pack (not the number of bytes). Allowed range is 1 - 10.</field>
+      <field type="uint8_t[250]" name="messages">Concatenation of encoded OpenDroneID messages. Shall be filled with nulls in the unused portion of the field.</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Multiple changes to the message fields and new messages were added in version 0.8 of the OpenDroneID specification. This PR aligns the Mavlink messages.

The OpenDroneID specification is basically frozen but you never really know so let's keep the WIP tags for the time being.