### PR TITLE
extend param_ext protocol by adding messages to start and commit a parameter transaction

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3923,7 +3923,7 @@
         <description>Parameter failed to set</description>
       </entry>
       <entry value="3" name="PARAM_ACK_IN_PROGRESS">
-        <description>Parameter value received but not yet set/accepted. A subsequent PARAM_TRANSACT_ACK or PARAM_EXT_ACK with the final result will follow once operation is completed. This is returned immediately for parameters that take longer to set, indicating taht the the parameter was recieved and does not need to be resent.</description>
+        <description>Parameter value received but not yet set/accepted. A subsequent PARAM_ACK_TRANSACTION or PARAM_EXT_ACK with the final result will follow once operation is completed. This is returned immediately for parameters that take longer to set, indicating taht the the parameter was recieved and does not need to be resent.</description>
       </entry>
     </enum>
     <enum name="CAMERA_MODE">
@@ -4801,7 +4801,7 @@
       <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
     </message>
     <!-- IDs 15-17 reserved for PARAM_VALUE_UNION and other param messages -->
-    <message id="19" name="PARAM_TRANSACT_ACK">
+    <message id="19" name="PARAM_ACK_TRANSACTION">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Response from a PARAM_SET message when it is used in a transaction.</description>
@@ -4833,7 +4833,7 @@
       <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
     </message>
     <message id="23" name="PARAM_SET">
-      <description>Set a parameter value (write new value to permanent storage). Within a transaction the recieving componenent should respond with PARAM_TRANSACT_ACK to the setter component. IMPORTANT: If sent outside a transaction the receiving component should acknowledge the new parameter value by broadcasting a PARAM_VALUE message to all communication partners (broadcasting ensures that multiple GCS all have an up-to-date list of all parameters). If the sending GCS did not receive a PARAM_VALUE or PARAM_TRANSACT_ACK message within its timeout time, it should re-send the PARAM_SET message. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
+      <description>Set a parameter value (write new value to permanent storage). Within a transaction the recieving componenent should respond with PARAM_ACK_TRANSACTION to the setter component. IMPORTANT: If sent outside a transaction the receiving component should acknowledge the new parameter value by broadcasting a PARAM_VALUE message to all communication partners (broadcasting ensures that multiple GCS all have an up-to-date list of all parameters). If the sending GCS did not receive a PARAM_VALUE or PARAM_ACK_TRANSACTION message within its timeout time, it should re-send the PARAM_SET message. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1372,19 +1372,31 @@
         <description>Parameter meta data.</description>
       </entry>
     </enum>
-    <enum name="PARAM_EXT_TRANSACTION_RESPONSE">
-      <description>Possible responses from a PARAM_EXT_START_TRANSACTION and PARAM_EXT_COMMIT_TRANSACTION messages.</description>
-      <entry value="0" name="PARAM_EXT_TRANSACTION_RESPONSE_ACCEPTED">
+    <enum name="PARAM_TRANSACTION_RESPONSE">
+      <description>Possible responses from a PARAM_START_TRANSACTION and PARAM_COMMIT_TRANSACTION messages.</description>
+      <entry value="0" name="PARAM_TRANSACTION_RESPONSE_ACCEPTED">
         <description>Transaction accepted.</description>
       </entry>
-      <entry value="1" name="PARAM_EXT_TRANSACTION_RESPONSE_FAILED">
+      <entry value="1" name="PARAM_TRANSACTION_RESPONSE_FAILED">
         <description>Transaction failed.</description>
       </entry>
-      <entry value="2" name="PARAM_EXT_TRANSACTION_RESPONSE_UNSUPPORTED">
+      <entry value="2" name="PARAM_TRANSACTION_RESPONSE_UNSUPPORTED">
         <description>Transaction unsupported.</description>
       </entry>
-      <entry value="3" name="PARAM_EXT_TRANSACTION_RESPONSE_INPROGRESS">
+      <entry value="3" name="PARAM_TRANSACTION_RESPONSE_INPROGRESS">
         <description>Transaction in progress.</description>
+      </entry>
+    </enum>
+    <enum name="PARAM_TRANSACTION_TRANSPORT">
+      <description>Possible transport layers to set and get parameters via mavlink during a parameter transaction.</description>
+      <entry value="0" name="PARAM_TRANSACTION_TRANSPORT_PARAM">
+        <description>Transaction over param transport.</description>
+      </entry>
+      <entry value="1" name="PARAM_TRANSACTION_TRANSPORT_PARAM_EXT">
+        <description>Transaction over param_ext transport.</description>
+      </entry>
+      <entry value="2" name="PARAM_TRANSACTION_TRANSPORT_MAVFTP">
+        <description>Transaction over mavftp transport.</description>
       </entry>
     </enum>
     <!-- The MAV_CMD enum entries describe either: -->
