### PR TITLE
Include ASLUAV into all dialect

### DIFF
--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -270,6 +270,7 @@
       <field type="uint8_t" name="sinr_ecio">SINR (LTE) or ECIO (WCDMA) as reported by modem (unconverted)</field>
       <field type="uint8_t" name="rsrq">RSRQ (LTE only) as reported by modem (unconverted)</field>
     </message>
+    <!-- Using mavlink 1 msg ID from the arudpilot reserved space, in order to save header size -->
     <message id="224" name="SATCOM_LINK_STATUS">
       <description>Status of the SatCom link</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp</field>

--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -54,7 +54,7 @@
     </enum>
   </enums>
   <messages>
-    <message id="78" name="COMMAND_INT_STAMPED">
+    <message id="8000" name="COMMAND_INT_STAMPED">
       <description>Message encoding a command with parameters as scaled integers and additional metadata. Scaling depends on the actual command value.</description>
       <field type="uint32_t" name="utc_time">UTC time, seconds elapsed since 01.01.1970</field>
       <field type="uint64_t" name="vehicle_timestamp">Microseconds elapsed since vehicle boot</field>
@@ -72,7 +72,7 @@
       <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
       <field type="float" name="z">PARAM7 / z position: global: altitude in meters (MSL, WGS84, AGL or relative to home - depending on frame).</field>
     </message>
-    <message id="79" name="COMMAND_LONG_STAMPED">
+    <message id="8001" name="COMMAND_LONG_STAMPED">
       <description>Send a command with up to seven parameters to the MAV and additional metadata</description>
       <field type="uint32_t" name="utc_time">UTC time, seconds elapsed since 01.01.1970</field>
       <field type="uint64_t" name="vehicle_timestamp">Microseconds elapsed since vehicle boot</field>
@@ -88,14 +88,14 @@
       <field type="float" name="param6">Parameter 6, as defined by MAV_CMD enum.</field>
       <field type="float" name="param7">Parameter 7, as defined by MAV_CMD enum.</field>
     </message>
-    <message id="201" name="SENS_POWER">
+    <message id="8002" name="SENS_POWER">
       <description>Voltage and current sensor data</description>
       <field type="float" name="adc121_vspb_volt" units="V"> Power board voltage sensor reading</field>
       <field type="float" name="adc121_cspb_amp" units="A"> Power board current sensor reading</field>
       <field type="float" name="adc121_cs1_amp" units="A"> Board current sensor 1 reading</field>
       <field type="float" name="adc121_cs2_amp" units="A"> Board current sensor 2 reading</field>
     </message>
-    <message id="202" name="SENS_MPPT">
+    <message id="8003" name="SENS_MPPT">
       <description>Maximum Power Point Tracker (MPPT) sensor data for solar module power performance tracking</description>
       <field type="uint64_t" name="mppt_timestamp" units="us"> MPPT last timestamp </field>
       <field type="float" name="mppt1_volt" units="V"> MPPT1 voltage </field>
@@ -111,7 +111,7 @@
       <field type="uint16_t" name="mppt3_pwm" units="us"> MPPT3 pwm </field>
       <field type="uint8_t" name="mppt3_status"> MPPT3 status </field>
     </message>
-    <message id="203" name="ASLCTRL_DATA">
+    <message id="8004" name="ASLCTRL_DATA">
       <description>ASL-fixed-wing controller data</description>
       <field type="uint64_t" name="timestamp" units="us"> Timestamp</field>
       <field type="uint8_t" name="aslctrl_mode"> ASLCTRL control-mode (manual, stabilized, auto, etc...)</field>
@@ -139,7 +139,7 @@
       <field type="float" name="uAil"> </field>
       <field type="float" name="uRud"> </field>
     </message>
-    <message id="204" name="ASLCTRL_DEBUG">
+    <message id="8005" name="ASLCTRL_DEBUG">
       <description>ASL-fixed-wing controller debug data</description>
       <field type="uint32_t" name="i32_1"> Debug data</field>
       <field type="uint8_t" name="i8_1"> Debug data</field>
@@ -153,7 +153,7 @@
       <field type="float" name="f_7"> Debug data</field>
       <field type="float" name="f_8"> Debug data</field>
     </message>
-    <message id="205" name="ASLUAV_STATUS">
+    <message id="8006" name="ASLUAV_STATUS">
       <description>Extended state information for ASLUAVs</description>
       <field type="uint8_t" name="LED_status"> Status of the position-indicator LEDs</field>
       <field type="uint8_t" name="SATCOM_status"> Status of the IRIDIUM satellite communication system</field>
