### PR TITLE
common: add param_action to param transaction commit

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1396,6 +1396,15 @@
         <description>Transaction over param_ext transport.</description>
       </entry>
     </enum>
+    <enum name="PARAM_TRANSACTION_ACTION">
+      <description>Possible parameter transaction action during a commit.</description>
+      <entry value="0" name="PARAM_TRANSACTION_ACTION_COMMIT">
+        <description>Commit the current parameter transaction.</description>
+      </entry>
+      <entry value="1" name="PARAM_TRANSACTION_ACTION_CANCEL">
+        <description>Cancel the current parameter transaction.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -6791,6 +6800,7 @@
       <description>Request to end the current parameter transaction. This message will have effect only if a transaction was previously opened using the PARAM_START_TRANSACTION message. The response will contain the same message but with a response attached to it. The response can either be a success/failure or and in progress in case the receiving side takes some time to apply the parameters.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="param_action" enum="PARAM_TRANSACTION_ACTION">Commit or cancel an ongoing transaction.</field>
       <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="330" name="OBSTACLE_DISTANCE">


### PR DESCRIPTION
This is a continuation for the parameter transaction protocol design. I added a field to the commit message to decide whether we want to commit or cancel the transaction. The reason for this is for bigger sets of parameters. In QGC we could open a transaction when the user opens a new view in the UI and set the parameters as the user is inserting them and then just send the commit when the user presses on the submit button. In this way we avoid sending all parameters at the end making the submit action slower. If we want to do this we should also be able to cancel a transaction in case a user changes some parameters but then goes to another view. 

FYI @dogmaphobic 