### PR TITLE
fix MAV_CMD_INJECT_FAILURE attribute

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2045,9 +2045,9 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Inject artificial failure for testing purposes. Note that autopilots should implement an additional protection before accepting this command such as a specific param setting.</description>
-        <param index="1" name="Failure unit" enum="FAILURE_UNIT">The unit which is affected by the failure.</param>
-        <param index="2" name="Failure type" enum="FAILURE_TYPE">The type how the failure manifests itself.</param>
-        <param index="3" name="Instance">Instance affected by failure (0 to signal all).</param>
+        <param index="1" label="Failure unit" enum="FAILURE_UNIT">The unit which is affected by the failure.</param>
+        <param index="2" label="Failure type" enum="FAILURE_TYPE">The type how the failure manifests itself.</param>
+        <param index="3" label="Instance">Instance affected by failure (0 to signal all).</param>
       </entry>
       <entry value="500" name="MAV_CMD_START_RX_PAIR" hasLocation="false" isDestination="false">
         <description>Starts receiver pairing.</description>


### PR DESCRIPTION
name is not valid attribute for parameter, label is
That fails the validator