### PR TITLE
[WIP] Move MAV_CMD_DO_UPGRADE to development.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1604,18 +1604,7 @@
         <param index="6">Reserved (set to 0)</param>
         <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
       </entry>
-      <entry value="247" name="MAV_CMD_DO_UPGRADE" hasLocation="false" isDestination="false">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Request a target system to start an upgrade of one (or all) of its components. For example, the command might be sent to a companion computer to cause it to upgrade a connected flight controller. The system doing the upgrade will report progress using the normal command protocol sequence for a long running operation. Command protocol information: https://mavlink.io/en/services/command.html.</description>
-        <param index="1" label="Component ID" enum="MAV_COMPONENT">Component id of the component to be upgraded. If set to 0, all components should be upgraded.</param>
-        <param index="2" label="Reboot" minValue="0" maxValue="1" increment="1">0: Do not reboot component after the action is executed, 1: Reboot component after the action is executed.</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Reserved</param>
-        <param index="6">Reserved</param>
-        <param index="7">WIP: upgrade progress report rate (can be used for more granular control).</param>
-      </entry>
+      <!-- id "247" reserved for MAV_CMD_DO_UPGRADE in development.xml -->
       <entry value="252" name="MAV_CMD_OVERRIDE_GOTO" hasLocation="true" isDestination="true">
         <description>Override current mission with command to pause mission, pause mission and move to position, continue/resume mission. When param 1 indicates that the mission is paused (MAV_GOTO_DO_HOLD), param 2 defines whether it holds in place or moves to another position.</description>
         <param index="1" label="Continue" enum="MAV_GOTO">MAV_GOTO_DO_HOLD: pause mission and either hold or move to specified position (depending on param2), MAV_GOTO_DO_CONTINUE: resume mission.</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -113,6 +113,19 @@
       </entry>
     </enum>
     <enum name="MAV_CMD">
+      <entry value="247" name="MAV_CMD_DO_UPGRADE" hasLocation="false" isDestination="false">
+        <description>Request a target system to start an upgrade of one (or all) of its components.
+          For example, the command might be sent to a companion computer to cause it to upgrade a connected flight controller.
+          The system doing the upgrade will report progress using the normal command protocol sequence for a long running operation.
+          Command protocol information: https://mavlink.io/en/services/command.html.</description>
+        <param index="1" label="Component ID" enum="MAV_COMPONENT">Component id of the component to be upgraded. If set to 0, all components should be upgraded.</param>
+        <param index="2" label="Reboot" minValue="0" maxValue="1" increment="1">0: Do not reboot component after the action is executed, 1: Reboot component after the action is executed.</param>
+        <param index="3">Reserved</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">WIP: upgrade progress report rate (can be used for more granular control).</param>
+      </entry>
       <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
         <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted.
           The end of a group is marked using MAV_CMD_GROUP_END with the same group id.


### PR DESCRIPTION
`MAV_CMD_DO_UPGRADE` was added in #1382 as WIP but appears to have no implementation in PX4.

We are trying to clean up common.xml of WIP features, and more generally of those that do not comply with the [governance model](https://docs.google.com/document/d/1Bb0qF_ldeqGpy3OqtECclrKm00TB1rjZNXCmRopgmio/edit). Work for this is being tracked in https://github.com/mavlink/mavlink/issues/1669

NOTE I have confirmed from @TSC21  that this is not yet in PX4, and may not even be in use by customers upstream of PX4. I am therefore merging this to move it into development. 

I am also going to create another PR to remove it from development.xml - I don't want to break upstream but this message is not great.