### PR TITLE
Edit documentation to handle case where cell voltages are not measured

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5388,7 +5388,7 @@
       <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
       <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
       <field type="int16_t" name="temperature" units="cdegC">Temperature of the battery. INT16_MAX for unknown temperature.</field>
-      <field type="uint16_t[10]" name="voltages" units="mV">Battery voltage of cells. Cells above the valid cell count for this battery should have the UINT16_MAX value.</field>
+      <field type="uint16_t[10]" name="voltages" units="mV">Battery voltage of cells. Cells above the valid cell count for this battery should have the UINT16_MAX value. If individual cell voltages are unknown or not measured for this battery, then the overall battery voltage should be filled in cell 0, with all others set to UINT16_MAX. If the voltage of the battery is greater than (UINT16_MAX - 1), then cell 0 should be set to (UINT16_MAX - 1), and cell 1 to the remaining voltage. This can be extended to multiple cells if the total voltage is greater than 2 * (UINT16_MAX - 1).</field>
       <field type="int16_t" name="current_battery" units="cA">Battery current, -1: autopilot does not measure the current</field>
       <field type="int32_t" name="current_consumed" units="mAh">Consumed charge, -1: autopilot does not provide consumption estimate</field>
       <field type="int32_t" name="energy_consumed" units="hJ">Consumed energy, -1: autopilot does not provide energy consumption estimate</field>


### PR DESCRIPTION
Currently, there are two ways to report battery voltage over MAVLink: `SYS_STATUS` and `BATTERY_STATUS`. `SYS_STATUS` only has one field for each battery value, so if there are multiple batteries in a system, there is ambiguity. There is discussion about this in https://github.com/mavlink/mavlink/pull/1182.

To solve this ambiguity, a vehicle can send multiple instances of `BATTERY_STATUS`, with different values for `id`. This is how PX4 currently does it.

In `BATTERY_STATUS`, there is the `voltages` field for sending individual voltages of each cell of the battery. This is useful for 'smart batteries' and other power monitors that can monitor individual cells. However, many power monitors cannot do this; they can only measure the overall voltage of the battery. 

This PR updates the documentation of `BATTERY_STATUS` to handle this case. It works as follows:

 - Set `voltages[0]` to the total battery voltage, in mV. Essentially, treat the battery as if it is one big cell.
 - If the total battery voltage is greater than or equal to `UINT16_MAX`, then set `voltages[0]` to `UINT16_MAX - 1`, and set `voltages[1]` to the remaining voltage.
 - This can be extended to multiple cells if the voltage is greater than `2 * (UINT16_MAX - 1)`.

In this way, the total voltage of the battery can still always be calculated by simply summing every value in `voltages` which is not `UINT16_MAX`.