### PR TITLE
common: add intent flags

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1151,17 +1151,35 @@
       <entry value="16" name="GIMBAL_MANAGER_FLAGS_YAW_LOCK">
         <description>Based on GIMBAL_DEVICE_FLAGS_YAW_LOCK</description>
       </entry>
-      <entry value="1048576" name="GIMBAL_MANAGER_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
+      <entry value="65536" name="GIMBAL_MANAGER_FLAGS_ANGULAR_VELOCITY_RELATIVE_TO_FOCAL_LENGTH">
         <description>Scale angular velocity relative to focal length. This means the gimbal moves slower if it is zoomed in.</description>
       </entry>
-      <entry value="2097152" name="GIMBAL_MANAGER_FLAGS_NUDGE">
-        <description>Interpret attitude control on top of pointing to a location or tracking. If this flag is set, the quaternion is relative to the existing tracking angle.</description>
+      <entry value="131072" name="GIMBAL_MANAGER_FLAGS_NUDGE">
+          <description>Interpret control request as nudging. Nudging means that the control request should be calculated as an additional relative offset to the control input. When setting nuding, one of the intents needs to be sent with it. Nudging should be given up by sending a message with both NUDGE and CONTROL unset.</description>
       </entry>
-      <entry value="4194304" name="GIMBAL_MANAGER_FLAGS_OVERRIDE">
-        <description>Completely override pointing to a location or tracking. If this flag is set, the quaternion is (as usual) according to GIMBAL_MANAGER_FLAGS_YAW_LOCK.</description>
+      <entry value="262144" name="GIMBAL_MANAGER_FLAGS_CONTROL">
+        <description>Interpret as full control request. If this flag is set, the source wants to fully control the gimbal. When setting control, one of the intents needs to be sent with it. Control should be given up by sending a message with both NUDGE and CONTROL unset.</description>
       </entry>
