### PR TITLE
Add PARAM_TYPE_CHAR and PARAM_EXT_TYPE_CHAR

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2340,6 +2340,9 @@
     </enum>
     <enum name="MAV_PARAM_TYPE">
       <description>Specifies the datatype of a MAVLink parameter.</description>
+      <entry value="0" name="MAV_PARAM_TYPE_CHAR">
+        <description>8-bit char</description>
+      </entry>
       <entry value="1" name="MAV_PARAM_TYPE_UINT8">
         <description>8-bit unsigned integer</description>
       </entry>
@@ -2373,6 +2376,9 @@
     </enum>
     <enum name="MAV_PARAM_EXT_TYPE">
       <description>Specifies the datatype of a MAVLink extended parameter.</description>
+      <entry value="0" name="MAV_PARAM_EXT_TYPE_CHAR">
+        <description>8-bit char</description>
+      </entry>
       <entry value="1" name="MAV_PARAM_EXT_TYPE_UINT8">
         <description>8-bit unsigned integer</description>
       </entry>


### PR DESCRIPTION
for some reason the enums MAV_PARAM_TYPE and MAV_PARAM_EXT_TYPE do not have entries for value 0. The mavgen C code however specifies MAVLINK_TYPE_CHAR = 0. I've done some searching if it is for a reason that this is so, but couldn't retrieve any. Also according to mavschema.xsd, char is a valid entry.

Hence this PR, which adds MAV_PARAM_TYPE_CHAR and MAV_PARAM_EXT_TYPE_CHAR, each with value 0.

If having omitted them was on purpose, please accept my apologies.