### PR TITLE
Gimbal Device: Add rc flags

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -415,6 +415,9 @@
       <entry value="2048" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
         <description>Gimbal device supports yawing/panning infinetely (e.g. using slip disk).</description>
       </entry>
+      <entry value="4096" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RC">
+        <description>Gimbal device supports control or nudge via an RC input signal.</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_CAP_FLAGS" bitmask="true">
       <description>Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_DEVICE_CAP_FLAGS which are identical with GIMBAL_DEVICE_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>
@@ -486,6 +489,12 @@
       </entry>
       <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+      </entry>
+      <entry value="65536" name="GIMBAL_DEVICE_FLAGS_RC_CONTROL">
+        <description>Set to RC control. The RC input signal fed to the gimbal device controls the gimbal's orientation.</description>
+      </entry>
+      <entry value="131072" name="GIMBAL_DEVICE_FLAGS_RC_NUDGE">
+        <description>Set to RC nudge. The RC input signal fed to the gimbal device nudges the gimbal's orientation.</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_FLAGS" bitmask="true">
@@ -6126,7 +6135,7 @@
       <field type="uint8_t[32]" name="vendor_name">Name of the gimbal vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the gimbal model</field>
       <field type="uint32_t" name="firmware_version">Version of the gimbal firmware, encoded as: (Dev &amp; 0xff) &lt;&lt; 24 | (Patch &amp; 0xff) &lt;&lt; 16 | (Minor &amp; 0xff) &lt;&lt; 8 | (Major &amp; 0xff)</field>
-      <field type="uint16_t" name="cap_flags" enum="GIMBAL_DEVICE_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
+      <field type="uint32_t" name="cap_flags" enum="GIMBAL_DEVICE_CAP_FLAGS" display="bitmask">Bitmap of gimbal capability flags.</field>
       <field type="float" name="tilt_max" units="rad">Maximum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_min" units="rad">Minimum tilt/pitch angle (positive: up, negative: down)</field>
       <field type="float" name="tilt_rate_max" units="rad/s">Maximum tilt/pitch angular rate (positive: up, negative: down)</field>
@@ -6140,7 +6149,7 @@
       <description>Low level message to control a gimbal device's attitude. This message is to be sent from the gimbal manager to the gimbal device component. Angles and rates can be set to NaN according to use case.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set, set all fields to NaN if only angular velocity should be used)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
@@ -6153,7 +6162,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
-      <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
       <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>


### PR DESCRIPTION
The gimbal protocol v2 messages may not be in a good shape and it's outcoming a bit unpredictable, but this pr is based on the assumption that the set of messages dealing with what is called the gimbal device is pretty solid and will remain irrespective of what happens to the other parts. Indeed, the latest pr #1466 is not affecting those (except of improvements of descriptions).

The pr adds RC flags to the gimbal device messages. The rational is the observation that many gimbals have the ability to digest an input rc signal, be it a PWM signal or other protocols like sbus and friends, and it even could be a RC_CHANNELS mavlink message. This rc input is processed by gimbal specific procedures possibly using gimbal specific parameters with the effect to move the gimbal. The added rc flags allow us to tell the gimbal what it is supposed to do with that rc input signal (possibly overriding settings made by the user via a gimbal specific gui, or gimbal default settings). It is functionality on the same level like RETRACT or NEUTRAL.

On this occasion I also took the liberty to expand the size of the gimbal device flags to uint32. I first note that the gimbal device failure_flags is also of size uint32, which appears to be massively oversized and very future proof. It doesn't make much sense to me to expect up to 32 error flags but only 16 state flags at most. I rather think the opposite seems more likely.

Currently the gimbal protocol v2's idea is that the 16 bits of the gimbal device flags are 1-to-1 mirrored into the first 16 bits of the 32-bit wide gimbal manager flags. If that is to prevail, the proposal here would be to continue to do so. That is, the lower 16 bit of the gimbal device flag would be mirrored into the lower 16 bits of the gimbal manager flags, but the higher 16 bits of the gimbal device flag would not be carried over to the gimbal manager flags (and are so to say hidden).

Indeed, the added rc gimbal device flags need not to show up in the gimbal manager flags at all, and in fact should not show up up there, since rc control would be handled by other means by the gimbal manager. Accordingly, I have placed the rc flags in the upper 16 bits.

In the case the current approach to mirror the gimbal device flags into the gimbal manager should not prevail, no harm has been done either. So, it makes much sense to me.
