### PR TITLE
Gimbal: CONFIGURE improvements

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -496,9 +496,6 @@
       <entry value="16" name="GIMBAL_MANAGER_FLAGS_YAW_LOCK">
         <description>Based on GIMBAL_DEVICE_FLAGS_YAW_LOCK</description>
       </entry>
-      <entry value="1048576" name="GIMBAL_MANAGER_FLAGS_NONE">
-        <description>This flag can be set to give up control previously set using MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW. This flag must not be combined with other flags.</description>
-      </entry>
     </enum>
     <enum name="GIMBAL_DEVICE_ERROR_FLAGS" bitmask="true">
       <description>Gimbal device (low level) error flags (bitmap, 0 means no error)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1751,10 +1751,10 @@
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Gimbal configuration to set which sysid/compid is in primary and secondary control.</description>
-        <param index="1" label="sysid primary control">Sysid for primary control (0: no one in control).</param>
-        <param index="2" label="compid primary control">Compid for primary control (0: no one in control).</param>
-        <param index="3" label="sysid secondary control">Sysid for secondary control (0: no one in control).</param>
-        <param index="4" label="compid secondary control">Compid for secondary control (0: no one in control).</param>
+        <param index="1" label="sysid primary control">Sysid for primary control (0: no one in control, -1: leave unchanged, -2: set itself in control (for missions where the own sysid is still unknown), -3: remove control if currently in control).</param>
+        <param index="2" label="compid primary control">Compid for primary control (0: no one in control, -1: leave unchanged, -2: set itself in control (for missions where the own sysid is still unknown), -3: remove control if currently in control).</param>
+        <param index="3" label="sysid secondary control">Sysid for secondary control (0: no one in control, -1: leave unchanged, -2: set itself in control (for missions where the own sysid is still unknown), -3: remove control if currently in control).</param>
+        <param index="4" label="compid secondary control">Compid for secondary control (0: no one in control, -1: leave unchanged, -2: set itself in control (for missions where the own sysid is still unknown), -3: remove control if currently in control).</param>
         <param index="7" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. Send command multiple times for more than one gimbal (but not all gimbals).</param>
       </entry>
       <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE" hasLocation="false" isDestination="false">


### PR DESCRIPTION
This removes the NONE flag and adds two special values to configure control. For more details check the commit messages.

@olliw42 I would appreciate your feedback.