### PR TITLE
Add setpoint types for position setpoint [DO NOT MERGE]

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3432,7 +3432,7 @@
         <description>Ignore yaw rate</description>
       </entry>
       <entry value="4096" name="POSITION_TARGET_TYPEMASK_TAKEOFF_SETPOINT">
-        <description>Position setpoint is a target setpoint.</description>
+        <description>Position setpoint is a takeoff setpoint.</description>
       </entry>
       <entry value="8192" name="POSITION_TARGET_TYPEMASK_LAND_SETPOINT">
         <description>Position setpoint is a land setpoint.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3431,17 +3431,23 @@
       <entry value="2048" name="POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE">
         <description>Ignore yaw rate</description>
       </entry>
-      <entry value="4096" name="POSITION_TARGET_TYPEMASK_TAKEOFF_SETPOINT">
-        <description>Position setpoint is a takeoff setpoint.</description>
+    </enum>
+    <enum name="POSITION_TARGET_SETPOINT_TYPE">
+      <description>Value indicating type of position setpoint. This may be used to customise flight behaviour e.g. extend landing gear.</description>
+      <entry value="0" name="POSITION_TARGET_SETPOINT_TYPE_NORMAL">
+        <description>Normal/default setpoint.</description>
       </entry>
-      <entry value="8192" name="POSITION_TARGET_TYPEMASK_LAND_SETPOINT">
-        <description>Position setpoint is a land setpoint.</description>
+      <entry value="4096" name="POSITION_TARGET_SETPOINT_TYPE_TAKEOFF">
+        <description>Takeoff setpoint.</description>
       </entry>
-      <entry value="12288" name="POSITION_TARGET_TYPEMASK_LOITER_SETPOINT">
-        <description>Position setpoint is a loiter setpoint.</description>
+      <entry value="8192" name=POSITION_TARGET_SETPOINT_TYPE_LAND">
+        <description>Land setpoint.</description>
       </entry>
-      <entry value="16384" name="POSITION_TARGET_TYPEMASK_IDLE_SETPOINT">
-        <description>Position setpoint is an idle setpoint.</description>
+      <entry value="12288" name="POSITION_TARGET_SETPOINT_TYPE_LOITER">
+        <description>Loiter setpoint.</description>
+      </entry>
+      <entry value="16384" name="POSITION_TARGET_SETPOINT_TYPE_IDLE">
+        <description>Idle setpoint.</description>
       </entry>
     </enum>
     <enum name="UTM_FLIGHT_STATE">
@@ -4479,7 +4485,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
-      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle. May also indicate the type of a setpoint - e.g. takeoff, landing, etc.</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
       <field type="float" name="x" units="m">X Position in NED frame</field>
       <field type="float" name="y" units="m">Y Position in NED frame</field>
       <field type="float" name="z" units="m">Z Position in NED frame (note, altitude is negative in NED)</field>
@@ -4491,12 +4497,14 @@
       <field type="float" name="afz" units="m/s/s">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
       <field type="float" name="yaw" units="rad">yaw setpoint</field>
       <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint</field>
+      <extensions/>
+      <field type="uint8_t" name="setpoint_type" enum="POSITION_TARGET_SETPOINT_TYPE">Position setpoint type: takeoff, landing, etc. Default is 0 (normal setpoint).</field>
     </message>
     <message id="85" name="POSITION_TARGET_LOCAL_NED">
       <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_LOCAL_NED if the vehicle is being controlled this way.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
-      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle. May also indicate the type of a setpoint - e.g. takeoff, landing, etc.</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
       <field type="float" name="x" units="m">X Position in NED frame</field>
       <field type="float" name="y" units="m">Y Position in NED frame</field>
       <field type="float" name="z" units="m">Z Position in NED frame (note, altitude is negative in NED)</field>
@@ -4508,6 +4516,8 @@
       <field type="float" name="afz" units="m/s/s">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
       <field type="float" name="yaw" units="rad">yaw setpoint</field>
       <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint</field>
+      <extensions/>
+      <field type="uint8_t" name="setpoint_type" enum="POSITION_TARGET_SETPOINT_TYPE">Position setpoint type: takeoff, landing, etc. Default is 0 (normal setpoint).</field>
     </message>
     <message id="86" name="SET_POSITION_TARGET_GLOBAL_INT">
       <description>Sets a desired vehicle position, velocity, and/or acceleration in a global coordinate system (WGS84). Used by an external controller to command the vehicle (manual controller or other system).</description>
@@ -4515,7 +4525,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
-      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle. May also indicate the type of a setpoint - e.g. takeoff, landing, etc.</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
       <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
       <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
       <field type="float" name="alt" units="m">Altitude (MSL, Relative to home, or AGL - depending on frame)</field>
@@ -4527,12 +4537,14 @@
       <field type="float" name="afz" units="m/s/s">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
       <field type="float" name="yaw" units="rad">yaw setpoint</field>
       <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint</field>
+      <extensions/>
+      <field type="uint8_t" name="setpoint_type" enum="POSITION_TARGET_SETPOINT_TYPE">Position setpoint type: takeoff, landing, etc. Default is 0 (normal setpoint).</field>
     </message>
     <message id="87" name="POSITION_TARGET_GLOBAL_INT">
       <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_GLOBAL_INT if the vehicle is being controlled this way.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot). The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
       <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
