### PR TITLE
[WIP] MAV_BATTERY_FUNCTION: Clarify values

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3364,7 +3364,7 @@
         <description>Battery function is unknown</description>
       </entry>
       <entry value="1" name="MAV_BATTERY_FUNCTION_ALL">
-        <description>Battery supports all flight systems</description>
+        <description>Battery supports all systems</description>
       </entry>
       <entry value="2" name="MAV_BATTERY_FUNCTION_PROPULSION">
         <description>Battery for the propulsion system</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3364,7 +3364,7 @@
         <description>Battery function is unknown</description>
       </entry>
       <entry value="1" name="MAV_BATTERY_FUNCTION_ALL">
-        <description>Battery supports all systems</description>
+        <description>Battery supports all functions (of vehicle if sent by autopilot, otherwise the current component).</description>
       </entry>
       <entry value="2" name="MAV_BATTERY_FUNCTION_PROPULSION">
         <description>Battery for the propulsion system</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3364,7 +3364,7 @@
         <description>Battery function is unknown</description>
       </entry>
       <entry value="1" name="MAV_BATTERY_FUNCTION_ALL">
-        <description>Battery supports all functions (of vehicle if sent by autopilot, otherwise the current component).</description>
+        <description>Battery supports all functions of the current system/vehicle. Should not be set by components with individual batteries, such as cameras.</description>
       </entry>
       <entry value="2" name="MAV_BATTERY_FUNCTION_PROPULSION">
         <description>Battery for the propulsion system</description>


### PR DESCRIPTION
This is created for _discussion_ of [BATTERY_STATUS.battery_function](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) and more specifically of [MAV_BATTERY_FUNCTION](https://mavlink.io/en/messages/common.html#MAV_BATTERY_FUNCTION).

>**Note** Also "function" appears to be omitted from [SMART_BATTERY_INFO](https://mavlink.io/en/messages/common.html#SMART_BATTERY_INFO). Should this not be added?

This discussion arises from https://github.com/mavlink/mavlink-devguide/pull/218#issuecomment-549240327

The design assumption is that `BATTERY_STATUS` is emitted by an **autopilot** for each battery that is part of the system. So a vehicle might have one battery for everything which has `MAV_BATTERY_FUNCTION_ALL` or a different battery for supporting different operations - e.g. payload, avionics, propulsion. 

But what if you have a component that has its own battery, for which it emits its own battery status - e,g, a gopro camera.
1. The main battery for the whole system is no longer _really_ `MAV_BATTERY_FUNCTION_ALL` because the gopro has its own battery.
2. From the autopilot perspective the battery would be `MAV_BATTERY_TYPE_PAYLOAD`  but from the camera perspective (which is emitting the type) the battery powers everything - e.g. `MAV_BATTERY_FUNCTION_ALL` .
   - An implication of this is that a camera might need to emit `MAV_BATTERY_TYPE_PAYLOAD` if in a vehicle and `MAV_BATTERY_FUNCTION_ALL` if standalone. 
3. For a component sending the message the function is redundant - a GCS can infer the function from the component sending the message.

Obvious options:
- Specify that a component other than autopilot should specify `MAV_BATTERY_FUNCTION_ALL` (this is kind of what the PR does at the moment).
- Add a type `MAV_BATTERY_FUNCTION_CAMERA` for a autopilot to emit for a camera or for a camera to emit for itself? 
- Also we should specify that `MAV_BATTERY_FUNCTION_ALL` is "all functions other than ones covered by an explicit battery type for the same system"

What else could we do?