### PR TITLE
TAKEOFF - clarify behaviour on VTOL

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1348,7 +1348,7 @@
         <param index="7" label="Altitude" units="m">Landing altitude (ground level in current frame).</param>
       </entry>
       <entry value="22" name="MAV_CMD_NAV_TAKEOFF" hasLocation="true" isDestination="true">
-        <description>Takeoff from ground / hand</description>
+        <description>Takeoff from ground / hand. Vehicles that support multiple takeoff modes (e.g. VTOL quadplane) should take off using the currently configured mode.</description>
         <param index="1" label="Pitch">Minimum pitch (if airspeed sensor present), desired pitch without sensor</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>


### PR DESCRIPTION
This clarifies that if a vehicle supports multiple modes (e.g. like a VTOL quadplane) then the takeoff command should do so in the current mode. The alternative is that it should switch to the VTOL/multicopter mode everyt time before takeoff. This behaviour is I believe the "standard" for both ArduPilot and PX4.

We should similarly define how  vehicles should behave for MAV_CMD_NAV_VTOL_TAKEOFF. We could define as:
- should only be used on vehicles that support both vtol and fixed wing flight.
- can be used on any vtol vehicle, but ignore transition heading parameter.
- can be used on any vehicle but ignore irrelevant parameters (heading and yaw). 

Note, the specific behaviour we choose not as important as consistent experience for GCS users.

Thoughts? @auturgy @julianoes ?
