### PR TITLE
AUTOPILOT_STATE_FOR_GIMBAL_DEVICE: it's Hamilton

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6164,10 +6164,10 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Low level message containing autopilot state relevant for a gimbal device. This message is to be sent from the gimbal manager to the gimbal device component. The data of this message server for the gimbal's estimator corrections in particular horizon compensation, as well as the autopilot's control intention e.g. feed forward angular control in z-axis.</description>
-      <field type="uint64_t" name="time_boot_us" units="us">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="float[4]" name="q">Quaternion components of autopilot attitude: w, x, y, z (1 0 0 0 is the null-rotation, Hamiltonian convention).</field>
+      <field type="uint64_t" name="time_boot_us" units="us">Timestamp (time since system boot).</field>
+      <field type="float[4]" name="q">Quaternion components of autopilot attitude: w, x, y, z (1 0 0 0 is the null-rotation, Hamilton convention).</field>
       <field type="uint32_t" name="q_estimated_delay_us" units="us">Estimated delay of the attitude data.</field>
       <field type="float" name="vx" units="m/s">X Speed in NED (North, East, Down).</field>
       <field type="float" name="vy" units="m/s">Y Speed in NED (North, East, Down).</field>


### PR DESCRIPTION
Hamiltonian convention is nonsense, it's Hamilton convention, or Hamilton's convention, or whatever

(Hamiltonian is the Hamilton function or Hamilton operator, or related mathematical constructs, nothing to do at all with quaternions)

I also grabbed the opportunity to move the two target fields to the front. A simple search through common.xml shows that this is so for all other messages (except one which has a network thing).