### PR TITLE
common: add missing SENSOR_ORIENTATION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3065,6 +3065,9 @@
       <entry value="40" name="MAV_SENSOR_ROTATION_ROLL_90_PITCH_315">
         <description>Roll: 90, Pitch: 315</description>
       </entry>
+      <entry value="41" name="MAV_SENSOR_ROTATION_ROLL_270_YAW_180">
+        <description>Roll: 270, Yaw: 180</description>
+      </entry>
       <entry value="100" name="MAV_SENSOR_ROTATION_CUSTOM">
         <description>Custom orientation</description>
       </entry>


### PR DESCRIPTION
It seems like this rotation is missing.

These are equivalent:

ROLL_270_YAW_180
PITCH_180_ROLL_270
YAW_180_ROLL_90

FYI @jinchengde @nicovanduijn.