### PR TITLE
Add COMMAND_CANCEL - message to cancel long running commands

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5178,7 +5178,7 @@
       <field type="uint8_t" name="target_system">WIP: System which requested the command to be executed</field>
       <field type="uint8_t" name="target_component">WIP: Component which requested the command to be executed</field>
     </message>
-    <message id="78" name="COMMAND_CANCEL">
+    <message id="80" name="COMMAND_CANCEL">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Cancel a long running command. The target system should respond with a COMMAND_ACK to the original command with result=MAV_RESULT_CANCELLED if the long running process was cancelled. If it has already completed, the cancel action can be ignored. The cancel action can be retried until some sort of acknowledgement to the original command has been received. The command microservice is documented at https://mavlink.io/en/services/command.html</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5116,7 +5116,9 @@
       <field type="uint8_t" name="target_component">WIP: Component which requested the command to be executed</field>
     </message>
     <message id="78" name="COMMAND_CANCEL">
-      <description>Cancel a long running command. The target system should respond with a COMMAND_ACK to original command with result=MAV_RESULT_CANCELLED if the long running process was cancelled. If it has already completed, the cancel action can be ignored. The cancel action can be retried until some sort of acknowledgement to the original command has been received. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Cancel a long running command. The target system should respond with a COMMAND_ACK to the original command with result=MAV_RESULT_CANCELLED if the long running process was cancelled. If it has already completed, the cancel action can be ignored. The cancel action can be retried until some sort of acknowledgement to the original command has been received. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
       <field type="uint8_t" name="target_system">System executing long running command. Should not be broadcast (0).</field>
       <field type="uint8_t" name="target_component">Component executing long running command.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">Command ID (of command to cancel).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2850,7 +2850,7 @@
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
         <description>Command is valid and is being executed. This will be followed by further progress updates, i.e. the component may send further COMMAND_ACK messages with result MAV_RESULT_IN_PROGRESS (at a rate decided by the implementation), and must terminate by sending a COMMAND_ACK message with final result of the operation. The COMMAND_ACK.progress field can be used to indicate the progress of the operation.</description>
       </entry>
-      <entry value="5" name="MAV_RESULT_CANCELLED">
+      <entry value="6" name="MAV_RESULT_CANCELLED">
         <description>Command has been cancelled (as a result of receiving a COMMAND_CANCEL message).</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5116,7 +5116,7 @@
       <field type="uint8_t" name="target_component">WIP: Component which requested the command to be executed</field>
     </message>
     <message id="78" name="COMMAND_CANCEL">
-      <description>Cancel a long running command. The target system should respond with a COMMAND_ACK to original command with result=MAV_RESULT_CANCELLED (whether or not an operation is running). Cancelling must always succeed. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
+      <description>Cancel a long running command. The target system should respond with a COMMAND_ACK to original command with result=MAV_RESULT_CANCELLED (whether or not an operation is running). The command should retry if no MAV_RESULT_CANCELLED acknowledgement is recieved. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
       <field type="uint8_t" name="target_system">System executing long running command. Should not be broadcast (0).</field>
       <field type="uint8_t" name="target_component">Component executing long running command.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">Command ID (of command to cancel).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5116,7 +5116,7 @@
       <field type="uint8_t" name="target_component">WIP: Component which requested the command to be executed</field>
     </message>
     <message id="78" name="COMMAND_CANCEL">
-      <description>Cancel a long running command. The target system should respond with a COMMAND_ACK to original command with result=MAV_RESULT_CANCELLED (whether or not an operation is running). The command should retry if no MAV_RESULT_CANCELLED acknowledgement is recieved. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
+      <description>Cancel a long running command. The target system should respond with a COMMAND_ACK to original command with result=MAV_RESULT_CANCELLED if the long running process was cancelled. If it has already completed, the cancel action can be ignored. The cancel action can be retried until some sort of acknowledgement to the original command has been received. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
       <field type="uint8_t" name="target_system">System executing long running command. Should not be broadcast (0).</field>
       <field type="uint8_t" name="target_component">Component executing long running command.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">Command ID (of command to cancel).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5115,6 +5115,12 @@
       <field type="uint8_t" name="target_system">WIP: System which requested the command to be executed</field>
       <field type="uint8_t" name="target_component">WIP: Component which requested the command to be executed</field>
     </message>
