### PR TITLE
PLAY_TUNE: Specify default format

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5416,12 +5416,13 @@
       <field type="uint8_t" name="state" display="bitmask">Bitmap for state of buttons.</field>
     </message>
     <message id="258" name="PLAY_TUNE">
-      <description>Control vehicle tone generation (buzzer)</description>
+      <description>Control vehicle tone generation (buzzer). Default format is QBasic 1.1 Play Format: https://www.qbasic.net/en/reference/qb11/Statement/PLAY-006.htm. </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[30]" name="tune">tune in board specific format</field>
+      <field type="char[30]" name="tune">Tune in format specified in the field: format</field>
       <extensions/>
-      <field type="char[200]" name="tune2">tune extension (appended to tune)</field>
+      <field type="char[200]" name="tune2">Tune extension (appended to tune field)</field>
+      <field type="uint8_t" name="format">Tune format. 0 (default) indicates QBasic 1.1 Play Format.</field>
     </message>
     <message id="259" name="CAMERA_INFORMATION">
       <description>Information about a camera</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5416,13 +5416,12 @@
       <field type="uint8_t" name="state" display="bitmask">Bitmap for state of buttons.</field>
     </message>
     <message id="258" name="PLAY_TUNE">
-      <description>Control vehicle tone generation (buzzer). Default format is QBasic 1.1 Play Format: https://www.qbasic.net/en/reference/qb11/Statement/PLAY-006.htm. </description>
+      <description>Control vehicle tone generation (buzzer). Format is QBasic 1.1 Play: https://www.qbasic.net/en/reference/qb11/Statement/PLAY-006.htm.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[30]" name="tune">Tune in format specified in the field: format</field>
+      <field type="char[30]" name="tune">Tune in QBasic 1.1 Play Format</field>
       <extensions/>
       <field type="char[200]" name="tune2">Tune extension (appended to tune field)</field>
-      <field type="uint8_t" name="format">Tune format. 0 (default) indicates QBasic 1.1 Play Format.</field>
     </message>
     <message id="259" name="CAMERA_INFORMATION">
       <description>Information about a camera</description>


### PR DESCRIPTION
Fixes #1251

This adds a field that specifies the tune format, and sets the default value (0) as QBasic (the format used by both ArduPilot and PX4).

This should not break existing systems that use another format (although they will be non-compliant). For example, ArduPilot supports another format, but gets the matching firmware version out of band.

The supported formats can be extended by adding new format field values. The cost would be that the tune buffer would no longer be truncated.
If a new format is added we might consider creating a new tune message (along with enum for the formats) and a mechanism to query the format).