### PR TITLE
Set and Get WiFi configuration, adding new fields and enums in the pr…

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1246,6 +1246,33 @@
         <description>Yaw controlled by RC input.</description>
       </entry>
     </enum>
+    <enum name="WIFI_CONFIG_AP_RESPONSE">
+      <description>Possible responses from a WIFI_CONFIG_AP message.</description>
+      <entry value="0" name="WIFI_CONFIG_AP_RESPONSE_ACCEPTED">
+        <description>Changes accepted.</description>
+      </entry>
+      <entry value="1" name="WIFI_CONFIG_AP_RESPONSE_REJECTED">
+        <description>Changes rejected.</description>
+      </entry>
+      <entry value="2" name="WIFI_CONFIG_AP_RESPONSE_MODE_ERROR">
+        <description>Invalid Mode.</description>
+      </entry>
+      <entry value="3" name="WIFI_CONFIG_AP_RESPONSE_SSID_ERROR">
+        <description>Invalid SSID.</description>
+      </entry>
+      <entry value="4" name="WIFI_CONFIG_AP_RESPONSE_PASSWORD_ERROR">
+        <description>Invalid Password.</description>
+      </entry>
+    </enum>
+    <enum name="WIFI_CONFIG_AP_MODE">
+      <description>WiFi Mode.</description>
+      <entry value="0" name="WIFI_CONFIG_AP_MODE_AP">
+        <description>WiFi configured as an access point.</description>
+      </entry>
+      <entry value="1" name="WIFI_CONFIG_AP_MODE_STATION">
+        <description>WiFi configured as a station connected to an existing local WiFi network.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM and MISSION_ITEM_INT messages) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -2279,6 +2306,16 @@
       <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY" hasLocation="false" isDestination="false">
         <description>Request to start/stop transmitting over the high latency telemetry</description>
         <param index="1" label="Enable" minValue="0" maxValue="1" increment="1">Control transmission over high latency telemetry (0: stop, 1: start)</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="2620" name="MAV_CMD_REQUEST_WIFI_CONFIG" hasLocation="false" isDestination="false">
+        <description>Request WiFi configuration (WIFI_CONFIG_AP)</description>
+        <param index="1">Empty</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -6200,6 +6237,9 @@
       <description>Configure AP SSID and Password.</description>
       <field type="char[32]" name="ssid">Name of Wi-Fi network (SSID). Leave it blank to leave it unchanged.</field>
       <field type="char[64]" name="password">Password. Leave it blank for an open AP.</field>
+      <extensions/>
+      <field type="int8_t" name="mode" enum="WIFI_CONFIG_AP_MODE">WiFi Mode.</field>
+      <field type="int8_t" name="response" enum="WIFI_CONFIG_AP_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="300" name="PROTOCOL_VERSION">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1250,28 +1250,34 @@
     </enum>
     <enum name="WIFI_CONFIG_AP_RESPONSE">
       <description>Possible responses from a WIFI_CONFIG_AP message.</description>
-      <entry value="0" name="WIFI_CONFIG_AP_RESPONSE_ACCEPTED">
+      <entry value="0" name="WIFI_CONFIG_AP_RESPONSE_UNDEFINED">
+        <description>Undefined response. Likely an indicative of a system that doesn't support this request.</description>
+      </entry>
+      <entry value="1" name="WIFI_CONFIG_AP_RESPONSE_ACCEPTED">
         <description>Changes accepted.</description>
       </entry>
-      <entry value="1" name="WIFI_CONFIG_AP_RESPONSE_REJECTED">
+      <entry value="2" name="WIFI_CONFIG_AP_RESPONSE_REJECTED">
         <description>Changes rejected.</description>
       </entry>
-      <entry value="2" name="WIFI_CONFIG_AP_RESPONSE_MODE_ERROR">
+      <entry value="3" name="WIFI_CONFIG_AP_RESPONSE_MODE_ERROR">
         <description>Invalid Mode.</description>
       </entry>
-      <entry value="3" name="WIFI_CONFIG_AP_RESPONSE_SSID_ERROR">
+      <entry value="4" name="WIFI_CONFIG_AP_RESPONSE_SSID_ERROR">
         <description>Invalid SSID.</description>
       </entry>
