### PR TITLE
Add MAV_CMD_DELETE_IMAGE command

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1772,6 +1772,10 @@
         <param index="4" reserved="true" default="NaN"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
+      <entry value="533" name="MAV_CMD_DELETE_IMAGE" hasLocation="false" isDestination="false">
+        <description>Delete image from image log. This operation will decrement all image indexes after deleted image and number of images in CAMERA_CAPTURE_STATUS.image_count. Camera responds with CAMERA_CAPTURE_STATUS message with updated image count.</description>
+        <param index="1" label="Number" minValue="0" increment="1">Sequence number for image log entry to be deleted.</param>
+      </entry>
       <entry value="600" name="MAV_CMD_JUMP_TAG" hasLocation="false" isDestination="false">
         <description>Tagged jump target. Can be jumped to with MAV_CMD_DO_JUMP_TAG.</description>
         <param index="1" label="Tag" minValue="0" increment="1">Tag.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1772,7 +1772,7 @@
         <param index="4" reserved="true" default="NaN"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
-      <entry value="533" name="MAV_CMD_UNLOG_IMAGE" hasLocation="false" isDestination="false">
+      <entry value="533" name="MAV_CMD_REMOVE_IMAGE_RECORD" hasLocation="false" isDestination="false">
         <description>Remove image from the image log (no longer accessible using the MAVLink camera API). Note that the image may still be present on actual storage media.</description>
         <param index="1" label="Number" minValue="0" increment="1">Sequence number for image log entry to be removed.</param>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1772,9 +1772,9 @@
         <param index="4" reserved="true" default="NaN"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
-      <entry value="533" name="MAV_CMD_DELETE_IMAGE" hasLocation="false" isDestination="false">
-        <description>Delete image from image log.</description>
-        <param index="1" label="Number" minValue="0" increment="1">Sequence number for image log entry to be deleted.</param>
+      <entry value="533" name="MAV_CMD_UNLOG_IMAGE" hasLocation="false" isDestination="false">
+        <description>Remove image from the image log (no longer accessible using the MAVLink camera API). Note that the image may still be present on actual storage media.</description>
+        <param index="1" label="Number" minValue="0" increment="1">Sequence number for image log entry to be removed.</param>
       </entry>
       <entry value="600" name="MAV_CMD_JUMP_TAG" hasLocation="false" isDestination="false">
         <description>Tagged jump target. Can be jumped to with MAV_CMD_DO_JUMP_TAG.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1773,7 +1773,7 @@
         <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="533" name="MAV_CMD_DELETE_IMAGE" hasLocation="false" isDestination="false">
-        <description>Delete image from image log. This operation will decrement all image indexes after deleted image and number of images in CAMERA_CAPTURE_STATUS.image_count. Camera responds with CAMERA_CAPTURE_STATUS message with updated image count.</description>
+        <description>Delete image from image log.</description>
         <param index="1" label="Number" minValue="0" increment="1">Sequence number for image log entry to be deleted.</param>
       </entry>
       <entry value="600" name="MAV_CMD_JUMP_TAG" hasLocation="false" isDestination="false">


### PR DESCRIPTION
Add a command for deleting image from the image log.

Related messages and commands:

CAMERA_IMAGE_CAPTURED contains index in image log
CAMERA_CAPTURE_STATUS  contains total number of images in the image log
MAV_CMD_STORAGE_FORMAT has an option to reset image log
MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE to request CAMERA_IMAGE_CAPTURED from image log