### PR TITLE
COMPONENT_INFORMATION: Parameter meta data - Support indexed naming

### DIFF
--- a/component_information/parameter.schema.json
+++ b/component_information/parameter.schema.json
@@ -26,7 +26,8 @@
                 "name": {
                     "description":  "Parameter Name.",
                     "type":         "string",
-                    "pattern":      "^[a-zA-Z0-9_]{1,16}$"
+                    "pattern":      "^[a-zA-Z0-9_]{1,16}$",
+                    "comment":      "FOO<#>_BAR for name will match actual name of FOO1_BAR, FOO3_BAR and so forth." 
                 },
                 "type": {
                     "description":  "Parameter type.",


### PR DESCRIPTION
* Parameter name can be in format `FOO<#>_BAR` which will match `FOO1_BAR`, `FOO_6_BAR` and so forth
* Reduces duplication and file size