-      <entry value="4" name="WIFI_CONFIG_AP_RESPONSE_PASSWORD_ERROR">
+      <entry value="5" name="WIFI_CONFIG_AP_RESPONSE_PASSWORD_ERROR">
         <description>Invalid Password.</description>
       </entry>
     </enum>
     <enum name="WIFI_CONFIG_AP_MODE">
       <description>WiFi Mode.</description>
-      <entry value="0" name="WIFI_CONFIG_AP_MODE_AP">
+      <entry value="0" name="WIFI_CONFIG_AP_MODE_UNDEFINED">
+        <description>WiFi mode is undefined.</description>
+      </entry>
+      <entry value="1" name="WIFI_CONFIG_AP_MODE_AP">
         <description>WiFi configured as an access point.</description>
       </entry>
-      <entry value="1" name="WIFI_CONFIG_AP_MODE_STATION">
+      <entry value="2" name="WIFI_CONFIG_AP_MODE_STATION">
         <description>WiFi configured as a station connected to an existing local WiFi network.</description>
       </entry>
     </enum>
@@ -2331,16 +2337,6 @@
       <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY" hasLocation="false" isDestination="false">
         <description>Request to start/stop transmitting over the high latency telemetry</description>
         <param index="1" label="Enable" minValue="0" maxValue="1" increment="1">Control transmission over high latency telemetry (0: stop, 1: start)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
-      <entry value="2620" name="MAV_CMD_REQUEST_WIFI_CONFIG" hasLocation="false" isDestination="false">
-        <description>Request WiFi configuration (WIFI_CONFIG_AP)</description>
-        <param index="1">Empty</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
@@ -6260,8 +6256,8 @@
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>
-      <field type="char[32]" name="ssid">Name of Wi-Fi network (SSID). Leave it blank to leave it unchanged.</field>
-      <field type="char[64]" name="password">Password. Leave it blank for an open AP.</field>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network (SSID). Blank to leave it unchanged when setting. Current SSID when sent back as a response.</field>
+      <field type="char[64]" name="password">Password. Blank for an open AP. MD5 hash when message is sent back as a response.</field>
       <extensions/>
       <field type="int8_t" name="mode" enum="WIFI_CONFIG_AP_MODE">WiFi Mode.</field>
       <field type="int8_t" name="response" enum="WIFI_CONFIG_AP_RESPONSE">Message acceptance response (sent back to GS).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6255,7 +6255,7 @@
       <field type="float" name="feed_forward_angular_velocity_z" units="rad/s">Feed forward Z component of angular velocity, positive is yawing to the right, NaN to be ignored. This is to indicate if the autopilot is actively yawing.</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
-      <description>Configure AP SSID and Password.</description>
+      <description>Configure WiFi AP SSID, password, and mode. This message is re-emitted as an acknowledgement by the AP. The message may also be explicitly requested using MAV_CMD_REQUEST_MESSAGE</description>
       <field type="char[32]" name="ssid">Name of Wi-Fi network (SSID). Blank to leave it unchanged when setting. Current SSID when sent back as a response.</field>
       <field type="char[64]" name="password">Password. Blank for an open AP. MD5 hash when message is sent back as a response.</field>
       <extensions/>


### PR DESCRIPTION
As discussed in dev call

@dogmaphobic Dev call discussed this and created PR. 

Main points:
- Need to make sure that extensions default to 0 for zero truncation. Also that if this is sent by a system that does not know about the fields, this will set the modes to the values  you have specified - is that appropriate? Normally you'd have a 0 value which says - don't change the mode or whatever.
- The interaction is that you can send MAV_CMD_REQUEST_WIFI_CONFIG to get the WIFI_CONFIG_AP:
  - Should it send back the password? If you do this then anyone who sends the message gets whatever the person set, which might be their phone number or whatever. Perhaps if emitting this message it should leave password empty or a hash?
  - Use MAV_CMD_REQUEST_MESSAGE and id for WIFI_CONFIG_AP - ie delete MAV_CMD_REQUEST_WIFI_CONFIG 
- Similarly, Jonas seemed to think that WIFI_CONFIG_AP being received should result in it being emitted again (as an acknowledgement)
  - If this is the case, it should be documented
  - Again, the password should not really be emitted ?
  - This is a broadcast message so will be processed by everyone. SHould it be? I guess only a wifi can act on it - everything else will just ignore, and that you'll only have one Wifi set up in a MAVLink network?