### PR TITLE
Move CELLULAR_STATUS back to common dialect

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3618,6 +3618,49 @@
         <description>The fields next_lat, next_lon and next_alt contain valid data.</description>
       </entry>
     </enum>
+    <!-- cellular status information -->
+    <enum name="CELLULAR_STATUS_FLAG">
+      <description>These flags encode the cellular network status</description>
+      <entry value="0" name="CELLULAR_STATUS_FLAG_UNKNOWN">
+        <description>State unknown or not reportable.</description>
+      </entry>
+      <entry value="1" name="CELLULAR_STATUS_FLAG_FAILED">
+        <description>Modem is unusable</description>
+      </entry>
+      <entry value="2" name="CELLULAR_STATUS_FLAG_INITIALIZING">
+        <description>Modem is being initialized</description>
+      </entry>
+      <entry value="3" name="CELLULAR_STATUS_FLAG_LOCKED">
+        <description>Modem is locked</description>
+      </entry>
+      <entry value="4" name="CELLULAR_STATUS_FLAG_DISABLED">
+        <description>Modem is not enabled and is powered down</description>
+      </entry>
+      <entry value="5" name="CELLULAR_STATUS_FLAG_DISABLING">
+        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_DISABLED state</description>
+      </entry>
+      <entry value="6" name="CELLULAR_STATUS_FLAG_ENABLING">
+        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_ENABLED state</description>
+      </entry>
+      <entry value="7" name="CELLULAR_STATUS_FLAG_ENABLED">
+        <description>Modem is enabled and powered on but not registered with a network provider and not available for data connections</description>
+      </entry>
+      <entry value="8" name="CELLULAR_STATUS_FLAG_SEARCHING">
+        <description>Modem is searching for a network provider to register</description>
+      </entry>
+      <entry value="9" name="CELLULAR_STATUS_FLAG_REGISTERED">
+        <description>Modem is registered with a network provider, and data connections and messaging may be available for use</description>
+      </entry>
+      <entry value="10" name="CELLULAR_STATUS_FLAG_DISCONNECTING">
+        <description>Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated</description>
+      </entry>
+      <entry value="11" name="CELLULAR_STATUS_FLAG_CONNECTING">
+        <description>Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered</description>
+      </entry>
+      <entry value="12" name="CELLULAR_STATUS_FLAG_CONNECTED">
+        <description>One or more packet data bearers is active and connected</description>
+      </entry>
+    </enum>
     <enum name="PRECISION_LAND_MODE">
       <description>Precision land modes (used in MAV_CMD_NAV_LAND).</description>
       <entry value="0" name="PRECISION_LAND_MODE_DISABLED">
@@ -6456,7 +6499,31 @@
       <field type="float[5]" name="delta" units="s" invalid="[NaN]">Bezier time horizon. Set to NaN if velocity/acceleration should not be incorporated</field>
       <field type="float[5]" name="pos_yaw" units="rad" invalid="[NaN]">Yaw. Set to NaN for unchanged</field>
     </message>
-    <!-- id 344 reserved for CELLULAR_STATUS (development.xml) -->
+    <!-- cellular status information -->
+    <message id="334" name="CELLULAR_STATUS">
+      <description>Report current used cellular network status</description>
+      <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
+      <field type="uint8_t" name="failure_reason" enum="CELLULAR_NETWORK_FAILED_REASON">Failure reason when status in in CELLUAR_STATUS_FAILED</field>
+      <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
+      <field type="uint8_t" name="quality" invalid="UINT8_MAX">Signal quality in percent. If unknown, set to UINT8_MAX</field>
+      <field type="uint16_t" name="mcc" invalid="UINT16_MAX">Mobile country code. If unknown, set to UINT16_MAX</field>
+      <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
+      <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
+    </message>
+    <message id="414" name="GROUP_START">
+      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>
+      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_START).</field>
+      <field type="uint32_t" name="mission_checksum">CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
+    <message id="415" name="GROUP_END">
+      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_END.</description>
+      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_END).</field>
+      <field type="uint32_t" name="mission_checksum">CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+    </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -97,49 +97,6 @@
       <entry value="3" name="CELLULAR_NETWORK_RADIO_TYPE_WCDMA"/>
       <entry value="4" name="CELLULAR_NETWORK_RADIO_TYPE_LTE"/>
     </enum>
