### PR TITLE
common: add MAV_CMD_CAMERA_TRACK_SCENE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1841,6 +1841,11 @@
         <param index="3" label="Bottom right corner x" minValue="0" maxValue="1">Bottom right corner of rectangle x value (normalized 0..1, 0 is left, 1 is right).</param>
         <param index="4" label="Bottom right corner y" minValue="0" maxValue="1">Bottom right corner of rectangle y value (normalized 0..1, 0 is top, 1 is bottom).</param>
       </entry>
+      <entry value="2006" name="MAV_CMD_CAMERA_TRACK_SCENE" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>If the camera supports scene visual tracking (CAMERA_CAP_FLAGS_HAS_TRACKING_SCENE is set), this command allows to initiate the tracking.</description>
+      </entry>
       <entry value="2010" name="MAV_CMD_CAMERA_STOP_TRACKING" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
@@ -3338,6 +3343,9 @@
       </entry>
       <entry value="2048" name="CAMERA_CAP_FLAGS_HAS_TRACKING_GEO_STATUS">
         <description>Camera supports tracking geo status (CAMERA_TRACKING_GEO_STATUS).</description>
+      </entry>
+      <entry value="4096" name="CAMERA_CAP_FLAGS_HAS_TRACKING_SCENE">
+        <description>Camera supports tracking of the whole camera view.</description>
       </entry>
     </enum>
     <enum name="VIDEO_STREAM_STATUS_FLAGS" bitmask="true">


### PR DESCRIPTION
This adds a message for a "TRACK_SCENE" mode, next to the existing "TRACK_POINT" and "TRACK_RECTANGLE" messages.