### PR TITLE
common.xml: COMP_METADATA_TYPE - tidy up - not used in messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -769,21 +769,21 @@
       </entry>
     </enum>
     <enum name="COMP_METADATA_TYPE">
-      <description>Possible values for COMPONENT_INFORMATION.comp_metadata_type.</description>
+      <description>Supported component metadata types. These are used in the "general" metadata file returned by COMPONENT_INFORMATION to provide information about supported metadata types. The types are not used directly in MAVLink messages.</description>
       <entry value="0" name="COMP_METADATA_TYPE_GENERAL">
-        <description>General information which also includes information on other optional supported COMP_METADATA_TYPE's. Must be supported. Only downloadable from vehicle.</description>
+        <description>General information about the component. General metadata includes information about other COMP_METADATA_TYPE's supported by the component. This type must be supported and must be downloadable from vehicle.</description>
       </entry>
       <entry value="1" name="COMP_METADATA_TYPE_PARAMETER">
         <description>Parameter meta data.</description>
       </entry>
       <entry value="2" name="COMP_METADATA_TYPE_COMMANDS">
-        <description>Meta data which specifies the commands the vehicle supports. (WIP)</description>
+        <description>Meta data that specifies which commands and command parameters the vehicle supports. (WIP)</description>
       </entry>
       <entry value="3" name="COMP_METADATA_TYPE_PERIPHERALS">
-        <description>Meta data which specifies potential external peripherals that do not talk MAVLink</description>
+        <description>Meta data that specifies external non-MAVLink peripherals.</description>
       </entry>
       <entry value="4" name="COMP_METADATA_TYPE_EVENTS">
-        <description>Meta data for events interface</description>
+        <description>Meta data for the events interface.</description>
       </entry>
     </enum>
     <enum name="PARAM_TRANSACTION_TRANSPORT">


### PR DESCRIPTION
@bkueng This tidies up COMP_METADATA_TYPE to reflect, in particular, that it is not used in `COMPONENT_INFORMATION.comp_metadata_typ2`