-      <entry value="8388608" name="GIMBAL_MANAGER_FLAGS_NONE">
-        <description>This flag can be set to give up control previously set using MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE. This flag must not be combined with other flags.</description>
+      <entry value="524288" name="GIMBAL_MANAGER_FLAGS_INTENT_PILOT">
+        <description>Intent to nudge or control the gimbal as pilot (e.g. from RC)</description>
+      </entry>
+      <entry value="1048576" name="GIMBAL_MANAGER_FLAGS_INTENT_GIMBAL_OPERATOR">
+        <description>Intent to nudge or control the gimbal as gimbal operator (e.g. from an additional camera operator tablet)</description>
+      </entry>
+      <entry value="2097152" name="GIMBAL_MANAGER_FLAGS_INTENT_SMARTSHOT">
+        <description>Intent to control the gimbal for a smartshot (e.g. from a companion computer performing a smart shot)</description>
+      </entry>
+      <entry value="4194304" name="GIMBAL_MANAGER_FLAGS_INTENT_MISSION">
+        <description>Intent to control the gimbal for a mission (e.g. from the autopilot's mission)</description>
+      </entry>
+      <entry value="8388608" name="GIMBAL_MANAGER_FLAGS_INTENT_TEST">
+        <description>Intent to nudge or control the gimbal for testing purposes.</description>
+      </entry>
+      <entry value="16777216" name="GIMBAL_MANAGER_FLAGS_INTENT_CUSTOM1">
+        <description>Custom intent 1.</description>
+      </entry>
+      <entry value="16777216" name="GIMBAL_MANAGER_FLAGS_INTENT_CUSTOM2">
+        <description>Custom intent 2.</description>
       </entry>
     </enum>
     <enum name="GIMBAL_DEVICE_ERROR_FLAGS" bitmask="true">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1155,7 +1155,7 @@
         <description>Scale angular velocity relative to focal length. This means the gimbal moves slower if it is zoomed in.</description>
       </entry>
       <entry value="131072" name="GIMBAL_MANAGER_FLAGS_NUDGE">
-          <description>Interpret control request as nudging. Nudging means that the control request should be calculated as an additional relative offset to the control input. When setting nuding, one of the intents needs to be sent with it. Nudging should be given up by sending a message with both NUDGE and CONTROL unset.</description>
+          <description>Interpret control request as nudging. Nudging means that the control request should be calculated as an additional relative offset to the control input. When setting nudging, one of the intents needs to be sent with it. Nudging should be given up by sending a message with both NUDGE and CONTROL unset.</description>
       </entry>
       <entry value="262144" name="GIMBAL_MANAGER_FLAGS_CONTROL">
         <description>Interpret as full control request. If this flag is set, the source wants to fully control the gimbal. When setting control, one of the intents needs to be sent with it. Control should be given up by sending a message with both NUDGE and CONTROL unset.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1178,7 +1178,7 @@
       <entry value="16777216" name="GIMBAL_MANAGER_FLAGS_INTENT_CUSTOM1">
         <description>Custom intent 1.</description>
       </entry>
-      <entry value="16777216" name="GIMBAL_MANAGER_FLAGS_INTENT_CUSTOM2">
+      <entry value="33554432" name="GIMBAL_MANAGER_FLAGS_INTENT_CUSTOM2">
         <description>Custom intent 2.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1954,7 +1954,7 @@
       </entry>
       <!-- Camera Mount Mission Commands Enumeration -->
       <entry value="204" name="MAV_CMD_DO_MOUNT_CONFIGURE" hasLocation="false" isDestination="false">
-        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message has been superseded by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE. The message can still be used to communicate with legacy gimbals implementing it.</deprecated>
+        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_TILTPAN">This message has been superseded by MAV_CMD_DO_GIMBAL_MANAGER_TILTPAN. The message can still be used to communicate with legacy gimbals implementing it.</deprecated>
         <description>Mission command to configure a camera or antenna mount</description>
         <param index="1" label="Mode" enum="MAV_MOUNT_MODE">Mount operation mode</param>
         <param index="2" label="Stabilize Roll" minValue="0" maxValue="1" increment="1">stabilize roll? (1 = yes, 0 = no)</param>
@@ -1966,7 +1966,7 @@
       </entry>
       <!-- this one is messed up! altitude should be param 7, not param4 -->
       <entry value="205" name="MAV_CMD_DO_MOUNT_CONTROL" hasLocation="false" isDestination="false">
-        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is ambiguous and inconsistent. It has been superseded by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE and MAV_CMD_DO_SET_ROI_*. The message can still be used to communicate with legacy gimbals implementing it.</deprecated>
+        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_TILTPAN">This message is ambiguous and inconsistent. It has been superseded by MAV_CMD_DO_GIMBAL_MANAGER_TILTPAN and MAV_CMD_DO_SET_ROI_*. The message can still be used to communicate with legacy gimbals implementing it.</deprecated>
         <description>Mission command to control a camera or antenna mount</description>
         <param index="1" label="Pitch">pitch depending on mount mode (degrees or degrees/second depending on pitch input).</param>
         <param index="2" label="Roll">roll depending on mount mode (degrees or degrees/second depending on roll input).</param>
@@ -2048,7 +2048,7 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT" hasLocation="false" isDestination="false">
-        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE"/>
+        <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_TILTPAN"/>
         <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>
         <param index="1" label="Q1">quaternion param q1, w (1 in null-rotation)</param>
         <param index="2" label="Q2">quaternion param q2, x (0 in null-rotation)</param>
@@ -6429,7 +6429,7 @@
       <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of log files</field>
     </message>
     <message id="265" name="MOUNT_ORIENTATION">
-      <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE">This message is being superseded by MAV_CMD_DO_GIMBAL_MANAGER_ATTITUDE. The message can still be used to communicate with legacy gimbals implementing it.</deprecated>
+      <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_TILTPAN">This message is being superseded by MAV_CMD_DO_GIMBAL_MANAGER_TILTPAN. The message can still be used to communicate with legacy gimbals implementing it.</deprecated>
       <description>Orientation of a mount</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="roll" units="deg">Roll in global frame (set to NaN for invalid).</field>


### PR DESCRIPTION
@olliw42 discovered that the current gimbal v2 proposal still does not properly address deconfliction of various sources. The rule was to favor commands over the message streamed at a certain rate. This worked for the case where manual control is overridden by a command as part of a mission, however, it does not support e.g. a smart shot being sent from a companion computer using the message (and not the command).

Therefore, the idea here is to add flags for the intent of the source.
This then lets the gimbal manager decide which intent it wants to allow at any given time. The default order of the intents would be:
PILOT
GIMBAL_OPERATOR
SMARTSHOT
MISSION
TEST
CUSTOM1
CUSTOM2
with PILOT being the lowest and CUSTOM2 the highest "priority". However, a gimbal manager is allowed to be configured differently depending on the use case.

Clients sending gimbal control or nudging messages or commands are supposed to set NUDGE or CONTROL if they want to start nudging or controlling and follow up with at least one message with both NUDGE and CONTROL unset in order to give up their control.

This proposal is by no means perfect but I argue it's better than the current state and should enable many use cases, as well as make the deconfliction rules easier to grasp.

Somewhat resolves #1380

FYI @olliw42 