### PR TITLE
PROJECT_SOURCE_DIR for MAVLINK_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 project (mavlink)
 
 if (NOT DEFINED MAVLINK_SOURCE_DIR)
-    set(MAVLINK_SOURCE_DIR ${CMAKE_SOURCE_DIR})
+    set(MAVLINK_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 endif ()
 
 # settings


### PR DESCRIPTION
Hi,

Can we set MAVLINK_SOURCE_DIR to PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR so that building as a subdirectory works? Otherwise MAVLINK_SOURCE_DIR incorrectly points to the top level project directory instead of the mavlink directory and cmake fails.

- Jacob