### PR TITLE
CI improvements, add deploy to c_library_v1/2 back in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,39 @@
-name: test mavlink
+name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
 # paths:
 # - "*"
 # - "!README.md" <-- don't rebuild on doc change
 
 jobs:
-  build:
+  format:
+    name: Formatting check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - run: |
+          sudo apt update
+          sudo apt install -y libxml2-dev libxml2-utils
+      - name: Check formatting
+        run: |
+          ./scripts/test.sh format
 
+  python-generator:
+    name: Python ${{ matrix.python-version }} generator test
     runs-on: ubuntu-20.04
     strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
+      fail-fast: false
       matrix:
         python-version: [2.7, 3.6, 3.7, 3.8]
-        node: ['12', '13', '14']
 
     steps:
       - uses: actions/checkout@v2
@@ -25,15 +45,34 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install future lxml
-          sudo apt update
-          sudo apt install -y libxml2-dev libxml2-utils
+      - name : Test Python generator
+        run: |
+          ./scripts/test.sh py
+
+  node-generator:
+    name: Node ${{ matrix.node-version }} generator test
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['14', '15']
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install future lxml
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
       - run: npm install
       - name : Test mavlink
         run: |
-          ./scripts/test.sh
-
+          ./scripts/test.sh node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
         node: ['12', '13', '14']
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,13 @@ jobs:
         run: |
           ./scripts/test.sh format
 
-  python-generator:
-    name: Python ${{ matrix.python-version }} generator test
+  python-tests:
+    name: Python ${{ matrix.python-version }} tests
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         python-version: [2.7, 3.6, 3.7, 3.8]
-
     steps:
       - uses: actions/checkout@v2
         with:
@@ -50,14 +49,13 @@ jobs:
         run: |
           ./scripts/test.sh py
 
-  node-generator:
-    name: Node ${{ matrix.node-version }} generator test
+  node-tests:
+    name: Node ${{ matrix.node-version }} test
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         node-version: ['12', '14'] # 15 fails for some weird reason
-
     steps:
       - uses: actions/checkout@v2
         with:
@@ -76,3 +74,23 @@ jobs:
       - name : Test mavlink
         run: |
           ./scripts/test.sh node
+
+  deploy:
+    name: Generate and push C headers
+    needs: [format, python-tests, node-tests]
+    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install future lxml
+      - name: Run deploy script
+        run: |
+          echo "Would deploy now!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14', '15']
+        node-version: ['12', '14'] # 15 fails for some weird reason
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install future lxml
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test and deploy
 
 on:
   push:
@@ -80,6 +80,8 @@ jobs:
     needs: [format, python-tests, node-tests]
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/master'
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -93,4 +95,4 @@ jobs:
           pip install future lxml
       - name: Run deploy script
         run: |
-          echo "Would deploy now!"
+          ./scripts/update_generated_repos.sh

--- a/scripts/format_xml.sh
+++ b/scripts/format_xml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # A POSIX variable

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 SRC_DIR=$(pwd)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,14 +7,16 @@ SRC_DIR=$(pwd)
 # on the build tree. Otherwise the testing is invalid and may not
 # indicate the code actually works
 
