### PR TITLE
Stalebot: don't auto-close issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 120
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: false
 # Issues with these labels will never be considered stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,16 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 120
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 30
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
The stale bot is great to remind us to follow up but I think the stale bot should not auto-close issues and PRs because:
- We might miss important things that were closed.
- We can no longer find issues that we remembered to be there because they have been closed but not actually resolved.
- It creates a lot of noise in the comments because we have to keep deleting the stale bot's comments or shout against the bot.

Instead, I think, it is good to have the stale label as a reminder when it appears the first time and also as a way to search for old issues to go through them and close them if it makes sense.

Also, this PR reduces the time for something to be stale to 2 months.