### PR TITLE
Add RAW_RPM message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6402,6 +6402,11 @@
       <field type="uint8_t" name="tx_session_pending">1: Transmission session pending, 0: No transmission session pending.</field>
       <field type="uint8_t" name="rx_session_pending">1: Receiving session pending, 0: No receiving session pending.</field>
     </message>
+    <message id="339" name="RAW_RPM">
+      <description>RPM sensor data message.</description>
+      <field type="uint8_t" name="index">Index of this RPM sensor (0-indexed)</field>
+      <field type="float" name="frequency" units="rpm">Indicated rate</field>
+    </message>
     <message id="340" name="UTM_GLOBAL_POSITION">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->


### PR DESCRIPTION
Hi, I would like to add new MAVLINK message for RPM data. This message is related to TFRPM01A sensor implemented in PX4 PX4/Firmware#14018. It can be used with other RPM sensors or for broadcasting RPM from some CAN ESC.

RAW_RPM
```
uint64 timestamp
float32 indicated_frequency_rpm       # indicated rotor Frequency in Revolution per minute
float32 estimated_accurancy_rpm       # estimated accurancy in Revolution per minute
```

Plese, I'm not sure about message ID. 
