### PR TITLE
common: added generator status message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3328,33 +3328,33 @@
         <description>Generator is charging the batteries (generating enough power to charge and provide the load).</description>
       </entry>
       <entry value="16" name="GENERATOR_STATUS_FLAG_REDUCED_POWER">
-        <description>Generator is providing the maximum output.</description>
-      </entry>
-      <entry value="32" name="GENERATOR_STATUS_FLAG_MAXPOWER">
         <description>Generator is operating at a reduced maximum power.</description>
       </entry>
+      <entry value="32" name="GENERATOR_STATUS_FLAG_MAXPOWER">
+        <description>Generator is providing the maximum output.</description>
+      </entry>
       <entry value="64" name="GENERATOR_STATUS_FLAG_OVERTEMP_WARNING">
-        <description>Generator is near the maximum operating temperature, cooling is insufficient (may be running at reduced power).</description>
+        <description>Generator is near the maximum operating temperature, cooling is insufficient.</description>
       </entry>
       <entry value="128" name="GENERATOR_STATUS_FLAG_OVERTEMP_FAULT">
         <description>Generator hit the maximum operating temperature and shutdown.</description>
       </entry>
-      <entry value="256" name="GENERATOR_STATUS_FLAG_RECTIFIER_OVERTEMP_WARNING">
-        <description>Power electronics are near the maximum operating temperature, cooling is insufficient (may be running at reduced power).</description>
+      <entry value="256" name="GENERATOR_STATUS_FLAG_ELECTRONICS_OVERTEMP_WARNING">
+        <description>Power electronics are near the maximum operating temperature, cooling is insufficient.</description>
       </entry>
-      <entry value="512" name="GENERATOR_STATUS_FLAG_RECTIFIER_OVERTEMP_WARNING">
+      <entry value="512" name="GENERATOR_STATUS_FLAG_ELECTRONICS_OVERTEMP_FAULT">
         <description>Power electronics hit the maximum operating temperature and shutdown.</description>
       </entry>
-      <entry value="1024" name="GENERATOR_STATUS_FLAG_RECTIFIER_FAULT">
-        <description>Power electronics experienced an error.</description>
+      <entry value="1024" name="GENERATOR_STATUS_FLAG_ELECTRONICS_FAULT">
+        <description>Power electronics experienced an fault and shutdown.</description>
       </entry>
       <entry value="2048" name="GENERATOR_STATUS_FLAG_POWERSOURCE_FAULT">
-        <description>The power source providing the generator failed e.g. mechanical generator stopped, tether is no longer providing power, solar cell is in shade, hydrogen reaction no longer happening.</description>
+        <description>The power source supplying the generator failed e.g. mechanical generator stopped, tether is no longer providing power, solar cell is in shade, hydrogen reaction no longer happening.</description>
       </entry>
-      <entry value="4096" name="GENERATOR_STATUS_FLAG_COMMUNICATION_ERROR">
+      <entry value="4096" name="GENERATOR_STATUS_FLAG_COMMUNICATION_WARNING">
         <description>Generator controller having communication problems.</description>
       </entry>
-      <entry value="8192" name="GENERATOR_STATUS_FLAG_COOLING_ERROR">
+      <entry value="8192" name="GENERATOR_STATUS_FLAG_COOLING_WARNING">
         <description>Power electronic or generator cooling system error.</description>
       </entry>
       <entry value="16384" name="GENERATOR_STATUS_FLAG_POWER_RAIL_FAULT">
