### PR TITLE
changed uint8_t[x] to char[x] where used for strings

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5574,9 +5574,9 @@
       <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
       <field type="uint8_t" name="request_id">Request ID. This ID should be re-used when sending back URI contents</field>
       <field type="uint8_t" name="uri_type">The type of requested URI. 0 = a file via URL. 1 = a UAVCAN binary</field>
-      <field type="uint8_t[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
+      <field type="char[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
       <field type="uint8_t" name="transfer_type">The way the autopilot wants to receive the URI. 0 = MAVLink FTP. 1 = binary stream.</field>
-      <field type="uint8_t[120]" name="storage">The storage path the autopilot wants the URI to be stored in. Will only be valid if the transfer_type has a storage associated (e.g. MAVLink FTP).</field>
+      <field type="char[120]" name="storage">The storage path the autopilot wants the URI to be stored in. Will only be valid if the transfer_type has a storage associated (e.g. MAVLink FTP).</field>
     </message>
     <message id="143" name="SCALED_PRESSURE3">
       <description>Barometer readings for 3rd barometer</description>
@@ -5993,8 +5993,8 @@
     <message id="259" name="CAMERA_INFORMATION">
       <description>Information about a camera. Can be requested with a MAV_CMD_REQUEST_MESSAGE command.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
-      <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
-      <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
+      <field type="char[32]" name="vendor_name">Name of the camera vendor</field>
+      <field type="char[32]" name="model_name">Name of the camera model</field>
       <field type="uint32_t" name="firmware_version">Version of the camera firmware, encoded as: (Dev &amp; 0xff) &lt;&lt; 24 | (Patch &amp; 0xff) &lt;&lt; 16 | (Minor &amp; 0xff) &lt;&lt; 8 | (Major &amp; 0xff)</field>
       <field type="float" name="focal_length" units="mm">Focal length</field>
       <field type="float" name="sensor_size_h" units="mm">Image sensor size horizontal</field>


### PR DESCRIPTION
I've noticed that when using messages that contain uint8_t[] arrays for stringvalues the generated code for python (pymavlink) throws index out of range errors in case the string is not exactly the required length or longer. This can be prevented by padding the Strings with the appropriate number of zero bytes, but there is no easy and clean(as in simple) way to do this in python. At first I thought I needed to change the generator, but then I noticed that the python struct.pack method padds data automatically when it is a char array 

> For the 's' format character, the count is interpreted as the length of the bytes, not a repeat count like for the other format characters; for example, '10s' means a single 10-byte string, while '10c' means 10 characters. If a count is not given, it defaults to 1. For packing, the string is truncated or padded with null bytes as appropriate to make it fit. 
[https://docs.python.org/3/library/struct.html](https://docs.python.org/3/library/struct.html)

As I can see no negative impact to the change of this datatype at the few places where it is used for a string, I made this pull-request. I am looking forward to the discussion!