### PR TITLE
Move CELLULAR_CONFIG to development.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3600,71 +3600,6 @@
         <description>The fields next_lat, next_lon and next_alt contain valid data.</description>
       </entry>
     </enum>
-    <enum name="CELLULAR_NETWORK_RADIO_TYPE">
-      <description>Cellular network radio type</description>
-      <entry value="0" name="CELLULAR_NETWORK_RADIO_TYPE_NONE"/>
-      <entry value="1" name="CELLULAR_NETWORK_RADIO_TYPE_GSM"/>
-      <entry value="2" name="CELLULAR_NETWORK_RADIO_TYPE_CDMA"/>
-      <entry value="3" name="CELLULAR_NETWORK_RADIO_TYPE_WCDMA"/>
-      <entry value="4" name="CELLULAR_NETWORK_RADIO_TYPE_LTE"/>
-    </enum>
-    <enum name="CELLULAR_STATUS_FLAG">
-      <description>These flags encode the cellular network status</description>
-      <entry value="0" name="CELLULAR_STATUS_FLAG_UNKNOWN">
-        <description>State unknown or not reportable.</description>
-      </entry>
-      <entry value="1" name="CELLULAR_STATUS_FLAG_FAILED">
-        <description>Modem is unusable</description>
-      </entry>
-      <entry value="2" name="CELLULAR_STATUS_FLAG_INITIALIZING">
-        <description>Modem is being initialized</description>
-      </entry>
-      <entry value="3" name="CELLULAR_STATUS_FLAG_LOCKED">
-        <description>Modem is locked</description>
-      </entry>
-      <entry value="4" name="CELLULAR_STATUS_FLAG_DISABLED">
-        <description>Modem is not enabled and is powered down</description>
-      </entry>
-      <entry value="5" name="CELLULAR_STATUS_FLAG_DISABLING">
-        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_DISABLED state</description>
-      </entry>
-      <entry value="6" name="CELLULAR_STATUS_FLAG_ENABLING">
-        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_ENABLED state</description>
-      </entry>
-      <entry value="7" name="CELLULAR_STATUS_FLAG_ENABLED">
-        <description>Modem is enabled and powered on but not registered with a network provider and not available for data connections</description>
-      </entry>
-      <entry value="8" name="CELLULAR_STATUS_FLAG_SEARCHING">
-        <description>Modem is searching for a network provider to register</description>
-      </entry>
-      <entry value="9" name="CELLULAR_STATUS_FLAG_REGISTERED">
-        <description>Modem is registered with a network provider, and data connections and messaging may be available for use</description>
-      </entry>
-      <entry value="10" name="CELLULAR_STATUS_FLAG_DISCONNECTING">
-        <description>Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated</description>
-      </entry>
-      <entry value="11" name="CELLULAR_STATUS_FLAG_CONNECTING">
-        <description>Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered</description>
-      </entry>
-      <entry value="12" name="CELLULAR_STATUS_FLAG_CONNECTED">
-        <description>One or more packet data bearers is active and connected</description>
-      </entry>
-    </enum>
-    <enum name="CELLULAR_NETWORK_FAILED_REASON">
-      <description>These flags are used to diagnose the failure state of CELLULAR_STATUS</description>
-      <entry value="0" name="CELLULAR_NETWORK_FAILED_REASON_NONE">
-        <description>No error</description>
-      </entry>
-      <entry value="1" name="CELLULAR_NETWORK_FAILED_REASON_UNKNOWN">
-        <description>Error state is unknown</description>
-      </entry>
-      <entry value="2" name="CELLULAR_NETWORK_FAILED_REASON_SIM_MISSING">
-        <description>SIM is required for the modem but missing</description>
-      </entry>
-      <entry value="3" name="CELLULAR_NETWORK_FAILED_REASON_SIM_ERROR">
-        <description>SIM is available, but not usuable for connection</description>
-      </entry>
-    </enum>
     <enum name="PRECISION_LAND_MODE">
       <description>Precision land modes (used in MAV_CMD_NAV_LAND).</description>
       <entry value="0" name="PRECISION_LAND_MODE_DISABLED">
@@ -6497,18 +6432,7 @@
       <field type="float[5]" name="delta" units="s" invalid="[NaN]">Bezier time horizon. Set to NaN if velocity/acceleration should not be incorporated</field>
       <field type="float[5]" name="pos_yaw" units="rad" invalid="[NaN]">Yaw. Set to NaN for unchanged</field>
     </message>
-    <message id="334" name="CELLULAR_STATUS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Report current used cellular network status</description>
-      <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
-      <field type="uint8_t" name="failure_reason" enum="CELLULAR_NETWORK_FAILED_REASON">Failure reason when status in in CELLUAR_STATUS_FAILED</field>
-      <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
-      <field type="uint8_t" name="quality" invalid="UINT8_MAX">Signal quality in percent. If unknown, set to UINT8_MAX</field>
-      <field type="uint16_t" name="mcc" invalid="UINT16_MAX">Mobile country code. If unknown, set to UINT16_MAX</field>
-      <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
-      <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
-    </message>
+    <!-- id 344 reserved for CELLULAR_STATUS (development.xml) -->
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -89,6 +89,73 @@
         <param index="1" label="Action" enum="FENCE_ACTION">Fence action on breach.</param>
       </entry>
     </enum>
