### PR TITLE
common: add target for timesync

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5321,6 +5321,9 @@
       <description>Time synchronization message.</description>
       <field type="int64_t" name="tc1">Time sync timestamp 1</field>
       <field type="int64_t" name="ts1">Time sync timestamp 2</field>
+      <extensions/>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
     </message>
     <message id="112" name="CAMERA_TRIGGER">
       <description>Camera-IMU triggering and synchronisation message.</description>


### PR DESCRIPTION
This would be an attempt to enable timesync for more than two nodes.
I'm not sure if this is enough though because the timesync spec/comments are fairly confusing.

FYI @potaito @JonasVautherin 