### PR TITLE
Move RPM message from ardupilotmega.xml to common.xml 

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1552,11 +1552,6 @@
       <field type="float" name="throttle_out" units="%">Output throttle</field>
       <field type="float" name="pt_compensation">Pressure/temperature compensation</field>
     </message>
-    <message id="226" name="RPM">
-      <description>RPM sensor output.</description>
-      <field type="float" name="rpm1">RPM Sensor1.</field>
-      <field type="float" name="rpm2">RPM Sensor2.</field>
-    </message>
     <!-- ardupilot specific mavlink2 messages starting at 11000-->
     <message id="11000" name="DEVICE_OP_READ">
       <description>Read registers for a device.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5708,11 +5708,13 @@
       <extensions/>
       <field type="uint8_t" name="breach_mitigation" enum="FENCE_MITIGATE">Active action to prevent fence breach</field>
     </message>
+    <!-- imported from ardupilotmega.xml (2020) -->
     <message id="226" name="RPM">
       <description>RPM sensor output.</description>
+      <field type="float" name="rpm1" units="rpm">RPM values 1</field>
+      <field type="float" name="rpm2" units="rpm">RPM values 2</field>
+      <extensions/>
       <field type="uint8_t" name="index">Sensor ID</field>
-      <field type="float" name="rpm1" units="rpm">RPM Sensor1.</field>
-      <field type="float" name="rpm2" units="rpm">RPM Sensor2.</field>
     </message>
     <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
     <message id="230" name="ESTIMATOR_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1943,6 +1943,11 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+      <message id="226" name="RPM">
+        <description>RPM sensor output.</description>
+        <field type="float" name="rpm1">RPM Sensor1.</field>
+        <field type="float" name="rpm2">RPM Sensor2.</field>
+      </message>
       <entry value="240" name="MAV_CMD_DO_LAST" hasLocation="false" isDestination="false">
         <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
         <param index="1">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5710,8 +5710,9 @@
     </message>
     <message id="226" name="RPM">
       <description>RPM sensor output.</description>
-      <field type="float" name="rpm1">RPM Sensor1.</field>
-      <field type="float" name="rpm2">RPM Sensor2.</field>
+      <field type="uint8_t" name="index">Sensor ID</field>
+      <field type="float" name="rpm1" units="rpm">RPM Sensor1.</field>
+      <field type="float" name="rpm2" units="rpm">RPM Sensor2.</field>
     </message>
     <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
     <message id="230" name="ESTIMATOR_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1943,11 +1943,6 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <message id="226" name="RPM">
-        <description>RPM sensor output.</description>
-        <field type="float" name="rpm1">RPM Sensor1.</field>
-        <field type="float" name="rpm2">RPM Sensor2.</field>
-      </message>
       <entry value="240" name="MAV_CMD_DO_LAST" hasLocation="false" isDestination="false">
         <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
         <param index="1">Empty</param>
@@ -5712,6 +5707,11 @@
       <field type="uint32_t" name="breach_time" units="ms">Time (since boot) of last breach.</field>
       <extensions/>
       <field type="uint8_t" name="breach_mitigation" enum="FENCE_MITIGATE">Active action to prevent fence breach</field>
+    </message>
+    <message id="226" name="RPM">
+      <description>RPM sensor output.</description>
+      <field type="float" name="rpm1">RPM Sensor1.</field>
+      <field type="float" name="rpm2">RPM Sensor2.</field>
     </message>
     <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
     <message id="230" name="ESTIMATOR_STATUS">


### PR DESCRIPTION
based on PR #1337 I have created this PR. The content of this issue is to move RPM message from ardupilotmega definition to common for widest compatibility. 

Into RPM message was also added index field and data units. 

I'm not sure if I can change message ID (and to which id to change it) and with the placement of message definitions in common messages. 