### PR TITLE
common: make PARACHUTE_ACTION enum consistent

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3700,13 +3700,13 @@
     <!-- parachute action enum -->
     <enum name="PARACHUTE_ACTION">
       <description>Parachute actions. Trigger release and enable/disable auto-release.</description>
-      <entry value="0" name="PARACHUTE_DISABLE">
+      <entry value="0" name="PARACHUTE_ACTION_DISABLE">
         <description>Disable auto-release of parachute (i.e. release triggered by crash detectors).</description>
       </entry>
-      <entry value="1" name="PARACHUTE_ENABLE">
+      <entry value="1" name="PARACHUTE_ACTION_ENABLE">
         <description>Enable auto-release of parachute.</description>
       </entry>
-      <entry value="2" name="PARACHUTE_RELEASE">
+      <entry value="2" name="PARACHUTE_ACTION_RELEASE">
         <description>Release parachute and kill motors.</description>
       </entry>
     </enum>


### PR DESCRIPTION
I think that's more consistent and easier to grep this way.