### PR TITLE
ESC_INFO: invalid invalid attribute

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6273,7 +6273,7 @@
       <field type="uint8_t" name="info" display="bitmask">Information regarding online/offline status of each ESC.</field>
       <field type="uint16_t[4]" name="failure_flags" enum="ESC_FAILURE_FLAGS" display="bitmask">Bitmap of ESC failure flags.</field>
       <field type="uint32_t[4]" name="error_count">Number of reported errors by each ESC since boot.</field>
-      <field type="int16_t[4]" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of each ESC. INT16_MAX: if data not supplied by ESC.</field>
+      <field type="int16_t[4]" name="temperature" units="cdegC" invalid="[INT16_MAX]">Temperature of each ESC. INT16_MAX: if data not supplied by ESC.</field>
     </message>
     <message id="291" name="ESC_STATUS">
       <wip/>


### PR DESCRIPTION
My fastMavlink parser was smart enough to catch this bug:

For the ESC_INFO message, the invalid attribute of the temperature field was incorrect. Since it is an array field the invalid attribute must be of the form [] too. We had determined and fixed the "rules" for how they must look like somewhere else in a thread I couldn't find that quickly. 

PS: it seems it's all in this long thread, https://github.com/mavlink/mavlink/pull/1614, maybe one should write them up:

if field is not an array then invalid="value"

if field is an array then 
* invalid="[value]" means all array elements
* invalid="[value,]" means the first array element, but no invalid for all the rest elements
* invalid="[value1,value2,value3]" means array has 3 elements and each element has the respective invalid attribute
* invalid="[value1,value2,value3,]" means array has more than 3 elements and the first 3 element have the respective invalid attribute but all higher elements do not have an invalid attribute
* invalid="[value1,,value3]" means array has 3 elements and the 1st and 3rd elements have the respective invalid attribute but the 2nd has none
* etc pp
