### PR TITLE
represent BASE_MODE field in messages SET_MODE and MAV_CMD_DO_SET_MODE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1112,7 +1112,7 @@
       </entry>
       <entry value="176" name="MAV_CMD_DO_SET_MODE" hasLocation="false" isDestination="false">
         <description>Set system mode.</description>
-        <param index="1" label="Mode" enum="MAV_MODE">Mode</param>
+        <param index="1" label="Mode" enum="MAV_MODE_FLAG" display="bitmask">Mode bitmask</param>
         <param index="2" label="Custom Mode">Custom mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
         <param index="3" label="Custom Submode">Custom sub mode - this is system specific, please refer to the individual autopilot specifications for details.</param>
         <param index="4">Empty</param>
@@ -4418,7 +4418,7 @@
       <deprecated since="2015-12" replaced_by="MAV_CMD_DO_SET_MODE">Use COMMAND_LONG with MAV_CMD_DO_SET_MODE instead</deprecated>
       <description>Set the system mode, as defined by enum MAV_MODE. There is no target component id as the mode is by definition for the overall aircraft, not only for one component.</description>
       <field type="uint8_t" name="target_system">The system setting the mode</field>
-      <field type="uint8_t" name="base_mode" enum="MAV_MODE">The new base mode.</field>
+      <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">The new base mode bitmask.</field>
       <field type="uint32_t" name="custom_mode">The new autopilot-specific mode. This field can be ignored by an autopilot.</field>
     </message>
     <!-- IDs 15-17 reserved for PARAM_VALUE_UNION and other param messages -->


### PR DESCRIPTION
Attribute bitmask used for my tool [go-mavgen](https://github.com/asmyasnikov/go-mavlink) for serialise message to string as bitmask array of MAV_MODE_FLAG bits. But current definition interpret BASE_MODE as enum with switch-case rules. Ardupilot and PX4 interprets BASE_MODE as bitmap value