-# check format
-sep="##############################################"
-echo $sep
-echo "FORMAT TEST"
-echo $sep
-cd "$SRC_DIR"
-./scripts/format_xml.sh -c
-echo PASS
+test_format() {
+    # check format
+    sep="##############################################"
+    echo $sep
+    echo "FORMAT TEST"
+    echo $sep
+    cd "$SRC_DIR"
+    ./scripts/format_xml.sh -c
+    echo PASS
+}
 
 generate_mavlink() {
     echo $sep
@@ -30,34 +32,59 @@ generate_mavlink() {
     echo PASS
 }
 
-cd "$SRC_DIR"
-for msg_def in message_definitions/v1.0/*.xml
-do
-    [ -e "$msg_def" ] || continue
-    wire_protocol="1.0"
-    for lang in Python C CS WLua Java
+test_py() {
+    cd "$SRC_DIR"
+    for msg_def in message_definitions/v1.0/*.xml
     do
-        generate_mavlink
+        [ -e "$msg_def" ] || continue
+        wire_protocol="1.0"
+        for lang in Python C CS WLua Java
+        do
+            generate_mavlink
+        done
+        wire_protocol="2.0"
+        for lang in Python C C++11 CS WLua Java
+        do
+            generate_mavlink
+        done
     done
-    wire_protocol="2.0"
-    for lang in Python C C++11 CS WLua Java
-    do
-        generate_mavlink
-    done
-done
-# Avoid `spurious errors` caused by ~/.npm permission issues
-# ref: https://github.com/travis-ci/travis-ci/issues/2244
-# ref: https://github.com/npm/npm/issues/4815
-# Does it already exist? Who owns? What permissions?
-ls -lah ~/.npm || mkdir ~/.npm
-# Make sure we own it
-# $USER references the current user in Travis env
-chown -R "$USER" ~/.npm
-if [ -f /usr/bin/nodejs ]
-then
-	mkdir -p ~/bin
-	ln -sf /usr/bin/nodejs ~/bin/node
-	. ~/.bashrc	
+}
+
+test_node() {
+    # Avoid `spurious errors` caused by ~/.npm permission issues
+    # ref: https://github.com/travis-ci/travis-ci/issues/2244
+    # ref: https://github.com/npm/npm/issues/4815
+    # Does it already exist? Who owns? What permissions?
+    ls -lah ~/.npm || mkdir ~/.npm
+    # Make sure we own it
+    # $USER references the current user in Travis env
+    chown -R "$USER" ~/.npm
+    if [ -f /usr/bin/nodejs ]
+    then
+        mkdir -p ~/bin
+        ln -sf /usr/bin/nodejs ~/bin/node
+        . ~/.bashrc
+    fi
+    cd "$SRC_DIR/pymavlink/generator/javascript" && npm test
+}
+
+if [ "$#" -eq 1 ]; then
+    if [ "$1" == "format" ]; then
+        test_format
+    elif [ "$1" == "py" ]; then
+        test_py
+    elif [ "$1" == "node" ]; then
+        test_node
+    else
+        echo "Error: unknown argument '$1'"
+        echo ""
+        echo "Usage:"
+        echo "  $0 [py|node|format]"
+        exit 1
+    fi
+else
+    test_format
+    test_py
+    test_node
 fi
-cd "$SRC_DIR/pymavlink/generator/javascript" && npm test
 

--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # c_library repository update script
 # Author: Thomas Gubler <thomasgubler@gmail.com>

--- a/scripts/update_generated_repos.sh
+++ b/scripts/update_generated_repos.sh
@@ -1,27 +1,4 @@
-#!/bin/bash
-
-# Do only build for Python 2.7
-# as we only want to deploy for one
-# unique generator.
-PYTHONVER=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-
-if [[ $PYTHONVER != "2.7"* ]]
-then
-	echo -e "Skipping header generation for Python $PYTHONVER"
-	exit 0
-fi
-
-# Do not build pull requests
-if [[ $TRAVIS_PULL_REQUEST != "false" ]]
-then
-	exit 0
-fi
-
-# Do only build master branch
-if [[ $TRAVIS_BRANCH != "master" ]]
-then
-	exit 0
-fi
+#!/usr/bin/env bash
 
 # Config for auto-building
 git remote rename origin upstream
@@ -44,5 +21,3 @@ cd include/mavlink/v1.0
 git clone https://github.com/mavlink/c_library_v1.git
 cd ../../..
 ./scripts/update_c_library.sh 1
-
-# XXX add build steps for other libraries as well


### PR DESCRIPTION
This is an attempt to add the deploy step to https://github.com/mavlink/c_library_v2/ and https://github.com/mavlink/c_library_v1/ back in which was removed in https://github.com/mavlink/mavlink/pull/1544.