### PR TITLE
Fix typo: MAV_COMP_ID_USE16 > MAV_COMP_ID_USER16

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -426,7 +426,7 @@
       <entry value="39" name="MAV_COMP_ID_USER15">
         <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
       </entry>
-      <entry value="40" name="MAV_COMP_ID_USE16">
+      <entry value="40" name="MAV_COMP_ID_USER16">
         <description>Id for a component on privately managed MAVLink network. Can be used for any purpose but may not be published by components outside of the private network.</description>
       </entry>
       <entry value="41" name="MAV_COMP_ID_USER17">


### PR DESCRIPTION
Shouldn't have any end user implications.