### PR TITLE
Add simple FSM support to ORBIT_EXECUTION_STATUS message in common.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -704,6 +704,21 @@
         <description>Yaw controlled by RC input.</description>
       </entry>
     </enum>
+    <enum name="ORBIT_EXECUTION_STATE">
+      <description>State of execution during orbit flight.</description>
+      <entry value="0" name="ORBIT_EXECUTION_STATE_UNKNOWN">
+        <description>Vehicle state is unknown according to orbit action.</description>
+      </entry>
+      <entry value="1" name="ORBIT_EXECUTION_STATE_APPROACH_TO_CIRCLE">
+        <description>Vehicle is approaching to orbit track.</description>
+      </entry>
+      <entry value="2" name="ORBIT_EXECUTION_STATE_STARTED">
+        <description>Vehicle started following orbit track.</description>
+      </entry>
+      <entry value="3" name="ORBIT_EXECUTION_STATE_FINISHED">
+        <description>Vehicle finished following orbit track.</description>
+      </entry>
+    </enum>
     <enum name="WIFI_CONFIG_AP_RESPONSE">
       <description>Possible responses from a WIFI_CONFIG_AP message.</description>
       <entry value="0" name="WIFI_CONFIG_AP_RESPONSE_UNDEFINED">
@@ -6572,6 +6587,7 @@
       <field type="int32_t" name="x">X coordinate of center point. Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
       <field type="int32_t" name="y">Y coordinate of center point.  Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
       <field type="float" name="z" units="m">Altitude of center point. Coordinate system depends on frame field.</field>
+      <field type="uint8_t" name="state" enum="ORBIT_EXECUTION_STATE">State of execution during the orbit action.</field>
     </message>
     <!-- Smart battery messages -->
     <message id="370" name="SMART_BATTERY_INFO">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -943,14 +943,14 @@
       <entry value="34" name="MAV_CMD_DO_ORBIT" hasLocation="true" isDestination="true">
         <wip/>
         <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Start orbiting on the circumference of a circle defined by the parameters. Setting any value NaN results in using defaults.</description>
-        <param index="1" label="Radius" units="m">Radius of the circle. positive: Orbit clockwise. negative: Orbit counter-clockwise.</param>
-        <param index="2" label="Velocity" units="m/s">Tangential Velocity. NaN: Vehicle configuration default.</param>
+        <description>Start orbiting on the circumference of a circle defined by the parameters. Setting values to NaN/INT32_MAX (as appropriate) results in using defaults.</description>
+        <param index="1" label="Radius" units="m">Radius of the circle. Positive: orbit clockwise. Negative: orbit counter-clockwise. NaN: Use vehicle default radius, or current radius if already orbiting.</param>
+        <param index="2" label="Velocity" units="m/s">Tangential Velocity. NaN: Use vehicle default velocity, or current velocity if already orbiting.</param>
         <param index="3" label="Yaw Behavior" enum="ORBIT_YAW_BEHAVIOUR">Yaw behavior of the vehicle.</param>
-        <param index="4" label="Orbits" units="rad" minValue="0" default="0">Orbit centre point for this many radians (i.e. for a three-quarter orbit set 270*Pi/180). 0: Orbit forever.</param>
-        <param index="5" label="Latitude/X">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
-        <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
-        <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
+        <param index="4" label="Orbits" units="rad" minValue="0" default="0">Orbit around the centre point for this many radians (i.e. for a three-quarter orbit set 270*Pi/180). 0: Orbit forever. NaN: Use vehicle default, or current value if already orbiting.</param>
+        <param index="5" label="Latitude/X">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. INT32_MAX (or NaN if sent in COMMAND_LONG): Use current vehicle position, or current center if already orbiting.</param>
+        <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. INT32_MAX (or NaN if sent in COMMAND_LONG): Use current vehicle position, or current center if already orbiting.</param>
+        <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -962,7 +962,7 @@
         <param index="1" label="Radius" units="m">Radius of the circle. positive: Orbit clockwise. negative: Orbit counter-clockwise.</param>
         <param index="2" label="Velocity" units="m/s">Tangential Velocity. NaN: Vehicle configuration default.</param>
         <param index="3" label="Yaw Behavior" enum="ORBIT_YAW_BEHAVIOUR">Yaw behavior of the vehicle.</param>
-        <param index="4">Reserved (e.g. for dynamic center beacon options)</param>
+        <param index="4" label="Turn in Radians" units="rad" minValue="0" default="0">Orbital turn in radians.</param>
         <param index="5" label="Latitude/X">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
@@ -6588,6 +6588,7 @@
       <field type="int32_t" name="y">Y coordinate of center point.  Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
       <field type="float" name="z" units="m">Altitude of center point. Coordinate system depends on frame field.</field>
       <field type="uint8_t" name="state" enum="ORBIT_EXECUTION_STATE">State of execution during the orbit action.</field>