@@ -6573,15 +6573,15 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Telemetry of power generation system. Alternator or mechanical generator.</description>
-      <field type="uint64_t" name="status" display="bitmask" enum="GENERATOR_STATUS_FLAG">Status message</field>
-      <field type="uint16_t" name="generator_speed" units="rpm">Speed of electrical generator or alternator. 0: field not provided.</field>
-      <field type="float" name="battery_current" units="A">Current into/out of battery. Positive for out. Negative for in. 0: field not provided.</field>
-      <field type="float" name="load_current" units="A">Current going to the UAV. If battery current not available this is the DC current from the generator. Positive for out. Negative for in.</field>
-      <field type="float" name="power_generated" units="W">The power being generated.</field>
-      <field type="float" name="bus_voltage" units="V">Voltage of the bus seen at the generator or battery bus if battery bus is controlled by generator and at a different voltage to main bus.</field>
-      <field type="int16_t" name="rectifier_temperature" units="degC">The temperature of the rectifier or power converter.</field>
-      <field type="float" name="bat_current_setpoint" units="A">The target battery current. Positive for out. Negative for in. -10000: field not provided</field>
-      <field type="int16_t" name="generator_temperature" units="degC">The temperature of the mechanical motor, fuel cell core or generator. UINT16_MAX: field not provided.</field>
+      <field type="uint64_t" name="status" display="bitmask" enum="GENERATOR_STATUS_FLAG">Status flags.</field>
+      <field type="uint16_t" name="generator_speed" units="rpm">Speed of electrical generator or alternator. UINT16_MAX: field not provided.</field>
+      <field type="float" name="battery_current" units="A">Current into/out of battery. Positive for out. Negative for in. NaN: field not provided.</field>
+      <field type="float" name="load_current" units="A">Current going to the UAV. If battery current not available this is the DC current from the generator. Positive for out. Negative for in. NaN: field not provided</field>
+      <field type="float" name="power_generated" units="W">The power being generated. NaN: field not provided</field>
+      <field type="float" name="bus_voltage" units="V">Voltage of the bus seen at the generator, or battery bus if battery bus is controlled by generator and at a different voltage to main bus.</field>
+      <field type="int16_t" name="rectifier_temperature" units="degC">The temperature of the rectifier or power converter. INT16_MAX: field not provided.</field>
+      <field type="float" name="bat_current_setpoint" units="A">The target battery current. Positive for out. Negative for in. NaN: field not provided</field>
+      <field type="int16_t" name="generator_temperature" units="degC">The temperature of the mechanical motor, fuel cell core or generator. INT16_MAX: field not provided.</field>
     </message>
     <message id="375" name="ACTUATOR_OUTPUT_STATUS">
       <description>The raw values of the actuator outputs (e.g. on Pixhawk, from MAIN, AUX ports). This message supersedes SERVO_OUTPUT_RAW.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6451,14 +6451,14 @@
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Telemetry of power generation system. Alternator or mechanical generator.</description>
       <field type="uint64_t" name="status">Status message</field>
-      <field type="uint16_t" name="generator_speed" units="rpm">Speed of electrical generator or alternator. Set to 0 if non rotating generator such as fuel cell.</field>
-      <field type="float" name="battery_current" units="A">Current into/out of battery. Positive for out. Negative for in.</field>
-      <field type="float" name="load_current" units="A">Current going to the UAV.</field>
+      <field type="uint16_t" name="generator_speed" units="rpm">Speed of electrical generator or alternator. 0: field not provided.</field>
+      <field type="float" name="battery_current" units="A">Current into/out of battery. Positive for out. Negative for in. 0: field not provided.</field>
+      <field type="float" name="load_current" units="A">Current going to the UAV. If battery current not available this is the DC current from the generator. Positive for out. Negative for in.</field>
       <field type="float" name="power_generated" units="W">The power being generated.</field>
       <field type="uint16_t" name="bus_voltage" units="mV">Voltage of the bus seen at the generator.</field>
       <field type="int16_t" name="rectifier_temperature" units="degC">The temperature of the rectifier or power converter.</field>
-      <field type="float" name="bat_current_setpoint" units="A">The target battery current. Positive for out. Negative for in.</field>
-      <field type="int16_t" name="generator_temperature" units="degC">The temperature of the mechanical motor, fuel cell core or generator.</field>
+      <field type="float" name="bat_current_setpoint" units="A">The target battery current. Positive for out. Negative for in. -10000: field not provided</field>
+      <field type="int16_t" name="generator_temperature" units="degC">The temperature of the mechanical motor, fuel cell core or generator. UINT16_MAX: field not provided.</field>
     </message>
     <message id="375" name="ACTUATOR_OUTPUT_STATUS">
       <description>The raw values of the actuator outputs (e.g. on Pixhawk, from MAIN, AUX ports). This message supersedes SERVO_OUTPUT_RAW.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3259,8 +3259,6 @@
     </enum>
     <enum name="GENERATOR_STATUS_FLAG" bitmask="true">
       <description>Flags to report status/failure case for a power generator (used in GENERATOR_STATUS).</description>
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <entry value="1" name="GENERATOR_STATUS_FLAG_OFF">
         <description>Generator is off.</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6512,7 +6512,7 @@
       <field type="float" name="battery_current" units="A">Current into/out of battery. Positive for out. Negative for in. 0: field not provided.</field>
       <field type="float" name="load_current" units="A">Current going to the UAV. If battery current not available this is the DC current from the generator. Positive for out. Negative for in.</field>
       <field type="float" name="power_generated" units="W">The power being generated.</field>
