### PR TITLE
update_c_library - build devfirst

### DIFF
--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -60,12 +60,12 @@ rm -rf $CLIBRARY_PATH/*
 
 # generate new c headers
 echo -e "\0033[34mStarting to generate c headers\0033[0m\n"
+generate_headers development $1
 generate_headers ardupilotmega $1
 generate_headers matrixpilot $1
 generate_headers test $1
 generate_headers ASLUAV $1
 generate_headers standard $1
-generate_headers development $1
 mkdir -p $CLIBRARY_PATH/message_definitions
 cp message_definitions/v1.0/* $CLIBRARY_PATH/message_definitions/.
 echo -e "\0033[34mFinished generating c headers\0033[0m\n"


### PR DESCRIPTION
This updates the build script to generate the C library for **development.xml** first, rather than last. This will allow us to add commands to development.xml without breaking the common.xml or ardupilot.xml builds. This is logically safer, and has been verified by testing.

Note that it doesn't "fix" the problems with enum generation. It just means that the issues with enum generation are fixed by the later build.

The short version is that since later builds swamp generated dialect folders of earlier builds, building development.xml first means that it cannot break anything that happens afterwards.

----

The TLDR of this is that when you build an XML file, all the dialects it includes are built as well. In theory the order should not matter because the generator is supposed to create the same code for the dialects irrespective of whether they are top level or included, but in fact this is not true:
- An index def "MAVLINK_THIS_XML_IDX" is created based on level of inclusion. This is used to determine whether the set of definitions are included or not. Inconsistent and poor design I think - raised in https://github.com/ArduPilot/pymavlink/pull/537
- All commands (duplicate enums) are merged in the top level file, and stripped from lower ones. That means if you build just ardupilot.xml, the included common.xml will be wrong because it will have all the commands stripped from the common library. Discussed in https://github.com/ArduPilot/pymavlink/pull/544

The reason this works without development.xml is that ardupilot is built first, with IDX of 1. It includes commonx.xml which is built with IDX1 and stripped of commands. That would be wrong but later on we build standard.xml which fixes things up. Firstly, it includes common.xml so common.xml ends up with a consistent IDX of 1 (note consistent, but inherently wrong because does not match what we would get if we just built common.xml). Further standard.xml does not have any content, so there are no merged MAV_CMDs - which means that the common library gets to keep all the definitions. Upshot, building standard.xml FIXES the errors in the common library from building just ardupilot.xml.

Now if we build development.xml last we have a problem. Development.xml includes common.xml so the IDX would be correct. However it has MAV_CMDs, so the commands in common.xml are stripped out - undoing the fixes from building standard.xml last. 

If we put the development.xml first then it acts just like ardupilot.xml - it strips out the XML in common.xml, which later gets fixed. It has no effect on ardupilot folder, because it doesn't include that. 

IN summary,
- this is a good fix for now.
- This is still fragile and will have to be re-addressed if we generate any more librarys OR if we add any MAV_CMDs to standard.xml, which is something we intend to do.
