### PR TITLE
COMMAND_PROGRESS message proposal 

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -119,7 +119,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">Mission command being reported.</field>
-      <field type="uint8_t" name="progress" units="%">Progress of main command action. 0 if has not started. UINT16_MAX if progress cannot be estimated.</field>
+      <field type="uint8_t" name="progress" units="%">Progress of main command action. 0 if has not started. UINT8_MAX if progress cannot be estimated.</field>
       <field type="uint8_t" name="state" enum="COMMAND_STATE">State of command execution.</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -44,6 +44,33 @@
         <description>Synthetic/calculated airspeed.</description>
       </entry>
     </enum>
+    <enum name="COMMAND_STATE">
+      <description>Command execution state. This is used in COMMAND_PROGRESS message to indicate progress of the main action performed by a command.</description>
+      <entry value="0" name="COMMAND_STATE_UNKNOWN">
+        <description>Command state unknown.</description>
+      </entry>
+      <entry value="1" name="COMMAND_STATE_PENDING">
+        <description>Action has not yet started.</description>
+      </entry>
+      <entry value="3" name="COMMAND_STATE_PRE_ACTION">
+        <description>Command is executing/doing stuff but the action has not yet started (e.g. flying to orbit position).</description>
+      </entry>
+      <entry value="4" name="COMMAND_STATE_STARTED">
+        <description>Action has started.</description>
+      </entry>
+      <entry value="5" name="COMMAND_STATE_COMPLETE">
+        <description>Action has completed normally (e.g. takeoff altitude reached, commanded number of orbits reached).</description>
+      </entry>
+      <entry value="6" name="COMMAND_STATE_FAILED">
+        <description>Commanded action has failed (e.g takeoff, but did not reach altitude, format error on file write).</description>
+      </entry>
+      <entry value="7" name="COMMAND_STATE_INTERRUPTED">
+        <description>Commanded action has been replaced with some other operation (e.g. a goto command has been received half way through a takeoff).</description>
+      </entry>
+      <entry value="8" name="COMMAND_STATE_CANCELLED">
+        <description>Commanded action has been excplicitly cancelled (e.g. by COMMAND_CANCEL message).</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="53" name="MISSION_CHECKSUM">
@@ -81,6 +108,19 @@
       <field type="uint8_t" name="signal_quality" units="%">WiFi network signal quality.</field>
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
+    </message>
+    <message id="78" name="COMMAND_PROGRESS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Command protocol progress message.
+      This is used to indicate progress and completion of the action associated with a command (i.e. completion of takeoff), even if the command itself completes immediately with MAV_RESULT_ACCEPTED.
+      It should be streamed from the point the command has been accepted until the main action has completed or otherwise ceased (e.g. if the action is superseded by another action or). The final state should be streamed at least three times following the action ending.
+      The streaming rate is nominally 5Hz, but is expected to be appropriate for the operation being reported, and configurable using normal MAVLink methods. </description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="command" enum="MAV_CMD">Mission command being reported.</field>
+      <field type="uint8_t" name="progress" units="%">Progress of main command action. 0 if has not started. UINT16_MAX if progress cannot be estimated.</field>
+      <field type="uint8_t" name="state" enum="COMMAND_STATE">State of command execution.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -68,7 +68,7 @@
         <description>Commanded action has been replaced with some other operation (e.g. a goto command has been received half way through a takeoff).</description>
       </entry>
       <entry value="8" name="COMMAND_STATE_CANCELLED">
-        <description>Commanded action has been excplicitly cancelled (e.g. by COMMAND_CANCEL message).</description>
+        <description>Commanded action has been explicitly cancelled (e.g. by COMMAND_CANCEL message).</description>
       </entry>
     </enum>
   </enums>


### PR DESCRIPTION
This PR adds proposal for a new message `COMMAND_PROGRESS` that can be streamed to indicate progress and completion of the action associated with a command. For example, if you send the `MAV_CMD_NAV_TAKEOFF` command it may complete immediately with a `COMMAND_ACK.result=MAV_RESULT_ACCEPTED`. You can then monitor COMMAND_PROGRESS to understand whether it is close to reaching the takeoff altitude, and when it has reached the altitude.

While it is possible to detect command completion in this case by other means (e.g. checking altitude and comparing to the expected target), `COMMAND_PROGRESS` provides a _generic_ solution to detecting completion of any command.

> **Note** Further, this is better than the [long running commands protocol](https://mavlink.io/en/services/command.html#long_running_commands) (and can in theory replace it) because many commands that are actually long running (like takeoff) predate the protocol and cannot be updated. This allows a non-breaking update path. 

This proposal originated from discussion of https://github.com/mavlink/mavlink/pull/1622

--- 

Notes:
- if desired, we could add a configurable field or two of zero-default "data" that could be used for whatever purpose is required and documented in a particular command. E.g. additional error values that make sense for that system, current count of turns, etc. FYI @MaEtUgR 
- This states this is only for commands. My thinking is that for commands uses in missions you already have the notification of changed waypoint to know you reached end of particular item.
- I have stated this is streamed after command accepted, and until it is complete + at least 3 messages. Reasonable?
- Note this is directed to the vehicle that sent the command via the target system/command id.