### PR TITLE
MAV_CMD_COMPONENT_ARM_DISARM: Clarify forced arm/disarm

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1806,7 +1806,7 @@
       <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM" hasLocation="false" isDestination="false">
         <description>Arms / Disarms a component</description>
         <param index="1" label="Arm" minValue="0" maxValue="1" increment="1">0: disarm, 1: arm</param>
-        <param index="2" label="Enforce in-air" minValue="0" maxValue="21196" increment="21196">0: only arm-disarm when landed, 21196: enforce arming/disarming even in-air (during flight)</param>
+        <param index="2" label="Force" minValue="0" maxValue="21196" increment="21196">0: arm-disarm unless prevented by safety checks (i.e. when landed), 21196: force arming/disarming (e.g. allow arming to override preflight checks and disarming in flight)</param>
       </entry>
       <entry value="410" name="MAV_CMD_GET_HOME_POSITION" hasLocation="false" isDestination="false">
         <description>Request the home position from the vehicle.</description>


### PR DESCRIPTION
Generalised forced arm/disarm.

The current text is confusing because it refers mainly to enabling in-flight disarming. I believe this is a better interpretation - essentially that the magic number simply forces arming/disarming irrespective of other checks.

This may make some flight stacks only partially compliant. For example, I know that PX4 implements force disarm in flight, and that will still be valid. But this requires that it also supports force arm even if preflight checks fail, so might not be compliant in that sense.

Discussion comes from https://github.com/mavlink/qgroundcontrol/issues/6624#issuecomment-537243404