### PR TITLE
gimbal: add missing flag to stop previous command

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1147,6 +1147,9 @@
       <entry value="4194304" name="GIMBAL_MANAGER_FLAGS_OVERRIDE">
         <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_MANAGER_FLAGS_YAW_LOCK.</description>
       </entry>
+      <entry value="8388608" name="GIMBAL_MANAGER_FLAGS_NONE">
+        <description>This flag can be set to give up control previously set using MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE. This flag must not be combined with other flags.</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_DEVICE_ERROR_FLAGS">
       <description>Gimbal device (low level) error flags (bitmap, 0 means no error)</description>


### PR DESCRIPTION
The NONE flag is required to stop a previously set command. This somehow got lost previously but came up when writing the docs of the new gimbal protocol.