### PR TITLE
commom.xml: add FUEL_TANK

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6767,6 +6767,16 @@
       <field type="uint16_t" name="sequence_oldest_available">Oldest Sequence number that is still available after the sequence set in REQUEST_EVENT.</field>
       <field type="uint8_t" name="reason" enum="MAV_EVENT_ERROR_REASON">Error reason.</field>
     </message>
+    <message id="420" name="FUEL_TANK">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description></description>
+      <field type="uint8_t" name="available_fuel_volume_percent">Available fuel volume percent, from 0% to 100%</field>
+      <field type="float" name="available_fuel_volume_cm3">Available fuel volume, centimeter^3</field>
+      <field type="float" name="fuel_consumption_rate_cm3pm">Estimate of the current fuel consumption rate, (centimeter^3)/minute</field>
+      <field type="float" name="fuel_temperature">Fuel temperature, kelvin</field>
+      <field type="uint8_t" name="fuel_tank_id">The ID of the current fuel tank.</field>
+    </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6767,16 +6767,6 @@
       <field type="uint16_t" name="sequence_oldest_available">Oldest Sequence number that is still available after the sequence set in REQUEST_EVENT.</field>
       <field type="uint8_t" name="reason" enum="MAV_EVENT_ERROR_REASON">Error reason.</field>
     </message>
-    <message id="420" name="FUEL_TANK">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description></description>
-      <field type="uint8_t" name="available_fuel_volume_percent">Available fuel volume percent, from 0% to 100%</field>
-      <field type="float" name="available_fuel_volume_cm3">Available fuel volume, centimeter^3</field>
-      <field type="float" name="fuel_consumption_rate_cm3pm">Estimate of the current fuel consumption rate, (centimeter^3)/minute</field>
-      <field type="float" name="fuel_temperature">Fuel temperature, kelvin</field>
-      <field type="uint8_t" name="fuel_tank_id">The ID of the current fuel tank.</field>
-    </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -82,5 +82,15 @@
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
     </message>
+    <message id="420" name="FUEL_TANK">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Generic fuel tank status message</description>
+      <field type="uint8_t" name="id" instance="true">The ID of the current fuel tank.</field>
+      <field type="float" name="fuel_remaining" units="cm^3">Available fuel volume</field>
+      <field type="float" name="max_fuel_volume" units="cm^3">Maximum value of fuel volume</field>
+      <field type="float" name="fuel_consumption_rate" units="cm^3/min">Estimate of the current fuel consumption rate</field>
+      <field type="float" name="fuel_temperature" units="K">Fuel temperature</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
According to the discussion opened in [PX4 issue #17861](https://github.com/PX4/PX4-Autopilot/issues/17861), there is no any mavlink message that has info about current level of fuel tank (only fuel_consumed and fuel_flow from [EFI_STATUS](https://mavlink.io/en/messages/common.html#EFI_STATUS)). This PR added new mavlink message `FUEL_TANK` similar to [ uavcan.equipment.ice.FuelTankStatus](https://legacy.uavcan.org/Specification/7._List_of_standard_data_types/#fueltankstatus).