### PR TITLE
New CERTIFICATE message for new encryption system

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6170,6 +6170,17 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="format" enum="TUNE_FORMAT" display="bitmask">Bitfield of supported tune formats.</field>
     </message>
+
+    <message id="1000" name="CERTIFICATE">
+      <description>Signed certificate by authority, that is meant to validate another device public key and privileges. If certificate is trusted, then it is possible to communicate with other device</description>
+      <field type="uint8_t" name="system_id" units="">Network address</field>
+      <field type="char[20]" name="device_name" units="">Name of machine</field>
+      <field type="char[20]" name="maintainer" units="">Name of maintainer</field>
+      <field type="uint8_t" name="privileges" units="rad">Privilages of device</field>
+      <field type="uint8_t[32]" name="public_key" units="rad">Public key of device</field>
+      <field type="uint8_t[32]" name="nonce" units="rad/s">Random nonce to generate different key each time</field>
+      <field type="uint8_t[64]" name="sign" units="rad/s">Hash of previous fields signed by authority </field>
+</message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6173,14 +6173,14 @@
 
     <message id="1000" name="CERTIFICATE">
       <description>Signed certificate by authority, that is meant to validate another device public key and privileges. If certificate is trusted, then it is possible to communicate with other device</description>
-      <field type="uint8_t" name="system_id" units="">Network address</field>
+      <field type="uint8_t" name="device_id" units="">Network address</field>
       <field type="char[20]" name="device_name" units="">Name of machine</field>
       <field type="char[20]" name="maintainer" units="">Name of maintainer</field>
       <field type="uint8_t" name="privileges" units="rad">Privilages of device</field>
       <field type="uint8_t[32]" name="public_key" units="rad">Public key of device</field>
       <field type="uint8_t[32]" name="nonce" units="rad/s">Random nonce to generate different key each time</field>
       <field type="uint8_t[64]" name="sign" units="rad/s">Hash of previous fields signed by authority </field>
-</message>
+    </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6170,7 +6170,6 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="format" enum="TUNE_FORMAT" display="bitmask">Bitfield of supported tune formats.</field>
     </message>
-
     <message id="1000" name="CERTIFICATE">
       <description>Signed certificate by authority, that is meant to validate another device public key and privileges. If certificate is trusted, then it is possible to communicate with other device</description>
       <field type="uint8_t" name="device_id" units="">Network address</field>


### PR DESCRIPTION
New encryption system has been build for PX4 based on mavlink protocol. To make encryption possible, keys for encryption needs to be exchanged. To do it we need to send mavlink CERTIFICATE message, that contains public key, sign and all information about device. If certificate has valid sign, then using Diffie-Hellman protocol symmetric keys is exchanged and both devices can communicate using encrypted messages. To get more information I recommend to read preview of my diploma thesis (You can find it here: PX4/Firmware#13538).

It is my first pull request into public repository so please be patient with me :D Any recommendations are welcome.