### PR TITLE
MAV_RESULT: Clarify exactly what the possible results mean

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2475,22 +2475,22 @@
     <enum name="MAV_RESULT">
       <description>Result from a MAVLink command (MAV_CMD)</description>
       <entry value="0" name="MAV_RESULT_ACCEPTED">
-        <description>Command is supported and was executed.</description>
+        <description>Command is valid (is supported and has valid parameters), and was executed.</description>
       </entry>
       <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
-        <description>Command is supported, but could not be executed at this time. This usually indicates that a state machine is busy. Retrying later may work.</description>
+        <description>Command is valid, but cannot be executed at this time. This usually indicates that the system is not ready to process the command (i.e. a state machine is busy). Retrying later may work.</description>
       </entry>
       <entry value="2" name="MAV_RESULT_DENIED">
-        <description>Command is supported but cannot be executed as specified (e.g. uses invalid parameter values). Retrying later will not work.</description>
+        <description>Command is invalid (is supported but has invalid parameters). Retrying same command and parameters will not work.</description>
       </entry>
       <entry value="3" name="MAV_RESULT_UNSUPPORTED">
         <description>Command is not supported (unknown).</description>
       </entry>
       <entry value="4" name="MAV_RESULT_FAILED">
-        <description>Command is supported but execution failed. This may indicate an environmental issue - e.g. attempting to write a file when out of memory. Retrying later may work.</description>
+        <description>Command is valid, but execution failed. This may indicate an environmental issue that must be fixed before retrying the command (e.g. attempting to write a file when out of memory).</description>
       </entry>
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
-        <description>WIP: Command is supported and is being executed.</description>
+        <description>WIP: Command is valid and is being executed.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2478,7 +2478,7 @@
         <description>Command is valid (is supported and has valid parameters), and was executed.</description>
       </entry>
       <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
