### PR TITLE
common: add new_mission extension to MISSION_COUNT message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4618,6 +4618,7 @@
       <field type="uint16_t" name="count">Number of mission items in the sequence</field>
       <extensions/>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+      <field type="uint8_t" name="new_mission">Boolean to indicate a new mission has be loaded, when true the MISSION_COUNT message is emitted without having received MISSION_REQUEST_LIST, this notifies the GCS the mission has changed and it should re-load</field>
     </message>
     <message id="45" name="MISSION_CLEAR_ALL">
       <description>Delete all mission items at once.</description>


### PR DESCRIPTION
This adds a extension to allow the flight controller to notify that the mission has been changed, this allows the GSC to re-load. The mission could have been changed by a second GCS, companion computer or onboard scripting.

The use case here is to deal with fences automatically set and loaded by scripting https://github.com/ArduPilot/ardupilot/pull/15598


This is the demo that just streams the fence back, this is not a feasible solution IRL due to flooding the link and/or packet loss, but it shows the functionality that I would like to duplicate with this extension. 
https://youtu.be/WakSwFTCeV8

