### PR TITLE
Clarify how MAV_MISSION_TYPE_ALL checksum is calculated

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -195,13 +195,15 @@
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
     </message>
     <message id="53" name="MISSION_CHECKSUM">
-      <description>Checksum for the current mission, rally points or geofence plan (a GCS can use this checksum to determine if it has a matching plan definition).
-        This message must be broadcast following any change to a plan (immediately after the MISSION_ACK that completes the plan upload sequence).
-        It may also be requested using MAV_CMD_REQUEST_MESSAGE, where param 2 indicates the plan type for which the hash is required.
+      <description>Checksum for the current mission, rally point or geofence plan, or for the "combined" plan (a GCS can use these checksums to determine if it has matching plans).
+        This message must be broadcast with the appropriate checksum following any change to a mission, geofence or rally point definition
+        (immediately after the MISSION_ACK that completes the upload sequence).
+        It may also be requested using MAV_CMD_REQUEST_MESSAGE, where param 2 indicates the plan type for which the checksum is required.
         The checksum must be calculated on the autopilot, but may also be calculated by the GCS.
         The checksum uses the same CRC32 algorithm as MAVLink FTP (https://mavlink.io/en/services/ftp.html#crc32-implementation).
-        It is run over each item in the plan in seq order (excluding the home location if present in the plan), and covers the following fields (in order):
+        The checksum for a mission, geofence or rally point definition is run over each item in the plan in seq order (excluding the home location if present in the plan), and covers the following fields (in order):
         frame, command, autocontinue, param1, param2, param3, param4, param5, param6, param7.
+        The checksum for the whole plan (MAV_MISSION_TYPE_ALL) is calculated using the same approach, running over each sub-plan in the following order: mission, geofence then rally point.
       </description>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
       <field type="uint32_t" name="checksum">CRC32 checksum of current plan for specified type.</field>


### PR DESCRIPTION
This updates the `MISSION_CHECKSUM` definition to clarify exactly how the `MAV_MISSION_TYPE_ALL` is calculated - my understanding is that the order in which you parse the mission, geofence and rally point part of the plan matters!

I also took the opportunity to make it _more_ clear that if you update just the mission (say) then the checksum you get is the mission checksum, not the `MAV_MISSION_TYPE_ALL` checksum. 

@IamPete1 @MatejFranceskin @julianoes This makes sense? Pete, I am assuming you did not do the "all" case in another order? If so, we can modify to match you.

Guys, this also counts as an introduction. Pete is implementing this on ArduPilot/Mission Planner. Matej will do on PX4 and (presumably) QGC and Julian will do on MAVSDK. If you have concerns about this, or suggestions for improvement then please get together and discuss them. You're all in Europe!

Pete, FYI there has been some work done to start integrating MAVSDK with ArduPilot. This means that with some luck soon we may be able to use MAVSDK as a first class test for this kind of change. 
