### PR TITLE
Clarify MAV_CMD_NAV_FENCE_RETURN_POINT vs rally points

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1967,8 +1967,7 @@
         <param index="7" label="Altitude" units="m">Altitude</param>
       </entry>
       <entry value="5000" name="MAV_CMD_NAV_FENCE_RETURN_POINT" hasLocation="true" isDestination="true">
-        <description>Fence return point. There can only be one fence return point.
-        </description>
+        <description>Fence return point (there can only be one such point in a geofence definition). If rally points are supported they should be used instead.</description>
         <param index="1">Reserved</param>
         <param index="2">Reserved</param>
         <param index="3">Reserved</param>


### PR DESCRIPTION
@auturgy As discussed the deprecation of MAV_CMD_NAV_FENCE_RETURN_POINT was removed. I've proposed new wording in the description that captures when this should be used vs rally points - essentially IF rally points are supported they should be trusted instead. 

I think this works for systems that support the point (ArduPlane), systems that don't (ArduCopter, PX4) and things that support both (none that I know of, though possibly ArduPlane will do so in when updated to support rally points).

What this means though is that if a system supports both, then it must use the rally points, if enabled. 