### PR TITLE
Add auxiliary actuator commands

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1304,27 +1304,6 @@
         <description>Parameter meta data.</description>
       </entry>
     </enum>
-    <enum name="ACTUATOR_CYCLE_INTERPOLATION">
-      <description>Type of interpolation to use when cycling actuator values using MAV_CMD_DO_CYCLE_ACTUATOR</description>
-      <entry value="0" name="ACTUATOR_CYCLE_INTERPOLATION_CONSTANT">
-        <description>Toggles between the two cycle values, no interpolation done.</description>
-      </entry>
-      <entry value="1" name="ACTUATOR_CYCLE_INTERPOLATION_LINEAR">
-        <description>Linear interpolation between the two cycle values.</description>
-      </entry>
-      <entry value="2" name="ACTUATOR_CYCLE_INTERPOLATION_QUADRATIC">
-        <description>Interpolates between the two cycle value with a quadratic curve.</description>
-      </entry>
-      <entry value="3" name="ACTUATOR_CYCLE_INTERPOLATION_CUBIC">
-        <description>Interpolates between the two cycle value with a cubic curve.</description>
-      </entry>
-      <entry value="4" name="ACTUATOR_CYCLE_INTERPOLATION_QUARTIC">
-        <description>Interpolates between the two cycle value with a quartic curve.</description>
-      </entry>
-      <entry value="5" name="ACTUATOR_CYCLE_INTERPOLATION_SINUSOIDAL">
-        <description>Interpolates between the two cycle value with a sinusoidal curve.</description>
-      </entry>
-    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -1747,15 +1726,6 @@
         <param index="5" label="Actuator 5" minValue="-1" maxValue="1">Actuator 5 value, scaled from [-1 to 1]. NaN to ignore.</param>
         <param index="6" label="Actuator 6" minValue="-1" maxValue="1">Actuator 6 value, scaled from [-1 to 1]. NaN to ignore.</param>
         <param index="7" label="Index" minValue="0" increment="1">Index of actuator set (i.e if set to 1, Actuator 1 becomes Actuator 7)</param>
-      </entry>
-      <entry value="188" name="MAV_CMD_DO_CYCLE_ACTUATOR" hasLocation="false" isDestination="false">
-        <description>Cycle an actuator between two settings for a desired number of cycles with a desired period.</description>
-        <param index="1" label="Instance" minValue="1" increment="1">Actuator instance number (0 to control all actuators).</param>
-        <param index="2" label="Value 1" minValue="-1" maxValue="1">Actuator value 1, scaled from -1 to 1. NaN to use "nominal" value.</param>
-        <param index="3" label="Value 2" minValue="-1" maxValue="1">Actuator value 2, scaled from -1 to 1. NaN to use "nominal" value.</param>
-        <param index="4" label="Count" minValue="1" increment="1">Cycle counts.</param>
-        <param index="5" label="Period" minValue="0" units="s">Period of cycle.</param>
-        <param index="6" label="Interpolation" enum="ACTUATOR_CYCLE_INTERPOLATION">Interpolation to use for cycle values.</param>
       </entry>
       <entry value="189" name="MAV_CMD_DO_LAND_START" hasLocation="true" isDestination="false">
         <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1718,6 +1718,8 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="187" name="MAV_CMD_DO_SET_ACTUATOR" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Sets actuators (e.g. servos) to a desired value. The actuator numbers are mapped to specific outputs (e.g. on any MAIN or AUX PWM or UAVCAN) using a flight-stack specific mechanism (i.e. a parameter).</description>
         <param index="1" label="Actuator 1" minValue="-1" maxValue="1">Actuator 1 value, scaled from [-1 to 1]. NaN to ignore.</param>
         <param index="2" label="Actuator 2" minValue="-1" maxValue="1">Actuator 2 value, scaled from [-1 to 1]. NaN to ignore.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1304,6 +1304,27 @@
         <description>Parameter meta data.</description>
       </entry>
     </enum>