-      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle. May also indicate the type of a setpoint - e.g. takeoff, landing, etc.</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
       <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
       <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
       <field type="float" name="alt" units="m">Altitude (MSL, AGL or relative to home altitude, depending on frame)</field>
@@ -4544,6 +4556,8 @@
       <field type="float" name="afz" units="m/s/s">Z acceleration or force (if bit 10 of type_mask is set) in NED frame in meter / s^2 or N</field>
       <field type="float" name="yaw" units="rad">yaw setpoint</field>
       <field type="float" name="yaw_rate" units="rad/s">yaw rate setpoint</field>
+      <extensions/>
+      <field type="uint8_t" name="setpoint_type" enum="POSITION_TARGET_SETPOINT_TYPE">Position setpoint type: takeoff, landing, etc. Default is 0 (normal setpoint).</field>
     </message>
     <message id="89" name="LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET">
       <description>The offset in X, Y, Z and yaw between the LOCAL_POSITION_NED messages of MAV X and the global coordinate frame in NED coordinates. Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3431,6 +3431,18 @@
       <entry value="2048" name="POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE">
         <description>Ignore yaw rate</description>
       </entry>
+      <entry value="4096" name="POSITION_TARGET_TYPEMASK_TAKEOFF_SETPOINT">
+        <description>Position setpoint is a target setpoint.</description>
+      </entry>
+      <entry value="8192" name="POSITION_TARGET_TYPEMASK_LAND_SETPOINT">
+        <description>Position setpoint is a land setpoint.</description>
+      </entry>
+      <entry value="12288" name="POSITION_TARGET_TYPEMASK_LOITER_SETPOINT">
+        <description>Position setpoint is a loiter setpoint.</description>
+      </entry>
+      <entry value="16384" name="POSITION_TARGET_TYPEMASK_IDLE_SETPOINT">
+        <description>Position setpoint is an idle setpoint.</description>
+      </entry>
     </enum>
     <enum name="UTM_FLIGHT_STATE">
       <description>Airborne status of UAS.</description>
@@ -4467,7 +4479,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
-      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle. May also indicate the type of a setpoint - e.g. takeoff, landing, etc.</field>
       <field type="float" name="x" units="m">X Position in NED frame</field>
       <field type="float" name="y" units="m">Y Position in NED frame</field>
       <field type="float" name="z" units="m">Z Position in NED frame (note, altitude is negative in NED)</field>
@@ -4484,7 +4496,7 @@
       <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_LOCAL_NED if the vehicle is being controlled this way.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_LOCAL_NED = 1, MAV_FRAME_LOCAL_OFFSET_NED = 7, MAV_FRAME_BODY_NED = 8, MAV_FRAME_BODY_OFFSET_NED = 9</field>
-      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle. May also indicate the type of a setpoint - e.g. takeoff, landing, etc.</field>
       <field type="float" name="x" units="m">X Position in NED frame</field>
       <field type="float" name="y" units="m">Y Position in NED frame</field>
       <field type="float" name="z" units="m">Z Position in NED frame (note, altitude is negative in NED)</field>
@@ -4503,7 +4515,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
-      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle. May also indicate the type of a setpoint - e.g. takeoff, landing, etc.</field>
       <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
       <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
       <field type="float" name="alt" units="m">Altitude (MSL, Relative to home, or AGL - depending on frame)</field>
@@ -4520,7 +4532,7 @@
       <description>Reports the current commanded vehicle position, velocity, and acceleration as specified by the autopilot. This should match the commands sent in SET_POSITION_TARGET_GLOBAL_INT if the vehicle is being controlled this way.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot). The rationale for the timestamp in the setpoint is to allow the system to compensate for the transport delay of the setpoint. This allows the system to compensate processing latency.</field>
       <field type="uint8_t" name="coordinate_frame" enum="MAV_FRAME">Valid options are: MAV_FRAME_GLOBAL_INT = 5, MAV_FRAME_GLOBAL_RELATIVE_ALT_INT = 6, MAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11</field>
-      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle.</field>
+      <field type="uint16_t" name="type_mask" enum="POSITION_TARGET_TYPEMASK" display="bitmask">Bitmap to indicate which dimensions should be ignored by the vehicle. May also indicate the type of a setpoint - e.g. takeoff, landing, etc.</field>
       <field type="int32_t" name="lat_int" units="degE7">X Position in WGS84 frame</field>
       <field type="int32_t" name="lon_int" units="degE7">Y Position in WGS84 frame</field>
       <field type="float" name="alt" units="m">Altitude (MSL, AGL or relative to home altitude, depending on frame)</field>


### PR DESCRIPTION
It is useful to specify the setpoint type (e.g. land, takeoff) in calls like `SET_POSITION_TARGET_LOCAL_NED` so that you can define additional behaviour - e.g. deploy landing gear, if you intend to land.

This adds the information as an enum in an extension field to all the position target messages. Default is "normal" and 0, so this change will not affect existing implementations.

**EDITED** Original version showed PX4 implementation - which silently/privately added unused values to the `type_mask`  (as discussed [here](https://github.com/PX4/Firmware/pull/13199#issuecomment-542569388)). The new approach is cleaner, and avoids the inconsistency that type_mask is a bitmask (flags) while setpoints are mutually exclusive values
