### PR TITLE
common: Add a DECAROTOR type

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -173,6 +173,9 @@
       <entry value="34" name="MAV_TYPE_ODID">
         <description>Open Drone ID. See https://mavlink.io/en/services/opendroneid.html.</description>
       </entry>
+      <entry value="35" name="MAV_TYPE_DECAROTOR">
+        <description>Decarotor</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
I've updated the source and added a 10-rotor helicopter type.

Before:
#1479
