### PR TITLE
VISION_POSITION_ESTIMATE is local estimate

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4629,11 +4629,11 @@
       <field type="uint8_t" name="reset_counter">Estimate reset counter. This should be incremented when the estimate resets in any of the dimensions (position, velocity, attitude, angular speed). This is designed to be used when e.g an external SLAM system detects a loop-closure and the estimate jumps.</field>
     </message>
     <message id="102" name="VISION_POSITION_ESTIMATE">
-      <description>Global position/attitude estimate from a vision source.</description>
+      <description>Local position/attitude estimate from a vision source.</description>
       <field type="uint64_t" name="usec" units="us">Timestamp (UNIX time or time since system boot)</field>
-      <field type="float" name="x" units="m">Global X position</field>
-      <field type="float" name="y" units="m">Global Y position</field>
-      <field type="float" name="z" units="m">Global Z position</field>
+      <field type="float" name="x" units="m">Local X position</field>
+      <field type="float" name="y" units="m">Local Y position</field>
+      <field type="float" name="z" units="m">Local Z position</field>
       <field type="float" name="roll" units="rad">Roll angle</field>
       <field type="float" name="pitch" units="rad">Pitch angle</field>
       <field type="float" name="yaw" units="rad">Yaw angle</field>


### PR DESCRIPTION
[GLOBAL_VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#GLOBAL_VISION_POSITION_ESTIMATE) and [VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE) are identical. It seems likely that `VISION_POSITION_ESTIMATE` is actually intended for local estimates. 

@jkflying @TSC21 Can you please confirm this was the intention - and that therefore this change can be merged.