@@ -6717,21 +6729,18 @@
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
     </message>
-    <message id="325" name="PARAM_EXT_START_TRANSACTION">
-      <description>Request to start a new parameter transaction. The response (ack) will contain the same message but with a response attached to it.</description>
+    <message id="325" name="PARAM_START_TRANSACTION">
+      <description>Request to start a new parameter transaction. Multiple kinds of transport layers can be used to exchange parameters in the transaction (param, param_ext and mavftp). The response (ack) will contain the same message but with a response attached to it.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint32_t" name="client_transaction_id">This field contains the transaction id for the sending side. </field>
-      <field type="uint32_t" name="server_transaction_id">This field contains the transaction id for the receiving side. It will be set to zero in the request and will be filled in only in the response. </field>
-      <field type="uint8_t" name="response" enum="PARAM_EXT_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
+      <field type="uint8_t" name="param_transport" enum="PARAM_TRANSACTION_TRANSPORT">Message acceptance response (sent back to GS).</field>
+      <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
-    <message id="326" name="PARAM_EXT_COMMIT_TRANSACTION">
-      <description>Request to end the current parameter transaction. This message will have effect only if a transaction was previously opened using the PARAM_EXT_START_TRANSACTION message. The response will contain the same message but with a response attached to it. The response can either be a success/failure or and in progress in case the receiving side takes some time to apply the parameters.</description>
+    <message id="326" name="PARAM_COMMIT_TRANSACTION">
+      <description>Request to end the current parameter transaction. This message will have effect only if a transaction was previously opened using the PARAM_START_TRANSACTION message. The response will contain the same message but with a response attached to it. The response can either be a success/failure or and in progress in case the receiving side takes some time to apply the parameters.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint32_t" name="client_transaction_id">This field contains the transaction id for the sending side.  </field>
-      <field type="uint32_t" name="server_transaction_id">This field contains the transaction id for the receiving side. It will be set to zero in the request and will be filled in only in the response. </field>
-      <field type="uint8_t" name="response" enum="PARAM_EXT_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
+      <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="330" name="OBSTACLE_DISTANCE">
       <description>Obstacle distances in front of the sensor, starting from the left in increment degrees to the right</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6729,14 +6729,14 @@
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
     </message>
-    <message id="325" name="PARAM_START_TRANSACTION">
+    <message id="328" name="PARAM_START_TRANSACTION">
       <description>Request to start a new parameter transaction. Multiple kinds of transport layers can be used to exchange parameters in the transaction (param, param_ext and mavftp). The response (ack) will contain the same message but with a response attached to it.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="param_transport" enum="PARAM_TRANSACTION_TRANSPORT">Message acceptance response (sent back to GS).</field>
       <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
-    <message id="326" name="PARAM_COMMIT_TRANSACTION">
+    <message id="329" name="PARAM_COMMIT_TRANSACTION">
       <description>Request to end the current parameter transaction. This message will have effect only if a transaction was previously opened using the PARAM_START_TRANSACTION message. The response will contain the same message but with a response attached to it. The response can either be a success/failure or and in progress in case the receiving side takes some time to apply the parameters.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1372,6 +1372,21 @@
         <description>Parameter meta data.</description>
       </entry>
     </enum>
+    <enum name="PARAM_EXT_TRANSACTION_RESPONSE">
+      <description>Possible responses from a PARAM_EXT_START_TRANSACTION and PARAM_EXT_COMMIT_TRANSACTION messages.</description>
+      <entry value="0" name="PARAM_EXT_TRANSACTION_RESPONSE_ACCEPTED">
+        <description>Transaction accepted.</description>
+      </entry>
+      <entry value="1" name="PARAM_EXT_TRANSACTION_RESPONSE_FAILED">
+        <description>Transaction failed.</description>
+      </entry>
+      <entry value="2" name="PARAM_EXT_TRANSACTION_RESPONSE_UNSUPPORTED">
+        <description>Transaction unsupported.</description>
+      </entry>
+      <entry value="3" name="PARAM_EXT_TRANSACTION_RESPONSE_INPROGRESS">
+        <description>Transaction in progress.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -6701,6 +6716,22 @@
       <field type="char[128]" name="param_value">Parameter value (new value if PARAM_ACK_ACCEPTED, current value otherwise)</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
