### PR TITLE
gimbal: change manual control input

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6222,10 +6222,9 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="flags" enum="GIMBAL_MANAGER_FLAGS">High level gimbal manager flags.</field>
       <field type="uint8_t" name="gimbal_device_id" instance="true">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. Send command multiple times for more than one gimbal (but not all gimbals).</field>
-      <field type="float" name="pitch">Pitch angle unitless (-1..1, positive: up, negative: down, NaN to be ignored).</field>
-      <field type="float" name="yaw">Yaw angle unitless (-1..1, positive: to the right, negative: to the left, NaN to be ignored).</field>
-      <field type="float" name="pitch_rate">Pitch angular rate unitless (-1..1, positive: up, negative: down, NaN to be ignored).</field>
-      <field type="float" name="yaw_rate">Yaw angular rate unitless (-1..1, positive: to the right, negative: to the left, NaN to be ignored).</field>
+      <field type="float" name="pitch">Pitch unitless (-1..1, positive: up, negative: down, NaN to be ignored).</field>
+      <field type="float" name="yaw">Yaw unitless (-1..1, positive: to the right, negative: to the left, NaN to be ignored).</field>
+      <field type="uint8_t" name="input_mode">0: Angle input, 1: angular rate input.</field>
     </message>
     <message id="290" name="ESC_INFO">
       <wip/>


### PR DESCRIPTION
I think it makes more sense to have a flag to signal angle or angular rate instead of having both fields and then setting two out of four to NAN.
I don't have a strong opinion on this but it just occurred to me.

@olliw42 what do you think?