### PR TITLE
common: HIL_GPS: extend with an ID field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5443,7 +5443,7 @@
       <field type="uint16_t" name="cog" units="cdeg">Course over ground (NOT heading, but direction of movement), 0.0..359.99 degrees. If unknown, set to: 65535</field>
       <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
       <extensions/>
-      <field type="uint8_t" name="id">ID of the GPS. Used for multiple GPS inputs</field>
+      <field type="uint8_t" name="id">GPS ID (zero indexed). Used for multiple GPS inputs</field>
     </message>
     <message id="114" name="HIL_OPTICAL_FLOW">
       <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5442,6 +5442,8 @@
       <field type="int16_t" name="vd" units="cm/s">GPS velocity in down direction in earth-fixed NED frame</field>
       <field type="uint16_t" name="cog" units="cdeg">Course over ground (NOT heading, but direction of movement), 0.0..359.99 degrees. If unknown, set to: 65535</field>
       <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
+      <extensions/>
+      <field type="uint8_t" name="id">ID of the GPS. Used for multiple GPS inputs</field>
     </message>
     <message id="114" name="HIL_OPTICAL_FLOW">
       <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>


### PR DESCRIPTION
If one wants to simulate multiple GPS inputs from simulation, and using the same messaging structure, i.e., `HIL_GPS` messages, we need a field that identifies the sensor source so it can be properly handled and logged in the autopilot side.

An alternative could be use `GPS_INPUT` instead of `HIL_GPS`, but then we would be using messages which purpose is not really to be used as simulation in/outputs. 