### PR TITLE
COMPONENT_INFORMATION:COMP_METADATA_TYPE_COMMANDS (WIP)

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1372,6 +1372,9 @@
       <entry value="1" name="COMP_METADATA_TYPE_PARAMETER">
         <description>Parameter meta data.</description>
       </entry>
+      <entry value="2" name="COMP_METADATA_TYPE_COMMANDS">
+        <description>Meta data which specifies the commands the vehicle supports. (WIP)</description>
+      </entry>
     </enum>
     <enum name="PARAM_TRANSACTION_TRANSPORT">
       <description>Possible transport layers to set and get parameters via mavlink during a parameter transaction.</description>


### PR DESCRIPTION
I"m going to start work on figure out the metadata which specifies the commands a vehicle supports. This allows  gcs to at a minimum know what commands to show when creating missions. It could end up being more than that but I'm going to start simple.

Once this passes CI I'm going to merge so I can start implementation in QGC and work my way through it.