### PR TITLE
dev: add new message for component capability

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4226,15 +4226,6 @@
         <description>Format is Modern Music Markup Language (MML): https://en.wikipedia.org/wiki/Music_Macro_Language#Modern_MML.</description>
       </entry>
     </enum>
-    <enum name="COMPONENT_CAP_FLAGS" bitmask="true">
-      <description>Component capability flags (Bitmap)</description>
-      <entry value="1" name="COMPONENT_CAP_FLAGS_PARAM">
-        <description>Component has parameters, and supports the parameter protocol (PARAM messages).</description>
-      </entry>
-      <entry value="2" name="COMPONENT_CAP_FLAGS_PARAM_EXT">
-        <description>Component has parameters, and supports the extended parameter protocol (PARAM_EXT messages).</description>
-      </entry>
-    </enum>
     <!-- AIS related enums-->
     <enum name="AIS_TYPE">
       <description>Type of AIS vessel, enum duplicated from AIS standard, https://gpsd.gitlab.io/gpsd/AIVDM.html</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -120,6 +120,27 @@
           Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
     </enum>
+    <enum name="COMPONENT_CAP_FLAGS" bitmask="true">
+      <description>Component capability flags (Bitmap)</description>
+      <entry value="1" name="COMPONENT_CAP_FLAGS_PARAM">
+        <description>Component has parameters, and supports the parameter protocol (PARAM messages).</description>
+      </entry>
+      <entry value="2" name="COMPONENT_CAP_FLAGS_PARAM_EXT">
+        <description>Component has parameters, and supports the extended parameter protocol (PARAM_EXT messages).</description>
+      </entry>
+      <entry value="4" name="COMPONENT_CAP_FLAGS_COMPONENT_INFORMATION">
+        <description>Component supports the component information protocol.</description>
+      </entry>
+      <entry value="8" name="COMPONENT_CAP_FLAGS_GIMBAL_V2">
+        <description>Component supports the gimbal v2 protocol.</description>
+      </entry>
+      <entry value="16" name="COMPONENT_CAP_FLAGS_MAVLINK_FTP">
+        <description>Component supports the MAVLink FTP protocol.</description>
+      </entry>
+      <entry value="32" name="COMPONENT_CAP_FLAGS_EVENTS_INTERFACE">
+        <description>Component supports the events interface protocol.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -172,6 +193,11 @@
       <field type="uint8_t" name="signal_quality" units="%">WiFi network signal quality.</field>
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
+    </message>
+    <message id="396" name="COMPONENT_CAPABILITY">
+      <description>Information about what MAVLink meta-protocols/micro-services a component supports.</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint64_t" name="component_cap_flags" enum="COMPONENT_CAP_FLAGS" display="bitmask">Component capability flags</field>
     </message>
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -197,16 +197,15 @@
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
     </message>
-    <message id="396" name="COMPONENT_INFORMATION_BASICS">
+    <message id="396" name="COMPONENT_INFORMATION_BASIC">
       <description>Basic component information data.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the component vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the component model</field>
-      <field type="uint64_t" name="component_cap_flags1" enum="COMPONENT_CAP_FLAGS1" display="bitmask">Component capability flags 1</field>
-      <field type="uint64_t" name="component_cap_flags2" enum="COMPONENT_CAP_FLAGS2" display="bitmask">Component capability flags 2 (reserved for future use)</field>
-      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="char[24]" name="software_version">Sofware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
       <field type="char[24]" name="hardware_version">Hardware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
+      <field type="uint64_t" name="component_cap_flags1" enum="COMPONENT_CAP_FLAGS1" display="bitmask">Component capability flags 1</field>
+      <field type="uint64_t" name="component_cap_flags2" enum="COMPONENT_CAP_FLAGS2" display="bitmask">Component capability flags 2 (reserved for future use)</field>
     </message>
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -141,9 +141,6 @@
         <description>Component supports the events interface protocol.</description>
       </entry>
     </enum>
-    <enum name="COMPONENT_CAP_FLAGS2" bitmask="true">
-      <description>Component capability flags 2 (Bitmap), reserved for future use.</description>
-    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -204,8 +201,7 @@
       <field type="uint8_t[32]" name="model_name">Name of the component model</field>
       <field type="char[24]" name="software_version">Sofware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
       <field type="char[24]" name="hardware_version">Hardware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
