### PR TITLE
Add battery faults flags for wrong firmware and battery models

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2929,6 +2929,12 @@
       <entry value="64" name="MAV_BATTERY_FAULT_INCOMPATIBLE_VOLTAGE">
         <description>Vehicle voltage is not compatible with this battery (batteries on same power rail should have similar voltage).</description>
       </entry>
+      <entry value="128" name="MAV_BATTERY_FAULT_INCOMPATIBLE_FIRMWARE">
+        <description>Battery firmware is not compatible with current autopilot firmware.</description>
+      </entry>
+      <entry value="256" name="MAV_BATTERY_FAULT_INCOMPATIBLE_MODEL">
+        <description>Battery model is not compatible.</description>
+      </entry>
     </enum>
     <enum name="MAV_GENERATOR_STATUS_FLAG" bitmask="true">
       <description>Flags to report status/failure cases for a power generator (used in GENERATOR_STATUS). Note that FAULTS are conditions that cause the generator to fail. Warnings are conditions that require attention before the next use (they indicate the system is not operating properly).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2932,8 +2932,8 @@
       <entry value="128" name="MAV_BATTERY_FAULT_INCOMPATIBLE_FIRMWARE">
         <description>Battery firmware is not compatible with current autopilot firmware.</description>
       </entry>
-      <entry value="256" name="MAV_BATTERY_FAULT_INCOMPATIBLE_MODEL">
-        <description>Battery model is not compatible.</description>
+      <entry value="256" name="BATTERY_FAULT_INCOMPATIBLE_CELLS_CONFIGURATION">
+        <description>Battery is not compatible due to cell configuration (e.g. 5s1p when vehicle requires 6s).</description>
       </entry>
     </enum>
     <enum name="MAV_GENERATOR_STATUS_FLAG" bitmask="true">


### PR DESCRIPTION
This PR extends `MAV_BATTERY_FAULT` with two new fault types:
- Battery firmware incompatible: when the smart battery has a too old/new firmware compared to the autopilot.
- Battery model incompatible: when the battery model (e.g 2s1p, 2s2p,...) is not compatible with the vehicle