### PR TITLE
Add a new bit field to indicate position target reached

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3529,6 +3529,9 @@
       <entry value="2048" name="POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE">
         <description>Ignore yaw rate</description>
       </entry>
+      <entry value="4096" name="POSITION_TARGET_TYPEMASK_POS_REACHED">
+        <description>vehicle reached position target</description>
+      </entry>
     </enum>
     <enum name="ATTITUDE_TARGET_TYPEMASK" bitmask="true">
       <description>Bitmap to indicate which dimensions should be ignored by the vehicle: a value of 0b00000000 indicates that none of the setpoint dimensions should be ignored.</description>


### PR DESCRIPTION
It allows a vehicle to inform GCS through POSITION_TARGET_LOCAL_NED (with type_mask 0x1DF8) that the desired position target is reached. 