### PR TITLE
Mark COMMAND_INT.current as not used.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4815,7 +4815,7 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the mission item.</field>
-      <field type="uint8_t" name="current">false:0, true:1</field>
+      <field type="uint8_t" name="current">Not used.</field>
       <field type="uint8_t" name="autocontinue">autocontinue to next wp</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>


### PR DESCRIPTION
[COMMAND_INT.current](https://mavlink.io/en/messages/common.html#COMMAND_INT) doc just says it is a value of true or false (boolean). I searched PX4 and ArduPilot and I'm pretty sure it is not used. This makes sense because I think it is a hold over from whoever copied MISSION_INT (and in that context it meant "current mission item).

@auturgy @julianoes OK?