### PR TITLE
MAV_CMD_NAV_FENCE_RETURN_POINT - deprecate

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1915,6 +1915,7 @@
         <param index="7" label="Altitude" units="m">Altitude</param>
       </entry>
       <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT" hasLocation="true" isDestination="true">
+        <deprecated since="2020-09" replaced_by="MAV_CMD_NAV_RALLY_POINT">This mechanism was superseded by rally points. If rally points are defined then they take precedence.</description>
         <description>Fence return point. There can only be one fence return point.
         </description>
         <param index="1">Reserved</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1915,7 +1915,7 @@
         <param index="7" label="Altitude" units="m">Altitude</param>
       </entry>
       <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT" hasLocation="true" isDestination="true">
-        <deprecated since="2020-09" replaced_by="MAV_CMD_NAV_RALLY_POINT">This mechanism was superseded by rally points. If rally points are defined then they take precedence.</description>
+        <deprecated since="2020-09" replaced_by="MAV_CMD_NAV_RALLY_POINT">This mechanism was superseded by rally points. If rally points are defined then they take precedence.</deprecated>
         <description>Fence return point. There can only be one fence return point.
         </description>
         <param index="1">Reserved</param>


### PR DESCRIPTION
As discussed in the dev call, `MAV_CMD_NAV_FENCE_RETURN_POINT` predates the use of rally points and is superseded by them. This change deprecates the command, and further clarifies that if a rally point is defined as well then that rally point would be used instead. 

FYI @DonLakeFlyer ,@meee1 
- We wont be removing this arbitrarily because we never remove things arbitrarily :-). But in particular, because this is still being used by some ArduPilot systems that won't update. 
- PX4 appears to support setting this through QGC, but it also appears to ignore the setting. Worth removing as an option in the UI IMO.
