### PR TITLE
common: Remove WIP on video streaming

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1854,14 +1854,10 @@
         <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING" hasLocation="false" isDestination="false">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Start video streaming</description>
         <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
       </entry>
       <entry value="2503" name="MAV_CMD_VIDEO_STOP_STREAMING" hasLocation="false" isDestination="false">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Stop the given video stream</description>
         <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams, 1 for first, 2 for second, etc.)</param>
       </entry>
@@ -6086,8 +6082,6 @@
       <field type="char[160]" name="uri">Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to).</field>
     </message>
     <message id="270" name="VIDEO_STREAM_STATUS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about the status of a video stream. It may be requested using MAV_CMD_REQUEST_MESSAGE.</description>
       <field type="uint8_t" name="stream_id" instance="true">Video Stream ID (1 for first, 2 for second, etc.)</field>
       <field type="uint16_t" name="flags" enum="VIDEO_STREAM_STATUS_FLAGS">Bitmap of stream status flags</field>


### PR DESCRIPTION
Fixes #1448 

This removes the `wip` tagging on `VIDEO_STREAM_STATUS`, [VIDEO_STREAM_INFORMATION](https://mavlink.io/en/messages/common.html#VIDEO_STREAM_INFORMATION), `MAV_CMD_VIDEO_START_STREAMING`,
`MAV_CMD_VIDEO_STOP_STREAMING` that was added with the PR in https://github.com/mavlink/mavlink/pull/1060

Generally WIP has been mis-used. Previously we've added it to common.xml to indicate "we're about to implement this". What should happen is that the message with wip gets added when there is a complete but untested implementation - essentially as a shakedown phase. It should have a date and be removed when that date has passed. 

PS.
@dogmaphobic 
1. These are part of [camera protocol](https://mavlink.io/en/services/camera.html) right? Were you planning on adding to docs or should I?
2. The camera docs have a whole bunch of requestor messages replaced/deprecated by `MAV_CMD_REQUEST_MESSAGE`: 
MAV_CMD_REQUEST_CAMERA_INFORMATION (521 )
MAV_CMD_REQUEST_CAMERA_SETTINGS (522 )
MAV_CMD_REQUEST_STORAGE_INFORMATION (525 )
MAV_CMD_REQUEST_VIDEO_STREAM_STATUS 
MAV_CMD_REQUEST_STORAGE_INFORMATION 
MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE 
MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS (527 )
MAV_CMD_REQUEST_FLIGHT_INFORMATION
Is it OK to remove these from the camera protocol docs? https://mavlink.io/en/services/camera.html#messageenum-summary