-    <!-- cellular status information -->
-    <enum name="CELLULAR_STATUS_FLAG">
-      <description>These flags encode the cellular network status</description>
-      <entry value="0" name="CELLULAR_STATUS_FLAG_UNKNOWN">
-        <description>State unknown or not reportable.</description>
-      </entry>
-      <entry value="1" name="CELLULAR_STATUS_FLAG_FAILED">
-        <description>Modem is unusable</description>
-      </entry>
-      <entry value="2" name="CELLULAR_STATUS_FLAG_INITIALIZING">
-        <description>Modem is being initialized</description>
-      </entry>
-      <entry value="3" name="CELLULAR_STATUS_FLAG_LOCKED">
-        <description>Modem is locked</description>
-      </entry>
-      <entry value="4" name="CELLULAR_STATUS_FLAG_DISABLED">
-        <description>Modem is not enabled and is powered down</description>
-      </entry>
-      <entry value="5" name="CELLULAR_STATUS_FLAG_DISABLING">
-        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_DISABLED state</description>
-      </entry>
-      <entry value="6" name="CELLULAR_STATUS_FLAG_ENABLING">
-        <description>Modem is currently transitioning to the CELLULAR_STATUS_FLAG_ENABLED state</description>
-      </entry>
-      <entry value="7" name="CELLULAR_STATUS_FLAG_ENABLED">
-        <description>Modem is enabled and powered on but not registered with a network provider and not available for data connections</description>
-      </entry>
-      <entry value="8" name="CELLULAR_STATUS_FLAG_SEARCHING">
-        <description>Modem is searching for a network provider to register</description>
-      </entry>
-      <entry value="9" name="CELLULAR_STATUS_FLAG_REGISTERED">
-        <description>Modem is registered with a network provider, and data connections and messaging may be available for use</description>
-      </entry>
-      <entry value="10" name="CELLULAR_STATUS_FLAG_DISCONNECTING">
-        <description>Modem is disconnecting and deactivating the last active packet data bearer. This state will not be entered if more than one packet data bearer is active and one of the active bearers is deactivated</description>
-      </entry>
-      <entry value="11" name="CELLULAR_STATUS_FLAG_CONNECTING">
-        <description>Modem is activating and connecting the first packet data bearer. Subsequent bearer activations when another bearer is already active do not cause this state to be entered</description>
-      </entry>
-      <entry value="12" name="CELLULAR_STATUS_FLAG_CONNECTED">
-        <description>One or more packet data bearers is active and connected</description>
-      </entry>
-    </enum>
     <enum name="CELLULAR_NETWORK_FAILED_REASON">
       <description>These flags are used to diagnose the failure state of CELLULAR_STATUS</description>
       <entry value="0" name="CELLULAR_NETWORK_FAILED_REASON_NONE">
@@ -225,31 +182,6 @@
       <field type="uint8_t" name="signal_quality" units="%">WiFi network signal quality.</field>
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
-    </message>
-    <!-- cellular status information -->
-    <message id="334" name="CELLULAR_STATUS">
-      <description>Report current used cellular network status</description>
-      <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
-      <field type="uint8_t" name="failure_reason" enum="CELLULAR_NETWORK_FAILED_REASON">Failure reason when status in in CELLUAR_STATUS_FAILED</field>
-      <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
-      <field type="uint8_t" name="quality" invalid="UINT8_MAX">Signal quality in percent. If unknown, set to UINT8_MAX</field>
-      <field type="uint16_t" name="mcc" invalid="UINT16_MAX">Mobile country code. If unknown, set to UINT16_MAX</field>
-      <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
-      <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
-    </message>
-    <message id="414" name="GROUP_START">
-      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>
-      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_START).</field>
-      <field type="uint32_t" name="mission_checksum">CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot).
-        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-    </message>
-    <message id="415" name="GROUP_END">
-      <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_END.</description>
-      <field type="uint32_t" name="group_id">Mission-unique group id (from MAV_CMD_GROUP_END).</field>
-      <field type="uint32_t" name="mission_checksum">CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot).
-        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
**Problem Description**
The `CELLULAR_STATUS` message was removed from the common dialect in https://github.com/mavlink/mavlink/pull/1697 as it was considered that there were no public implementation. @hamishwillee 

However, the message is used in PX4(https://github.com/PX4/PX4-Autopilot/blob/6d78054f5001548ea2f1d48bb59966e2352bc9fe/src/modules/mavlink/mavlink_receiver.cpp#L206), and this change seems to break updating mavlink.

The message is quite useful to monitor the cellular status e.g. LTE module status of the vehicle in case it has cellular connections