### PR TITLE
common: add not feasible mission results

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2486,6 +2486,12 @@
       <entry value="15" name="MAV_MISSION_OPERATION_CANCELLED">
         <description>Current mission operation cancelled (e.g. mission upload, mission download).</description>
       </entry>
+      <entry value="16" name="MAV_MISSION_NOT_FEASIBLE_TOO_LONG">
+        <description>Mission is not feasible because it's too long for this airframe.</description>
+      </entry>
+      <entry value="17" name="MAV_MISSION_NOT_FEASIBLE_GEOFENCE">
+        <description>Mission is not feasible because it's outside of a geofence.</description>
+      </entry>
     </enum>
     <enum name="MAV_SEVERITY">
       <description>Indicates the severity level, generally used for status messages to indicate their relative urgency. Based on RFC-5424 using expanded definitions at: http://www.kiwisyslog.com/kb/info:-syslog-message-levels/.</description>


### PR DESCRIPTION
It came up that it should be possible for the flight controller to communicate with the ground station if an uploaded mission is not actually feasible.

Hence I'm adding two cases for where the upload is not feasible. This is probably not the full list. And I'm wondering if we should have only one `NOT_FEASIBLE` result and then communicate the exact reason via statustext/event.