-      <field type="float" name="bus_voltage" units="V">Voltage of the bus seen at the generator.</field>
+      <field type="float" name="bus_voltage" units="V">Voltage of the bus seen at the generator or battery bus if battery bus is controlled by generator and at a different voltage to main bus.</field>
       <field type="int16_t" name="rectifier_temperature" units="degC">The temperature of the rectifier or power converter.</field>
       <field type="float" name="bat_current_setpoint" units="A">The target battery current. Positive for out. Negative for in. -10000: field not provided</field>
       <field type="int16_t" name="generator_temperature" units="degC">The temperature of the mechanical motor, fuel cell core or generator. UINT16_MAX: field not provided.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3257,6 +3257,65 @@
         <description>Under-temperature fault.</description>
       </entry>
     </enum>
+    <enum name="GENERATOR_STATUS_FLAG" bitmask="true">
+      <description>Flags to report status/failure case for a power generator (used in GENERATOR_STATUS).</description>
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <entry value="1" name="GENERATOR_STATUS_FLAG_OFF">
+        <description>Generator is off.</description>
+      </entry>
+      <entry value="2" name="GENERATOR_STATUS_FLAG_READY">
+        <description>Generator is ready to start generating power.</description>
+      </entry>
+      <entry value="4" name="GENERATOR_STATUS_FLAG_GENERATING">
+        <description>Generator is generating power.</description>
+      </entry>
+      <entry value="8" name="GENERATOR_STATUS_FLAG_CHARGING">
+        <description>Generator is charging the batteries (generating enough power to charge and provide the load).</description>
+      </entry>
+      <entry value="16" name="GENERATOR_STATUS_FLAG_REDUCED_POWER">
+        <description>Generator is providing the maximum output.</description>
+      </entry>
+      <entry value="32" name="GENERATOR_STATUS_FLAG_MAXPOWER">
+        <description>Generator is operating at a reduced maximum power.</description>
+      </entry>
+      <entry value="64" name="GENERATOR_STATUS_FLAG_OVERTEMP_WARNING">
+        <description>Generator is near the maximum operating temperature, cooling is insufficient (may be running at reduced power).</description>
+      </entry>
+      <entry value="128" name="GENERATOR_STATUS_FLAG_OVERTEMP_FAULT">
+        <description>Generator hit the maximum operating temperature and shutdown.</description>
+      </entry>
+      <entry value="256" name="GENERATOR_STATUS_FLAG_RECTIFIER_OVERTEMP_WARNING">
+        <description>Power electronics are near the maximum operating temperature, cooling is insufficient (may be running at reduced power).</description>
+      </entry>
+      <entry value="512" name="GENERATOR_STATUS_FLAG_RECTIFIER_OVERTEMP_WARNING">
+        <description>Power electronics hit the maximum operating temperature and shutdown.</description>
+      </entry>
+      <entry value="1024" name="GENERATOR_STATUS_FLAG_RECTIFIER_FAULT">
+        <description>Power electronics experienced an error.</description>
+      </entry>
+      <entry value="2048" name="GENERATOR_STATUS_FLAG_POWERSOURCE_FAULT">
+        <description>The power source providing the generator failed e.g. mechanical generator stopped, tether is no longer providing power, solar cell is in shade, hydrogen reaction no longer happening.</description>
+      </entry>
+      <entry value="4096" name="GENERATOR_STATUS_FLAG_COMMUNICATION_ERROR">
+        <description>Generator controller having communication problems.</description>
+      </entry>
+      <entry value="8192" name="GENERATOR_STATUS_FLAG_COOLING_ERROR">
+        <description>Power electronic or generator cooling system error.</description>
+      </entry>
+      <entry value="16384" name="GENERATOR_STATUS_FLAG_POWER_RAIL_FAULT">
+        <description>Generator controller power rail experienced a fault.</description>
+      </entry>
+      <entry value="32768" name="GENERATOR_STATUS_FLAG_OVERCURRENT_FAULT">
+        <description>Generator controller exceeded the overcurrent threshold and shutdown to prevent damage.</description>
+      </entry>
+      <entry value="65536" name="GENERATOR_STATUS_FLAG_BATTERY_OVERCHARGE_CURRENT_FAULT">
+        <description>Generator controller detected a high current going into the batteries and shutdown to prevent battery damage.</description>
+      </entry>
+      <entry value="131072" name="GENERATOR_STATUS_FLAG_OVERVOLTAGE_FAULT">
+        <description>Generator controller exceeded it's overvoltage threshold and shutdown to prevent it exceeding the voltage rating.</description>
+      </entry>
+    </enum>
     <enum name="MAV_VTOL_STATE">
       <description>Enumeration of VTOL states</description>
       <entry value="0" name="MAV_VTOL_STATE_UNDEFINED">
