### PR TITLE
common: make tracking target data enum consistent

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3392,16 +3392,16 @@
     </enum>
     <enum name="CAMERA_TRACKING_TARGET_DATA" bitmask="true">
       <description>Camera tracking target data (shows where tracked target is within image)</description>
-      <entry value="0" name="CAMERA_TRACKING_TARGET_NONE">
+      <entry value="0" name="CAMERA_TRACKING_TARGET_DATA_NONE">
         <description>No target data</description>
       </entry>
-      <entry value="1" name="CAMERA_TRACKING_TARGET_EMBEDDED">
+      <entry value="1" name="CAMERA_TRACKING_TARGET_DATA_EMBEDDED">
         <description>Target data embedded in image data (proprietary)</description>
       </entry>
-      <entry value="2" name="CAMERA_TRACKING_TARGET_RENDERED">
+      <entry value="2" name="CAMERA_TRACKING_TARGET_DATA_RENDERED">
         <description>Target data rendered in image</description>
       </entry>
-      <entry value="4" name="CAMERA_TRACKING_TARGET_IN_STATUS">
+      <entry value="4" name="CAMERA_TRACKING_TARGET_DATA_IN_STATUS">
         <description>Target data within status message (Point or Rectangle)</description>
       </entry>
     </enum>


### PR DESCRIPTION
This would be more consistent.