### PR TITLE
Create development.xml and seed with MISSION_CHECKSUM

### DIFF
--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -6,6 +6,7 @@
   <!-- autoquad.xml: AQ_TELEMETRY_F also used by ArduPilotMega SENSOR_OFFSETS -->
   <!-- <include>autoquad.xml</include> -->
   <include>common.xml</include>
+  <include>development.xml</include>
   <include>icarous.xml</include>
   <!-- matrixpilot.xml: ERROR: Duplicate message id 150 for FLEXIFUNCTION_SET (matrixpilot.xml:50) also used by SENSOR_OFFSETS (ardupilotmega.xml:1101) -->
   <!-- <include>matrixpilot.xml</include> -->

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- XML file for prototyping definitions for standard.xml  -->
+  <include>standard.xml</include>
+  <version>0</version>
+  <dialect>0</dialect>
+  <enums>
+    <!-- none defined (yet) -->
+  </enums>
+  <messages>
+    <message id="53" name="MISSION_CHECKSUM">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Checksum for the current mission, rally points or geofence plan (a GCS can use this checksum to determine if it has a matching plan definition).
+        This message must be broadcast following any change to a plan (immediately after the MISSION_ACK that completes the plan upload sequence).
+        It may also be requested using MAV_CMD_REQUEST_MESSAGE, where param 2 indicates the plan type for which the hash is required.
+        The checksum must be calculated on the autopilot, but may also be calculated by the GCS.
+        The checksum uses the same CRC32 algorithm as MAVLink FTP (https://mavlink.io/en/services/ftp.html#crc32-implementation).
+        It is run over each item in the plan in seq order (excluding the home location if present in the plan), and covers the following fields (in order):
+        frame, command, autocontinue, param1, param2, param3, param4, param5, param6, param7.
+      </description>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+      <field type="uint32_t" name="checksum">CRC32 checksum of current plan for specified type.</field>
+    </message>
+  </messages>
+</mavlink>


### PR DESCRIPTION
Fixes #1172
Replaces #1172

Under the new governance model xml definitions don't get accepted into standard set until they have been prototyped on one flight stack and at least one other key stakeholder stacks have agreed to implement them. To ease development this PR creates `development.xml` (includes `standard.xml`) and imports it into all.xml. This is where proposals to the standard set should be added before being implemented and proposed.

In addition, this adds the `MISSION_CHECKSUM` message which was agreed in #1172. 

As discussed in devcall - @auturgy @LorenzMeier @julianoes 
FYI @IamPete1 @holmnikolaj @amilcarlucas 