@@ -161,7 +161,7 @@
       <field type="float" name="Motor_rpm"> Motor RPM </field>
       <!-- to be extended-->
     </message>
-    <message id="206" name="EKF_EXT">
+    <message id="8007" name="EKF_EXT">
       <description>Extended EKF state estimates for ASLUAVs</description>
       <field type="uint64_t" name="timestamp" units="us"> Time since system start</field>
       <field type="float" name="Windspeed" units="m/s"> Magnitude of wind velocity (in lateral inertial plane)</field>
@@ -171,7 +171,7 @@
       <field type="float" name="beta" units="rad"> Sideslip angle</field>
       <field type="float" name="alpha" units="rad"> Angle of attack</field>
     </message>
-    <message id="207" name="ASL_OBCTRL">
+    <message id="8008" name="ASL_OBCTRL">
       <description>Off-board controls/commands for ASLUAVs</description>
       <field type="uint64_t" name="timestamp" units="us"> Time since system start</field>
       <field type="float" name="uElev"> Elevator command [~]</field>
@@ -182,13 +182,13 @@
       <field type="float" name="uRud"> Rudder command [~]</field>
       <field type="uint8_t" name="obctrl_status"> Off-board computer status</field>
     </message>
-    <message id="208" name="SENS_ATMOS">
+    <message id="8009" name="SENS_ATMOS">
       <description>Atmospheric sensors (temperature, humidity, ...) </description>
       <field type="uint64_t" name="timestamp" units="us">Time since system boot</field>
       <field type="float" name="TempAmbient" units="degC"> Ambient temperature</field>
       <field type="float" name="Humidity" units="%"> Relative humidity</field>
     </message>
-    <message id="209" name="SENS_BATMON">
+    <message id="8010" name="SENS_BATMON">
       <description>Battery pack monitoring data for Li-Ion batteries</description>
       <field type="uint64_t" name="batmon_timestamp" units="us">Time since system start</field>
       <field type="float" name="temperature" units="degC">Battery pack temperature</field>
@@ -206,7 +206,7 @@
       <field type="uint16_t" name="cellvoltage5" units="mV">Battery pack cell 5 voltage</field>
       <field type="uint16_t" name="cellvoltage6" units="mV">Battery pack cell 6 voltage</field>
     </message>
-    <message id="210" name="FW_SOARING_DATA">
+    <message id="8011" name="FW_SOARING_DATA">
       <description>Fixed-wing soaring (i.e. thermal seeking) data</description>
       <field type="uint64_t" name="timestamp" units="ms">Timestamp</field>
       <field type="uint64_t" name="timestampModeChanged" units="ms">Timestamp since last mode change</field>
@@ -234,7 +234,7 @@
       <field type="uint8_t" name="ControlMode">Control Mode [-]</field>
       <field type="uint8_t" name="valid">Data valid [-]</field>
     </message>
-    <message id="211" name="SENSORPOD_STATUS">
+    <message id="8012" name="SENSORPOD_STATUS">
       <description>Monitoring of sensorpod status</description>
       <field type="uint64_t" name="timestamp" units="ms">Timestamp in linuxtime (since 1.1.1970)</field>
       <field type="uint8_t" name="visensor_rate_1">Rate of ROS topic 1</field>
@@ -245,7 +245,7 @@
       <field type="uint8_t" name="cpu_temp" units="degC">Temperature of sensorpod CPU in</field>
       <field type="uint16_t" name="free_space">Free space available in recordings directory in [Gb] * 1e2</field>
     </message>
-    <message id="212" name="SENS_POWER_BOARD">
+    <message id="8013" name="SENS_POWER_BOARD">
       <description>Monitoring of power board status</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
       <field type="uint8_t" name="pwr_brd_status">Power board status register</field>
@@ -260,7 +260,7 @@
       <field type="float" name="pwr_brd_ext_amp" units="A">Power board extension current sensor</field>
       <field type="float" name="pwr_brd_aux_amp" units="A">Power board aux current sensor</field>
     </message>
-    <message id="213" name="GSM_LINK_STATUS">
+    <message id="8014" name="GSM_LINK_STATUS">
       <description>Status of GSM modem (connected to onboard computer)</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (of OBC)</field>
       <field type="uint8_t" name="gsm_modem_type" enum="GSM_MODEM_TYPE">GSM modem used</field>
@@ -270,7 +270,7 @@
       <field type="uint8_t" name="sinr_ecio">SINR (LTE) or ECIO (WCDMA) as reported by modem (unconverted)</field>
       <field type="uint8_t" name="rsrq">RSRQ (LTE only) as reported by modem (unconverted)</field>
     </message>
