### PR TITLE
Remove WIP for messages implemented in MAVSDK

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6009,8 +6009,6 @@
       <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
     </message>
     <message id="264" name="FLIGHT_INFORMATION">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about flight since last arming.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint64_t" name="arming_time_utc" units="us">Timestamp at arming (time since UNIX epoch) in UTC, 0 for unknown</field>
@@ -6052,8 +6050,6 @@
       <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
     </message>
     <message id="269" name="VIDEO_STREAM_INFORMATION">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about video stream. It may be requested using MAV_CMD_REQUEST_MESSAGE, where param2 indicates the video stream id: 0 for all streams, 1 for first, 2 for second, etc.</description>
       <field type="uint8_t" name="stream_id" instance="true">Video Stream ID (1 for first, 2 for second, etc.)</field>
       <field type="uint8_t" name="count">Number of streams available.</field>
@@ -6508,8 +6504,6 @@
       <field type="float" name="frequency" units="rpm">Indicated rate</field>
     </message>
     <message id="340" name="UTM_GLOBAL_POSITION">
-      <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>The global position resulting from GPS and sensor fusion.</description>
       <field type="uint64_t" name="time" units="us">Time of applicability of position (microseconds since UNIX epoch).</field>
       <field type="uint8_t[18]" name="uas_id">Unique UAS ID.</field>
@@ -6644,8 +6638,6 @@
       <field type="char[70]" name="translation_uri">The translations for strings within the metadata file. If null the either do not exist or may be included in the metadata file itself. The translations specified here supercede any which may be in the metadata file itself. The uri format is the same as component_metadata_uri . Files are in Json Translation spec format. Empty string indicates no tranlsation file.</field>
     </message>
     <message id="400" name="PLAY_TUNE_V2">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Play vehicle tone/tune (buzzer). Supersedes message PLAY_TUNE.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>


### PR DESCRIPTION
I went through the MAVSDK source and removed all WIP notes/flags in common for messages that are already implemented and released.

Regarding the gimbal v2 messages I would personally leave them WIP a few weeks longer, for the rest it should be fairly clear.

This is in response to the request by @LorenzMeier in the [last dev call](https://github.com/mavlink/mavlink/wiki/20201028-Dev-Meeting#notes). The same would have to be done for PX4.