### PR TITLE
improve format_xml.sh script, tab to spaces

### DIFF
--- a/scripts/format_xml.sh
+++ b/scripts/format_xml.sh
@@ -6,8 +6,10 @@ OPTIND=1         # Reset in case getopts has been used previously in the shell.
 
 # Initialize variables
 mode="format"
+xml_dir="."
+keep_old=0
 
-while getopts "h?c" opt; do
+while getopts "h?cd:o" opt; do
     case "$opt" in
     h|\?)
         show_help
@@ -15,31 +17,50 @@ while getopts "h?c" opt; do
         ;;
     c)  mode="check"
         ;;
+    d)  xml_dir=${OPTARG}
+        ;;
+    o)  keep_old=1
+        ;;
     esac
 done
 
-xml_files=$(find . -name "*.xml")
+shift $(($OPTIND - 1))
+
+xml_file="$1"
+
+if [ "$xml_file" == "" ]
+then
+    xml_files=$(find $xml_dir -name "*.xml")
+else
+    xml_files="$xml_dir/$xml_file"
+fi
+echo "processing file(s) $xml_files"
+
 ret=0
-for  f in $xml_files
+for f in $xml_files
 do
-	xmllint -format "${f}" > "${f}".new
-	case "$mode" in
-	format)
-		if ! cmp "${f}" "${f}".new >/dev/null 2>&1
-		then
-			echo "formatting $f"
-			cp "${f}".new "${f}"
-		fi
-		;;
-	check)
-		if ! cmp "${f}" "${f}".new >/dev/null 2>&1
-		then
-			echo "$f needs formatting - run ./scripts/format_xml.sh $f"
-			ret=1
-		fi
-		;;
-	esac
-	rm "${f}".new
+    xmllint -format "${f}" > "${f}".new
+    case "$mode" in
+    format)
+        if ! cmp "${f}" "${f}".new >/dev/null 2>&1
+        then
+            echo "formatting $f"
+            if [ $keep_old -eq 1 ]
+            then
+                cp "${f}" "${f}".old
+            fi
+            cp "${f}".new "${f}"
+        fi
+        ;;
+    check)
+        if ! cmp "${f}" "${f}".new >/dev/null 2>&1
+        then
+            echo "file $f needs formatting - run ./scripts/format_xml.sh $f"
+            ret=1
+        fi
+        ;;
+    esac
+    rm "${f}".new
 done
 
 exit $ret


### PR DESCRIPTION
this attempts to improve the script format_xml.sh, also making it to work as it is saying itself:

* It cannot be run with a filename argument, i.e., it cannot be applied to one specific file. That's particularly weird, since when run with option -c it is saying "run ./scripts/format_xml.sh $f" when a file needs formatting! This has been corrected by removing all options from the arguments list and filling xml_files with the first argument if there is an argument. (lines 27 - 37).

* It could not be easily applied to a specific directory, such as (the potentially upcoming) mavlink/external/dialects. Currently it would process ALL xml files it finds in the tree of subfolders from which the script is run. This has been overcome by a new option -d, which sets the $(find ...) accordingly.

* It cannot be easily figured out what exactly the formatting has changed. This has been overcome by a new option -o, which copies the old file to $f.old before it overwrites with the formatted file. This is for sure only a matter of convenience.

* I did change slightly the output. (line 37, line 58)

* In some places indenting was achieved by tabs in others by spaces; tabs have been replaced by spaces now.

Comment: show_help doesn't work for me. Since I don't know if that is just my installation, I haven't fooled around with this (I'm using git powershell on win7). I guess it would be more robust to simply do some echo.