+    <message id="78" name="COMMAND_CANCEL">
+      <description>Cancel a long running command. The target system should respond with a COMMAND_ACK to original command with result=MAV_RESULT_CANCELLED (whether or not an operation is running). Cancelling must always succeed. The command microservice is documented at https://mavlink.io/en/services/command.html</description>
+      <field type="uint8_t" name="target_system">System executing long running command. Should not be broadcast (0).</field>
+      <field type="uint8_t" name="target_component">Component executing long running command.</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">Command ID (of command to cancel).</field>
+    </message>
     <message id="81" name="MANUAL_SETPOINT">
       <description>Setpoint in roll, pitch, yaw and thrust from the operator</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2848,7 +2848,10 @@
         <description>Command is valid, but execution has failed. This is used to indicate any non-temporary or unexpected problem, i.e. any problem that must be fixed before the command can succeed/be retried. For example, attempting to write a file when out of memory, attempting to arm when sensors are not calibrated, etc.</description>
       </entry>
       <entry value="5" name="MAV_RESULT_IN_PROGRESS">
-        <description>Command is valid and is being executed. This will be followed by further progress updates, i.e. the component may send further COMMAND_ACK messages with result MAV_RESULT_IN_PROGRESS (at a rate decided by the implementation), and must terminate by sending a COMMAND_ACK message with final result of the operation. The COMMAND_ACK.progress field can be used to indicate the progress of the operation. There is no need for the sender to retry the command, but if done during execution, the component will return MAV_RESULT_IN_PROGRESS with an updated progress.</description>
+        <description>Command is valid and is being executed. This will be followed by further progress updates, i.e. the component may send further COMMAND_ACK messages with result MAV_RESULT_IN_PROGRESS (at a rate decided by the implementation), and must terminate by sending a COMMAND_ACK message with final result of the operation. The COMMAND_ACK.progress field can be used to indicate the progress of the operation.</description>
+      </entry>
+      <entry value="5" name="MAV_RESULT_CANCELLED">
+        <description>Command has been cancelled (as a result of receiving a COMMAND_CANCEL message).</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">


### PR DESCRIPTION
@julianoes @auturgy This adds message to cancel a long running command, as suggested by @LorenzMeier 

The message just takes a target sysid and compid, and the command being cancelled (not strictly needed if concurrency not supported, but a good check to make).

I don't have to implement this, so important you check the logic.

Essentially the sequence continues with progress updates until it completes - with one of acceptance, failure or cancellation. If the cancel message was sent, received and obeyed the flow would look like this.

