### PR TITLE
MAV_CMD_REQUEST_MESSAGE: Define that parameters can be used

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1864,6 +1864,10 @@
         <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).</description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID of the requested message.</param>
         <param index="2" label="Index ID" minValue="0" increment="1">Index id (if appropriate). The use of this parameter (if any), must be defined in the requested message.</param>
+        <param index="3">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="4">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="5">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="6">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
         <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address for requested message (if message has target address fields). 0: Flight-stack default, 1: address of requestor, 2: broadcast.</param>
       </entry>
       <entry value="519" name="MAV_CMD_REQUEST_PROTOCOL_VERSION" hasLocation="false" isDestination="false">


### PR DESCRIPTION
This allows us to request messages using MAV_CMD_REQUEST_MESSAGE where the value of the returned message can be conditional on values passed to the target system.

In most cases message don't depend on parameters and the new params should be set to zero. In cases where parameters are expected, the values of the params must be specified in the message that is requested.