### PR TITLE
common: add target for SERIAL_CONTROL

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5563,6 +5563,9 @@
       <field type="uint32_t" name="baudrate" units="bits/s">Baudrate of transfer. Zero means no change.</field>
       <field type="uint8_t" name="count" units="bytes">how many bytes in this transfer</field>
       <field type="uint8_t[70]" name="data">serial data</field>
+      <extensions/>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
     </message>
     <message id="127" name="GPS_RTK">
       <description>RTK GPS data. Gives information on the relative baseline calculation the GPS is reporting</description>


### PR DESCRIPTION
It turns out the SERIAL_CONTROL messages did not have a target which means they are broadcast even though they are really meant for one system and component only.

I know adding this prevents truncating the message. The only workaround for that would be to create a new message to replace it.