### PR TITLE
common.xml: TRAJECTORY_REPRESENTATION_WAYPOINTS.command - is command id

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6530,7 +6530,7 @@
       <field type="float[5]" name="acc_z" units="m/s/s" invalid="[NaN]">Z-acceleration of waypoint, set to NaN if not being used</field>
       <field type="float[5]" name="pos_yaw" units="rad" invalid="[NaN]">Yaw angle, set to NaN if not being used</field>
       <field type="float[5]" name="vel_yaw" units="rad/s" invalid="[NaN]">Yaw rate, set to NaN if not being used</field>
-      <field type="uint16_t[5]" name="command" enum="MAV_CMD" invalid="[UINT16_MAX]">Scheduled action for each waypoint, UINT16_MAX if not being used.</field>
+      <field type="uint16_t[5]" name="command" enum="MAV_CMD" invalid="[UINT16_MAX]">MAV_CMD command id of waypoint, set to UINT16_MAX if not being used.</field>
     </message>
     <message id="333" name="TRAJECTORY_REPRESENTATION_BEZIER">
       <description>Describe a trajectory using an array of up-to 5 bezier control points in the local frame (MAV_FRAME_LOCAL_NED).</description>


### PR DESCRIPTION
The original doc said the field was a scheduled action for waypoint. That was misinterpreted by a user as "how do I encode the whole command in that array": https://github.com/mavlink/mavlink/issues/1666

It should now be clear that each index in all the arrays is for a particular waypoint, and this particular field represents the command ID of the associated waypoint's MAV_CMD.

This was confirmed by @TSC21 