### PR TITLE
common.xml: Add a status flag for generic motor malfunction

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -211,6 +211,9 @@
       <entry value="536870912" name="MAV_SYS_STATUS_OBSTACLE_AVOIDANCE">
         <description>0x20000000 Avoidance/collision prevention</description>
       </entry>
+      <entry value="1073741824" name="MAV_SYS_STATUS_SENSOR_PORPULSION">
+        <description>0x40000000 porpulsion (actuator, esc, motor or propellor)</description>
+      </entry>
     </enum>
     <enum name="MAV_FRAME">
       <entry value="0" name="MAV_FRAME_GLOBAL">


### PR DESCRIPTION
GCS and/or companion computers can then warn the user or take automated action