### PR TITLE
CMake: Removing slugs.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ set(v1.0Definitions
     minimal.xml
     paparazzi.xml
     python_array_test.xml
-    slugs.xml
     test.xml
     ualberta.xml
     )


### PR DESCRIPTION
Looks like this XML has been removed over time. I'm just wondering why nobody noticed that it is missing.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)