### PR TITLE
common: distance_sensor: add signal_quality field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5676,6 +5676,7 @@
       <field type="float" name="horizontal_fov" units="rad">Horizontal Field of View (angle) where the distance measurement is valid and the field of view is known. Otherwise this is set to 0.</field>
       <field type="float" name="vertical_fov" units="rad">Vertical Field of View (angle) where the distance measurement is valid and the field of view is known. Otherwise this is set to 0.</field>
       <field type="float[4]" name="quaternion">Quaternion of the sensor orientation in vehicle body frame (w, x, y, z order, zero-rotation is 1, 0, 0, 0). Zero-rotation is along the vehicle body x-axis. This field is required if the orientation is set to MAV_SENSOR_ROTATION_CUSTOM. Set it to 0 if invalid."</field>
+      <field type="uint8_t" name="signal_quality" units="%">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. 0 = unknown/unset signal quality, 1 = invalid signal, 100 = perfect signal.</field>
     </message>
     <message id="133" name="TERRAIN_REQUEST">
       <description>Request for terrain data and terrain status</description>


### PR DESCRIPTION
Adds a relevant field to the `distance_sensor` message, representing the quality of the sensor signal. If the sensor is external to the flight controller, meaning, not a device connected to the flight controller board and having the reading processed in a driver, but instead connected to a companion computer, even more relevant it becomes to have a way of sending this data, considering we are to process the raw data in the flight controller side. The inverse direction stream, meaning from the flight controller to a ground station for example, is also relevant for sensor debugging. For the simulated sensors, which data is being streamed using MAVLink, this is also a relevant field.

Solves https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_receiver.cpp#L719.