### PR TITLE
Improve param transactions

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -709,6 +709,10 @@
       <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
         <description>Component that can generate/supply a mission flight plan (e.g. GCS or developer API).</description>
       </entry>
+      <entry value="191" name="MAV_COMP_ID_MISSION_COMPUTER">
+        <description>Component that lives on the mission computer (companion computer) and has some generic functionalities, such as settings system parameters and monitoring the status of some processes that don't directly speak mavlink and so on.</description>
+      </entry>
+      <!-- Component ids from 192-194 are reserved for any future mavlink components related to the mission computer. -->
       <entry value="195" name="MAV_COMP_ID_PATHPLANNER">
         <description>Component that finds an optimal path between points based on a certain constraint (e.g. minimum snap, shortest path, cost, etc.).</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6830,7 +6830,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="param_transport" enum="PARAM_TRANSACTION_TRANSPORT">Possible transport layers to set and get parameters via mavlink during a parameter transaction.</field>
-      <field type="uint32_t" name="transaction_id">Identifier for a specific transaction.</field>
+      <field type="uint16_t" name="transaction_id">Identifier for a specific transaction.</field>
       <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="329" name="PARAM_COMMIT_TRANSACTION">
@@ -6840,7 +6840,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="param_action" enum="PARAM_TRANSACTION_ACTION">Commit or cancel an ongoing transaction.</field>
-      <field type="uint32_t" name="transaction_id">Identifier for a specific transaction.</field>
+      <field type="uint16_t" name="transaction_id">Identifier for a specific transaction.</field>
       <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="330" name="OBSTACLE_DISTANCE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -709,8 +709,8 @@
       <entry value="190" name="MAV_COMP_ID_MISSIONPLANNER">
         <description>Component that can generate/supply a mission flight plan (e.g. GCS or developer API).</description>
       </entry>
-      <entry value="191" name="MAV_COMP_ID_MISSION_COMPUTER">
-        <description>Component that lives on the mission computer (companion computer) and has some generic functionalities, such as settings system parameters and monitoring the status of some processes that don't directly speak mavlink and so on.</description>
+      <entry value="191" name="MAV_COMP_ID_ONBOARD_COMPUTER">
+        <description>Component that lives on the onboard computer (companion computer) and has some generic functionalities, such as settings system parameters and monitoring the status of some processes that don't directly speak mavlink and so on.</description>
       </entry>
       <!-- Component ids from 192-194 are reserved for any future mavlink components related to the mission computer. -->
       <entry value="195" name="MAV_COMP_ID_PATHPLANNER">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6826,6 +6826,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="param_transport" enum="PARAM_TRANSACTION_TRANSPORT">Possible transport layers to set and get parameters via mavlink during a parameter transaction.</field>
+      <field type="uint32_t" name="transaction_id">Identifier for a specific transaction.</field>
       <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="329" name="PARAM_COMMIT_TRANSACTION">
@@ -6835,6 +6836,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="param_action" enum="PARAM_TRANSACTION_ACTION">Commit or cancel an ongoing transaction.</field>
+      <field type="uint32_t" name="transaction_id">Identifier for a specific transaction.</field>
       <field type="uint8_t" name="response" enum="PARAM_TRANSACTION_RESPONSE">Message acceptance response (sent back to GS).</field>
     </message>
     <message id="330" name="OBSTACLE_DISTANCE">


### PR DESCRIPTION
This pr solves 2 issues with parameter transactions and also introduces a new generic component ID for a mission computer (companion computer). I saw that there was already some discussion about this component id here: https://github.com/mavlink/mavlink/issues/1344. The component IDs we currently have for the mission computer are very specific. In my case I have a process on the mission computer that handles various types of mavlink parameters and interacts with a few other processes that are not exposed via mavlink. This is the reason why I would like to have a generic comp id and also reserve 3 more ids for other mission computer related components in the future.

Instead, regarding the parameter transaction protocol I extended with two fields:
- transaction_id: this was a proposal from @DonLakeFlyer since on the vehicle side we will need to keep some kind of transaction history. This is because if the ack to a transaction_commit is dropped then the next time qgc will retry the transaction_commit the transaction will already be closed (on the vehicle side) and we would reply with a fail. With this transaction id we can look up also through the closed transactions history and respond with the right state.
- param_group: in our process on the vehicle we have multiple groups of parameters (grouped by functionalities). We made a clear interface to be able to easily add new sets of parameters that could be used by other processes in the future. The architecture is already in place that multiple transactions could happen at once as long as they are from different groups (to avoid conflicts). To keep the protocol simple and easy to understand I think it would make sense to have this new field so that we already know which group a transaction will be setting (even before the first param set). Otherwise when we receive the transaction_start we need a lot of additional logic for this that would be removed with just one new field in the message. For now I made it 32 bits but it could also be 16. We could also make this field optional (eg. unused if set to 0).

@dogmaphobic can you please review this just to be sure that this matches what we discussed earlier today?