### PR TITLE
Add some "missing" fields to AUTOPILOT_VERSION, CAMERA_INFORMATION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5544,6 +5544,8 @@
       <field type="uint64_t" name="uid">UID if provided by hardware (see uid2)</field>
       <extensions/>
       <field type="uint8_t[18]" name="uid2">UID if provided by hardware (supersedes the uid field. If this is non-zero, use this field, otherwise use uid)</field>
+      <field type="uint8_t[32]" name="vendor_name">Name of vendor</field>
+      <field type="uint8_t[32]" name="model_name">Name of model</field>
     </message>
     <message id="149" name="LANDING_TARGET">
       <description>The location of a landing target. See: https://mavlink.io/en/services/landing_target.html</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5851,6 +5851,8 @@
       <field type="uint32_t" name="flags" enum="CAMERA_CAP_FLAGS" display="bitmask">Bitmap of camera capability flags.</field>
       <field type="uint16_t" name="cam_definition_version">Camera definition version (iteration)</field>
       <field type="char[140]" name="cam_definition_uri">Camera definition URI (if any, otherwise only basic functions will be available). HTTP- (http://) and MAVLink FTP- (mavlinkftp://) formatted URIs are allowed (and both must be supported by any GCS that implements the Camera Protocol).</field>
+      <extensions/>
+      <field type="uint32_t" name="hardware_version">Version of the camera hardware, encoded as: (Dev &amp; 0xff) &lt;&lt; 24 | (Patch &amp; 0xff) &lt;&lt; 16 | (Minor &amp; 0xff) &lt;&lt; 8 | (Major &amp; 0xff)</field>
     </message>
     <message id="260" name="CAMERA_SETTINGS">
       <description>Settings of a camera. Can be requested with a MAV_CMD_REQUEST_MESSAGE command.</description>


### PR DESCRIPTION
The current COMPONENT_INFORMATION has become pretty much useless for typical components or embedded gcses. However, info such as vendor, model, firmware version, and hardware version are quite useful to the user even for typical components. The AUTOPILOT_VERSION message is the typical component's best bet to provide it, and CAMERA_INFORMATION for cameras.

Unfortunately, some of these info is missing in each of them, and this PR is attempting to make them more complete and consistent as regards these info. That is, the two messages are extended such that they each provide these four items
* vendor name
* model name
* firmware version (aka flight_sw_version in AUTOPILOT_VERSION)
* hardware version (aka board_version in AUTOPILOT_VERSION)

For AUTOPILOT_VERSION this is a quite natural extension with essentially no consequences, and thus should be agreeable.

For CAMERA_INFORMATION it would be the first extension, and thus has to follow the large uri field (of type char[140]). It thus breaks the effectiveness of zero-byte truncation. However, CAMERA_INFORMATION is exchanged only very rarely, and I thus argue that zero-byte truncation is not really of importance here. I thus think that the extension should also be agreeable.