-      <field type="uint64_t" name="component_cap_flags1" enum="COMPONENT_CAP_FLAGS1" display="bitmask">Component capability flags 1</field>
-      <field type="uint64_t" name="component_cap_flags2" enum="COMPONENT_CAP_FLAGS2" display="bitmask">Component capability flags 2 (reserved for future use)</field>
+      <field type="uint64_t" name="component_cap_flags1" enum="COMPONENT_CAP_FLAGS1" display="bitmask">Component capability flags 1 (this is called 1, so that number 2 could be added in the future).</field>
     </message>
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -120,26 +120,29 @@
           Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
     </enum>
-    <enum name="COMPONENT_CAP_FLAGS" bitmask="true">
-      <description>Component capability flags (Bitmap)</description>
-      <entry value="1" name="COMPONENT_CAP_FLAGS_PARAM">
+    <enum name="COMPONENT_CAP_FLAGS1" bitmask="true">
+      <description>Component capability flags 1 (Bitmap)</description>
+      <entry value="1" name="COMPONENT_CAP_FLAGS1_PARAM">
         <description>Component has parameters, and supports the parameter protocol (PARAM messages).</description>
       </entry>
-      <entry value="2" name="COMPONENT_CAP_FLAGS_PARAM_EXT">
+      <entry value="2" name="COMPONENT_CAP_FLAGS1_PARAM_EXT">
         <description>Component has parameters, and supports the extended parameter protocol (PARAM_EXT messages).</description>
       </entry>
-      <entry value="4" name="COMPONENT_CAP_FLAGS_COMPONENT_INFORMATION">
+      <entry value="4" name="COMPONENT_CAP_FLAGS1_COMPONENT_INFORMATION">
         <description>Component supports the component information protocol.</description>
       </entry>
-      <entry value="8" name="COMPONENT_CAP_FLAGS_GIMBAL_V2">
+      <entry value="8" name="COMPONENT_CAP_FLAGS1_GIMBAL_V2">
         <description>Component supports the gimbal v2 protocol.</description>
       </entry>
-      <entry value="16" name="COMPONENT_CAP_FLAGS_MAVLINK_FTP">
+      <entry value="16" name="COMPONENT_CAP_FLAGS1_MAVLINK_FTP">
         <description>Component supports the MAVLink FTP protocol.</description>
       </entry>
-      <entry value="32" name="COMPONENT_CAP_FLAGS_EVENTS_INTERFACE">
+      <entry value="32" name="COMPONENT_CAP_FLAGS1_EVENTS_INTERFACE">
         <description>Component supports the events interface protocol.</description>
       </entry>
+    </enum>
+    <enum name="COMPONENT_CAP_FLAGS2" bitmask="true">
+      <description>Component capability flags 2 (Bitmap), reserved for future use.</description>
     </enum>
   </enums>
   <messages>
@@ -194,10 +197,16 @@
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
     </message>
-    <message id="396" name="COMPONENT_CAPABILITY">
-      <description>Information about what MAVLink meta-protocols/micro-services a component supports.</description>
+    <message id="396" name="COMPONENT_INFORMATION_BASICS">
+      <description>Basic component information data.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
-      <field type="uint64_t" name="component_cap_flags" enum="COMPONENT_CAP_FLAGS" display="bitmask">Component capability flags</field>
+      <field type="uint8_t[32]" name="vendor_name">Name of the component vendor</field>
+      <field type="uint8_t[32]" name="model_name">Name of the component model</field>
+      <field type="uint64_t" name="component_cap_flags1" enum="COMPONENT_CAP_FLAGS1" display="bitmask">Component capability flags 1</field>
+      <field type="uint64_t" name="component_cap_flags2" enum="COMPONENT_CAP_FLAGS2" display="bitmask">Component capability flags 2 (reserved for future use)</field>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="char[24]" name="software_version">Sofware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
+      <field type="char[24]" name="hardware_version">Hardware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
     </message>
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>


### PR DESCRIPTION
This moves the existing but unesd COMPONENT_CAP_FLAGS enum from common.xml to development.xml.

This came up because a gimbal manufacturer would like to have an easy way to know if a system (drone or camera) supports the v2 gimbal protocol.

The alternative is sending a MAV_CMD_REQUEST_MESSAGE for GIMBAL_INFORMATION which might work for this case but not well for any case, e.g. MAVLink FTP or params. The challenge when trying to detect these protocols is usually whether a timeout means it's not supported or whether the link was bad at the time we wanted to find out (e.g. at the beginning when you get a lot of initialization traffic).

This brings back part of what was removed in https://github.com/mavlink/mavlink/pull/1408.