### PR TITLE
Add MAVLINK_INCOMPAT_FLAGS to minimal.xml

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -2,6 +2,12 @@
 <mavlink>
   <version>3</version>
   <enums>
+    <enum name="MAVLINK_INCOMPAT_FLAGS" bitmask="true">
+      <description>These flags encode the incompat_flags field in the header of MAVLink v2 messages.</description>
+      <entry value="1" name="MAVLINK_INCOMPAT_FLAGS_SIGNED">
+        <description>The packet is signed (a signature has been appended to the packet).</description>
+      </entry>
+    </enum>
     <enum name="MAV_AUTOPILOT">
       <description>Micro air vehicle / autopilot classes. This identifies the individual model.</description>
       <entry value="0" name="MAV_AUTOPILOT_GENERIC">


### PR DESCRIPTION
the mavgen C language specifies e.g. a define MAVLINK_IFLAG_SIGNED in order to flag in the header's incompat_flags field that a packet is signed

however, that's clearly a protocol thing and not a thing of a particular implementation, and I thus think that it should (must) be specified in an xml accordingly. Since it is so basic I put it into minimal.xml.