@@ -6450,12 +6509,12 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Telemetry of power generation system. Alternator or mechanical generator.</description>
-      <field type="uint64_t" name="status">Status message</field>
+      <field type="uint64_t" name="status" display="bitmask" enum="GENERATOR_STATUS_FLAG">Status message</field>
       <field type="uint16_t" name="generator_speed" units="rpm">Speed of electrical generator or alternator. 0: field not provided.</field>
       <field type="float" name="battery_current" units="A">Current into/out of battery. Positive for out. Negative for in. 0: field not provided.</field>
       <field type="float" name="load_current" units="A">Current going to the UAV. If battery current not available this is the DC current from the generator. Positive for out. Negative for in.</field>
       <field type="float" name="power_generated" units="W">The power being generated.</field>
-      <field type="uint16_t" name="bus_voltage" units="mV">Voltage of the bus seen at the generator.</field>
+      <field type="float" name="bus_voltage" units="V">Voltage of the bus seen at the generator.</field>
       <field type="int16_t" name="rectifier_temperature" units="degC">The temperature of the rectifier or power converter.</field>
       <field type="float" name="bat_current_setpoint" units="A">The target battery current. Positive for out. Negative for in. -10000: field not provided</field>
       <field type="int16_t" name="generator_temperature" units="degC">The temperature of the mechanical motor, fuel cell core or generator. UINT16_MAX: field not provided.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3314,7 +3314,7 @@
       </entry>
     </enum>
     <enum name="GENERATOR_STATUS_FLAG" bitmask="true">
-      <description>Flags to report status/failure case for a power generator (used in GENERATOR_STATUS).</description>
+      <description>Flags to report status/failure cases for a power generator (used in GENERATOR_STATUS). Note that FAULTS are conditions that cause the generator to fail. Warnings are conditions that require attention before the next use (they indicate the system is not operating properly).</description>
       <entry value="1" name="GENERATOR_STATUS_FLAG_OFF">
         <description>Generator is off.</description>
       </entry>
@@ -3346,7 +3346,7 @@
         <description>Power electronics hit the maximum operating temperature and shutdown.</description>
       </entry>
       <entry value="1024" name="GENERATOR_STATUS_FLAG_ELECTRONICS_FAULT">
-        <description>Power electronics experienced an fault and shutdown.</description>
+        <description>Power electronics experienced a fault and shutdown.</description>
       </entry>
       <entry value="2048" name="GENERATOR_STATUS_FLAG_POWERSOURCE_FAULT">
         <description>The power source supplying the generator failed e.g. mechanical generator stopped, tether is no longer providing power, solar cell is in shade, hydrogen reaction no longer happening.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6446,6 +6446,20 @@
       <field type="uint16_t" default="0" name="cell_offset">The cell number of the first index in the 'voltages' array field. Using this field allows you to specify cell voltages for batteries with more than 16 cells.</field>
       <field type="uint16_t[16]" name="voltages" units="mV">Individual cell voltages. Batteries with more 16 cells can use the cell_offset field to specify the cell offset for the array specified in the current message . Index values above the valid cell count for this battery should have the UINT16_MAX value.</field>
     </message>
+    <message id="373" name="GENERATOR_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Telemetry of power generation system. Alternator or mechanical generator.</description>
+      <field type="uint64_t" name="status">Status message</field>
+      <field type="uint16_t" name="generator_speed" units="rpm">Speed of electrical generator or alternator. Set to 0 if non rotating generator such as fuel cell.</field>
+      <field type="float" name="battery_current" units="A">Current into/out of battery. Positive for out. Negative for in.</field>
+      <field type="float" name="load_current" units="A">Current going to the UAV.</field>
+      <field type="float" name="power_generated" units="W">The power being generated.</field>
+      <field type="uint16_t" name="bus_voltage" units="mV">Voltage of the bus seen at the generator.</field>
+      <field type="int16_t" name="rectifier_temperature" units="degC">The temperature of the rectifier or power converter.</field>
+      <field type="float" name="bat_current_setpoint" units="A">The target battery current. Positive for out. Negative for in.</field>
+      <field type="int16_t" name="generator_temperature" units="degC">The temperature of the mechanical motor, fuel cell core or generator.</field>
+    </message>
     <message id="375" name="ACTUATOR_OUTPUT_STATUS">
       <description>The raw values of the actuator outputs (e.g. on Pixhawk, from MAIN, AUX ports). This message supersedes SERVO_OUTPUT_RAW.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (since system boot).</field>


### PR DESCRIPTION
I want to add a message for doing telemetry messages used for on board electrical generators such as alternators, generators, fuel cells, solar cells.

I tagged it WIP for now, not sure if this is the right thing to do.