### PR TITLE
Add MAV_MISSION_TOO_MANY_ITEMS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2826,6 +2826,9 @@
       <entry value="15" name="MAV_MISSION_OPERATION_CANCELLED">
         <description>Current mission operation cancelled (e.g. mission upload, mission download).</description>
       </entry>
+      <entry value="16" name="MAV_MISSION_TOO_MANY_ITEMS">
+        <description>Mission has too many items for recipient. Upload cancelled.</description>
+      </entry>
     </enum>
     <enum name="MAV_SEVERITY">
       <description>Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.</description>


### PR DESCRIPTION
@DonLakeFlyer This fixes #822, making it possible for an autopilot to report if the mission has too many items - such that the stored mission might not match the uploaded mission. What you wanted?

@auturgy FYI, this should be good for ArduPilot, which I understand may just overwrite the last item if it runs out of space.