### PR TITLE
add avoidance sys_status

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -836,8 +836,8 @@
       <entry value="268435456" name="MAV_SYS_STATUS_PREARM_CHECK">
         <description>0x10000000 pre-arm check status. Always healthy when armed</description>
       </entry>
-      <entry value="536870912" name="MAV_SYS_STATUS_VISION_SAFETY_SYSTEMS">
-        <description>0x20000000 Vision based safety systems status </description>
+      <entry value="536870912" name="MAV_SYS_STATUS_OBSTACLE_AVOIDANCE">
+        <description>0x20000000 Avoidance/collision prevention</description>
       </entry>
     </enum>
     <enum name="MAV_FRAME">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -836,6 +836,9 @@
       <entry value="268435456" name="MAV_SYS_STATUS_PREARM_CHECK">
         <description>0x10000000 pre-arm check status. Always healthy when armed</description>
       </entry>
+      <entry value="536870912" name="MAV_SYS_STATUS_VISION_SAFETY_SYSTEMS">
+        <description>0x20000000 Vision based safety systems status </description>
+      </entry>
     </enum>
     <enum name="MAV_FRAME">
       <entry value="0" name="MAV_FRAME_GLOBAL">


### PR DESCRIPTION
This change would allow to report the healthiness and use of different avoidance components from the fight controller to the ground station with a single message. For example in PX4 we have the Collision Prevention working in manual modes and Obstacle Avoidance working in auto modes. This message would report to the ground station if any of the avoidance systems is functional in the flight mode the vehicle currently is. The ground station can simply check the SYS_STATUS message to display the information to the user. 
