### PR TITLE
common: MAV_CMD_DO_ORBIT: add new option for heading behaviour (param index #3)

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1038,6 +1038,24 @@
         <description>Camera does not supply storage status information. Capacity information in STORAGE_INFORMATION fields will be ignored.</description>
       </entry>
     </enum>
+    <enum name="ORBIT_YAW_BEHAVIOUR">
+      <description>Yaw behaviour during orbit flight.</description>
+      <entry value="0" name="ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER">
+        <description>Vehicle front points to the center (default).</description>
+      </entry>
+      <entry value="1" name="ORBIT_YAW_BEHAVIOUR_HOLD_INITIAL_HEADING">
+        <description>Vehicle front holds heading when message received.</description>
+      </entry>
+      <entry value="2" name="ORBIT_YAW_BEHAVIOUR_UNCONTROLLED">
+        <description>Yaw uncontrolled.</description>
+      </entry>
+      <entry value="3" name="ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TANGENT_TO_CIRCLE">
+        <description>Vehicle front follows flight path (tangential to circle).</description>
+      </entry>
+      <entry value="4" name="ORBIT_YAW_BEHAVIOUR_RC_CONTROLLED">
+        <description>Yaw controlled by RC input.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM and MISSION_ITEM_INT messages) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -1190,7 +1208,7 @@
         <description>Start orbiting on the circumference of a circle defined by the parameters. Setting any value NaN results in using defaults.</description>
         <param index="1" label="Radius" units="m">Radius of the circle. positive: Orbit clockwise. negative: Orbit counter-clockwise.</param>
         <param index="2" label="Velocity" units="m/s">Tangential Velocity. NaN: Vehicle configuration default.</param>
-        <param index="3" label="Yaw Behavior" minValue="0" maxValue="3" increment="1">Yaw behavior of the vehicle. 0: Vehicle front points to the center (default). 1: Vehicle front holds heading when message received. 2: Yaw uncontrolled. 3: Vehicle front follows flight path (tangential to circle). 4: Yaw controlled by RC input.</param>
+        <param index="3" label="Yaw Behavior" enum="ORBIT_YAW_BEHAVIOUR">Yaw behavior of the vehicle.</param>
         <param index="4">Reserved (e.g. for dynamic center beacon options)</param>
         <param index="5">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="6">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1190,7 +1190,7 @@
         <description>Start orbiting on the circumference of a circle defined by the parameters. Setting any value NaN results in using defaults.</description>
         <param index="1" label="Radius" units="m">Radius of the circle. positive: Orbit clockwise. negative: Orbit counter-clockwise.</param>
         <param index="2" label="Velocity" units="m/s">Tangential Velocity. NaN: Vehicle configuration default.</param>
-        <param index="3" label="Yaw Behavior" minValue="0" maxValue="2" increment="1">Yaw behavior of the vehicle. 0: vehicle front points to the center (default). 1: Hold last heading. 2: Leave yaw uncontrolled.</param>
+        <param index="3" label="Yaw Behavior" minValue="0" maxValue="3" increment="1">Yaw behavior of the vehicle. 0: Vehicle front points to the center (default). 1: Vehicle front holds heading when message received. 2: Yaw uncontrolled. 3: Vehicle front follows flight path (tangential to circle). 4: Yaw controlled by RC input.</param>
         <param index="4">Reserved (e.g. for dynamic center beacon options)</param>
         <param index="5">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="6">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>


### PR DESCRIPTION
Extends param index 3 of `MAV_CMD_DO_ORBIT` with a new option for the heading behaviour in Orbit mode that allows the vehicle to keep its heading forward while executing the flight following the orbit circle. Will follow a PR to PX4 with support for it. QGC to come later.

@dayjaby FYI.