### PR TITLE
removed 0.9 messages from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,15 +138,6 @@ endmacro()
 
 # build
 set(mavgen -m pymavlink.tools.mavgen)
-set(v0.9Definitions
-    ardupilotmega.xml
-    common.xml
-    minimal.xml
-    slugs.xml
-    test.xml
-    ualberta.xml
-    )
-generateMavlink("0.9" "${v0.9Definitions}")
 set(v1.0Definitions
     ASLUAV.xml
     ardupilotmega.xml
@@ -165,7 +156,7 @@ generateMavlink("1.0" "${v1.0Definitions}")
 # testing
 if (BUILD_TEST)
     if (UNIX) 
-        include_directories(${CMAKE_BINARY_DIR}/include/v0.9/common)
+        include_directories(${CMAKE_BINARY_DIR}/include/v1.0/common)
         # TODO fix udp example
         #add_executable(mavlink_udp examples/linux/mavlink_udp.c)
     endif()


### PR DESCRIPTION
In https://github.com/mavlink/mavlink/pull/835 the 0.9 message files were already removed. This PR cleans up the CMakeLists.txt as otherwise you get this error message while building:

```
Scanning dependencies of target test.xml-v0.9                                                 
[ 11%] Generating test.xml-v0.9-stamp                                                         
Validating /home/dummy/Development/mavlink/message_definitions/v0.9/test.xml    
Traceback (most recent call last):                                                            
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code               
    exec code in run_globals                                                                  
  File "/home/dummy/Development/mavlink/pymavlink/tools/mavgen.py", line 31, in <module>                                                                                                     
    mavgen.mavgen(args, args.definitions)
  File "/home/dummy/Development/mavlink/pymavlink/generator/mavgen.py", line 136, in mavgen
    if not mavgen_validate(fname):
  File "/home/dummy/Development/mavlink/pymavlink/generator/mavgen.py", line 105, in mavgen_validate
    with open(xmlfile, 'r') as f:
IOError: [Errno 2] No such file or directory: '/home/dummy/Development/mavlink/message_definitions/v0.9/test.xml'
CMakeFiles/test.xml-v0.9.dir/build.make:60: recipe for target 'test.xml-v0.9-stamp' failed
make[2]: *** [test.xml-v0.9-stamp] Error 1
CMakeFiles/Makefile2:104: recipe for target 'CMakeFiles/test.xml-v0.9.dir/all' failed
make[1]: *** [CMakeFiles/test.xml-v0.9.dir/all] Error 2
Makefile:151: recipe for target 'all' failed
make: *** [all] Error 2

```