### PR TITLE
Add MAV_VTOL_STATE_QC field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1933,7 +1933,8 @@
       </entry>
       <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION" hasLocation="false" isDestination="false">
         <description>Request VTOL transition</description>
-        <param index="1" label="State" enum="MAV_VTOL_STATE">The target VTOL state. For normal transitions, only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used. To force an immediate transition to MC (QuadChute), use MAV_VTOL_STATE_QC.</param>
+        <param index="1" label="State" enum="MAV_VTOL_STATE">The target VTOL state. For normal transitions, only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
+        <param index="2" label="mc_immediate">A transition to MAV_VTOL_STATE_MC will be immediate. Can be used, for example, to engage rotors as an emergency 'parachute'.</param>
       </entry>
       <entry value="3001" name="MAV_CMD_ARM_AUTHORIZATION_REQUEST" hasLocation="false" isDestination="false">
         <description>Request authorization to arm the vehicle to a external entity, the arm authorizer is responsible to request all data that is needs from the vehicle before authorize or deny the request. If approved the progress of command_ack message should be set with period of time that this authorization is valid in seconds or in case it was denied it should be set with one of the reasons in ARM_AUTH_DENIED_REASON.
@@ -3019,9 +3020,6 @@
       </entry>
       <entry value="4" name="MAV_VTOL_STATE_FW">
         <description>VTOL is in fixed-wing state</description>
-      </entry>
-      <entry value="5" name="MAV_VTOL_STATE_QC">
-        <description>VTOL is in QuadChute state</description>
       </entry>
     </enum>
     <enum name="MAV_LANDED_STATE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1934,7 +1934,7 @@
       <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION" hasLocation="false" isDestination="false">
         <description>Request VTOL transition</description>
         <param index="1" label="State" enum="MAV_VTOL_STATE">The target VTOL state. For normal transitions, only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
-        <param index="2" label="force_immediate_transition">Force an immediate transition to the desired MAV_VTOL_STATE. Can be used, for example, to trigger an emergency "Quadchute". Caution: Can be dangerous. Check your autopilot's implementation of this command.</param>
+        <param index="2" label="Immediate">Force immediate transition to the specified MAV_VTOL_STATE. 1: Force immediate, 0: normal transition. Can be used, for example, to trigger an emergency "Quadchute". Caution: Can be dangerous/damage vehicle, depending on autopilot implementation of this command.</param>
       </entry>
       <entry value="3001" name="MAV_CMD_ARM_AUTHORIZATION_REQUEST" hasLocation="false" isDestination="false">
         <description>Request authorization to arm the vehicle to a external entity, the arm authorizer is responsible to request all data that is needs from the vehicle before authorize or deny the request. If approved the progress of command_ack message should be set with period of time that this authorization is valid in seconds or in case it was denied it should be set with one of the reasons in ARM_AUTH_DENIED_REASON.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1934,7 +1934,7 @@
       <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION" hasLocation="false" isDestination="false">
         <description>Request VTOL transition</description>
         <param index="1" label="State" enum="MAV_VTOL_STATE">The target VTOL state. For normal transitions, only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
-        <param index="2" label="force_immediate_transition">Force an immediate transition to the desired MAV_VTOL_STATE. Can be used, for example, to trigger an emergency "Quadchute". Caution: Can be dangerous. Check your autopiliot's implementation of this command.</param>
+        <param index="2" label="force_immediate_transition">Force an immediate transition to the desired MAV_VTOL_STATE. Can be used, for example, to trigger an emergency "Quadchute". Caution: Can be dangerous. Check your autopilot's implementation of this command.</param>
       </entry>
       <entry value="3001" name="MAV_CMD_ARM_AUTHORIZATION_REQUEST" hasLocation="false" isDestination="false">
         <description>Request authorization to arm the vehicle to a external entity, the arm authorizer is responsible to request all data that is needs from the vehicle before authorize or deny the request. If approved the progress of command_ack message should be set with period of time that this authorization is valid in seconds or in case it was denied it should be set with one of the reasons in ARM_AUTH_DENIED_REASON.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3020,7 +3020,7 @@
       <entry value="4" name="MAV_VTOL_STATE_FW">
         <description>VTOL is in fixed-wing state</description>
       </entry>
-      <entry value="4" name="MAV_VTOL_STATE_QC">
+      <entry value="5" name="MAV_VTOL_STATE_QC">
         <description>VTOL is in QuadChute state</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1934,7 +1934,7 @@
       <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION" hasLocation="false" isDestination="false">
         <description>Request VTOL transition</description>
         <param index="1" label="State" enum="MAV_VTOL_STATE">The target VTOL state. For normal transitions, only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
-        <param index="2" label="mc_immediate">A transition to MAV_VTOL_STATE_MC will be immediate. Can be used, for example, to engage rotors as an emergency 'parachute'.</param>
+        <param index="2" label="force_immediate_transition">Force an immediate transition to the desired MAV_VTOL_STATE. Can be used, for example, to trigger an emergency "Quadchute". Caution: Can be dangerous. Check your autopiliot's implementation of this command.</param>
       </entry>
       <entry value="3001" name="MAV_CMD_ARM_AUTHORIZATION_REQUEST" hasLocation="false" isDestination="false">
         <description>Request authorization to arm the vehicle to a external entity, the arm authorizer is responsible to request all data that is needs from the vehicle before authorize or deny the request. If approved the progress of command_ack message should be set with period of time that this authorization is valid in seconds or in case it was denied it should be set with one of the reasons in ARM_AUTH_DENIED_REASON.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1933,7 +1933,7 @@
       </entry>
       <entry value="3000" name="MAV_CMD_DO_VTOL_TRANSITION" hasLocation="false" isDestination="false">
         <description>Request VTOL transition</description>
-        <param index="1" label="State" enum="MAV_VTOL_STATE">The target VTOL state. Only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used.</param>
+        <param index="1" label="State" enum="MAV_VTOL_STATE">The target VTOL state. For normal transitions, only MAV_VTOL_STATE_MC and MAV_VTOL_STATE_FW can be used. To force an immediate transition to MC (QuadChute), use MAV_VTOL_STATE_QC.</param>
       </entry>
       <entry value="3001" name="MAV_CMD_ARM_AUTHORIZATION_REQUEST" hasLocation="false" isDestination="false">
         <description>Request authorization to arm the vehicle to a external entity, the arm authorizer is responsible to request all data that is needs from the vehicle before authorize or deny the request. If approved the progress of command_ack message should be set with period of time that this authorization is valid in seconds or in case it was denied it should be set with one of the reasons in ARM_AUTH_DENIED_REASON.
@@ -3019,6 +3019,9 @@
       </entry>
       <entry value="4" name="MAV_VTOL_STATE_FW">
         <description>VTOL is in fixed-wing state</description>
+      </entry>
+      <entry value="4" name="MAV_VTOL_STATE_QC">
+        <description>VTOL is in QuadChute state</description>
       </entry>
     </enum>
     <enum name="MAV_LANDED_STATE">


### PR DESCRIPTION
Linked to https://github.com/PX4/PX4-Autopilot/pull/16691.

I would like to add the ability to trigger a QuadChute from an external command over MAVLINK (in our case using MAVROS). Our main motivation for it is to be able to react and stop the drone as fast as possible e.g. if it is about to breach a Geofence in FW mode.

The new field would also allow to send additional info on the drone's state in https://mavlink.io/en/messages/common.html#EXTENDED_SYS_STATE so that any offboard control is aware that there was a quadchute.