### PR TITLE
Improve cellular status mavlink message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3949,10 +3949,61 @@
       <entry value="3" name="CELLULAR_NETWORK_RADIO_TYPE_WCDMA"/>
       <entry value="4" name="CELLULAR_NETWORK_RADIO_TYPE_LTE"/>
     </enum>
-    <enum name="CELLULAR_NETWORK_STATUS_FLAG" bitmask="true">
+    <enum name="CELLULAR_STATUS_FLAG">
       <description>These flags encode the cellular network status</description>
-      <entry value="1" name="CELLULAR_NETWORK_STATUS_FLAG_ROAMING">
-        <description>Roaming is active</description>
+      <entry value="0" name="CELLULAR_STATUS_FLAG_FAILED">
+        <description>Modem is unusable</description>
+      </entry>
+      <entry value="1" name="CELLULAR_STATUS_FLAG_UNKNOWN">
+        <description>State unknown or not reportable.</description>
+      </entry>
+      <entry value="2" name="CELLULAR_STATUS_FLAG_INITIALIZING">
+        <description>Modem is being initialized</description>
+      </entry>
+      <entry value="3" name="CELLULAR_STATUS_FLAG_LOCKED">
+        <description>Modem is locked</description>
+      </entry>
+      <entry value="4" name="CELLULAR_STATUS_FLAG_DISABLED">
+        <description>Modem is not enabled and is powered down</description>
+      </entry>
+      <entry value="5" name="CELLULAR_STATUS_FLAG_DISABLING">
+        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_DISABLED state</description>
+      </entry>
+      <entry value="6" name="CELLULAR_STATUS_FLAG_ENABLING">
+        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_ENABLED state</description>
+      </entry>
+      <entry value="7" name="CELLULAR_STATUS_FLAG_ENABLED">
+        <description>Modem is enabled and powered on but not registered with a network provider and not available for data connections</description>
+      </entry>
+      <entry value="8" name="CELLULAR_STATUS_FLAG_SEARCHING">
+        <description>Modem is searching for a network provider to register</description>
+      </entry>
+      <entry value="9" name="CELLULAR_STATUS_FLAG_REGISTERED">
+        <description>Modem is registered with a network provider, and data connections and messaging may be available for use</description>
+      </entry>
+      <entry value="10" name="CELLULAR_STATUS_FLAG_DISCONNECTING">
+        <description>Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated</description>
+      </entry>
+      <entry value="11" name="CELLULAR_STATUS_FLAG_CONNECTING">
+        <description>Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered</description>
+      </entry>
+      <entry value="12" name="CELLULAR_STATUS_FLAG_CONNECTED">
+        <description>One or more packet data bearers is active and connected</description>
+      </entry>
+    </enum>
+    <enum name="CELLULAR_NETWORK_FAILED_REASON">
+      <description>These flags are used to diagnose the failure state of CELLULAR_STATUS</description>
+      <entry value="0" name="CELLULAR_NETWORK_FAILED_REASON_NONE">
+        <description>No error</description>
+      </entry>
+      <entry value="1" name="CELLULAR_NETWORK_FAILED_REASON_UNKNOWN">
+        <description>Error state is unknown</description>
+      </entry>
+      <entry value="2" name="CELLULAR_NETWORK_FAILED_REASON_SIM_MISSING">
+        <description>SIM is required for the modem but missing</description>
+      </entry>
+      <entry value="3" name="CELLULAR_NETWORK_FAILED_REASON_SIM_ERROR">
+        <description>SIM is available, but not usuable for connection</description>
       </entry>
     </enum>
     <enum name="PRECISION_LAND_MODE">
@@ -6604,13 +6655,14 @@
     <message id="334" name="CELLULAR_STATUS">
       <wip/>
       <description>Report current used cellular network status</description>
-      <field type="uint16_t" name="status" enum="CELLULAR_NETWORK_STATUS_FLAG" display="bitmask">Status bitmap</field>
+      <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
+      <field type="uint8_t" name="failure_status" enum="CELLULAR_NETWORK_FAILED_REASON">Failure status when status in in CELLUAR_STATUS_FAILED</field>
       <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
-      <field type="uint8_t" name="quality">Cellular network RSSI/RSRP in dBm, absolute value</field>
+      <field type="uint8_t" name="quality">Signal Quality in percent</field>
+      <field type="uint16_t[5]" name="band" enum="CELLULAR_NETWORK_BAND">Currently used band</field>
       <field type="uint16_t" name="mcc">Mobile country code. If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="mnc">Mobile network code. If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="lac">Location area code. If unknown, set to: 0</field>
