### PR TITLE
Introduce image groups to allow for correlating images with surveys

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1785,6 +1785,14 @@
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Stops ongoing tracking.</description>
       </entry>
+      <entry value="2020" name="MAV_CMD_IMAGE_START_GROUP" hasLocation="false" isDestination="false">
+        <description>Instruct the camera to tag all subsequently captured images with the specified group ID. This is to later correlate images with mission items (surveys). Each camera should track independent groupings (as cameras may be occupied capturing different targets at different schedules). Vehicles are encouraged to bake the group ID into the image's exif and it must report the group ID within the CAMERA_IMAGE_CAPTURED.</description>
+        <param index="1" label="Number" minValue="0">Image Group ID.</param>
+        <param index="2" reserved="true" default="NaN"/>
+        <param index="3" reserved="true" default="NaN"/>
+        <param index="4" reserved="true" default="NaN"/>
+        <param index="7" reserved="true" default="NaN"/>
+      </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE" hasLocation="false" isDestination="false">
         <description>Starts video capture (recording).</description>
         <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams)</param>
@@ -5975,6 +5983,7 @@
       <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
       <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="int32_t" name="image_index">Zero based index of this image (i.e. a new image will have index CAMERA_CAPTURE_STATUS.image count -1)</field>
+      <field type="int32_t" name="image_group">Image Group ID (if set by MAV_CMD_IMAGE_START_GROUP preceeding this image capture) or -1 if no image group set. Image downloaders should consider grouping images into folders named after 'image_group'.</field>
       <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
       <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1786,7 +1786,7 @@
         <description>Stops ongoing tracking.</description>
       </entry>
       <entry value="2020" name="MAV_CMD_IMAGE_START_GROUP" hasLocation="false" isDestination="false">
-        <description>Instruct the camera to tag all subsequently captured images with the specified group ID. This is to later correlate images with mission items (surveys). Each camera should track independent groupings (as cameras may be occupied capturing different targets at different schedules). Vehicles are encouraged to bake the group ID into the image's exif and it must report the group ID within the CAMERA_IMAGE_CAPTURED.</description>
+        <description>Instruct the camera to tag all subsequently captured images with the specified group ID. This is to later correlate images with mission items (surveys). Each camera should track independent groupings (as cameras may be occupied capturing different targets at different schedules). Vehicles are encouraged to bake the group ID into the image's exif and it must report the group ID within the CAMERA_IMAGE_CAPTURED. A group ID once set can only be unset by setting another group ID (with another MAV_CMD_IMAGE_START_GROUP).</description>
         <param index="1" label="Image Group" minValue="0">Image group ID (an integer)</param>
         <param index="2" reserved="true" default="NaN"/>
         <param index="3" reserved="true" default="NaN"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5983,7 +5983,6 @@
       <field type="int32_t" name="relative_alt" units="mm">Altitude above ground</field>
       <field type="float[4]" name="q">Quaternion of camera orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="int32_t" name="image_index">Zero based index of this image (i.e. a new image will have index CAMERA_CAPTURE_STATUS.image count -1)</field>
-      <field type="int32_t" name="image_group">Image Group ID (if set by MAV_CMD_IMAGE_START_GROUP preceeding this image capture) or -1 if no image group set. Image downloaders should consider grouping images into folders named after 'image_group'.</field>
       <field type="int8_t" name="capture_result">Boolean indicating success (1) or failure (0) while capturing this image.</field>
       <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1787,7 +1787,7 @@
       </entry>
       <entry value="2020" name="MAV_CMD_IMAGE_START_GROUP" hasLocation="false" isDestination="false">
         <description>Instruct the camera to tag all subsequently captured images with the specified group ID. This is to later correlate images with mission items (surveys). Each camera should track independent groupings (as cameras may be occupied capturing different targets at different schedules). Vehicles are encouraged to bake the group ID into the image's exif and it must report the group ID within the CAMERA_IMAGE_CAPTURED.</description>
-        <param index="1" label="Number" minValue="0">Image Group ID.</param>
+        <param index="1" label="Image Group" minValue="0">Image group ID (an integer)</param>
         <param index="2" reserved="true" default="NaN"/>
         <param index="3" reserved="true" default="NaN"/>
         <param index="4" reserved="true" default="NaN"/>


### PR DESCRIPTION
This PR re-approaches the image->survey correlation problem - one of two that [this](https://github.com/mavlink/mavlink/pull/1319) (now stale and closed) PR aimed to solve.
I choose to start a new PR because:
- the other problem, one of lost images, has been since solved at a higher lever ([with `MAV_CMD_REQUEST_MESSAGE`](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE))
- to shake off the comment clutter the previous PR amassed.

### The problem:
In a general case a mission features multiple surveys and each survey captures multiple images. Surveys are processed to produce orthomosaics, digital elevation models or 360 panoramas. The processing software needs to pick all images pertaining to a specific survey and no image beyond it (no image from other surveys) it thus needs the images grouped per survey. It could, in theory, attempt it by careful analysis of geotags and timestamps, but this is a blunt tool and one difficult to use. 

### Proposal
This PR proposes an "image group" that it asks to be communicated both in the;
- image exifs and 
- `CAMERA_IMAGE_CAPTURED` broadcast - to relieve the processors from needing to parse exif. A most simplistic processor - e.g.: [a photo gallery](https://github.com/mavlink/qgroundcontrol/blob/srr-qgc/src/PhotoGallery/PhotoGalleryVehicleGlue.cc#L102) arguably should group the photos by survey. 

[As suggested earlier](https://github.com/mavlink/mavlink/pull/1319#issuecomment-612441126) this PR reluctantly introduces a dedicated message (`MAV_CMD_IMAGE_START_GROUP`) that allows the GCS to set a group for all followup images. It does it reluctantly because I think the image->survey correlation problem is more fundamental and deserves to be the first class citizen. Many surveys per mission is not a corner case. Survey is a a thing within a plan and natural grouping. Images are captured for a purpose and very often that purpose is automated processing. This is why I suggest to scrap `MAV_CMD_IMAGE_START_GROUP` and allow the image group within [`MAV_CMD_IMAGE_START_CAPTURE`](https://mavlink.io/en/messages/common.html#MAV_CMD_IMAGE_START_CAPTURE) - there are still vacant parameter slots.


