### PR TITLE
common> FAILURE_UNIT / _TYPE are not bitmasks

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4293,7 +4293,7 @@
       <entry value="2048" name="AIS_FLAGS_VALID_CALLSIGN"/>
       <entry value="4096" name="AIS_FLAGS_VALID_NAME"/>
     </enum>
-    <enum name="FAILURE_UNIT" bitmask="true">
+    <enum name="FAILURE_UNIT">
       <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>List of possible units where failures can be injected.</description>
       <entry value="0" name="FAILURE_UNIT_SENSOR_GYRO"/>
@@ -4311,7 +4311,7 @@
       <entry value="104" name="FAILURE_UNIT_SYSTEM_RC_SIGNAL"/>
       <entry value="105" name="FAILURE_UNIT_SYSTEM_MAVLINK_SIGNAL"/>
     </enum>
-    <enum name="FAILURE_TYPE" bitmask="true">
+    <enum name="FAILURE_TYPE">
       <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>List of possible failure type to inject.</description>
       <entry value="0" name="FAILURE_TYPE_OK">


### PR DESCRIPTION
Removes `bitmask="true"` attribute from the FAILURE_UNIT and FAILURE_TYPE enums as noted in https://github.com/mavlink/mavlink/pull/1331