### PR TITLE
Mission item grouping commands and messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1610,6 +1610,14 @@
         <param index="1" label="First Item" minValue="0" increment="1">first_item: the first mission item to run</param>
         <param index="2" label="Last Item" minValue="0" increment="1">last_item:  the last mission item to run (after this item is run, the mission ends)</param>
       </entry>
+      <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
+        <description>Define beginning of a group of mission items. When control reaches this command a GROUP_START message is emitted. Groups can be nested.</description>
+        <param index="1" label="Group ID" minValue="0" increment="1">Unique group id</param>
+      </entry>
+      <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
+        <description>Define ending of a group of mission items. When control reaches this command a GROUP_END message is emitted. Groups can be nested.</description>
+        <param index="1" label="Group ID" minValue="0" increment="1">Unique group id</param>
+      </entry>
       <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM" hasLocation="false" isDestination="false">
         <description>Arms / Disarms a component</description>
         <param index="1" label="Arm" minValue="0" maxValue="1" increment="1">0: disarm, 1: arm</param>
@@ -4690,6 +4698,20 @@
       <field type="float" name="p2x" units="m">x position 2 / Latitude 2</field>
       <field type="float" name="p2y" units="m">y position 2 / Longitude 2</field>
       <field type="float" name="p2z" units="m">z position 2 / Altitude 2</field>
+    </message>
+    <message id="56" name="GROUP_START">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Emitted when control reaches MAV_CMD_GROUP_START with unique group id and time stamp of the event.</description>
+      <field type="uint32_t" name="group_id">Unique group id.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
+    <message id="57" name="GROUP_END">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Emitted when control reaches MAV_CMD_GROUP_END with unique group id and time stamp of the event.</description>
+      <field type="uint32_t" name="group_id">Unique group id.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <message id="61" name="ATTITUDE_QUATERNION_COV">
       <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1610,14 +1610,6 @@
         <param index="1" label="First Item" minValue="0" increment="1">first_item: the first mission item to run</param>
         <param index="2" label="Last Item" minValue="0" increment="1">last_item:  the last mission item to run (after this item is run, the mission ends)</param>
       </entry>
-      <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
-        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted. The end of a group is marked using MAV_CMD_GROUP_END with the same group id. Groups can be nested or overlap.</description>
-        <param index="1" label="Group ID" minValue="0" increment="1">Mission-unique group id</param>
-      </entry>
-      <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
-        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted. The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id. Groups can be nested or overlap.</description>
-        <param index="1" label="Group ID" minValue="0" increment="1">Mission-unique group id</param>
-      </entry>
       <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM" hasLocation="false" isDestination="false">
         <description>Arms / Disarms a component</description>
         <param index="1" label="Arm" minValue="0" maxValue="1" increment="1">0: disarm, 1: arm</param>
@@ -6663,20 +6655,6 @@
       <field type="uint16_t" name="sequence">Sequence number.</field>
       <field type="uint16_t" name="sequence_oldest_available">Oldest Sequence number that is still available after the sequence set in REQUEST_EVENT.</field>
       <field type="uint8_t" name="reason" enum="MAV_EVENT_ERROR_REASON">Error reason.</field>
-    </message>
-    <message id="414" name="GROUP_START">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>
-      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_START).</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-    </message>
-    <message id="415" name="GROUP_END">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_END.</description>
-      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_END).</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1611,12 +1611,12 @@
         <param index="2" label="Last Item" minValue="0" increment="1">last_item:  the last mission item to run (after this item is run, the mission ends)</param>
       </entry>
       <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
-        <description>Define beginning of a group of mission items. When control reaches this command a GROUP_START message is emitted. Groups can be nested.</description>
-        <param index="1" label="Group ID" minValue="0" increment="1">Unique group id</param>
+        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted. The end of a group is marked using MAV_CMD_GROUP_END with the same group id. Groups can be nested or overlap.</description>
+        <param index="1" label="Group ID" minValue="0" increment="1">Mission-unique group id</param>
       </entry>
       <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
-        <description>Define ending of a group of mission items. When control reaches this command a GROUP_END message is emitted. Groups can be nested.</description>
-        <param index="1" label="Group ID" minValue="0" increment="1">Unique group id</param>
+        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted. The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id. Groups can be nested or overlap.</description>
+        <param index="1" label="Group ID" minValue="0" increment="1">Mission-unique group id</param>
       </entry>
       <entry value="400" name="MAV_CMD_COMPONENT_ARM_DISARM" hasLocation="false" isDestination="false">
         <description>Arms / Disarms a component</description>
@@ -6667,15 +6667,15 @@
     <message id="414" name="GROUP_START">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Emitted when control reaches MAV_CMD_GROUP_START with unique group id and time stamp of the event.</description>
-      <field type="uint32_t" name="group_id">Unique group id.</field>
+      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>
+      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_START).</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <message id="415" name="GROUP_END">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Emitted when control reaches MAV_CMD_GROUP_END with unique group id and time stamp of the event.</description>
-      <field type="uint32_t" name="group_id">Unique group id.</field>
+      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_END.</description>
+      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_END).</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <!-- Rover specific messages -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4699,20 +4699,6 @@
       <field type="float" name="p2y" units="m">y position 2 / Longitude 2</field>
       <field type="float" name="p2z" units="m">z position 2 / Altitude 2</field>
     </message>
