### PR TITLE
common: make tracking mode enum consistent

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3377,13 +3377,13 @@
     </enum>
     <enum name="CAMERA_TRACKING_MODE">
       <description>Camera tracking modes</description>
-      <entry value="0" name="CAMERA_TRACKING_NONE">
+      <entry value="0" name="CAMERA_TRACKING_MODE_NONE">
         <description>Not tracking</description>
       </entry>
-      <entry value="1" name="CAMERA_TRACKING_POINT">
+      <entry value="1" name="CAMERA_TRACKING_MODE_POINT">
         <description>Target is a point</description>
       </entry>
-      <entry value="2" name="CAMERA_TRACKING_RECTANGLE">
+      <entry value="2" name="CAMERA_TRACKING_MODE_RECTANGLE">
         <description>Target is a rectangle</description>
       </entry>
     </enum>
@@ -6142,13 +6142,13 @@
       <field type="uint8_t" name="tracking_status" enum="CAMERA_TRACKING_STATUS_FLAGS">Current tracking status</field>
       <field type="uint8_t" name="tracking_mode" enum="CAMERA_TRACKING_MODE">Current tracking mode</field>
       <field type="uint8_t" name="target_data" enum="CAMERA_TRACKING_TARGET_DATA">Defines location of target data</field>
-      <field type="float" name="point_x">Current tracked point x value if CAMERA_TRACKING_POINT (normalized 0..1, 0 is left, 1 is right), NAN if unknown</field>
-      <field type="float" name="point_y">Current tracked point y value if CAMERA_TRACKING_POINT (normalized 0..1, 0 is top, 1 is bottom), NAN if unknown</field>
-      <field type="float" name="radius">Current tracked radius if CAMERA_TRACKING_POINT (normalized 0..1, 0 is image left, 1 is image right), NAN if unknown</field>
-      <field type="float" name="rec_top_x">Current tracked rectangle top x value if CAMERA_TRACKING_RECTANGLE (normalized 0..1, 0 is left, 1 is right), NAN if unknown</field>
-      <field type="float" name="rec_top_y">Current tracked rectangle top y value if CAMERA_TRACKING_RECTANGLE (normalized 0..1, 0 is top, 1 is bottom), NAN if unknown</field>
-      <field type="float" name="rec_bottom_x">Current tracked rectangle bottom x value if CAMERA_TRACKING_RECTANGLE (normalized 0..1, 0 is left, 1 is right), NAN if unknown</field>
-      <field type="float" name="rec_bottom_y">Current tracked rectangle bottom y value if CAMERA_TRACKING_RECTANGLE (normalized 0..1, 0 is top, 1 is bottom), NAN if unknown</field>
+      <field type="float" name="point_x">Current tracked point x value if CAMERA_TRACKING_MODE_POINT (normalized 0..1, 0 is left, 1 is right), NAN if unknown</field>
+      <field type="float" name="point_y">Current tracked point y value if CAMERA_TRACKING_MODE_POINT (normalized 0..1, 0 is top, 1 is bottom), NAN if unknown</field>
+      <field type="float" name="radius">Current tracked radius if CAMERA_TRACKING_MODE_POINT (normalized 0..1, 0 is image left, 1 is image right), NAN if unknown</field>
+      <field type="float" name="rec_top_x">Current tracked rectangle top x value if CAMERA_TRACKING_MODE_RECTANGLE (normalized 0..1, 0 is left, 1 is right), NAN if unknown</field>
+      <field type="float" name="rec_top_y">Current tracked rectangle top y value if CAMERA_TRACKING_MODE_RECTANGLE (normalized 0..1, 0 is top, 1 is bottom), NAN if unknown</field>
+      <field type="float" name="rec_bottom_x">Current tracked rectangle bottom x value if CAMERA_TRACKING_MODE_RECTANGLE (normalized 0..1, 0 is left, 1 is right), NAN if unknown</field>
+      <field type="float" name="rec_bottom_y">Current tracked rectangle bottom y value if CAMERA_TRACKING_MODE_RECTANGLE (normalized 0..1, 0 is top, 1 is bottom), NAN if unknown</field>
     </message>
     <message id="276" name="CAMERA_TRACKING_GEO_STATUS">
       <wip/>


### PR DESCRIPTION
The entries of CAMERA_TRACKING_MODE were missing the _MODE suffix which is not consistent and might to mix up with CAMERA_TRACKING_STATUS_FLAGS and CAMERA_TRACKING_TARGET_DATA.