### PR TITLE
CMakeLists: Allow mavlink v2.0 build and installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ install(FILES ${CMAKE_BINARY_DIR}/config.h DESTINATION include/${PROJECT_NAME} C
 macro(generateMavlink version definitions)
     foreach(definition ${definitions})
         set(targetName ${definition}-v${version})
-        set(definitionAbsPath ${MAVLINK_SOURCE_DIR}/message_definitions/v${version}/${definition})
+        set(definitionAbsPath ${MAVLINK_SOURCE_DIR}/message_definitions/v1.0/${definition})
         message(STATUS "processing: ${definitionAbsPath}")
         add_custom_command( 
             OUTPUT ${targetName}-stamp
@@ -152,6 +152,7 @@ set(v1.0Definitions
     ualberta.xml
     )
 generateMavlink("1.0" "${v1.0Definitions}")
+generateMavlink("2.0" "${v1.0Definitions}")
 
 # testing
 if (BUILD_TEST)


### PR DESCRIPTION
- Mavlink 2.0 is built from v1.0 folder
- Build both MavLink 1.0 and Mavlink 2.0 C libraries

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>