### PR TITLE
common: add "error" flag for calibration state

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1190,6 +1190,9 @@
       <entry value="128" name="GIMBAL_DEVICE_ERROR_FLAGS_COMMS_ERROR">
         <description>There is an error with the gimbal's communication.</description>
       </entry>
+      <entry value="256" name="GIMBAL_DEVICE_ERROR_CALIBRATING">
+        <description>Gimbal is currently calibrating.</description>
+      </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
     <enum name="UAVCAN_NODE_HEALTH">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1190,7 +1190,7 @@
       <entry value="128" name="GIMBAL_DEVICE_ERROR_FLAGS_COMMS_ERROR">
         <description>There is an error with the gimbal's communication.</description>
       </entry>
-      <entry value="256" name="GIMBAL_DEVICE_ERROR_CALIBRATING">
+      <entry value="256" name="GIMBAL_DEVICE_ERROR_FLAGS_CALIBRATION_RUNNING">
         <description>Gimbal is currently calibrating.</description>
       </entry>
     </enum>


### PR DESCRIPTION
This is not an error per se but something that could be happening and a flag would explain why the gimbal is not working properly as it is calibrating.

FYI @olliw42 