-    <message id="56" name="GROUP_START">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Emitted when control reaches MAV_CMD_GROUP_START with unique group id and time stamp of the event.</description>
-      <field type="uint32_t" name="group_id">Unique group id.</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-    </message>
-    <message id="57" name="GROUP_END">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Emitted when control reaches MAV_CMD_GROUP_END with unique group id and time stamp of the event.</description>
-      <field type="uint32_t" name="group_id">Unique group id.</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-    </message>
     <message id="61" name="ATTITUDE_QUATERNION_COV">
       <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
@@ -6677,6 +6663,20 @@
       <field type="uint16_t" name="sequence">Sequence number.</field>
       <field type="uint16_t" name="sequence_oldest_available">Oldest Sequence number that is still available after the sequence set in REQUEST_EVENT.</field>
       <field type="uint8_t" name="reason" enum="MAV_EVENT_ERROR_REASON">Error reason.</field>
+    </message>
+    <message id="414" name="GROUP_START">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Emitted when control reaches MAV_CMD_GROUP_START with unique group id and time stamp of the event.</description>
+      <field type="uint32_t" name="group_id">Unique group id.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
+    <message id="415" name="GROUP_END">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Emitted when control reaches MAV_CMD_GROUP_END with unique group id and time stamp of the event.</description>
+      <field type="uint32_t" name="group_id">Unique group id.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -155,6 +155,16 @@
         <description>SIM is available, but not usuable for connection</description>
       </entry>
     </enum>
+    <enum name="MAV_CMD">
+      <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
+        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted. The end of a group is marked using MAV_CMD_GROUP_END with the same group id. Groups can be nested or overlap.</description>
+        <param index="1" label="Group ID" minValue="0" increment="1">Mission-unique group id</param>
+      </entry>
+      <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
+        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted. The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id. Groups can be nested or overlap.</description>
+        <param index="1" label="Group ID" minValue="0" increment="1">Mission-unique group id</param>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -216,6 +226,16 @@
       <field type="uint16_t" name="mcc" invalid="UINT16_MAX">Mobile country code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
+    </message>
+    <message id="414" name="GROUP_START">
+      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>
+      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_START).</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
+    <message id="415" name="GROUP_END">
+      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_END.</description>
+      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_END).</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -158,11 +158,11 @@
     <enum name="MAV_CMD">
       <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
         <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted. The end of a group is marked using MAV_CMD_GROUP_END with the same group id. Groups can be nested or overlap.</description>
-        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.</param>
+        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id. Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
       <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
         <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted. The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id. Groups can be nested or overlap.</description>
-        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.</param>
+        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id. Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
     </enum>
   </enums>
@@ -230,11 +230,13 @@
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>
       <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_START).</field>
+      <field type="uint32_t" name="mission_checksum">CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <message id="415" name="GROUP_END">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_END.</description>
       <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_END).</field>
+      <field type="uint32_t" name="mission_checksum">CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -157,11 +157,11 @@
     </enum>
     <enum name="MAV_CMD">
       <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
-        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted. The end of a group is marked using MAV_CMD_GROUP_END with the same group id. Groups can be nested or overlap.</description>
+        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted. The end of a group is marked using MAV_CMD_GROUP_END with the same group id. Groups can be nested.</description>
         <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id. Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
       <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
-        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted. The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id. Groups can be nested or overlap.</description>
+        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted. The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id. Groups can be nested.</description>
         <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id. Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
     </enum>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -158,11 +158,11 @@
     <enum name="MAV_CMD">
       <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
         <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted. The end of a group is marked using MAV_CMD_GROUP_END with the same group id. Groups can be nested or overlap.</description>
-        <param index="1" label="Group ID" minValue="0" increment="1">Mission-unique group id</param>
+        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.</param>
       </entry>
       <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
         <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted. The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id. Groups can be nested or overlap.</description>
-        <param index="1" label="Group ID" minValue="0" increment="1">Mission-unique group id</param>
+        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.</param>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -157,12 +157,20 @@
     </enum>
     <enum name="MAV_CMD">
       <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
-        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted. The end of a group is marked using MAV_CMD_GROUP_END with the same group id. Groups can be nested.</description>
-        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id. Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
+        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted.
+          The end of a group is marked using MAV_CMD_GROUP_END with the same group id.
+          Group ids are expected, but not required, to iterate sequentially.
+          Groups can be nested.</description>
+        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.
+          Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
       <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
-        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted. The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id. Groups can be nested.</description>
-        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id. Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
+        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted.
+          The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id.
+          Group ids are expected, but not required, to iterate sequentially.
+          Groups can be nested.</description>
+        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.
+          Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
     </enum>
   </enums>
@@ -231,13 +239,15 @@
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>
       <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_START).</field>
       <field type="uint32_t" name="mission_checksum">CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <message id="415" name="GROUP_END">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_END.</description>
       <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_END).</field>
       <field type="uint32_t" name="mission_checksum">CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
This PR adds mission items grouping commands. Groups are defined by START/STOP items and 64bit unsigned integer ID. A group can be nested inside another group. When control reaches MAV_CMD_GROUP_START or MAV_CMD_GROUP_END it emits GROUP_START message with group ID and current timestamp.

Task requirements and what kind of problem are we trying to solve:
We want to be able to associate data acquired by the vehicle (f.e. photos) with groups of mission items.
For example: user wants to inspect 2 bridges and creates a flight plan with several way points in proximity of each bridge.
With the proposed solution we would group mission items in 2 groups. For each photo we will add current group id and group timestamp to image metadata. This metadata will be later used to f.e. filter out only photos taken at "bridge 2".