### PR TITLE
CMake: Using find_program to find mavgen(.py)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRARY_SOVERSION "0.0.0")
 # none required
 
 # options
+option(USE_SYSTEM_PYMAVLINK "Generate mavlink files with system-wide installed mavgen" OFF)
 option(WITH_TESTS "Build test programs." OFF)
 option(WITH_BUILD_DEPS "Build dependencies." OFF) # no deps currently to build
 option(WITH_BUILD_STATIC "Build preferring static linking." ON)
@@ -133,15 +134,22 @@ endif()
 configure_file(config.h.in config.h)
 install(FILES ${CMAKE_BINARY_DIR}/config.h DESTINATION include/${PROJECT_NAME} COMPONENT Dev)
 
-# mavlink generation
-find_program (
-    mavgen_EXECUTABLE
-    NAMES mavgen mavgen.py
-)
-message(STATUS "mavgen_EXECUTABLE: ${mavgen_EXECUTABLE}")
-if (mavgen_EXECUTABLE-NOTFOUND)
-    set(mavgen_EXECUTABLE ${PYTHON_EXECUTABLE} -m pymavlink.tools.mavgen)
+# mavgen location for mavlink generation
+set(mavgen_EXECUTABLE_WITH_PYTHON_INVOCATION ${CMAKE_COMMAND} -E env "PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_CURRENT_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pymavlink.tools.mavgen)
+if(USE_SYSTEM_PYMAVLINK)
+    find_program (
+        mavgen_EXECUTABLE
+        NAMES mavgen mavgen.py
+    )
+
+    # Fallback to Python invocation, if not found.
+    if (mavgen_EXECUTABLE-NOTFOUND)
+        set(mavgen_EXECUTABLE ${mavgen_EXECUTABLE_WITH_PYTHON_INVOCATION})
+    endif()
+else()
+    set(mavgen_EXECUTABLE ${mavgen_EXECUTABLE_WITH_PYTHON_INVOCATION})
 endif()
+message(STATUS "mavgen_EXECUTABLE: ${mavgen_EXECUTABLE}")
 
 macro(generateMavlink version definitions)
     foreach(definition ${definitions})
@@ -150,10 +158,12 @@ macro(generateMavlink version definitions)
         message(STATUS "processing: ${definitionAbsPath}")
         add_custom_command( 
             OUTPUT ${targetName}-stamp
-            COMMAND PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_CURRENT_SOURCE_DIR} ${mavgen_EXECUTABLE} --lang=C --wire-protocol=${version}
-                --output=include/v${version} ${definitionAbsPath}
+            COMMAND ${mavgen_EXECUTABLE} --lang=C
+                                         --wire-protocol=${version}
+                                         --output=include/v${version}
+                                         ${definitionAbsPath}
             COMMAND touch ${targetName}-stamp
-            )
+        )
         add_custom_target(${targetName} ALL DEPENDS ${targetName}-stamp)
     endforeach()
 endmacro()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,15 @@ configure_file(config.h.in config.h)
 install(FILES ${CMAKE_BINARY_DIR}/config.h DESTINATION include/${PROJECT_NAME} COMPONENT Dev)
 
 # mavlink generation
+find_program (
+    mavgen_EXECUTABLE
+    NAMES mavgen mavgen.py
+)
+message(STATUS "mavgen_EXECUTABLE: ${mavgen_EXECUTABLE}")
+if (mavgen_EXECUTABLE-NOTFOUND)
+    set(mavgen_EXECUTABLE ${PYTHON_EXECUTABLE} -m pymavlink.tools.mavgen)
+endif()
+
 macro(generateMavlink version definitions)
     foreach(definition ${definitions})
         set(targetName ${definition}-v${version})
@@ -141,7 +150,7 @@ macro(generateMavlink version definitions)
         message(STATUS "processing: ${definitionAbsPath}")
         add_custom_command( 
             OUTPUT ${targetName}-stamp
-            COMMAND PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_CURRENT_SOURCE_DIR} ${PYTHON_EXECUTABLE} -m pymavlink.tools.mavgen --lang=C --wire-protocol=${version}
+            COMMAND PYTHONPATH=$ENV{PYTHONPATH}:${CMAKE_CURRENT_SOURCE_DIR} ${mavgen_EXECUTABLE} --lang=C --wire-protocol=${version}
                 --output=include/v${version} ${definitionAbsPath}
             COMMAND touch ${targetName}-stamp
             )
@@ -150,7 +159,6 @@ macro(generateMavlink version definitions)
 endmacro()
 
 # build
-set(mavgen -m pymavlink.tools.mavgen)
 set(v1.0Definitions
     ASLUAV.xml
     ardupilotmega.xml

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1736,9 +1736,11 @@
         <description>Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture. Use NaN for reserved values.</description>
         <param index="1">Reserved (Set to 0)</param>
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
-        <param index="3" label="Capture Count" minValue="0" increment="1">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
-        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1. This is only valid for single-capture (param3 == 1). Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted. Use 0 to ignore it.</param>
-        <param index="5">Reserved (all remaining params)</param>
+        <param index="3" label="Total Images" minValue="0" increment="1">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
+        <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1. This is only valid for single-capture (param3 == 1), otherwise set to 0. Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted.</param>
+        <param index="5" reserved="true" default="NaN"/>
+        <param index="6" reserved="true" default="NaN"/>
+        <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE" hasLocation="false" isDestination="false">
         <description>Stop image capture sequence Use NaN for reserved values.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1915,6 +1915,7 @@
         <param index="7" label="Altitude" units="m">Altitude</param>
       </entry>
       <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT" hasLocation="true" isDestination="true">
+        <deprecated since="2020-09" replaced_by="MAV_CMD_NAV_RALLY_POINT">This mechanism was superseded by rally points. If rally points are defined then they take precedence.</deprecated>
         <description>Fence return point. There can only be one fence return point.
         </description>
         <param index="1">Reserved</param>


### PR DESCRIPTION
If neither mavgen nor mavgen.py have been found as executables in $PATH, then we will fallback to the hardcoded location (submodule).

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>