### PR TITLE
Adding some missing MAV_TYPEs

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -182,6 +182,18 @@
       <entry value="37" name="MAV_TYPE_PARACHUTE">
         <description>Parachute</description>
       </entry>
+      <entry value="38" name="MAV_TYPE_LOG">
+        <description>Log</description>
+      </entry>
+      <entry value="39" name="MAV_TYPE_OSD">
+        <description>OSD</description>
+      </entry>
+      <entry value="40" name="MAV_TYPE_IMU">
+        <description>IMU</description>
+      </entry>
+      <entry value="41" name="MAV_TYPE_GPS">
+        <description>GPS</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
In the heartbeat/connection protocol (https://mavlink.io/en/services/heartbeat.html) it is very nicely described that the type of the component should be identified through MAV_TYPE and not through its component id.

A necessary implication is that any type present in the MAV_COMP_ID list must also be present in the MAV_TYPE enum (i.e., that for each default MAV_COMP_ID there must be a suitable type available in the MAV_TYPE enu), but not vice versa.

For some types reflected in MAV_COMP_ID there is however no matching MAV_TYPE. This PR attempts to resolve this. (I actually wonder how it could happen that e.g. GPS isn't there).

For some MAV_COMP_ID it appears pretty clear what the MAV_TYPE should be, but for some it is actually not so clear to me. Hence this PR may not be the final answer and may have to be followed up by one adding what still turns out to be missing.

These MAV_COMP_IDs do not appear to have an obvious match in the MAV_TYPE enum:

MAV_COMP_ID_LOG
MAV_COMP_ID_OSD
MAV_COMP_ID_PERIPHERAL
MAV_COMP_ID_PATHPLANNER
MAV_COMP_ID_OBSTACLE_AVOIDANCE
MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY
MAV_COMP_ID_PAIRING_MANAGER
MAV_COMP_ID_IMU
MAV_COMP_ID_GPS
MAV_COMP_ID_UDP_BRIDGE
MAV_COMP_ID_UART_BRIDGE
MAV_COMP_ID_TUNNEL_NODE

Let's go through them.

For these MAV_COMP_IDs it seems to be obvious what their match should be, and these I have added in this PR

MAV_COMP_ID_LOG
MAV_COMP_ID_OSD
MAV_COMP_ID_IMU
MAV_COMP_ID_GPS

For these MAV_COMP_IDs I suspect that this would be the appropriate mapping, but I don't know, so here your input/checking is required:

MAV_COMP_ID_PATHPLANNER -> MAV_TYPE_ONBOARD_CONTROLLER
MAV_COMP_ID_OBSTACLE_AVOIDANCE -> MAV_TYPE_ONBOARD_CONTROLLER
MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY -> MAV_TYPE_ONBOARD_CONTROLLER
MAV_COMP_ID_UDP_BRIDGE -> MAV_TYPE_ONBOARD_CONTROLLER
MAV_COMP_ID_UART_BRIDGE -> MAV_TYPE_ONBOARD_CONTROLLER
MAV_COMP_ID_TUNNEL_NODE -> MAV_TYPE_GCS

For these MAV_COM_IDs I simply have no idea that their actual use is and what their types could be, you need to fill in your knowledge:

MAV_COMP_ID_PERIPHERAL -> ???
MAV_COMP_ID_PAIRING_MANAGER -> ???