[![](https://mermaid.ink/img/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgR0NTLT4-RHJvbmU6IENPTU1BTkRfTE9ORygpXG4gICAgR0NTLT4-R0NTOiBTdGFydCB0aW1lb3V0XG4gICAgRHJvbmUtPj5HQ1M6IENPTU1BTkRfQUNLKHJlc3VsdD1NQVZfUkVTVUxUX0lOX1BST0dSRVNTLHByb2dyZXNzPT8pXG4gICAgR0NTLT4-R0NTOiBTdGFydCAobG9uZ2VyKSB0aW1lb3V0XG4gICAgTm90ZSByaWdodCBvZiBHQ1M6IC4uLiBtb3JlIHVwZGF0ZXNcbiAgICBHQ1MtPj5Ecm9uZTogQ09NTUFORF9DQU5DRUwoY29tbWFuZClcbiAgICAgICAgR0NTLT4-R0NTOiBTdGFydCB0aW1lb3V0XG4gICAgRHJvbmUtPj5HQ1M6IENPTU1BTkRfQUNLKHJlc3VsdD1NQVZfUkVTVUxUX0NBTkNFTExFRCkiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgR0NTLT4-RHJvbmU6IENPTU1BTkRfTE9ORygpXG4gICAgR0NTLT4-R0NTOiBTdGFydCB0aW1lb3V0XG4gICAgRHJvbmUtPj5HQ1M6IENPTU1BTkRfQUNLKHJlc3VsdD1NQVZfUkVTVUxUX0lOX1BST0dSRVNTLHByb2dyZXNzPT8pXG4gICAgR0NTLT4-R0NTOiBTdGFydCAobG9uZ2VyKSB0aW1lb3V0XG4gICAgTm90ZSByaWdodCBvZiBHQ1M6IC4uLiBtb3JlIHVwZGF0ZXNcbiAgICBHQ1MtPj5Ecm9uZTogQ09NTUFORF9DQU5DRUwoY29tbWFuZClcbiAgICAgICAgR0NTLT4-R0NTOiBTdGFydCB0aW1lb3V0XG4gICAgRHJvbmUtPj5HQ1M6IENPTU1BTkRfQUNLKHJlc3VsdD1NQVZfUkVTVUxUX0NBTkNFTExFRCkiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)

If no cancellation or other completion ACK is received, the cancel request can be retried
[![](https://mermaid.ink/img/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgR0NTLT4-RHJvbmU6IENPTU1BTkRfTE9ORygpXG4gICAgR0NTLT4-R0NTOiBTdGFydCB0aW1lb3V0XG4gICAgRHJvbmUtPj5HQ1M6IENPTU1BTkRfQUNLKHJlc3VsdD1NQVZfUkVTVUxUX0lOX1BST0dSRVNTLHByb2dyZXNzPT8pXG4gICAgR0NTLT4-R0NTOiBTdGFydCAobG9uZ2VyKSB0aW1lb3V0XG4gICAgTm90ZSByaWdodCBvZiBHQ1M6IC4uLiBtb3JlIHVwZGF0ZXNcbiAgICBHQ1MtPj5Ecm9uZTogQ09NTUFORF9DQU5DRUwoY29tbWFuZClcbiAgICBHQ1MtPj5HQ1M6IFN0YXJ0IHRpbWVvdXRcbiAgICBEcm9uZS0-PkdDUzogQ09NTUFORF9BQ0socmVzdWx0PU1BVl9SRVNVTFRfSU5fUFJPR1JFU1Mgb3IgTUFWX1JFU1VMVF9BQ0NFUFRFRClcbiAgICBHQ1MtPj5Ecm9uZTogQ09NTUFORF9DQU5DRUwoY29tbWFuZClcbiAgICBHQ1MtPj5HQ1M6IFN0YXJ0IHRpbWVvdXRcbiAgICBEcm9uZS0-PkdDUzogQ09NTUFORF9BQ0socmVzdWx0PU1BVl9SRVNVTFRfSU5fQ0FOQ0VMTEVEKSIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgR0NTLT4-RHJvbmU6IENPTU1BTkRfTE9ORygpXG4gICAgR0NTLT4-R0NTOiBTdGFydCB0aW1lb3V0XG4gICAgRHJvbmUtPj5HQ1M6IENPTU1BTkRfQUNLKHJlc3VsdD1NQVZfUkVTVUxUX0lOX1BST0dSRVNTLHByb2dyZXNzPT8pXG4gICAgR0NTLT4-R0NTOiBTdGFydCAobG9uZ2VyKSB0aW1lb3V0XG4gICAgTm90ZSByaWdodCBvZiBHQ1M6IC4uLiBtb3JlIHVwZGF0ZXNcbiAgICBHQ1MtPj5Ecm9uZTogQ09NTUFORF9DQU5DRUwoY29tbWFuZClcbiAgICBHQ1MtPj5HQ1M6IFN0YXJ0IHRpbWVvdXRcbiAgICBEcm9uZS0-PkdDUzogQ09NTUFORF9BQ0socmVzdWx0PU1BVl9SRVNVTFRfSU5fUFJPR1JFU1Mgb3IgTUFWX1JFU1VMVF9BQ0NFUFRFRClcbiAgICBHQ1MtPj5Ecm9uZTogQ09NTUFORF9DQU5DRUwoY29tbWFuZClcbiAgICBHQ1MtPj5HQ1M6IFN0YXJ0IHRpbWVvdXRcbiAgICBEcm9uZS0-PkdDUzogQ09NTUFORF9BQ0socmVzdWx0PU1BVl9SRVNVTFRfSU5fQ0FOQ0VMTEVEKSIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9)

If the operation has completed, the cancel message can be ignored. 

Does this make sense?

- [ ] Do we need a capability bit to indicate cancellation is supported? I guess "yes" because we can't assume handlers just check for "not in progress" to decide the sequence is done. Wish we had microservices.