### PR TITLE
MAV_LANDED_STATE: add state for preparing for take off

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3564,6 +3564,9 @@
       <entry value="4" name="MAV_LANDED_STATE_LANDING">
         <description>MAV currently landing</description>
       </entry>
+      <entry value="5" name="MAV_LANDED_STATE_PREPARING_FOR_TAKEOFF">
+        <description>MAV will soon take off</description>
+      </entry>
     </enum>
     <enum name="ADSB_ALTITUDE_TYPE">
       <description>Enumeration of the ADSB altimeter types</description>


### PR DESCRIPTION
this PR adds a new, additional, but optional, state to MAV_LANDED_STATE, in order to indicate that the vehicle will soon take off.

ArduPilot for instance introduces (for copters) a 2 sec period after arming and before taking off (=motors engange and spool up). 

This period can be very useful for components, such as e.g. gimbals. A gimbal for instance could run its gyro bias calculations and other initialization or estimations up to this point, and then has enough time to safely apply them while the vehicle is still at rest, before the vehicle is actually taking off and thus not ensured to be at rest anymore. Since there is usually an significant longer time between power up and actual takeoff, this can yield much better results than the normal procedure of doing these estimations shortly after power up. For instance, the gimbal's IMUs might have better adjusted to the temperature, or "boat" modes which typically require longer estimation times become better feasible. 

For ArduPilot it in principle would be possible to infer this pre-takeoff period from the messages which yield the arming state and the messages which yield the landed state. However, these are emitted at relatively low frequency (1 Hz), and not synchronized to the arming nor taking-off, nor to each other, which means quite some ambiguity and cut-down of the safe time. Also, this is obviously very flight-stack specific.

Note that the landed_state is (can be) communicated to the gimbal by the AUTOPILOT_STATE_FOR_GIMBAL_DEVICE message, which is typically a high-frequency message, and adding the new state to the landed_state makes this info available to the gimbal in a very timely and synchronized fashion. Currently this is not so.

Also note that this state does not have to be supported by a vehicle, which should mitigate incompatibility concerns, i.e., vehicle codes do not have to be modified. Things would then just work as before.

One could consider adding as requirement for this state that a vehicle must set it only if the pre-takeoff period is guaranteed to be longer than e.g. 1 sec, or 2 sec, or whatever one finds reasonable to specify. This would have the advantage that a component could rely on a certain time span independent on implementation/flight-stack. But I would not make this a part of this PR, as it might need more discussion, so just wanted to mention it.