### PR TITLE
MAV_COMPONENT: Clarify broadcast ID only used for targets

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -375,7 +375,7 @@
       Components must use the appropriate ID in their source address when sending messages. Components can also use IDs to determine if they are the intended recipient of an incoming message. The MAV_COMP_ID_ALL value is used to indicate messages that must be processed by all components.
       When creating new entries, components that can have multiple instances (e.g. cameras, servos etc.) should be allocated sequential values. An appropriate number of values should be left free after these components to allow the number of instances to be expanded.</description>
       <entry value="0" name="MAV_COMP_ID_ALL">
-        <description>Used to broadcast messages to all components of the receiving system. Components should attempt to process messages with this component ID and forward to components on any other interfaces.</description>
+        <description>Target id (target_component) used to broadcast messages to all components of the receiving system. Components should attempt to process messages with this component ID and forward to components on any other interfaces. Note: This is not a valid *source* component id for a message.</description>
       </entry>
       <entry value="1" name="MAV_COMP_ID_AUTOPILOT1">
         <description>System flight controller component ("autopilot"). Only one autopilot is expected in a particular system.</description>


### PR DESCRIPTION
Follows on from https://github.com/mavlink/mavlink/issues/1244

0 ids are use to indicate broadcast address and should not be used as the source address of a component. If you did this a component could not be separately addressed as all systems would think the message was intended for them. In addition, if such a component sent a command the ACKs would go to all other systems. 