### PR TITLE
common: add gimbal manager attitude status message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6299,12 +6299,12 @@
     <message id="289" name="GIMBAL_MANAGER_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message reporting the status of a gimbal manager. This message should be broadcasted by a gimbal manager component and will basically mirror GIMBAL_DEVICE_ATTITUDE_STATUS. The angles encoded in the quaternion are in the global frame (roll: positive is rolling to the right, pitch: positive is pitching up, yaw is turn to the right). This message should be broadcast at a low regular rate (e.g. 10Hz).</description>
+      <description>Message reporting the attitude status by a gimbal manager. This message should be broadcasted by a gimbal manager component and will basically mirror GIMBAL_DEVICE_ATTITUDE_STATUS. The angles encoded in the quaternion are in the global frame (roll: positive is rolling to the right, pitch: positive is pitching up, yaw is turn to the right).</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint32_t" name="flags" enum="GIMBAL_MANAGER_FLAGS">Current gimbal flags set.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame depends on whether the flag GIMBAL_MANAGER_FLAGS_YAW_LOCK is set)</field>
       <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6296,6 +6296,20 @@
       <field type="float" name="pitch_rate">Pitch angular rate unitless (-1..1, positive: up, negative: down, NaN to be ignored).</field>
       <field type="float" name="yaw_rate">Yaw angular rate unitless (-1..1, positive: to the right, negative: to the left, NaN to be ignored).</field>
     </message>
+    <message id="289" name="GIMBAL_MANAGER_ATTITUDE_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Message reporting the status of a gimbal manager. This message should be broadcasted by a gimbal manager component and will basically mirror GIMBAL_DEVICE_ATTITUDE_STATUS. The angles encoded in the quaternion are in the global frame (roll: positive is rolling to the right, pitch: positive is pitching up, yaw is turn to the right). This message should be broadcast at a low regular rate (e.g. 10Hz).</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint32_t" name="flags" enum="GIMBAL_MANAGER_FLAGS">Current gimbal flags set.</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
+      <field type="float" name="angular_velocity_x" units="rad/s">X component of angular velocity (NaN if unknown)</field>
+      <field type="float" name="angular_velocity_y" units="rad/s">Y component of angular velocity (NaN if unknown)</field>
+      <field type="float" name="angular_velocity_z" units="rad/s">Z component of angular velocity (NaN if unknown)</field>
+      <field type="uint32_t" name="device_failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Gimbal device failure flags (0 for no failure)</field>
+    </message>
     <message id="290" name="ESC_INFO">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->


### PR DESCRIPTION
This adds an additional message which basically mirrors the GIMBAL_DEVICE_ATTITUDE_STATUS message.

The initial idea was that the gimbal device broadcasts its attitude status to everyone in the mavlink network and thus also a ground station. However, during implementation, we realized that this has some downsides:

1. In many network/messaging setups the attitude status message needs to be forwarded by mavlink components to finally reach the ground station. For instance, if the autopilot is the gimbal manager, it needs to bridge the mavlink connection between the gimbal device and the ground station. This is not always trivial, e.g. can require more RAM usage, more configuration required, or lead to inefficiencies because messages are forwarded from or to the gimbal which are not required.
2. This concept somewhat falls apart if there is no gimbal device because e.g. we are talking to an integrated camera/gimbal which does not actually contain or talk to a gimbal device.
3. This concept is a bit tricky to explain/document because it does not follow the rest of the messages which are symmetric between device and manager.

Basically, this change would move from the diagram on the left to the right:

![gimbal attitude feedback](https://user-images.githubusercontent.com/1419688/107381825-879eee80-6aef-11eb-9a03-90eb0a48737e.png)

FYI @olliw42 