### PR TITLE
common: SCALLED_PRESURE: add press diff temperature

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4879,7 +4879,9 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="press_abs" units="hPa">Absolute pressure</field>
       <field type="float" name="press_diff" units="hPa">Differential pressure 1</field>
-      <field type="int16_t" name="temperature" units="cdegC">Temperature</field>
+      <field type="int16_t" name="temperature" units="cdegC">Absolute pressure temperature</field>
+      <extensions/>
+      <field type="int16_t" name="temperature_press_diff" units="cdegC">Differential pressure temperature (UINT16_MAX, if not available)</field>
     </message>
     <message id="30" name="ATTITUDE">
       <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right).</description>
@@ -5934,7 +5936,9 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="press_abs" units="hPa">Absolute pressure</field>
       <field type="float" name="press_diff" units="hPa">Differential pressure</field>
-      <field type="int16_t" name="temperature" units="cdegC">Temperature measurement</field>
+      <field type="int16_t" name="temperature" units="cdegC">Absolute pressure temperature</field>
+      <extensions/>
+      <field type="int16_t" name="temperature_press_diff" units="cdegC">Differential pressure temperature (UINT16_MAX, if not available)</field>
     </message>
     <message id="138" name="ATT_POS_MOCAP">
       <description>Motion capture attitude and position</description>
@@ -5983,7 +5987,9 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="press_abs" units="hPa">Absolute pressure</field>
       <field type="float" name="press_diff" units="hPa">Differential pressure</field>
-      <field type="int16_t" name="temperature" units="cdegC">Temperature measurement</field>
+      <field type="int16_t" name="temperature" units="cdegC">Absolute pressure temperature</field>
+      <extensions/>
+      <field type="int16_t" name="temperature_press_diff" units="cdegC">Differential pressure temperature (UINT16_MAX, if not available)</field>
     </message>
     <message id="144" name="FOLLOW_TARGET">
       <description>Current motion information from a designated system</description>


### PR DESCRIPTION
Adds a second temperature field to SCALLED_PRESSURE to allow sending back of the air temp from the airspeed sensor. This is often quite different to the baro temp due to location. 

https://github.com/ArduPilot/mavlink/pull/142