+    
+    <enum name="CELLULAR_NETWORK_RADIO_TYPE">
+      <description>Cellular network radio type</description>
+      <entry value="0" name="CELLULAR_NETWORK_RADIO_TYPE_NONE"/>
+      <entry value="1" name="CELLULAR_NETWORK_RADIO_TYPE_GSM"/>
+      <entry value="2" name="CELLULAR_NETWORK_RADIO_TYPE_CDMA"/>
+      <entry value="3" name="CELLULAR_NETWORK_RADIO_TYPE_WCDMA"/>
+      <entry value="4" name="CELLULAR_NETWORK_RADIO_TYPE_LTE"/>
+    </enum>
+    <!-- cellular status information -->
+    <enum name="CELLULAR_STATUS_FLAG">
+      <description>These flags encode the cellular network status</description>
+      <entry value="0" name="CELLULAR_STATUS_FLAG_UNKNOWN">
+        <description>State unknown or not reportable.</description>
+      </entry>
+      <entry value="1" name="CELLULAR_STATUS_FLAG_FAILED">
+        <description>Modem is unusable</description>
+      </entry>
+      <entry value="2" name="CELLULAR_STATUS_FLAG_INITIALIZING">
+        <description>Modem is being initialized</description>
+      </entry>
+      <entry value="3" name="CELLULAR_STATUS_FLAG_LOCKED">
+        <description>Modem is locked</description>
+      </entry>
+      <entry value="4" name="CELLULAR_STATUS_FLAG_DISABLED">
+        <description>Modem is not enabled and is powered down</description>
+      </entry>
+      <entry value="5" name="CELLULAR_STATUS_FLAG_DISABLING">
+        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_DISABLED state</description>
+      </entry>
+      <entry value="6" name="CELLULAR_STATUS_FLAG_ENABLING">
+        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_ENABLED state</description>
+      </entry>
+      <entry value="7" name="CELLULAR_STATUS_FLAG_ENABLED">
+        <description>Modem is enabled and powered on but not registered with a network provider and not available for data connections</description>
+      </entry>
+      <entry value="8" name="CELLULAR_STATUS_FLAG_SEARCHING">
+        <description>Modem is searching for a network provider to register</description>
+      </entry>
+      <entry value="9" name="CELLULAR_STATUS_FLAG_REGISTERED">
+        <description>Modem is registered with a network provider, and data connections and messaging may be available for use</description>
+      </entry>
+      <entry value="10" name="CELLULAR_STATUS_FLAG_DISCONNECTING">
+        <description>Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated</description>
+      </entry>
+      <entry value="11" name="CELLULAR_STATUS_FLAG_CONNECTING">
+        <description>Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered</description>
+      </entry>
+      <entry value="12" name="CELLULAR_STATUS_FLAG_CONNECTED">
+        <description>One or more packet data bearers is active and connected</description>
+      </entry>
+    </enum>
+    <enum name="CELLULAR_NETWORK_FAILED_REASON">
+      <description>These flags are used to diagnose the failure state of CELLULAR_STATUS</description>
+      <entry value="0" name="CELLULAR_NETWORK_FAILED_REASON_NONE">
+        <description>No error</description>
+      </entry>
+      <entry value="1" name="CELLULAR_NETWORK_FAILED_REASON_UNKNOWN">
+        <description>Error state is unknown</description>
+      </entry>
+      <entry value="2" name="CELLULAR_NETWORK_FAILED_REASON_SIM_MISSING">
+        <description>SIM is required for the modem but missing</description>
+      </entry>
+      <entry value="3" name="CELLULAR_NETWORK_FAILED_REASON_SIM_ERROR">
+        <description>SIM is available, but not usuable for connection</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -139,6 +206,17 @@
       <field type="uint8_t" name="signal_quality" units="%">WiFi network signal quality.</field>
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
+    </message>
+    <!-- cellular status information -->
+    <message id="334" name="CELLULAR_STATUS">
+      <description>Report current used cellular network status</description>
+      <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
+      <field type="uint8_t" name="failure_reason" enum="CELLULAR_NETWORK_FAILED_REASON">Failure reason when status in in CELLUAR_STATUS_FAILED</field>
+      <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
+      <field type="uint8_t" name="quality" invalid="UINT8_MAX">Signal quality in percent. If unknown, set to UINT8_MAX</field>
+      <field type="uint16_t" name="mcc" invalid="UINT16_MAX">Mobile country code. If unknown, set to UINT16_MAX</field>
+      <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
+      <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -89,7 +89,6 @@
         <param index="1" label="Action" enum="FENCE_ACTION">Fence action on breach.</param>
       </entry>
     </enum>
-    
     <enum name="CELLULAR_NETWORK_RADIO_TYPE">
       <description>Cellular network radio type</description>
       <entry value="0" name="CELLULAR_NETWORK_RADIO_TYPE_NONE"/>


### PR DESCRIPTION
This moves WIP CELLULAR_CONFIG message and associated enums to development.xml

I **think* this was agreed in the dev call [20210901](https://github.com/mavlink/mavlink/wiki/20210901-Dev-Meeting) as there appears to be no public implementation. @julianoes @auturgy Was that what you remember?

FYI @DanielePettenuzzo 

