### PR TITLE
ack waypoints may violate geofence

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2470,6 +2470,9 @@
       <entry value="15" name="MAV_MISSION_OPERATION_CANCELLED">
         <description>Current mission operation cancelled (e.g. mission upload, mission download).</description>
       </entry>
+      <entry value="16" name="MAV_MISSION_GEOFENCE_VIOLATED">
+        <description>Mission item violates geofence.</description>
+      </entry>
     </enum>
     <enum name="MAV_SEVERITY">
       <description>Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.</description>


### PR DESCRIPTION
It allows FC informs GCS or companion computer that a mission item or waypoint may violates no-fly zone