### PR TITLE
Enums: Specify values explicitely in all enums

### DIFF
--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -48,7 +48,7 @@
       <entry value="0" name="GSM_MODEM_TYPE_UNKNOWN">
         <description>not specified</description>
       </entry>
-      <entry name="GSM_MODEM_TYPE_HUAWEI_E3372">
+      <entry value="1" name="GSM_MODEM_TYPE_HUAWEI_E3372">
         <description>HUAWEI LTE USB Stick E3372</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/autoquad.xml
+++ b/message_definitions/v1.0/autoquad.xml
@@ -5,7 +5,7 @@
   <enums>
     <enum name="AUTOQUAD_MAVLINK_DEFS_VERSION">
       <description>Track current version of these definitions (can be used by checking value of AUTOQUAD_MAVLINK_DEFS_VERSION_ENUM_END). Append a new entry for each published change.</description>
-      <entry name="AQ_MAVLINK_DEFS_VERSION_1"/>
+      <entry value="1" name="AQ_MAVLINK_DEFS_VERSION_1"/>
     </enum>
     <enum name="AUTOQUAD_NAV_STATUS">
       <description>Available operating modes/statuses for AutoQuad flight controller. 
@@ -111,7 +111,7 @@
     </enum>
     <!-- extend MAV_DATA_STREAM -->
     <enum name="MAV_DATA_STREAM">
-      <entry name="MAV_DATA_STREAM_PROPULSION">
+      <entry value="13" name="MAV_DATA_STREAM_PROPULSION">
         <description>Motor/ESC telemetry data.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/ualberta.xml
+++ b/message_definitions/v1.0/ualberta.xml
@@ -4,44 +4,44 @@
   <enums>
     <enum name="UALBERTA_AUTOPILOT_MODE">
       <description>Available autopilot modes for ualberta uav</description>
-      <entry name="MODE_MANUAL_DIRECT">
+      <entry value="1" name="MODE_MANUAL_DIRECT">
         <description>Raw input pulse widts sent to output</description>
       </entry>
-      <entry name="MODE_MANUAL_SCALED">
+      <entry value="2" name="MODE_MANUAL_SCALED">
         <description>Inputs are normalized using calibration, the converted back to raw pulse widths for output</description>
       </entry>
-      <entry name="MODE_AUTO_PID_ATT">
+      <entry value="3" name="MODE_AUTO_PID_ATT">
         <description> dfsdfs</description>
       </entry>
-      <entry name="MODE_AUTO_PID_VEL">
+      <entry value="4" name="MODE_AUTO_PID_VEL">
         <description> dfsfds</description>
       </entry>
-      <entry name="MODE_AUTO_PID_POS">
+      <entry value="5" name="MODE_AUTO_PID_POS">
         <description> dfsdfsdfs</description>
       </entry>
     </enum>
     <enum name="UALBERTA_NAV_MODE">
       <description>Navigation filter mode</description>
-      <entry name="NAV_AHRS_INIT"/>
-      <entry name="NAV_AHRS">
+      <entry value="1" name="NAV_AHRS_INIT"/>
+      <entry value="2" name="NAV_AHRS">
         <description>AHRS mode</description>
       </entry>
-      <entry name="NAV_INS_GPS_INIT">
+      <entry value="3" name="NAV_INS_GPS_INIT">
         <description>INS/GPS initialization mode</description>
       </entry>
-      <entry name="NAV_INS_GPS">
+      <entry value="4" name="NAV_INS_GPS">
         <description>INS/GPS mode</description>
       </entry>
     </enum>
     <enum name="UALBERTA_PILOT_MODE">
       <description>Mode currently commanded by pilot</description>
-      <entry name="PILOT_MANUAL">
+      <entry value="1" name="PILOT_MANUAL">
         <description> sdf</description>
       </entry>
-      <entry name="PILOT_AUTO">
+      <entry value="2" name="PILOT_AUTO">
         <description> dfs</description>
       </entry>
-      <entry name="PILOT_ROTO">
+      <entry value="3" name="PILOT_ROTO">
         <description> Rotomotion mode </description>
       </entry>
     </enum>


### PR DESCRIPTION
does https://github.com/mavlink/mavlink/pull/1552#issuecomment-763305515

Adds values to all enum entries which didn't yet had a value.

Procedure:
I ran mavgen for C for each and every xml file, and checked for the "An enum value was auto-generated: xxx = yy" print outs. I thus did not only check and corrected the xmls covered by all.xml, but all.

Comment:
For autoquad.xml this resulted in MAV_DATA_STREAM_PROPULSION = 13, which IMHO just shows how 'dangerous' the autogeneration is, since this value would have changed if the MAV_DATA_STREAM enum in common.xml would have changed, breaking implementations...
