### PR TITLE
specify invalid value for MAV_CMD_NAV_VTOL_LAND.param7 (ground altitude)

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1024,7 +1024,7 @@
         <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
-        <param index="7" label="Ground Altitude" units="m">Altitude (ground level) relative to the current coordinate frame. NaN if unspecified. Note that a system might ignore this parameter if it has a more trusted source of ground truth.</param>
+        <param index="7" label="Ground Altitude" units="m">Altitude (ground level) relative to the current coordinate frame. NaN to use system default landing altitude (ignore value).</param>
       </entry>
       <!-- IDs 90 and 91 are reserved until the end of 2014,
                     as they were used in some conflicting proposals


### PR DESCRIPTION
[MAV_CMD_NAV_VTOL_LAND.param7](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_VTOL_LAND) specifies the ground altitude at landing. 

This PR updates the description:
- Value is relative to current frame. That is always implied, but not necessarily obvious.
- Invalid value is NaN. 
  - This is important to specify because otherwise there is no way for a system that does not support ground altitudes to reject the command with a valid value - without this a mission would be silently accepted  even if not achievable.
  - It also allows the system to specify NaN to mean "use your own ground truth"
- Notes that the value can be ignored if the vehicle has a more trusted ground truth. This is "for discussion", but IMO if I have a distance sensor I'd rather use that.

@auturgy @julianoes Make sense?