+      <field type="float" name="progress">Progress of orbit in percentage, only meaningful if the orbit is finite.</field>
     </message>
     <!-- Smart battery messages -->
     <message id="370" name="SMART_BATTERY_INFO">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6588,7 +6588,7 @@
       <field type="int32_t" name="y">Y coordinate of center point.  Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
       <field type="float" name="z" units="m">Altitude of center point. Coordinate system depends on frame field.</field>
       <field type="uint8_t" name="state" enum="ORBIT_EXECUTION_STATE">State of execution during the orbit action.</field>
-      <field type="float" name="progress">Progress of orbit in percentage, only meaningful if the orbit is finite.</field>
+      <field type="uint8_t" units="%" name="progress">Progress of orbit. UINT_MAX8 if orbit is indefinite.</field>
     </message>
     <!-- Smart battery messages -->
     <message id="370" name="SMART_BATTERY_INFO">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -704,21 +704,6 @@
         <description>Yaw controlled by RC input.</description>
       </entry>
     </enum>
-    <enum name="ORBIT_EXECUTION_STATE">
-      <description>State of execution during orbit flight.</description>
-      <entry value="0" name="ORBIT_EXECUTION_STATE_UNKNOWN">
-        <description>Vehicle state is unknown according to orbit action.</description>
-      </entry>
-      <entry value="1" name="ORBIT_EXECUTION_STATE_APPROACH_TO_CIRCLE">
-        <description>Vehicle is approaching to orbit track.</description>
-      </entry>
-      <entry value="2" name="ORBIT_EXECUTION_STATE_STARTED">
-        <description>Vehicle started following orbit track.</description>
-      </entry>
-      <entry value="3" name="ORBIT_EXECUTION_STATE_FINISHED">
-        <description>Vehicle finished following orbit track.</description>
-      </entry>
-    </enum>
     <enum name="WIFI_CONFIG_AP_RESPONSE">
       <description>Possible responses from a WIFI_CONFIG_AP message.</description>
       <entry value="0" name="WIFI_CONFIG_AP_RESPONSE_UNDEFINED">
@@ -6587,8 +6572,6 @@
       <field type="int32_t" name="x">X coordinate of center point. Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
       <field type="int32_t" name="y">Y coordinate of center point.  Coordinate system depends on frame field: local = x position in meters * 1e4, global = latitude in degrees * 1e7.</field>
       <field type="float" name="z" units="m">Altitude of center point. Coordinate system depends on frame field.</field>
-      <field type="uint8_t" name="state" enum="ORBIT_EXECUTION_STATE">State of execution during the orbit action.</field>
-      <field type="uint8_t" units="%" name="progress">Progress of orbit. UINT_MAX8 if orbit is indefinite.</field>
     </message>
     <!-- Smart battery messages -->
     <message id="370" name="SMART_BATTERY_INFO">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -962,7 +962,7 @@
         <param index="1" label="Radius" units="m">Radius of the circle. positive: Orbit clockwise. negative: Orbit counter-clockwise.</param>
         <param index="2" label="Velocity" units="m/s">Tangential Velocity. NaN: Vehicle configuration default.</param>
         <param index="3" label="Yaw Behavior" enum="ORBIT_YAW_BEHAVIOUR">Yaw behavior of the vehicle.</param>
-        <param index="4" label="Turn in Radians" units="rad" minValue="0" default="0">Orbital turn in radians.</param>
+        <param index="4" label="Orbits" units="rad" minValue="0" default="0">Orbit centre point for this many radians (i.e. for a three-quarter orbit set 270*π/180). 0: Orbit forever.</param>
         <param index="5" label="Latitude/X">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -962,7 +962,7 @@
         <param index="1" label="Radius" units="m">Radius of the circle. positive: Orbit clockwise. negative: Orbit counter-clockwise.</param>
         <param index="2" label="Velocity" units="m/s">Tangential Velocity. NaN: Vehicle configuration default.</param>
         <param index="3" label="Yaw Behavior" enum="ORBIT_YAW_BEHAVIOUR">Yaw behavior of the vehicle.</param>
-        <param index="4" label="Orbits" units="rad" minValue="0" default="0">Orbit centre point for this many radians (i.e. for a three-quarter orbit set 270*π/180). 0: Orbit forever.</param>
+        <param index="4" label="Orbits" units="rad" minValue="0" default="0">Orbit centre point for this many radians (i.e. for a three-quarter orbit set 270*Pi/180). 0: Orbit forever.</param>
         <param index="5" label="Latitude/X">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle position or current center if already orbiting.</param>


### PR DESCRIPTION
This is a simple feature extension on orbit mode that allows the implementation of a very simple finite state machine structure in autopilot software. Normally orbit executes indefinitely, however the use-case I'm currently working on requires a finite orbit behavior for a certain amount of angles. 

Following is a diagram of the added states when the orbit is requested to happen only for 360 degrees.
![OrbitFSM](https://user-images.githubusercontent.com/10549928/115622596-bb24a300-a300-11eb-829d-928a2259fa73.png)


Based on use-cases, this state machine can be populated with more fine-grained states. Nevertheless this alone enables many capabilities.