-      <field type="uint32_t" name="cid">Cell ID. If unknown, set to: UINT32_MAX</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6658,10 +6658,10 @@
       <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
       <field type="uint8_t" name="failure_reason" enum="CELLULAR_NETWORK_FAILED_REASON">Failure reason when status in in CELLUAR_STATUS_FAILED</field>
       <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
-      <field type="uint8_t" name="quality">Signal Quality in percent. If unknown, set to : UINT8_MAX</field>
-      <field type="uint16_t" name="mcc">Mobile country code. If unknown, set to: UINT16_MAX</field>
-      <field type="uint16_t" name="mnc">Mobile network code. If unknown, set to: UINT16_MAX</field>
-      <field type="uint16_t" name="lac">Location area code. If unknown, set to: 0</field>
+      <field type="uint8_t" name="quality">Signal quality in percent. If unknown, set to UINT8_MAX</field>
+      <field type="uint16_t" name="mcc">Mobile country code. If unknown, set to UINT16_MAX</field>
+      <field type="uint16_t" name="mnc">Mobile network code. If unknown, set to UINT16_MAX</field>
+      <field type="uint16_t" name="lac">Location area code. If unknown, set to 0</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6659,7 +6659,6 @@
       <field type="uint8_t" name="failure_status" enum="CELLULAR_NETWORK_FAILED_REASON">Failure status when status in in CELLUAR_STATUS_FAILED</field>
       <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
       <field type="uint8_t" name="quality">Signal Quality in percent</field>
-      <field type="uint16_t[5]" name="band" enum="CELLULAR_NETWORK_BAND">Currently used band</field>
       <field type="uint16_t" name="mcc">Mobile country code. If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="mnc">Mobile network code. If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="lac">Location area code. If unknown, set to: 0</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3951,11 +3951,11 @@
     </enum>
     <enum name="CELLULAR_STATUS_FLAG">
       <description>These flags encode the cellular network status</description>
-      <entry value="0" name="CELLULAR_STATUS_FLAG_FAILED">
-        <description>Modem is unusable</description>
-      </entry>
-      <entry value="1" name="CELLULAR_STATUS_FLAG_UNKNOWN">
+      <entry value="0" name="CELLULAR_STATUS_FLAG_UNKNOWN">
         <description>State unknown or not reportable.</description>
+      </entry>
+      <entry value="1" name="CELLULAR_STATUS_FLAG_FAILED">
+        <description>Modem is unusable</description>
       </entry>
       <entry value="2" name="CELLULAR_STATUS_FLAG_INITIALIZING">
         <description>Modem is being initialized</description>
@@ -6656,9 +6656,9 @@
       <wip/>
       <description>Report current used cellular network status</description>
       <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
-      <field type="uint8_t" name="failure_status" enum="CELLULAR_NETWORK_FAILED_REASON">Failure status when status in in CELLUAR_STATUS_FAILED</field>
+      <field type="uint8_t" name="failure_reason" enum="CELLULAR_NETWORK_FAILED_REASON">Failure reason when status in in CELLUAR_STATUS_FAILED</field>
       <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
-      <field type="uint8_t" name="quality">Signal Quality in percent</field>
+      <field type="uint8_t" name="quality">Signal Quality in percent. If unknown, set to : UINT8_MAX</field>
       <field type="uint16_t" name="mcc">Mobile country code. If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="mnc">Mobile network code. If unknown, set to: UINT16_MAX</field>
       <field type="uint16_t" name="lac">Location area code. If unknown, set to: 0</field>


### PR DESCRIPTION
The current definition of mavlink fails to provide sufficient information to make use of cellular communications as a datalink. This PR improves the `CELLULAR_STATUS` message to improve monitoring / diagnoising  cellular modems.

The summary of the improvements include
- Extension of enum of `CELLULAR_STATUS_FLAG` to better represent the cellular status
- Switched unit of cellular quality from -dbm to percent
- Added `failure_status` flag in message to represent failur status when `CELLULAR_STATUS_FLAG` is in `CELLULAR_STATUS_FLAG_FAILED` state
- Added field of band with enum `CELLULAR_NETWORK_BAND` to represent band usage for cellular networks 

A lot of the enumerations and definitions are inspired from the definitions of [ModemManager API](https://www.freedesktop.org/software/ModemManager/api/latest/gdbus-org.freedesktop.ModemManager1.Modem.html),  which are widely used. This also makes the interfacing with Modem Manager simpler
