### PR TITLE
Remove MAV_MISSION_TOO_MANY_ITEMS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2801,7 +2801,7 @@
         <description>Command is not supported.</description>
       </entry>
       <entry value="4" name="MAV_MISSION_NO_SPACE">
-        <description>Mission item exceeds storage space.</description>
+        <description>Mission items exceed storage space.</description>
       </entry>
       <entry value="5" name="MAV_MISSION_INVALID">
         <description>One of the parameters has an invalid value.</description>
@@ -2835,9 +2835,6 @@
       </entry>
       <entry value="15" name="MAV_MISSION_OPERATION_CANCELLED">
         <description>Current mission operation cancelled (e.g. mission upload, mission download).</description>
-      </entry>
-      <entry value="16" name="MAV_MISSION_TOO_MANY_ITEMS">
-        <description>Mission has too many items for recipient. Upload cancelled.</description>
       </entry>
     </enum>
     <enum name="MAV_SEVERITY">


### PR DESCRIPTION
This was just added, but appears to duplicate the purpose of MAV_MISSION_NO_SPACE. Removing. Can re-add if justification provided