### PR TITLE
update update_c_library.sh script

### DIFF
--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -63,8 +63,6 @@ echo -e "\0033[34mStarting to generate c headers\0033[0m\n"
 generate_headers ardupilotmega $1
 generate_headers autoquad $1
 generate_headers matrixpilot $1
-generate_headers minimal $1
-generate_headers slugs $1
 generate_headers test $1
 generate_headers ASLUAV $1
 generate_headers standard $1


### PR DESCRIPTION
two corrections to update_c_library.sh

* slugs.xml isn't existing anymore
 
* minimal.xml doesn't need to be explicitly be generated, it in fact must not be explicitly be generated. First off, what was generated by generate_headers minimal $1 is later overwritten by generate_headers standard $1, as can be clearly proved by the fact that the IDX in minimal.h is 2 and not 0. Furthermore, generate_headers standard $1 must in fact be called as last since otherwise the library would not work, since IDX'es would be wrong as well as the MAV_CMD enums. Hence the generate_headers minimal $1 is superfluous.

comment: I couldn't manage to run the script itself, but I made me a win batch file which I strongly believe deos do exactly the same. So, I do have this experimental evidence. But the mentioned IDX argument should be proof enough.

(the IDX and MAV_CMD enum delicateness in fact exposes a serious issue with the current code generator(s)!! I do have a solution which weeds this out, but I don't really think it would be appreciated).

