### PR TITLE
NAV_CONTROLLER_OUTPUT: add airspeed setpoint field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4678,6 +4678,7 @@
       <field type="float" name="alt_error" units="m">Current altitude error</field>
       <field type="float" name="aspd_error" units="m/s">Current airspeed error</field>
       <field type="float" name="xtrack_error" units="m">Current crosstrack error on x-y plane</field>
+      <field type="float" name="aspd_sp" units="m/s">Current airspeed setpoint</field>
     </message>
     <message id="63" name="GLOBAL_POSITION_INT_COV">
       <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4678,7 +4678,8 @@
       <field type="float" name="alt_error" units="m">Current altitude error</field>
       <field type="float" name="aspd_error" units="m/s">Current airspeed error</field>
       <field type="float" name="xtrack_error" units="m">Current crosstrack error on x-y plane</field>
-      <field type="float" name="aspd_sp" units="m/s">Current airspeed setpoint</field>
+      <extensions/>
+      <field type="float" name="airspeed_sp" units="m/s">Current airspeed setpoint</field>
     </message>
     <message id="63" name="GLOBAL_POSITION_INT_COV">
       <description>The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.</description>


### PR DESCRIPTION
It would be useful to have a means of conveying the current airspeed setpoint from the vehicle to a groundstation. I don't know what exactly this message was designed to do, but as it already has attitude setpoint fields it would make sense to me to also have an airspeed setpoint field. 

Further we should indicate the kind of airspeed in this message, whether it is meant to be indicated/calibrated or true airspeed. In my opinion it should be IAS/CAS, as that is normally the setpoint that the user can interface with and that is constrained by physical limits (stall/max airspeed). 

@RomanBapst FYI.