### PR TITLE
COMPONENT_INFORMATION: add actual_compid field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6677,6 +6677,7 @@
       <field type="uint32_t" name="capability_flags" enum="COMPONENT_CAP_FLAGS">Bitmap of component capability flags.</field>
       <field type="uint16_t" name="component_definition_version">Component definition version (iteration)</field>
       <field type="char[140]" name="component_definition_uri">Component definition URI (if any, otherwise only basic functions will be available). The XML format is not yet specified and work in progress. </field>
+      <field type="uint8_t" name="actual_compid">ID of the component this message is about. Used if not the same as component ID of message sender. 0 if not used.</field>
     </message>
     <message id="400" name="PLAY_TUNE_V2">
       <wip/>


### PR DESCRIPTION
As discussed in https://px4.slack.com/archives/C52DXKYLV/p1591641605371800

This is useful to communicate component information for components that do not have their own mavlink interface. For example, a GPS device connected to a flight controller.

@julianoes I made it part of the message since it's still marked WIP, but I can make it an extension if you prefer.