### PR TITLE
common.xml: add chunks for statustext

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5671,6 +5671,9 @@
       <description>Status text message. These messages are printed in yellow in the COMM console of QGroundControl. WARNING: They consume quite some bandwidth, so use only for important status and error messages. If implemented wisely, these messages are buffered on the MCU and sent only at a limited rate (e.g. 10 Hz).</description>
       <field type="uint8_t" name="severity" enum="MAV_SEVERITY">Severity of status. Relies on the definitions within RFC-5424.</field>
       <field type="char[50]" name="text">Status text message, without null termination character</field>
+      <extensions/>
+      <field type="uint16_t" name="id">Unique (opaque) identifier for this statustext message.  May be used to reassemble a logical long-statustext message from a sequence of chunks.  A value of zero indicates this is the only chunk in the sequence and the message can be emitted immediately.</field>
+      <field type="uint8_t" name="chunk_seq">This chunk's sequence number; indexing is from zero.  Any null character in the text field is taken to mean this was the last chunk.</field>
     </message>
     <message id="254" name="DEBUG">
       <description>Send a debug value. The index is used to discriminate between values. These values show up in the plot of QGroundControl as DEBUG N.</description>


### PR DESCRIPTION
This has already been merged into ArduPilot's `common.xml`.

The three PRs mentioned below have been merged (or an equivalent merged in the case of the ardupilot mavlink PR).

GCS-developers announcement:

```
All,

  We look to be merging some mavlink2 extensions into ArduPilot's STATUSTEXT message.  The extensions allow a GCS to (optionally) reassemble a very long message from the autopilot into a single logical message.

  The PR into ArduPilot is here: https://github.com/ArduPilot/ardupilot/pull/13039
  The PR into ArduPilot's mavlink repository is here: https://github.com/ArduPilot/mavlink/pull/118
  The PR into MAVProxy to add support for the extensions is here: https://github.com/ArduPilot/MAVProxy/pull/718

  If a message would entirely fit within 50 characters then on-wire there's no changes except that the mavlink message length is 3 bytes longer - those three bytes will all be zero (and thus suitable for mavlink2 zero-truncation).  2 of these bytes are an "ID" field; if that field is zero then the message can be emitted immediately.  This takes into account null-termination; to be clear, a 50-non-null-character message elicits a *single* packet with an ID of 0.

  If a message would not fit within a single message then more than one message will be sent.  A new "ID" 16-bit field is set to uniquely identify the message - zero is never used for this case (see above; a zero indicates this message is in one part).  A second, (8-bit) field indicates where this particular chunk fits within the sequence of chunks you can expect.  Critically - a message is terminated by the presence of a null character in the text field.  In the cast of a message finishing on a 50-byte boundary another message will be sent with the chunk being of zero length.  The chunk sequence number starts at zero.

  Please see the referenced PR for a discussion of some of the advantages of this scheme.  The *most* notable one is that this is a backwards-compatible change.  If a GCS / OSD / whatever does not understand the extra fields then the message is not lost to them; they will simply display each chunk of message as they currently would.

  The ID is opaque.  ArduPilot currently emits these from a sequence, but don't assume that.  You can't anyway, as a statustext may go to a single channel which is not you, so there will naturally be gaps in any sequence.  I believe you *can* use the ID to de-duplicate messages received on multiple links, but that is not implemented in the MAVProxy patch.

  You will note in the MAVProxy patch that you *do* need to worry about missing chunks if you want to reassemble.  I chose an arbitrary time to assume no more chunks would be forthcoming and emit the message with missing chunks replaced by ellipsis (...).

  Nothing has yet been merged to ArduPilot.  I do intend to PR the mavlink change upstream - soon.  I wanted to get any feedback from those directly impacted by the change first - so please comment if you have concerns.  I will send another message here if / when changes get merged.

Peter
```