-    <message id="214" name="SATCOM_LINK_STATUS">
+    <message id="224" name="SATCOM_LINK_STATUS">
       <description>Status of the SatCom link</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
       <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session</field>
@@ -281,7 +281,7 @@
       <field type="uint8_t" name="tx_session_pending">Transmission session pending</field>
       <field type="uint8_t" name="rx_session_pending">Receiving session pending</field>
     </message>
-    <message id="215" name="SENSOR_AIRFLOW_ANGLES">
+    <message id="8015" name="SENSOR_AIRFLOW_ANGLES">
       <description>Calibrated airflow angle measurements</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
       <field type="float" name="angleofattack" units="deg">Angle of attack</field>

--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -54,7 +54,7 @@
     </enum>
   </enums>
   <messages>
-    <message id="8000" name="COMMAND_INT_STAMPED">
+    <message id="223" name="COMMAND_INT_STAMPED">
       <description>Message encoding a command with parameters as scaled integers and additional metadata. Scaling depends on the actual command value.</description>
       <field type="uint32_t" name="utc_time">UTC time, seconds elapsed since 01.01.1970</field>
       <field type="uint64_t" name="vehicle_timestamp">Microseconds elapsed since vehicle boot</field>
@@ -72,7 +72,7 @@
       <field type="int32_t" name="y">PARAM6 / local: y position in meters * 1e4, global: longitude in degrees * 10^7</field>
       <field type="float" name="z">PARAM7 / z position: global: altitude in meters (MSL, WGS84, AGL or relative to home - depending on frame).</field>
     </message>
-    <message id="8001" name="COMMAND_LONG_STAMPED">
+    <message id="224" name="COMMAND_LONG_STAMPED">
       <description>Send a command with up to seven parameters to the MAV and additional metadata</description>
       <field type="uint32_t" name="utc_time">UTC time, seconds elapsed since 01.01.1970</field>
       <field type="uint64_t" name="vehicle_timestamp">Microseconds elapsed since vehicle boot</field>
@@ -271,7 +271,7 @@
       <field type="uint8_t" name="rsrq">RSRQ (LTE only) as reported by modem (unconverted)</field>
     </message>
     <!-- Using mavlink 1 msg ID from the arudpilot reserved space, in order to save header size -->
-    <message id="224" name="SATCOM_LINK_STATUS">
+    <message id="8015" name="SATCOM_LINK_STATUS">
       <description>Status of the SatCom link</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
       <field type="uint64_t" name="last_heartbeat" units="us">Timestamp of the last successful sbd session</field>
@@ -282,7 +282,7 @@
       <field type="uint8_t" name="tx_session_pending">Transmission session pending</field>
       <field type="uint8_t" name="rx_session_pending">Receiving session pending</field>
     </message>
-    <message id="8015" name="SENSOR_AIRFLOW_ANGLES">
+    <message id="8016" name="SENSOR_AIRFLOW_ANGLES">
       <description>Calibrated airflow angle measurements</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
       <field type="float" name="angleofattack" units="deg">Angle of attack</field>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -3,7 +3,7 @@
   <include>ardupilotmega.xml</include>
   <!-- ASLUAV.xml range of IDs:
     messages: 8000 - 8999
-    commands: 800 - 8999
+    commands: 40001 - 41999
   -->
   <include>ASLUAV.xml</include>
   <include>common.xml</include>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <mavlink>
   <include>ardupilotmega.xml</include>
+  <!-- ASLUAV.xml range of IDs:
+    messages: 8000 - 8999
+    commands: 800 - 8999
+  -->
   <include>ASLUAV.xml</include>
   <include>common.xml</include>
   <include>development.xml</include>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <mavlink>
   <include>ardupilotmega.xml</include>
-  <!-- ASLUAV.xml: SENS_POWER conflicts with ardupilotmega.xml GIMBAL_CONTROL -->
-  <!-- <include>ASLUAV.xml</include> -->
+  <include>ASLUAV.xml</include>
   <include>common.xml</include>
   <include>development.xml</include>
   <include>icarous.xml</include>


### PR DESCRIPTION
**Problem Description**
The ASLUAV was not included in the `all.xml` dialect due to a message id conflict with ardupilot `GIMBAL_CONTROL` messages.

- This PR moves the ASLUAV dialect into `all` dialect by moving conflicting message IDs in the ASLUAV dialect
- `SATCOM_LINK_STATUS` message is using one of the ardupilot dialect's mavlink 1 IDs as was discussed in the mavlink dev call some weeks ago

@tstastny @acfloria 