### PR TITLE
add command 260 for Oblique Survey

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1589,7 +1589,7 @@
       </entry>
       <entry value="260" name="MAV_CMD_OBLIQUE_SURVEY" hasLocation="false" isDestination="false">
         <wip/>
-        <description>Mission command to set a Camera Auto Mount Pivoting Oblique Survey. The camera is triggered each time this distance is exceeded, then the mount moves to the next position. Params 4~6 set-up the angle limits and number of positions for oblique survey, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV). This command can also be used to set the shutter integration time for the camera.</description>
+        <description>Mission command to set a Camera Auto Mount Pivoting Oblique Survey (Replaces CAM_TRIGG_DIST for this purpose). The camera is triggered each time this distance is exceeded, then the mount moves to the next position. Params 4~6 set-up the angle limits and number of positions for oblique survey, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV). This command can also be used to set the shutter integration time for the camera.</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="0" increment="1" default="0">Camera shutter integration time. 0 to ignore</param>
         <param index="3" label="Min Interval" units="ms" minValue="0" maxValue="10000" increment="1" default="0">The minimum interval in which the camera is capable of taking subsequent pictures repeatedly. 0 to ignore.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1345,13 +1345,13 @@
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">
-        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. Params 4~6 enable a pseudo-oblique mode, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup.</description>
+        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. WIP: Params 4~6 enable a pseudo-oblique mode, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup.</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Positions" minValue="0" increment="1" default="0">Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (Greater or equal to 2 enables this feature)</param>
-        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is greater or equal to 2) </param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is greater or equal to 2)</param>
+        <param index="4" label="Positions" minValue="0" increment="1" default="0">WIP: Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (Greater or equal to 2 enables this feature)</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">WIP: Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is greater or equal to 2) </param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">WIP: Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is greater or equal to 2)</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1372,13 +1372,13 @@
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">
-        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. WIP: Params 4~6 enable a pseudo-oblique mode, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV).</description>
+        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera.</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Positions" minValue="0" increment="1" default="0">WIP: Total number of roll positions at which the camera will capture photos (images captures spread evenly across the limits defined by param5). Feature enabled if value is greater or equal to 2.</param>
-        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">WIP: Angle limits that the camera can be rolled to left and right of center. Enabled if param 4 is greater or equal to 2.</param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">WIP: Fixed pitch angle that the camera will hold in pseudo oblique mode if the mount supports it. Enabled if param 4 is greater or equal to 2.</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">
@@ -1586,6 +1586,17 @@
         <param index="5" label="Latitude/X">Latitude/X position.</param>
         <param index="6" label="Longitude/Y">Longitude/Y position.</param>
         <param index="7" label="Altitude/Z">Altitude/Z position.</param>
+      </entry>
+      <entry value="260" name="MAV_CMD_OBLIQUE_SURVEY" hasLocation="false" isDestination="false">
+        <wip/>
+        <description>Mission command to set a Camera Auto Mount Pivoting Oblique Survey. The camera is triggered each time this distance is exceeded, then the mount moves to the next position. This command can also be used to set the shutter integration time for the camera. Params 4~6 set-up the angle limits and number of positions for oblique survey, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV).</description>
+        <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
+        <param index="2" label="Shutter" units="ms" minValue="0" increment="1" default="0">Camera shutter integration time. 0 to ignore</param>
+        <param index="3" label="Min Interval" units="ms" minValue="0" maxValue="10000" increment="1" default="0">The minimum interval in which the camera is capable of taking subsequent pictures repeatedly. 0 to ignore.</param>
+        <param index="4" label="Positions" minValue="2" increment="1">Total number of roll positions at which the camera will capture photos (images captures spread evenly across the limits defined by param5).</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">Angle limits that the camera can be rolled to left and right of center.</param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">Fixed pitch angle that the camera will hold in pseudo oblique mode if the mount supports it.</param>
+        <param index="7">Empty</param>
       </entry>
       <entry value="300" name="MAV_CMD_MISSION_START" hasLocation="false" isDestination="false">
         <description>start running a mission</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1589,13 +1589,13 @@
       </entry>
       <entry value="260" name="MAV_CMD_OBLIQUE_SURVEY" hasLocation="false" isDestination="false">
         <wip/>