-        <description>Command is valid, but cannot be executed at this time. This usually indicates that the system is not ready to process the command (i.e. a state machine is busy). Retrying later may work.</description>
+        <description>Command is valid, but cannot be executed at this time. This is used to indicate a problem that should be fixed just by waiting (e.g. a state machine is busy, can't arm because have not got GPS lock, etc.). Retrying later should work.</description>
       </entry>
       <entry value="2" name="MAV_RESULT_DENIED">
         <description>Command is invalid (is supported but has invalid parameters). Retrying same command and parameters will not work.</description>
@@ -2487,7 +2487,7 @@
         <description>Command is not supported (unknown).</description>
       </entry>
       <entry value="4" name="MAV_RESULT_FAILED">
-        <description>Command is valid, but execution failed. The cause of the problem must be fixed before retrying the command. This typically indicates an environmental issue (e.g. attempting to write a file when out of memory).</description>
+        <description>Command is valid, but execution has failed. This is used to indicate any non-temporary or unexpected problem, i.e. any problem that must be fixed before the command can succeed/be retried. For example, attempting to write a file when out of memory, attempting to arm when sensors are not calibrated, etc.</description>
       </entry>
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
         <description>Command is valid and is being executed. This will be followed by further progress updates, i.e. the component may send further COMMAND_ACK messages with result MAV_RESULT_IN_PROGRESS (at a rate decided by the implementation), and must terminate by sending a COMMAND_ACK message with final result of the operation. The COMMAND_ACK.progress field can be used to indicate the progress of the operation. There is no need for the sender to retry the command, but if done during execution, the component will return MAV_RESULT_IN_PROGRESS with an updated progress.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2487,10 +2487,10 @@
         <description>Command is not supported (unknown).</description>
       </entry>
       <entry value="4" name="MAV_RESULT_FAILED">
-        <description>Command is valid, but execution failed. This may indicate an environmental issue that must be fixed before retrying the command (e.g. attempting to write a file when out of memory).</description>
+        <description>Command is valid, but execution failed. The cause of the problem must be fixed before retrying the command. This typically indicates an environmental issue (e.g. attempting to write a file when out of memory).</description>
       </entry>
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
-        <description>Command is valid and is being executed. This may be followed by more progress updates (in COMMAND_ACK) and must terminate with a final result (e.g. MAV_RESULT_ACCEPTED). There is no need to retry the command, but if done during execution, it will return the same result.</description>
+        <description>Command is valid and is being executed. This will be followed by further progress updates, i.e. the component may send further COMMAND_ACK messages with result MAV_RESULT_IN_PROGRESS (at a rate decided by the implementation), and must terminate by sending a COMMAND_ACK message with final result of the operation. The COMMAND_ACK.progress field can be used to indicate the progress of the operation. There is no need for the sender to retry the command, but if done during execution, the component will return MAV_RESULT_IN_PROGRESS with an updated progress.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2473,24 +2473,24 @@
       </entry>
     </enum>
     <enum name="MAV_RESULT">
-      <description>result from a mavlink command</description>
+      <description>Result from a MAVLink command (MAV_CMD)</description>
       <entry value="0" name="MAV_RESULT_ACCEPTED">
-        <description>Command ACCEPTED and EXECUTED</description>
+        <description>Command is supported and was executed.</description>
       </entry>
       <entry value="1" name="MAV_RESULT_TEMPORARILY_REJECTED">
-        <description>Command TEMPORARY REJECTED/DENIED</description>
+        <description>Command is supported, but could not be executed at this time. This usually indicates that a state machine is busy. Retrying later may work.</description>
       </entry>
       <entry value="2" name="MAV_RESULT_DENIED">
-        <description>Command PERMANENTLY DENIED</description>
+        <description>Command is supported but cannot be executed as specified (e.g. uses invalid parameter values). Retrying later will not work.</description>
       </entry>
       <entry value="3" name="MAV_RESULT_UNSUPPORTED">
-        <description>Command UNKNOWN/UNSUPPORTED</description>
+        <description>Command is not supported (unknown).</description>
       </entry>
       <entry value="4" name="MAV_RESULT_FAILED">
-        <description>Command executed, but failed</description>
+        <description>Command is supported but execution failed. This may indicate an environmental issue - e.g. attempting to write a file when out of memory. Retrying later may work.</description>
       </entry>
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
-        <description>WIP: Command being executed</description>
+        <description>WIP: Command is supported and is being executed.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2490,7 +2490,7 @@
         <description>Command is valid, but execution failed. This may indicate an environmental issue that must be fixed before retrying the command (e.g. attempting to write a file when out of memory).</description>
       </entry>
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
-        <description>Command is valid and is being executed. This may be followed by more progress updates (in COMMAND_ACK) and must terminate with a final result (MAV_RESULT_ACCEPTED or MAV_RESULT_FAILED). There is no need to retry the command, but if done during execution, it will return the same result.</description>
+        <description>Command is valid and is being executed. This may be followed by more progress updates (in COMMAND_ACK) and must terminate with a final result (e.g. MAV_RESULT_ACCEPTED). There is no need to retry the command, but if done during execution, it will return the same result.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2490,7 +2490,7 @@
         <description>Command is valid, but execution failed. This may indicate an environmental issue that must be fixed before retrying the command (e.g. attempting to write a file when out of memory).</description>
       </entry>
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
-        <description>Command is valid and is being executed. This should be followed by either more progress updates and eventually a final result.</description>
+        <description>Command is valid and is being executed. This may be followed by more progress updates (in COMMAND_ACK) and must terminate with a final result (MAV_RESULT_ACCEPTED or MAV_RESULT_FAILED). There is no need to retry the command, but if done during execution, it will return the same result.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2490,7 +2490,7 @@
         <description>Command is valid, but execution failed. This may indicate an environmental issue that must be fixed before retrying the command (e.g. attempting to write a file when out of memory).</description>
       </entry>
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
-        <description>WIP: Command is valid and is being executed.</description>
+        <description>Command is valid and is being executed. This should be followed by either more progress updates and eventually a final result.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">


### PR DESCRIPTION
This clarifies the meaning of possible results ([MAV_RESULT](https://mavlink.io/en/messages/common.html#MAV_RESULT)) of a command (in a [COMMAND_ACK](https://mavlink.io/en/messages/common.html#COMMAND_ACK)) to remove ambiguity on which should be used in what circumstance.