### PR TITLE
minimal: add compid for safety

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -581,6 +581,9 @@
       <entry value="160" name="MAV_COMP_ID_FLARM">
         <description>FLARM collision alert component.</description>
       </entry>
+      <entry value="161" name="MAV_COMP_ID_PARACHUTE">
+        <description>Parachute component.</description>
+      </entry>
       <entry value="171" name="MAV_COMP_ID_GIMBAL2">
         <description>Gimbal #2.</description>
       </entry>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -179,6 +179,9 @@
       <entry value="36" name="MAV_TYPE_BATTERY">
         <description>Battery</description>
       </entry>
+      <entry value="37" name="MAV_TYPE_PARACHUTE">
+        <description>Parachute</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
It would be nice to have a component ID for a safety device such as a parachute module.

FYI @MaEtUgR 