-        <description>Mission command to set a Camera Auto Mount Pivoting Oblique Survey. The camera is triggered each time this distance is exceeded, then the mount moves to the next position. This command can also be used to set the shutter integration time for the camera. Params 4~6 set-up the angle limits and number of positions for oblique survey, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV).</description>
+        <description>Mission command to set a Camera Auto Mount Pivoting Oblique Survey. The camera is triggered each time this distance is exceeded, then the mount moves to the next position. Params 4~6 set-up the angle limits and number of positions for oblique survey, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV). This command can also be used to set the shutter integration time for the camera.</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="0" increment="1" default="0">Camera shutter integration time. 0 to ignore</param>
         <param index="3" label="Min Interval" units="ms" minValue="0" maxValue="10000" increment="1" default="0">The minimum interval in which the camera is capable of taking subsequent pictures repeatedly. 0 to ignore.</param>
         <param index="4" label="Positions" minValue="2" increment="1">Total number of roll positions at which the camera will capture photos (images captures spread evenly across the limits defined by param5).</param>
         <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">Angle limits that the camera can be rolled to left and right of center.</param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">Fixed pitch angle that the camera will hold in pseudo oblique mode if the mount supports it.</param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">Fixed pitch angle that the camera will hold in oblique mode if the mount is actuated in the pitch axis.</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="300" name="MAV_CMD_MISSION_START" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1349,7 +1349,7 @@
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Positions" minValue="0" increment="1" default="0">Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (greater or equal to 2 enables this feature) (more info at: https://github.com/mavlink/mavlink/pull/1508)</param>
+        <param index="4" label="Positions" minValue="0" increment="1" default="0">Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (Greater or equal to 2 enables this feature)</param>
         <param index="5" label="Roll Angle" units="deg" minValue="0" default="20">Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is greater or equal to 2) </param>
         <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="-90">Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is greater or equal to 2)</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1350,8 +1350,8 @@
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
         <param index="4" label="Positions" minValue="0" increment="1" default="0">Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (Greater or equal to 2 enables this feature)</param>
