### PR TITLE
Add message COPTER_DRIVE_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6522,6 +6522,16 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="format" enum="TUNE_FORMAT" display="bitmask">Bitfield of supported tune formats.</field>
     </message>
+    <message id="410" name="COPTER_DRIVE_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Drive status information, applicable to multicopters, helicopters and VTOL/hybrid vehicles. Failed drives or drives operates close to min or max power limit might affect maneuverability or flight stability and immediate operator attention is advised.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint16_t" name="in_use" display="bitmask">Bitmap for drives that are in use in the current flight configuration and flight phase</field>
+      <field type="uint16_t" name="lower_limit" display="bitmask">Bitmap for drives that are running close to or at their minimum power limit.</field>
+      <field type="uint16_t" name="upper_limit" display="bitmask">Bitmap frives that are running close to or at their maxmimum power limit.</field>
+      <field type="uint16_t" name="failed" display="bitmask">Bitmap for drives which are known to be failed.</field>
+    </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>


### PR DESCRIPTION
Most hovering vehicles, including multicopters, helicopters and misc VTOLs and hybrid vehicles rely on drive thrust for attitude control and flight stability. A failed drive or a drive operating close to it's maximum (or even minimum) thrust limit, might seriously affect flight stability. But there might be recovery avaible if the operator knows about the situation early and is able to react and in a correct way, e.g. the operator could decide to enter an autorotation maneuver in case of a helicopter with a failed tail rotor drive. Therefore, this condition should be brought to the attention of the operator immediately, with enough detail information come to the correct conclusion.

Some very basic information for each drive should be enough for a sound decision. These are:
1. is the drive expected to be in use currently?
2. is it known to be failed?
3. is it performing at it's max power limit?
4. is it performing at it's min power limit?

Almost all combinations of failure could happen simultaneously, e.g. a hex-rotor with a drive known to be failed will probably max out two non-failed drives and throttle down to minimum at least one other drive, which is why a bit mask with one bit per drive is preferred to some a burst of per-drive messages in case of a single drive failure event.

To my best knowledge, there is no message for drive status in a vehicle with multiple/many drives in MAVLink currently. In the past, I have mad a hack for my vehicles in the flight controller specific error fields to make drive status information available at the GCS. The availability of this information has saved two vehicles so far, however the way of implementation is IMHO not the right one (other flight controllers might have the same problem) and has proven to be hard to maintain even in my fork of ArduPilot only.