### PR TITLE
COMMAND_INT.autocontinue - clarify not used

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4816,7 +4816,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the mission item.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
+      <field type="uint8_t" name="autocontinue">Not used (set 0).</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>


### PR DESCRIPTION
I'd like to also mark these as not used, or at least confirm that someone uses them and how:
- `COMMAND_INT.current` - false:0, true:1
- `COMMAND_LONG.confirmation` - 0: First transmission of this command. 1-255: Confirmation transmissions (e.g. for kill command)

According to @julianoes the `confirmation` is not used https://github.com/mavlink/mavlink-devguide/pull/217#issuecomment-547283478 by PX4, and I suspect not by ArduPilot. 

@auturgy Do you know anything about these two?