+    </message>
+    <message id="325" name="PARAM_EXT_START_TRANSACTION">
+      <description>Request to start a new parameter transaction. The response (ack) will contain the same message but with a response attached to it.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="client_transaction_id">This field contains the transaction id for the sending side. </field>
+      <field type="uint32_t" name="server_transaction_id">This field contains the transaction id for the receiving side. It will be set to zero in the request and will be filled in only in the response. </field>
+      <field type="uint8_t" name="response" enum="PARAM_EXT_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
+    </message>
+    <message id="326" name="PARAM_EXT_COMMIT_TRANSACTION">
+      <description>Request to end the current parameter transaction. This message will have effect only if a transaction was previously opened using the PARAM_EXT_START_TRANSACTION message. The response will contain the same message but with a response attached to it. The response can either be a success/failure or and in progress in case the receiving side takes some time to apply the parameters.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="client_transaction_id">This field contains the transaction id for the sending side.  </field>
+      <field type="uint32_t" name="server_transaction_id">This field contains the transaction id for the receiving side. It will be set to zero in the request and will be filled in only in the response. </field>
+      <field type="uint8_t" name="response" enum="PARAM_EXT_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="330" name="OBSTACLE_DISTANCE">
       <description>Obstacle distances in front of the sensor, starting from the left in increment degrees to the right</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3912,7 +3912,7 @@
       </entry>
     </enum>
     <enum name="PARAM_ACK">
-      <description>Result from a PARAM_SET or PARAM_EXT_SET message.</description>
+      <description>Result from PARAM_EXT_SET message (or a PARAM_SET within a transaction).</description>
       <entry value="0" name="PARAM_ACK_ACCEPTED">
         <description>Parameter value ACCEPTED and SET</description>
       </entry>
@@ -3923,7 +3923,7 @@
         <description>Parameter failed to set</description>
       </entry>
       <entry value="3" name="PARAM_ACK_IN_PROGRESS">
-        <description>Parameter value received but not yet validated or set. A subsequent PARAM_ACK or PARAM_EXT_ACK will follow once operation is completed with the actual result. These are for parameters that may take longer to set. Instead of waiting for an ACK and potentially timing out, you will immediately receive this response to let you know it was received.</description>
+        <description>Parameter value received but not yet set/accepted. A subsequent PARAM_TRANSACT_ACK or PARAM_EXT_ACK with the final result will follow once operation is completed. This is returned immediately for parameters that take longer to set, indicating taht the the parameter was recieved and does not need to be resent.</description>
       </entry>
     </enum>
     <enum name="CAMERA_MODE">
@@ -4800,9 +4800,13 @@
       <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode.</field>
       <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
     </message>
-    <!-- reserved for PARAM_VALUE_UNION -->
-    <message id="19" name="PARAM_ACK">
-      <description>Response from a PARAM_SET message.</description>
+    <!-- IDs 15-17 reserved for PARAM_VALUE_UNION and other param messages -->
+    <message id="19" name="PARAM_TRANSACT_ACK">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Response from a PARAM_SET message when it is used in a transaction.</description>
+      <field type="uint8_t" name="target_system">Id of system that sent PARAM_SET message.</field>
+      <field type="uint8_t" name="target_component">Id of system that sent PARAM_SET message.</field>
       <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
       <field type="float" name="param_value">Parameter value (new value if PARAM_ACCEPTED, current value otherwise)</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type.</field>
@@ -4829,7 +4833,7 @@
       <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
     </message>
     <message id="23" name="PARAM_SET">
-      <description>Set a parameter value (write new value to permanent storage). IMPORTANT: The receiving component should acknowledge the new parameter value by sending a PARAM_ACK message to all communication partners. This will also ensure that multiple GCS all have an up-to-date list of all parameters. If the sending GCS did not receive a PARAM_ACK message within its timeout time, it should re-send the PARAM_SET message. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
+      <description>Set a parameter value (write new value to permanent storage). Within a transaction the recieving componenent should respond with PARAM_TRANSACT_ACK to the setter component. IMPORTANT: If sent outside a transaction the receiving component should acknowledge the new parameter value by broadcasting a PARAM_VALUE message to all communication partners (broadcasting ensures that multiple GCS all have an up-to-date list of all parameters). If the sending GCS did not receive a PARAM_VALUE or PARAM_TRANSACT_ACK message within its timeout time, it should re-send the PARAM_SET message. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
@@ -6734,6 +6738,8 @@
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
     </message>
     <message id="328" name="PARAM_START_TRANSACTION">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Request to start a new parameter transaction. Multiple kinds of transport layers can be used to exchange parameters in the transaction (param, param_ext and mavftp). The response (ack) will contain the same message but with a response attached to it.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
@@ -6741,6 +6747,8 @@
       <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="329" name="PARAM_COMMIT_TRANSACTION">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Request to end the current parameter transaction. This message will have effect only if a transaction was previously opened using the PARAM_START_TRANSACTION message. The response will contain the same message but with a response attached to it. The response can either be a success/failure or and in progress in case the receiving side takes some time to apply the parameters.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3912,7 +3912,7 @@
       </entry>
     </enum>
     <enum name="PARAM_ACK">
-      <description>Result from a PARAM_EXT_SET message.</description>
+      <description>Result from a PARAM_SET or PARAM_EXT_SET message.</description>
       <entry value="0" name="PARAM_ACK_ACCEPTED">
         <description>Parameter value ACCEPTED and SET</description>
       </entry>
