### PR TITLE
Update ADS-B flags

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3064,6 +3064,9 @@
       <entry value="16" name="ADSB_FLAGS_VALID_CALLSIGN"/>
       <entry value="32" name="ADSB_FLAGS_VALID_SQUAWK"/>
       <entry value="64" name="ADSB_FLAGS_SIMULATED"/>
+      <entry value="128" name="ADSB_FLAGS_VERTICAL_VELOCITY_VALID"/>
+      <entry value="256" name="ADSB_FLAGS_BARO_VALID"/>
+      <entry value="32768" name="ADSB_FLAGS_SOURCE_UAT"/>
     </enum>
     <enum name="MAV_DO_REPOSITION_FLAGS">
       <description>Bitmap of options for the MAV_CMD_DO_REPOSITION</description>


### PR DESCRIPTION
This adds a couple of additional ADS-B flags. These have been shipping with uAvionix hardware for awhile, so this meaning is already present and deployed in the field, and the validity flags have a lot of value to be receiving either way.