### PR TITLE
Gimbal Device: Handling of absolute yaw

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -412,8 +412,11 @@
       <entry value="1024" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK">
         <description>Gimbal device supports locking to an absolute heading (often this is an option available)</description>
       </entry>
-      <entry value="2048" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
-        <description>Gimbal device supports yawing/panning infinetely (e.g. using slip disk).</description>
+      <entry value="2048" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_INFINITE_YAW">
+        <description>Gimbal device supports yawing/panning infinitely (e.g. using slip ring).</description>
+      </entry>
+      <entry value="4096" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_ABSOLUTE_YAW">
+        <description>Gimbal device supports absolute yaw angles (this usually requires support by an autopilot, and can be dynamic, i.e., go on and off during runtime).</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_CAP_FLAGS" bitmask="true">
@@ -487,6 +490,13 @@
       <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
+      <entry value="32" name="GIMBAL_DEVICE_FLAGS_CAN_ACCEPT_YAW_ABSOLUTE">
+        <description>Gimbal device can accept absolute yaw angle input. This flag cannot be set, is only for reporting (attempts to set it are rejected by the gimbal device).</description>
+      </entry>
+      <entry value="64" name="GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE">
+        <description>Yaw angle is absolute (is only accepted if GIMBAL_DEVICE_FLAGS_CAN_ACCEPT_YAW_ABSOLUTE is set). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute), else it is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+      </entry>
+      
     </enum>
     <enum name="GIMBAL_MANAGER_FLAGS" bitmask="true">
       <description>Flags for high level gimbal manager operation The first 16 bytes are identical to the GIMBAL_DEVICE_FLAGS.</description>
@@ -6141,24 +6151,24 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set, set all fields to NaN if only angular velocity should be used)</field>
-      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right, NaN to be ignored.</field>
-      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up, NaN to be ignored.</field>
-      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right, NaN to be ignored.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, Hamilton convention, the frame depends on GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, set all fields to NaN if only angular velocity should be used)</field>
+      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity, positive is banking to the right (NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity, positive is tilting up (NaN to be ignored).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity, positive is panning to the right (the frame depends on GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN to be ignored).</field>
     </message>
     <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal device component. The angles encoded in the quaternion are in the global frame (roll: positive is tilt to the right, pitch: positive is tilting up, yaw is turn to the right). This message should be broadcast at a low regular rate (e.g. 10Hz).</description>
+      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal device component at a low regular rate (e.g. 10Hz).</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
-      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
-      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
-      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>
-      <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, Hamilton convention, the frame depends on GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag).</field>
+      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown).</field>
+      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown).</field>
+      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (the frame depends on GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE flag, NaN if unknown).</field>
+      <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure).</field>
     </message>
     <message id="286" name="AUTOPILOT_STATE_FOR_GIMBAL_DEVICE">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -496,7 +496,6 @@
       <entry value="64" name="GIMBAL_DEVICE_FLAGS_YAW_ABSOLUTE">
         <description>Yaw angle is absolute (is only accepted if GIMBAL_DEVICE_FLAGS_CAN_ACCEPT_YAW_ABSOLUTE is set). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute), else it is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
-      
     </enum>
     <enum name="GIMBAL_MANAGER_FLAGS" bitmask="true">
       <description>Flags for high level gimbal manager operation The first 16 bytes are identical to the GIMBAL_DEVICE_FLAGS.</description>


### PR DESCRIPTION
This is my take at the issue of handling absolute yaw for gimbal devices. (related also to #1369).

Currently, the frame is linked to wether the yaw axis is in locked (= absolute yaw) or in follow (= relative yaw) mode. 

IMHO, this is not appropriate and a quite serious restriction to practical applications, making it essentially impossible for many gimbal users to put their gimbal into lock mode. Note that this can be a much desired operation, even if the gimbal doesn't have absolute yaw. If you want to dispute that watch the videos posted here done in a commercial context:  https://www.rcgroups.com/forums/showpost.php?p=45371373&postcount=12922

The idea of the flags is that a gimbal may not be able to support absolute yaw for every point in time during operation. For instance, it may take a while before it gets the supporting data from the autopilot. There might be also longer or shorter outages during operation.

The added capability flag indicates if the gimbal may support absolute yaw during runtime, or not. 

The added CAN_ACCEPT_YAW_ABSOLUTE is the flag which reports to the outside world if the gimbal device is currently able to accept absolute yaw angle inputs.

Finally, the added YAW_ABSOLUTE flag has the usual dual role of these flags, i.e. it can be set in a SET_ATTITUDE message which when indicates to the gimbal device that the data is in absolute frame, or else in relative frame. It is also raised in the STATUS message if the reported data is in absolute frame or not.

One point is left open, namely when should the gimbal device send STATUS with absolute yaw, and when not. A simple rule would be that gimbal device always sends in absolute frame whenever it can, else not. However, one also equally well could it just leave to the gimbal device implementation. Outside code needs to adapt to both cases anyhow.

The proposal is only for the gimbal device, at the level of the gimbal manager one may want to do whatever else.

EDIT:
If the extension of the gimbal device flag to uint32 as proposed in #1486 would be accepted, one also could consider to move the two newly added flags to the higher 16-bit area, if one thinks they should be hidden to a gimbal manager user.