### PR TITLE
MAV_CMD_REQUEST_MESSAGE: param 2 is multi-use too

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2067,7 +2067,7 @@
       <entry value="512" name="MAV_CMD_REQUEST_MESSAGE" hasLocation="false" isDestination="false">
         <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).</description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID of the requested message.</param>
-        <param index="2" label="Index ID" minValue="0" increment="1">Index id (if appropriate). The use of this parameter (if any), must be defined in the requested message.</param>
+        <param index="2">Use for index ID, if required. Otherwise, the use of this parameter (if any) must be defined in the requested message. By default assumed not used (0).</param>
         <param index="3">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
         <param index="4">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
         <param index="5">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -619,6 +619,11 @@
         <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).</description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID of the requested message.</param>
         <param index="2" label="Index ID" minValue="0" increment="1">Index id (if appropriate). The use of this parameter (if any), must be defined in the requested message.</param>
+        <param index="3">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="4">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="5">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="6">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address for requested message (if message has target address fields). 0: Flight-stack default, 1: address of requestor, 2: broadcast.</param>
       </entry>
       <entry value="519" name="MAV_CMD_REQUEST_PROTOCOL_VERSION" hasLocation="false" isDestination="false">
         <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>


### PR DESCRIPTION
Old verions, param 2 was "hard coded" to use for index. This change it to be a "hint" that it should be used for index, but can be used for anything.
This breaks nothing, and allows more natural use of param2