### PR TITLE
Remove the mentioning of 1E7 scaling

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1508,8 +1508,8 @@
         <param index="2" label="Bitmask" enum="MAV_DO_REPOSITION_FLAGS">Bitmask of option flags.</param>
         <param index="3">Reserved</param>
         <param index="4" label="Yaw">Yaw heading, NaN for unchanged. For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
-        <param index="5">Latitude (deg * 1E7)</param>
-        <param index="6">Longitude (deg * 1E7)</param>
+        <param index="5">Latitude</param>
+        <param index="6">Longitude</param>
         <param index="7">Altitude (meters)</param>
       </entry>
       <entry value="193" name="MAV_CMD_DO_PAUSE_CONTINUE" hasLocation="false" isDestination="false">
@@ -1622,8 +1622,8 @@
         <param index="2">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
         <param index="3">yaw depending on mount mode (degrees or degrees/second depending on yaw input).</param>
         <param index="4" label="Altitude" units="m">altitude depending on mount mode.</param>
-        <param index="5">latitude in degrees * 1E7, set if appropriate mount mode.</param>
-        <param index="6">longitude in degrees * 1E7, set if appropriate mount mode.</param>
+        <param index="5">latitude, set if appropriate mount mode.</param>
+        <param index="6">longitude, set if appropriate mount mode.</param>
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">


### PR DESCRIPTION
For MAV_CMD_DO_REPOSITION the scaling depends on whether it is being sent as a
COMMAND_LONG or COMMAND_INT, so it should not be mentioned explicitely.

FOr MAV_CMD_DO_MOUNT_CONFIGURE the same applies. Important here is to update the implementation in PX4, as param1-3 are being used there for longitude/latitude/altitude.