### PR TITLE
Remove deprecation/rename of MAV_FRAME_BODY_FRD

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -879,9 +879,8 @@
       <entry value="11" name="MAV_FRAME_GLOBAL_TERRAIN_ALT_INT">
         <description>Global (WGS84) coordinate frame (scaled) with AGL altitude (at the waypoint coordinate). First value / x: latitude in degrees*10e-7, second value / y: longitude in degrees*10e-7, third value / z: positive altitude in meters with 0 being at ground level in terrain model.</description>
       </entry>
-      <entry value="12" name="MAV_FRAME_RESERVED_12">
-        <deprecated since="2019-04" replaced_by="MAV_FRAME_BODY_OFFSET_NED"/>
-        <description>MAV_FRAME_BODY_FRD - Body fixed frame of reference, Z-down (x: Forward, y: Right, z: Down).</description>
+      <entry value="12" name="MAV_FRAME_BODY_FRD">
+        <description>Body fixed frame of reference, Z-down (x: Forward, y: Right, z: Down).</description>
       </entry>
       <entry value="13" name="MAV_FRAME_RESERVED_13">
         <deprecated since="2019-04" replaced_by=""/>


### PR DESCRIPTION
This undos the deprecation and rename of MAV_FRAME_BODY_FRD in #1112, for the reasons given in the comment: https://github.com/mavlink/mavlink/pull/1112#issuecomment-625050092. 

Essentially this is still needed and should not have been marked deprecated. I am self merging to get this in.

@FYI @kamilritz @julianoes 