### PR TITLE
Correct description in ESTIMATOR_STATUS_FLAGS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3486,7 +3486,7 @@
     </enum>
     <!-- ESTIMATOR_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
     <enum name="ESTIMATOR_STATUS_FLAGS" bitmask="true">
-      <description>Flags in EKF_STATUS message</description>
+      <description>Flags in ESTIMATOR_STATUS message</description>
       <entry value="1" name="ESTIMATOR_ATTITUDE">
         <description>True if the attitude estimate is good</description>
       </entry>


### PR DESCRIPTION
It seems to me that there is no EKF_STATUS message anymore, but that it has been replaced with  ESTIMATOR_STATUS. So the description in ESTIMATOR_STATUS_FLAGS would be wrong.

Pl double check if I'm not just running wild. :)