### PR TITLE
Update cellular config and message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1344,6 +1344,9 @@
       <entry value="3" name="CELLULAR_CONFIG_RESPONSE_REJECTED">
         <description>Changes rejected.</description>
       </entry>
+      <entry value="4" name="CELLULAR_CONFIG_BLOCKED_PUK_REQUIRED">
+        <description>PUK is required to unblock SIM card.</description>
+      </entry>
     </enum>
     <enum name="WIFI_CONFIG_AP_MODE">
       <description>WiFi Mode.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6783,6 +6783,7 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Configure cellular modems. This message is re-emitted as an acknowledgement by the modem. The message may also be explicitly requested using MAV_CMD_REQUEST_MESSAGE.</description>
+      <field type="uint8_t" name="enable_lte">Enable/disable LTE. 0: setting unchanged, 1: disabled, 2: enabled. Current setting when sent back as a response.</field>
       <field type="uint8_t" name="enable_pin">Enable/disable PIN on the SIM card. 0: setting unchanged, 1: disabled, 2: enabled. Current setting when sent back as a response.</field>
       <field type="char[16]" name="pin">PIN sent to the SIM card. Blank when PIN is disabled. Empty when message is sent back as a response.</field>
       <field type="char[16]" name="new_pin">New PIN when changing the PIN. Blank to leave it unchanged. Empty when message is sent back as a response.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6783,11 +6783,12 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Configure cellular modems. This message is re-emitted as an acknowledgement by the modem. The message may also be explicitly requested using MAV_CMD_REQUEST_MESSAGE.</description>
-      <field type="uint8_t" name="enable_pin">Enable / disable PIN on the SIM card. 0: Unchange setttings 1: PIN disabled, 2: PIN enabled.</field>
-      <field type="char[32]" name="pin">PIN sent to the simcard. Blank when PIN is disabled. Empty when message is sent back as a response.</field>
-      <field type="char[32]" name="apn">Name of the cellular APN. Blank to leave it unchanged when setting. Current APN when sent back as a response.</field>
-      <field type="char[32]" name="puk">Required PUK code in case the user failed to authenticate 3 times with the PIN.</field>
-      <field type="uint8_t" name="roaming">Configure whether roaming is allowed, 0: settings not changed, 1: roaming disabled, 2: roaming enabled.</field>
+      <field type="uint8_t" name="enable_pin">Enable/disable PIN on the SIM card. 0: setting unchanged, 1: disabled, 2: enabled. Current setting when sent back as a response.</field>
+      <field type="char[32]" name="pin">PIN sent to the SIM card. Blank when PIN is disabled. Empty when message is sent back as a response.</field>
+      <field type="char[32]" name="new_pin">New PIN when changing the PIN. Blank to leave it unchanged. Empty when message is sent back as a response.</field>
+      <field type="char[32]" name="apn">Name of the cellular APN. Blank to leave it unchanged. Current APN when sent back as a response.</field>
+      <field type="char[32]" name="puk">Required PUK code in case the user failed to authenticate 3 times with the PIN. Empty when message is sent back as a response.</field>
+      <field type="uint8_t" name="roaming">Enable/disable roaming. 0: setting unchanged, 1: disabled, 2: enabled. Current setting when sent back as a response.</field>
       <field type="uint8_t" name="response" enum="CELLULAR_CONFIG_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="339" name="RAW_RPM">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6784,10 +6784,10 @@
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Configure cellular modems. This message is re-emitted as an acknowledgement by the modem. The message may also be explicitly requested using MAV_CMD_REQUEST_MESSAGE.</description>
       <field type="uint8_t" name="enable_pin">Enable/disable PIN on the SIM card. 0: setting unchanged, 1: disabled, 2: enabled. Current setting when sent back as a response.</field>
-      <field type="char[32]" name="pin">PIN sent to the SIM card. Blank when PIN is disabled. Empty when message is sent back as a response.</field>
-      <field type="char[32]" name="new_pin">New PIN when changing the PIN. Blank to leave it unchanged. Empty when message is sent back as a response.</field>
+      <field type="char[16]" name="pin">PIN sent to the SIM card. Blank when PIN is disabled. Empty when message is sent back as a response.</field>
+      <field type="char[16]" name="new_pin">New PIN when changing the PIN. Blank to leave it unchanged. Empty when message is sent back as a response.</field>
       <field type="char[32]" name="apn">Name of the cellular APN. Blank to leave it unchanged. Current APN when sent back as a response.</field>
-      <field type="char[32]" name="puk">Required PUK code in case the user failed to authenticate 3 times with the PIN. Empty when message is sent back as a response.</field>
+      <field type="char[16]" name="puk">Required PUK code in case the user failed to authenticate 3 times with the PIN. Empty when message is sent back as a response.</field>
       <field type="uint8_t" name="roaming">Enable/disable roaming. 0: setting unchanged, 1: disabled, 2: enabled. Current setting when sent back as a response.</field>
       <field type="uint8_t" name="response" enum="CELLULAR_CONFIG_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>


### PR DESCRIPTION
This is a follow-up PR on PR: https://github.com/mavlink/mavlink/pull/1421

It contains the following changes:
* Add `CELLULAR_CONFIG_BLOCKED_PUK_REQUIRED` response code to `CELLULAR_CONFIG_RESPONSE`. This response code is needed to indicate that the PUK code is required to unblock SIM card.
* Add field `enable_lte` to CELLULAR_CONFIG message. This field is needed to enable/disable LTE on the vehicle.
* Add field `new_pin` to `CELLULAR_CONFIG` message. This field is needed when changing the PIN.
* Reduce length of the message fields for PIN and PUK to 16.
* Some minor message field description changes.
