### PR TITLE
Add ID field to HIL_SENSOR for multisensor  support

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5110,6 +5110,8 @@
       <field type="float" name="pressure_alt">Altitude calculated from pressure</field>
       <field type="float" name="temperature" units="degC">Temperature</field>
       <field type="uint32_t" name="fields_updated" display="bitmask">Bitmap for fields that have updated since last message, bit 0 = xacc, bit 12: temperature, bit 31: full reset of attitude/position/velocities/etc was performed in sim.</field>
+      <extensions/>
+      <field type="uint8_t" name="id">Sensor ID (zero indexed). Used for multiple sensor inputs</field>
     </message>
     <message id="108" name="SIM_STATE">
       <description>Status of simulation environment, if used</description>


### PR DESCRIPTION
This PR adds a ID field as an extension to the `HIL_SENSOR` message. This enables streaming multiple instances of `HIL_SENSOR` data so that we can simulate in HIL/SITL multi IMU/Airspeed/Barometer sensor scenarios.

I believe simulating multiple sensors have become of interest for various reasons and PX4 already has support for multi airspeed sensors. For me it doesn't make sense that this cannot be simulated because the message definition is unable to represent multiple instances, hence the extension.

The same approach is already being utilized in the `HIL_GPS` message for simulating multiple GPS sensors.

**Alternative approach**
An alternative approach would be to actually redefine the `HIL_SENSOR` message so that we have separate messages for each sensors. However, I think this might bring huge regression problems and a synchronous updates of each sensors are already being nicely handled with the `fields_updated` field. 

@TSC21 @RomanBapst FYI