+    <enum name="ACTUATOR_CYCLE_INTERPOLATION">
+      <description>Type of interpolation to use when cycling actuator values using MAV_CMD_DO_CYCLE_ACTUATOR</description>
+      <entry value="0" name="ACTUATOR_CYCLE_INTERPOLATION_CONSTANT">
+        <description>Toggles between the two cycle values, no interpolation done.</description>
+      </entry>
+      <entry value="1" name="ACTUATOR_CYCLE_INTERPOLATION_LINEAR">
+        <description>Linear interpolation between the two cycle values.</description>
+      </entry>
+      <entry value="2" name="ACTUATOR_CYCLE_INTERPOLATION_QUADRATIC">
+        <description>Interpolates between the two cycle value with a quadratic curve.</description>
+      </entry>
+      <entry value="3" name="ACTUATOR_CYCLE_INTERPOLATION_CUBIC">
+        <description>Interpolates between the two cycle value with a cubic curve.</description>
+      </entry>
+      <entry value="4" name="ACTUATOR_CYCLE_INTERPOLATION_QUARTIC">
+        <description>Interpolates between the two cycle value with a quartic curve.</description>
+      </entry>
+      <entry value="5" name="ACTUATOR_CYCLE_INTERPOLATION_SINUSOIDAL">
+        <description>Interpolates between the two cycle value with a sinusoidal curve.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -1716,6 +1737,25 @@
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>
+      </entry>
+      <entry value="187" name="MAV_CMD_DO_SET_ACTUATOR" hasLocation="false" isDestination="false">
+        <description>Sets actuators (e.g. servos) to a desired value. The actuator numbers are mapped to specific outputs (e.g. on any MAIN or AUX PWM or UAVCAN) using a flight-stack specific mechanism (i.e. a parameter).</description>
+        <param index="1" label="Actuator 1" minValue="-1" maxValue="1">Actuator 1 value, scaled from [-1 to 1]. NaN to ignore.</param>
+        <param index="2" label="Actuator 2" minValue="-1" maxValue="1">Actuator 2 value, scaled from [-1 to 1]. NaN to ignore.</param>
+        <param index="3" label="Actuator 3" minValue="-1" maxValue="1">Actuator 3 value, scaled from [-1 to 1]. NaN to ignore.</param>
+        <param index="4" label="Actuator 4" minValue="-1" maxValue="1">Actuator 4 value, scaled from [-1 to 1]. NaN to ignore.</param>
+        <param index="5" label="Actuator 5" minValue="-1" maxValue="1">Actuator 5 value, scaled from [-1 to 1]. NaN to ignore.</param>
+        <param index="6" label="Actuator 6" minValue="-1" maxValue="1">Actuator 6 value, scaled from [-1 to 1]. NaN to ignore.</param>
+        <param index="7" label="Index" minValue="0" increment="1">Index of actuator set (i.e if set to 1, Actuator 1 becomes Actuator 7)</param>
+      </entry>
+      <entry value="188" name="MAV_CMD_DO_CYCLE_ACTUATOR" hasLocation="false" isDestination="false">
+        <description>Cycle an actuator between two settings for a desired number of cycles with a desired period.</description>
+        <param index="1" label="Instance" minValue="1" increment="1">Actuator instance number (0 to control all actuators).</param>
+        <param index="2" label="Value 1" minValue="-1" maxValue="1">Actuator value 1, scaled from -1 to 1. NaN to use "nominal" value.</param>
+        <param index="3" label="Value 2" minValue="-1" maxValue="1">Actuator value 2, scaled from -1 to 1. NaN to use "nominal" value.</param>
+        <param index="4" label="Count" minValue="1" increment="1">Cycle counts.</param>
+        <param index="5" label="Period" minValue="0" units="s">Period of cycle.</param>
+        <param index="6" label="Interpolation" enum="ACTUATOR_CYCLE_INTERPOLATION">Interpolation to use for cycle values.</param>
       </entry>
       <entry value="189" name="MAV_CMD_DO_LAND_START" hasLocation="true" isDestination="false">
         <description>Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0 if not needed. If specified then it will be used to help find the closest landing sequence.</description>


### PR DESCRIPTION
This PR adds 2 commands for controlling auxiliary actuators (primarily designed for servos). MAV_CMD_DO_SET_ACTUATOR_AUX replaces MAV_CMD_DO_SET_SERVO, being less ambiguous and more flexible. MAV_CMD_DO_CYCLE_ACTUATOR_AUX replaces MAV_CMD_DO_REPEAT_SERVO but adds more functionality.

@bkueng @hamishwillee let me know if these messages make sense. I have gone a little extra with the CYCLE_ACTUATOR_AUX command, but let me know if you're fine with it or would prefer not to have this message. I think it could be useful in many cases, potentially even my own payload drop mechanism.

Note: For the PX4 implementation, if control group 3 is used, only the first 3 values will be mapped to actually do anything. I am simply adding 7 for future proofing/because I can :joy: 