### PR TITLE
Add additional WIFI_CONFIG_AP_MODE that allows to disable WiFi

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1279,6 +1279,9 @@
       <entry value="2" name="WIFI_CONFIG_AP_MODE_STATION">
         <description>WiFi configured as a station connected to an existing local WiFi network.</description>
       </entry>
+      <entry value="3" name="WIFI_CONFIG_AP_MODE_DISABLED">
+        <description>WiFi disabled.</description>
+      </entry>
     </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM and MISSION_ITEM_INT messages) -->


### PR DESCRIPTION
This change is a follow up on PR: https://github.com/mavlink/mavlink/pull/1362

The change adds an additional mode `WIFI_CONFIG_AP_MODE_DISABLED` to the WiFi Mode enum `WIFI_CONFIG_AP_MODE`.