### PR TITLE
smart_battery_info extend serial number

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6569,7 +6569,7 @@
       <field type="int32_t" name="capacity_full_specification" units="mAh">Capacity when full according to manufacturer, -1: field not provided.</field>
       <field type="int32_t" name="capacity_full" units="mAh">Capacity when full (accounting for battery degradation), -1: field not provided.</field>
       <field type="uint16_t" name="cycle_count">Charge/discharge cycle count. -1: field not provided.</field>
-      <field type="int32_t" name="serial_number">Serial number. -1: field not provided.</field>
+      <field type="char[16]" name="serial_number">Serial number in ASCII characters, 0 terminated. All 0: field not provided.</field>
       <field type="char[50]" name="device_name">Static device name. Encode as manufacturer and product names separated using an underscore.</field>
       <field type="uint16_t" name="weight" units="g">Battery weight. 0: field not provided.</field>
       <field type="uint16_t" name="discharge_minimum_voltage" units="mV">Minimum per-cell voltage when discharging. If not supplied set to UINT16_MAX value.</field>


### PR DESCRIPTION
Some smart batteries have serial numbers with a alpha numeric serial number. I would propose to extend the serial number from an integer to a array of ASCII characters