### PR TITLE
common: Add 'Inclusion Group' to fence for 'OR' fences

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1925,7 +1925,7 @@
         <description>Fence vertex for an inclusion polygon (the polygon must not be self-intersecting). The vehicle must stay within this area. Minimum of 3 vertices required.
         </description>
         <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count</param>
-        <param index="2">Reserved</param>
+        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group, must be the same for all points in each polygon</param>
         <param index="3">Reserved</param>
         <param index="4">Reserved</param>
         <param index="5" label="Latitude">Latitude</param>
@@ -1947,7 +1947,7 @@
         <description>Circular fence area. The vehicle must stay inside this area.
         </description>
         <param index="1" label="Radius" units="m">Radius.</param>
-        <param index="2">Reserved</param>
+        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group</param>
         <param index="3">Reserved</param>
         <param index="4">Reserved</param>
         <param index="5" label="Latitude">Latitude</param>


### PR DESCRIPTION
This adds a `Inclusion Group` number to fence polygons and circular inclusion zones. The vehicle must stay within ALL zones of a single group, this is the current behavior in AP. The vehicle can be within one group OR another, this would be new behavior. 

The goal being to enable one to configure a few fences for typically flying locations and be OK to fly so long as you were inside one of them.

https://youtu.be/_IkjcgyQbRI