### PR TITLE
Allow correlating CAMERA_IMAGE_CAPTURED with the camera command.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1821,7 +1821,7 @@
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1 (use 0 to ignore it). This is to: (1) Identify this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
+        <param index="4" label="Sequence Number" minValue="0" increment="1">Capture sequence number starting from 1  (0 indicates sequence number is not supported/used). This is to: (1) Identify this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>
@@ -2175,7 +2175,7 @@
         <param index="1">Reserved (Set to 0)</param>
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
         <param index="3" label="Capture Count" minValue="0" increment="1">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
-        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1 (use 0 to ignore it). This is to: (1) Identify this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
+        <param index="4" label="Sequence Number" minValue="0" increment="1">Capture sequence number starting from 1  (0 indicates sequence number is not supported/used). This is to: (1) Identify this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE" hasLocation="false" isDestination="false">
@@ -2186,8 +2186,8 @@
       <entry value="2002" name="MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Re-request a CAMERA_IMAGE_CAPTURE message. Use NaN for reserved values.</description>
-        <param index="1" label="Number" minValue="0" increment="1">Sequence number for missing CAMERA_IMAGE_CAPTURE messages</param>
+        <description>Re-request all CAMERA_IMAGE_CAPTURED messages that have the specified sequence number. Use NaN for reserved values.</description>
+        <param index="1" label="Sequence Number" minValue="0" increment="1">Sequence number for missing CAMERA_IMAGE_CAPTURED messages</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2003" name="MAV_CMD_DO_TRIGGER_CONTROL" hasLocation="false" isDestination="false">
@@ -5972,7 +5972,7 @@
       <field type="int32_t" name="image_index">Zero based index of this image (image count since armed -1)</field>
       <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
       <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
-      <field type="int32_t" name="sequence">If non-zero, sequence number of the MAV_CMD_IMAGE_START_CAPTURE or MAV_CMD_DO_SET_CAM_TRIGG_DIST command this image is a response to.</field>
+      <field type="int32_t" name="sequence">Sequence number of the MAV_CMD_IMAGE_START_CAPTURE or MAV_CMD_DO_SET_CAM_TRIGG_DIST command this image is a response to. 0 if the sequence number is not known or supported.</field>
     </message>
     <message id="264" name="FLIGHT_INFORMATION">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1821,7 +1821,7 @@
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1 (use 0 to ignore it). This is to: (1) Idenifty this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
+        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1 (use 0 to ignore it). This is to: (1) Identify this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>
@@ -2175,7 +2175,7 @@
         <param index="1">Reserved (Set to 0)</param>
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
         <param index="3" label="Capture Count" minValue="0" increment="1">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
-        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1 (use 0 to ignore it). This is to: (1) Idenifty this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
+        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1 (use 0 to ignore it). This is to: (1) Identify this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1821,7 +1821,7 @@
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4">Empty</param>
+        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1 (use 0 to ignore it). This is to: (1) Idenifty this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>
@@ -2175,7 +2175,7 @@
         <param index="1">Reserved (Set to 0)</param>
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
         <param index="3" label="Capture Count" minValue="0" increment="1">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
-        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1. This is only valid for single-capture (param3 == 1). Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted. Use 0 to ignore it.</param>
+        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1 (use 0 to ignore it). This is to: (1) Idenifty this command and prevent double captures when the command is re-transmitted (2) Correlate CAMERA_IMAGE_CAPTURED events (and underlying photos taken) with this command (see CAMERA_IMAGE_CAPTURED::sequence). Note; all CAMERA_IMAGE_CAPTURED corresponding with this command will share this sequence number</param>
         <param index="5">Reserved (all remaining params)</param>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE" hasLocation="false" isDestination="false">
@@ -2187,7 +2187,7 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Re-request a CAMERA_IMAGE_CAPTURE message. Use NaN for reserved values.</description>
-        <param index="1" label="Number" minValue="0" increment="1">Sequence number for missing CAMERA_IMAGE_CAPTURE message</param>
+        <param index="1" label="Number" minValue="0" increment="1">Sequence number for missing CAMERA_IMAGE_CAPTURE messages</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
       <entry value="2003" name="MAV_CMD_DO_TRIGGER_CONTROL" hasLocation="false" isDestination="false">
@@ -5972,6 +5972,7 @@
       <field type="int32_t" name="image_index">Zero based index of this image (image count since armed -1)</field>
       <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
       <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
+      <field type="int32_t" name="sequence">If non-zero, sequence number of the MAV_CMD_IMAGE_START_CAPTURE or MAV_CMD_DO_SET_CAM_TRIGG_DIST command this image is a response to.</field>
     </message>
     <message id="264" name="FLIGHT_INFORMATION">
       <wip/>


### PR DESCRIPTION
We fly (image) survey missions (grids, individual photos, with `MAV_CMD_IMAGE_START_CAPTURE` and `MAV_CMD_DO_SET_CAM_TRIGG_DIST`). We then process thus captured photos and therefore need to know what they are (their urls) and what command each corresponds to. We receive `CAMERA_IMAGE_CAPTURED`  - both response to `MAV_CMD_IMAGE_START_CAPTURE` and `MAV_CMD_DO_SET_CAM_TRIGG_DIST`, but not when photos were taken during the time the drone was disconnected. We also don't know what command these images correspond to. Because of that we cannot work out what photos did the drone take during a mission and don't thus know what to download.

There is the WIP [`MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE`](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE) (though its [WIP status](https://github.com/mavlink/mavlink/commit/da2f75e3937035f79b7ceb3403d07e26382ad1db) appears stale - 2 years). Provided its WIP status can be lifted, we think can use it to request missing `CAMERA_IMAGE_CAPTURED` events, but it is insufficient to allow us correlate these photos with commands. 

This PR is our first PR and the first stab in understanding this exchange. Here's how we justify these changes:

- remove unclear/unnecessary(?) caveat about the sequence number only applying to `MAV_CMD_IMAGE_START_CAPTURE` with image count of 1. We'd like to propose that the sequence number is semantically an asset number and an asset can be a group of photos resulting from one command. As a consequence we clarify that multiple `CAMERA_IMAGE_CAPTURED` can share the same sequence number. Elsewhere (QGC) we will propose to use this sequence number as a grouping folder for the associated photos. This will allow processing them automatically. 

- because `CAMERA_IMAGE_CAPTURED` is also sent in response to `MAV_CMD_DO_SET_CAM_TRIGG_DIST` allow specifying sequence there too;

- Add sequence field to `CAMERA_IMAGE_CAPTURED` event to allow correlating it with a specific `MAV_CMD_IMAGE_START_CAPTURE` or `MAV_CMD_DO_SET_CAM_TRIGG_DIST`. We don't know if there are any backwards compatibility requirements we need to obey;