### PR TITLE
common.xml: smart_battery_info fix cycles not available to UINT16_MAX

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6561,7 +6561,7 @@
       <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
       <field type="int32_t" name="capacity_full_specification" units="mAh">Capacity when full according to manufacturer, -1: field not provided.</field>
       <field type="int32_t" name="capacity_full" units="mAh">Capacity when full (accounting for battery degradation), -1: field not provided.</field>
-      <field type="uint16_t" name="cycle_count">Charge/discharge cycle count. -1: field not provided.</field>
+      <field type="uint16_t" name="cycle_count">Charge/discharge cycle count. UINT16_MAX: field not provided.</field>
       <field type="char[16]" name="serial_number">Serial number in ASCII characters, 0 terminated. All 0: field not provided.</field>
       <field type="char[50]" name="device_name">Static device name. Encode as manufacturer and product names separated using an underscore.</field>
       <field type="uint16_t" name="weight" units="g">Battery weight. 0: field not provided.</field>


### PR DESCRIPTION
Changes cycle_count to an int32 to allow for -1 if not available
