### PR TITLE
MAV_STATE enum, specify values explicitely

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -235,28 +235,28 @@
       <entry value="0" name="MAV_STATE_UNINIT">
         <description>Uninitialized system, state is unknown.</description>
       </entry>
-      <entry name="MAV_STATE_BOOT">
+      <entry value="1" name="MAV_STATE_BOOT">
         <description>System is booting up.</description>
       </entry>
-      <entry name="MAV_STATE_CALIBRATING">
+      <entry value="2" name="MAV_STATE_CALIBRATING">
         <description>System is calibrating and not flight-ready.</description>
       </entry>
-      <entry name="MAV_STATE_STANDBY">
+      <entry value="3" name="MAV_STATE_STANDBY">
         <description>System is grounded and on standby. It can be launched any time.</description>
       </entry>
-      <entry name="MAV_STATE_ACTIVE">
+      <entry value="4" name="MAV_STATE_ACTIVE">
         <description>System is active and might be already airborne. Motors are engaged.</description>
       </entry>
-      <entry name="MAV_STATE_CRITICAL">
+      <entry value="5" name="MAV_STATE_CRITICAL">
         <description>System is in a non-normal flight mode. It can however still navigate.</description>
       </entry>
-      <entry name="MAV_STATE_EMERGENCY">
+      <entry value="6" name="MAV_STATE_EMERGENCY">
         <description>System is in a non-normal flight mode. It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
       </entry>
-      <entry name="MAV_STATE_POWEROFF">
+      <entry value="7" name="MAV_STATE_POWEROFF">
         <description>System just initialized its power-down sequence, will shut down now.</description>
       </entry>
-      <entry name="MAV_STATE_FLIGHT_TERMINATION">
+      <entry value="8" name="MAV_STATE_FLIGHT_TERMINATION">
         <description>System is terminating itself.</description>
       </entry>
     </enum>


### PR DESCRIPTION
this specifies the values for all entries of the MAV_STATE enum

they are currently auto-generated by the code generator(s). I filled them in with what mavgen is auto-generating.

It may be seen as just a matter of convenience, but I actually think that this is not good practice, i.e., a specification should not have to rely on whatever code generator is doing, but rather be explicit and specify what the specification is to be. So, I actually also think that all the code generators should rather throw an error instead of auto-generating enum values...

COMMENT: This appears to also apply to the enum definitions in the ualberta.xml dialect ... but this is not a standard dialect, so I haven't touched that.