### PR TITLE
common: add gimbal device joing angles extension

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6223,6 +6223,10 @@
       <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (NaN if unknown)</field>
       <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
+      <extensions/>
+      <field type="float" name="joint_angle_1" units="rad" invalid="0">Joint 1 angle for debugging/visualization purposes, custom per gimbal</field>
+      <field type="float" name="joint_angle_2" units="rad" invalid="0">Joint 2 angle for debugging/visualization purposes, custom per gimbal</field>
+      <field type="float" name="joint_angle_3" units="rad" invalid="0">Joint 3 angle for debugging/visualization purposes, custom per gimbal</field>
     </message>
     <message id="286" name="AUTOPILOT_STATE_FOR_GIMBAL_DEVICE">
       <wip/>


### PR DESCRIPTION
For debugging and visualization purposes it would be nice to have the joint angles logged of a gimbal device. The quaterion is not enough for this purpose because the inverse kinematics to assume that attitude is not definied.

As requested by @cmic0.