### PR TITLE
all.xml: add matrixpilot

### DIFF
--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -6,8 +6,7 @@
   <include>common.xml</include>
   <include>development.xml</include>
   <include>icarous.xml</include>
-  <!-- matrixpilot.xml: ERROR: Duplicate message id 150 for FLEXIFUNCTION_SET (matrixpilot.xml:50) also used by SENSOR_OFFSETS (ardupilotmega.xml:1101) -->
-  <!-- <include>matrixpilot.xml</include> -->
+  <include>matrixpilot.xml</include>
   <include>minimal.xml</include>
   <!-- paparazzi.xml: : ERROR: Duplicate message id 180 for SCRIPT_ITEM (paparazzi.xml:9) also used by CAMERA_FEEDBACK (ardupilotmega.xml:1370) -->
   <!-- <include>paparazzi.xml</include> -->

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1058,21 +1058,7 @@
     </enum>
   </enums>
   <messages>
-    <message id="150" name="SENSOR_OFFSETS">
-      <description>Offsets and calibrations values for hardware sensors. This makes it easier to debug the calibration process.</description>
-      <field type="int16_t" name="mag_ofs_x">Magnetometer X offset.</field>
-      <field type="int16_t" name="mag_ofs_y">Magnetometer Y offset.</field>
-      <field type="int16_t" name="mag_ofs_z">Magnetometer Z offset.</field>
-      <field type="float" name="mag_declination" units="rad">Magnetic declination.</field>
-      <field type="int32_t" name="raw_press">Raw pressure from barometer.</field>
-      <field type="int32_t" name="raw_temp">Raw temperature from barometer.</field>
-      <field type="float" name="gyro_cal_x">Gyro X calibration.</field>
-      <field type="float" name="gyro_cal_y">Gyro Y calibration.</field>
-      <field type="float" name="gyro_cal_z">Gyro Z calibration.</field>
-      <field type="float" name="accel_cal_x">Accel X calibration.</field>
-      <field type="float" name="accel_cal_y">Accel Y calibration.</field>
-      <field type="float" name="accel_cal_z">Accel Z calibration.</field>
-    </message>
+    <!-- 150 was SENSOR_OFFSETS, which conflicted with matrixpilot's FLEXIFUNCTION_SET -->
     <message id="151" name="SET_MAG_OFFSETS">
       <deprecated since="2014-07" replaced_by="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS"/>
       <description>Set the magnetometer offsets</description>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1059,15 +1059,7 @@
   </enums>
   <messages>
     <!-- 150 was SENSOR_OFFSETS, which conflicted with matrixpilot's FLEXIFUNCTION_SET -->
-    <message id="151" name="SET_MAG_OFFSETS">
-      <deprecated since="2014-07" replaced_by="MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS"/>
-      <description>Set the magnetometer offsets</description>
-      <field type="uint8_t" name="target_system">System ID.</field>
-      <field type="uint8_t" name="target_component">Component ID.</field>
-      <field type="int16_t" name="mag_ofs_x">Magnetometer X offset.</field>
-      <field type="int16_t" name="mag_ofs_y">Magnetometer Y offset.</field>
-      <field type="int16_t" name="mag_ofs_z">Magnetometer Z offset.</field>
-    </message>
+    <!-- 151 was SET_MAG_OFFSETS, which conflicted with matrixpilot's FLEXIFUNCTION_READ_REQ -->
     <message id="152" name="MEMINFO">
       <description>State of APM memory.</description>
       <field type="uint16_t" name="brkval">Heap top.</field>


### PR DESCRIPTION
ArduPilot can remove SENSOR_OFFSETS

I initially expect this PR to fail because `SENSOR_OFFSETS` has not been removed from `ardupilotmega.xml`

Please do not merge this PR until I've cleared killing these messages with the ArduPilot project.