@@ -3923,7 +3923,7 @@
         <description>Parameter failed to set</description>
       </entry>
       <entry value="3" name="PARAM_ACK_IN_PROGRESS">
-        <description>Parameter value received but not yet validated or set. A subsequent PARAM_EXT_ACK will follow once operation is completed with the actual result. These are for parameters that may take longer to set. Instead of waiting for an ACK and potentially timing out, you will immediately receive this response to let you know it was received.</description>
+        <description>Parameter value received but not yet validated or set. A subsequent PARAM_ACK or PARAM_EXT_ACK will follow once operation is completed with the actual result. These are for parameters that may take longer to set. Instead of waiting for an ACK and potentially timing out, you will immediately receive this response to let you know it was received.</description>
       </entry>
     </enum>
     <enum name="CAMERA_MODE">
@@ -4801,6 +4801,13 @@
       <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
     </message>
     <!-- reserved for PARAM_VALUE_UNION -->
+    <message id="19" name="PARAM_ACK">
+      <description>Response from a PARAM_SET message.</description>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="float" name="param_value">Parameter value (new value if PARAM_ACCEPTED, current value otherwise)</field>
+      <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type.</field>
+      <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
+    </message>
     <message id="20" name="PARAM_REQUEST_READ">
       <description>Request to read the onboard parameter with the param_id string id. Onboard parameters are stored as key[const char*] -&gt; value[float]. This allows to send a parameter to any other component (such as the GCS) without the need of previous knowledge of possible parameter names. Thus the same GCS can store different parameters for different autopilots. See also https://mavlink.io/en/services/parameter.html for a full documentation of QGroundControl and IMU code.</description>
       <field type="uint8_t" name="target_system">System ID</field>
@@ -4822,7 +4829,7 @@
       <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
     </message>
     <message id="23" name="PARAM_SET">
-      <description>Set a parameter value (write new value to permanent storage). IMPORTANT: The receiving component should acknowledge the new parameter value by sending a PARAM_VALUE message to all communication partners. This will also ensure that multiple GCS all have an up-to-date list of all parameters. If the sending GCS did not receive a PARAM_VALUE message within its timeout time, it should re-send the PARAM_SET message. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
+      <description>Set a parameter value (write new value to permanent storage). IMPORTANT: The receiving component should acknowledge the new parameter value by sending a PARAM_ACK message to all communication partners. This will also ensure that multiple GCS all have an up-to-date list of all parameters. If the sending GCS did not receive a PARAM_ACK message within its timeout time, it should re-send the PARAM_SET message. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1395,9 +1395,6 @@
       <entry value="1" name="PARAM_TRANSACTION_TRANSPORT_PARAM_EXT">
         <description>Transaction over param_ext transport.</description>
       </entry>
-      <entry value="2" name="PARAM_TRANSACTION_TRANSPORT_MAVFTP">
-        <description>Transaction over mavftp transport.</description>
-      </entry>
     </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
@@ -6733,7 +6730,7 @@
       <description>Request to start a new parameter transaction. Multiple kinds of transport layers can be used to exchange parameters in the transaction (param, param_ext and mavftp). The response (ack) will contain the same message but with a response attached to it.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint8_t" name="param_transport" enum="PARAM_TRANSACTION_TRANSPORT">Message acceptance response (sent back to GS).</field>
+      <field type="uint8_t" name="param_transport" enum="PARAM_TRANSACTION_TRANSPORT">Possible transport layers to set and get parameters via mavlink during a parameter transaction.</field>
       <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="329" name="PARAM_COMMIT_TRANSACTION">


### PR DESCRIPTION
Lately we have created several mavlink messages to set some settings on the vehicle (eg. the wifi credentials message and the cellular config message. 

In mavlink we already have a parameter protocol that could be used although it currently has some limitations. The three main limitations are the following:
- We cannot set multiple parameters at the same time. Every parameter is set in a separate mavlink message and is applied as soon as it's received. For settings such as wifi SSID and password we would like to first set both parameters before applying them for obvious reasons.
- Currently we would need to use the PARAM_EXT to set such strings. The PARAM_EXT has a value field that is 128 bytes long and even if not all these bytes are used there is no trimming therefore we are always transmitting them for each parameter.
- There is no way to attach some description/metadata to a given parameter.

With this pr I try to solve the first issue. To do this I created two new messages to start and stop (commit) a parameter transaction. With the start command we tell the vehicle that we will set some parameters but they should not be applied right away. With the commit message we tell the vehicle that we are done setting parameters and they can now be applied. 

Both messages are sent out by the ground station and the vehicle will respond with the same message but adding its transaction id (server) and a response to the message. This response works as an ack for the messages. 