### PR TITLE
Change EFI_STATUS flow units from g to cm^3

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5688,8 +5688,8 @@
       <field type="uint8_t" name="health">EFI health status</field>
       <field type="float" name="ecu_index">ECU index</field>
       <field type="float" name="rpm">RPM</field>
-      <field type="float" name="fuel_consumed" units="g">Fuel consumed</field>
-      <field type="float" name="fuel_flow" units="g/min">Fuel flow rate</field>
+      <field type="float" name="fuel_consumed" units="cm^3">Fuel consumed</field>
+      <field type="float" name="fuel_flow" units="cm^3/min">Fuel flow rate</field>
       <field type="float" name="engine_load" units="%">Engine load</field>
       <field type="float" name="throttle_position" units="%">Throttle position</field>
       <field type="float" name="spark_dwell_time" units="ms">Spark dwell time</field>


### PR DESCRIPTION
Depends on https://github.com/ArduPilot/pymavlink/pull/479 and requires some user consultation for deployed systems.
Background is in the pymavlink PR, but basically this aligns the mavlink EFI_STATUS message flow and consumption units with uavcan v0 (https://github.com/UAVCAN/public_regulated_data_types/blob/c043498eacfe90a56e3246d4c2e4ae81aad13082/uavcan/equipment/ice/reciprocating/1120.Status.uavcan#L165) and ArduPilot AP_EFI (https://github.com/ArduPilot/ardupilot/blob/8561f5239d4bc10424e4bfe69ad69dfbdd7c5cc9/libraries/AP_EFI/AP_EFI.cpp#L128).  The change in units results in reporting volumetric flow and consumption, rather than mass flow and consumption (specific gravity of the fuel being the conversation factor if needed).
Both volumetric and mass flow are likely to be encountered in different EFI (and related) systems, so the key here is to pick the most common one and be consistent.  Some users will need to translate, and it may be necessary to add extensions for the other if there is demand for it.