### PR TITLE
Add yaw to HIL_GPS messsage

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5806,6 +5806,7 @@
       <field type="uint8_t" name="satellites_visible">Number of satellites visible. If unknown, set to 255</field>
       <extensions/>
       <field type="uint8_t" name="id">GPS ID (zero indexed). Used for multiple GPS inputs</field>
+      <field type="uint16_t" name="yaw" units="cdeg">Yaw of vehicle relative to Earth's North, zero means not available, use 36000 for north</field>
     </message>
     <message id="114" name="HIL_OPTICAL_FLOW">
       <description>Simulated optical flow from a flow sensor (e.g. PX4FLOW or optical mouse sensor)</description>


### PR DESCRIPTION
This PR adds a yaw field to the `HIL_GPS` message.

This is needed in order to simulate GPS sensors that provide yaw information in HITL / SITL simulations. 

This is added as an `extention` and is a identical field with the yaw field https://mavlink.io/en/messages/common.html#GPS_INPUT
- yaw is in cdeg which indicate the yaw from north.
- North is marked as 36000 and yaw=0 invalidates the field. 

