### PR TITLE
common: added MAV_SYS_STATUS_PREARM_CHECK

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -833,6 +833,9 @@
       <entry value="134217728" name="MAV_SYS_STATUS_SENSOR_SATCOM">
         <description>0x8000000 Satellite Communication </description>
       </entry>
+      <entry value="268435456" name="MAV_SYS_STATUS_PREARM_CHECK">
+        <description>0x10000000 pre-arm check status. Always healthy when armed</description>
+      </entry>
     </enum>
     <enum name="MAV_FRAME">
       <entry value="0" name="MAV_FRAME_GLOBAL">


### PR DESCRIPTION
Cherry-picked ardupilot/mavlink - https://github.com/ArduPilot/mavlink/pull/119

Is there a process for keeping these in sync? I was adding something similar before I stumbled across this.

FYI @MaEtUgR