### PR TITLE
REMOTE_LOG_BLOCK_STATUS message

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1331,14 +1331,14 @@
       <description>Send a block of log data to remote location.</description>
       <field type="uint8_t" name="target_system">System ID.</field>
       <field type="uint8_t" name="target_component">Component ID.</field>
-      <field type="uint32_t" name="seqno" enum="MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS">Log data block sequence number.</field>
+      <field type="uint32_t" name="seqno">Log data block sequence number.</field>
       <field type="uint8_t[200]" name="data">Log data block.</field>
     </message>
     <message id="185" name="REMOTE_LOG_BLOCK_STATUS">
       <description>Send Status of each log block that autopilot board might have sent.</description>
       <field type="uint8_t" name="target_system">System ID.</field>
       <field type="uint8_t" name="target_component">Component ID.</field>
-      <field type="uint32_t" name="seqno">Log data block sequence number.</field>
+      <field type="uint32_t" name="seqno" enum="MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS">Log data block sequence number.</field>
       <field type="uint8_t" name="status" enum="MAV_REMOTE_LOG_DATA_BLOCK_STATUSES">Log data block status.</field>
     </message>
     <message id="186" name="LED_CONTROL">


### PR DESCRIPTION
In order to start logging backend via Mavlink the communication must be started by sending a REMOTE_LOG_BLOCK_STATUS message which contains  as seqno MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS::START.

Currently it is stated to use  REMOTE_LOG_DATA_BLOCK message with MAV_REMOTE_LOG_DATA_BLOCK_COMMANDS::START which is wrong