-        <param index="5" label="Roll Angle" units="deg" minValue="0" default="20">Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is greater or equal to 2) </param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="-90">Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is greater or equal to 2)</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is greater or equal to 2) </param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is greater or equal to 2)</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1345,13 +1345,13 @@
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">
-        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. WIP: Params 4~6 enable a pseudo-oblique mode, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup.</description>
+        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. WIP: Params 4~6 enable a pseudo-oblique mode, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV).</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Positions" minValue="0" increment="1" default="0">WIP: Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (Greater or equal to 2 enables this feature)</param>
-        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">WIP: Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is greater or equal to 2) </param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">WIP: Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is greater or equal to 2)</param>
+        <param index="4" label="Positions" minValue="0" increment="1" default="0">WIP: Total number of roll positions at which the camera will capture photos (images captures spread evenly across the limits defined by param5). Feature enabled if value is greater or equal to 2.</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">WIP: Angle limits (in degrees) that the camera can be rolled to left and right of center. Enabled if param 4 is greater or equal to 2.</param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">WIP: Fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. Enabled if param 4 is greater or equal to 2.</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1345,13 +1345,13 @@
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">
-        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. Params 4~6 enable additional image captures at different gimbal orientations at each trigger point (this allows, for example, automatically roll of the camera between shots to emulate an oblique camera setup).</description>
+        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. Params 4~6 enable a special mode (CAMPOS) where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup.</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Positions" minValue="0" increment="1" default="0">Number of additional gimbal positions at which to capture photos at each trigger point. The gimbal orientations for each capture are defined by params 5 (roll) and param 6 (pitch). Default is 0 (gimbal orientation is fixed so only default position is captured)</param>
-        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">The angle limits (in degrees) that the camera will be rolled to left and right of the centerline.</param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">The fixed pitch angle that the camera will hold while capturing images at different roll angles (if the mount supports it).</param>
+        <param index="4" label="Positions" minValue="0" increment="1" default="0">Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (>= 2 enables this feature) (more info at: https://github.com/mavlink/mavlink/pull/1508)</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="20">Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is >= 2) </param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="-90">Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is >= 2)</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1345,13 +1345,13 @@
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">
-        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. Params 4~6 enable a special mode (CAMPOS) where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup.</description>
+        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. Params 4~6 enable a pseudo-oblique mode, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup.</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Positions" minValue="0" increment="1" default="0">Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (>= 2 enables this feature) (more info at: https://github.com/mavlink/mavlink/pull/1508)</param>
-        <param index="5" label="Roll Angle" units="deg" minValue="0" default="20">Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is >= 2) </param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="-90">Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is >= 2)</param>
+        <param index="4" label="Positions" minValue="0" increment="1" default="0">Extended parameter to specify the total number of positions the camera will capture photos by rolling repeatedly to emulate an oblique camera, providing an increased HFOV. (greater or equal to 2 enables this feature) (more info at: https://github.com/mavlink/mavlink/pull/1508)</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="20">Extended parameter to specify the angle limits (in degrees) that the camera will be rolled to left and right of center in pseudo oblique mode. (Enabled if param 4: Positions is greater or equal to 2) </param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="-90">Extended parameter to specify the fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. (Enabled if param 4: Positions is greater or equal to 2)</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1350,8 +1350,8 @@
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
         <param index="4" label="Positions" minValue="0" increment="1" default="0">WIP: Total number of roll positions at which the camera will capture photos (images captures spread evenly across the limits defined by param5). Feature enabled if value is greater or equal to 2.</param>
-        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">WIP: Angle limits (in degrees) that the camera can be rolled to left and right of center. Enabled if param 4 is greater or equal to 2.</param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">WIP: Fixed pitch angle (in degrees) that the camera will hold in pseudo oblique mode if the mount supports it. Enabled if param 4 is greater or equal to 2.</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">WIP: Angle limits that the camera can be rolled to left and right of center. Enabled if param 4 is greater or equal to 2.</param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">WIP: Fixed pitch angle that the camera will hold in pseudo oblique mode if the mount supports it. Enabled if param 4 is greater or equal to 2.</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1345,13 +1345,13 @@
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">
-        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. Params 4~6 enable a special mode (CAMPOS) where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup.</description>
+        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. Params 4~6 enable additional image captures at different gimbal orientations at each trigger point (this allows, for example, automatically roll of the camera between shots to emulate an oblique camera setup).</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4" label="Positions" minValue="0" increment="1">Number of positions to take photos in Camera Auto Mount Pseudo Oblique Solution (CAMPOS)</param>
-        <param index="5" label="Roll Angle" units="deg" minValue="0">The angle limits (in degrees) that the camera will be rolled to left and right of the centerline in CAMPOS mode</param>
-        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180">The fixed pitch angle that the camera will hold in CAMPOS mode if the mount supports it</param>
+        <param index="4" label="Positions" minValue="0" increment="1" default="0">Number of additional gimbal positions at which to capture photos at each trigger point. The gimbal orientations for each capture are defined by params 5 (roll) and param 6 (pitch). Default is 0 (gimbal orientation is fixed so only default position is captured)</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0" default="0">The angle limits (in degrees) that the camera will be rolled to left and right of the centerline.</param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180" default="0">The fixed pitch angle that the camera will hold while capturing images at different roll angles (if the mount supports it).</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1345,13 +1345,13 @@
         <param index="7" label="Mode" enum="MAV_MOUNT_MODE">Mount mode.</param>
       </entry>
       <entry value="206" name="MAV_CMD_DO_SET_CAM_TRIGG_DIST" hasLocation="false" isDestination="false">
-        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera.</description>
+        <description>Mission command to set camera trigger distance for this flight. The camera is triggered each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera. Params 4~6 enable a special mode (CAMPOS) where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup.</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="-1" increment="1">Camera shutter integration time. -1 or 0 to ignore</param>
         <param index="3" label="Trigger" minValue="0" maxValue="1" increment="1">Trigger camera once immediately. (0 = no trigger, 1 = trigger)</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
+        <param index="4" label="Positions" minValue="0" increment="1">Number of positions to take photos in Camera Auto Mount Pseudo Oblique Solution (CAMPOS)</param>
+        <param index="5" label="Roll Angle" units="deg" minValue="0">The angle limits (in degrees) that the camera will be rolled to left and right of the centerline in CAMPOS mode</param>
+        <param index="6" label="Pitch Angle" units="deg" minValue="-180" maxValue="180">The fixed pitch angle that the camera will hold in CAMPOS mode if the mount supports it</param>
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1589,6 +1589,7 @@
       </entry>
       <entry value="260" name="MAV_CMD_OBLIQUE_SURVEY" hasLocation="false" isDestination="false">
         <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Mission command to set a Camera Auto Mount Pivoting Oblique Survey (Replaces CAM_TRIGG_DIST for this purpose). The camera is triggered each time this distance is exceeded, then the mount moves to the next position. Params 4~6 set-up the angle limits and number of positions for oblique survey, where mount-enabled vehicles automatically roll the camera between shots to emulate an oblique camera setup (providing an increased HFOV). This command can also be used to set the shutter integration time for the camera.</description>
         <param index="1" label="Distance" units="m" minValue="0">Camera trigger distance. 0 to stop triggering.</param>
         <param index="2" label="Shutter" units="ms" minValue="0" increment="1" default="0">Camera shutter integration time. 0 to ignore</param>


### PR DESCRIPTION
**Problem**
A solution commonly used to increase the coverage and efficiency in mapping surveys is to have multiple cameras at oblique angles to capture a wider areas per flight line, this also has potential benefits of capturing more data from facades and tall objects. However, adding cameras increase cost, weight and complexity of the equipment, on the other hand, mapping cameras are generally capable of shooting multiple frames per second and are usually triggered about once every two seconds or less frequently in mapping missions. We could better use the hardware capabilities if we moved the camera mount between shots while decreasing the shooting distance to keep the overlap settings.

**Solution**
I decided to implement a solution that uses the already existing MAV_CMD_DO_SET_CAM_TRIGG_DIST, plus some unused parameters, 4~6, to issue MAV_CMD_DO_MOUNT_CONTROL between camera shots to move the camera from left to right in stages, right after it passes half the shooting distance, allowing time for mount actuation and camera exposure. To keep the frontlap the solution expects the GCS to adjust the trigger distance accordingly. The parameters usage are as follows:

4: number of oblique positions (this will generally be 2 or 3, but could be more, depending on desired frontlap, flying speed and hardware capabilities (how fast are the camera and mount))
5: the maximum angle to roll the camera left and right from the center, the solution calculates the interval angle between positions from this information and the previous parameter
6: the pitch angle for mounts that support pitching

**Implementation**
I implemented the proposed solution here: https://github.com/PX4/Firmware/pull/15882 and added to QGC here: https://github.com/mavlink/qgroundcontrol/pull/9103

**Alternative**
Other way would be to add a new command, but since it has many aspects that are essentially the same as the CAM_TRIGG_DIST, I thought it would be better to add a few parameters to the existing command, as it would also allow it to work under Mavlink 1 with the limited number of 255 commands.

**Test data / coverage**
I tested it with the gazebo_typhoon_h480 model and checked the outcome from the video stream in QGC.

**Additional context**
Later I plan to write a paper comparing the gains in area coverage and any accuracy change from using this solution with relation to the traditional survey mode. I am feeling confident about a positive outcome.