### PR TITLE
[WIP] Remove MAV_CMD_DO_UPGRADE from development.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1604,7 +1604,6 @@
         <param index="6">Reserved (set to 0)</param>
         <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
       </entry>
-      <!-- id "247" reserved for MAV_CMD_DO_UPGRADE in development.xml -->
       <entry value="252" name="MAV_CMD_OVERRIDE_GOTO" hasLocation="true" isDestination="true">
         <description>Override current mission with command to pause mission, pause mission and move to position, continue/resume mission. When param 1 indicates that the mission is paused (MAV_GOTO_DO_HOLD), param 2 defines whether it holds in place or moves to another position.</description>
         <param index="1" label="Continue" enum="MAV_GOTO">MAV_GOTO_DO_HOLD: pause mission and either hold or move to specified position (depending on param2), MAV_GOTO_DO_CONTINUE: resume mission.</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -113,19 +113,6 @@
       </entry>
     </enum>
     <enum name="MAV_CMD">
-      <entry value="247" name="MAV_CMD_DO_UPGRADE" hasLocation="false" isDestination="false">
-        <description>Request a target system to start an upgrade of one (or all) of its components.
-          For example, the command might be sent to a companion computer to cause it to upgrade a connected flight controller.
-          The system doing the upgrade will report progress using the normal command protocol sequence for a long running operation.
-          Command protocol information: https://mavlink.io/en/services/command.html.</description>
-        <param index="1" label="Component ID" enum="MAV_COMPONENT">Component id of the component to be upgraded. If set to 0, all components should be upgraded.</param>
-        <param index="2" label="Reboot" minValue="0" maxValue="1" increment="1">0: Do not reboot component after the action is executed, 1: Reboot component after the action is executed.</param>
-        <param index="3">Reserved</param>
-        <param index="4">Reserved</param>
-        <param index="5">Reserved</param>
-        <param index="6">Reserved</param>
-        <param index="7">WIP: upgrade progress report rate (can be used for more granular control).</param>
-      </entry>
       <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
         <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted.
           The end of a group is marked using MAV_CMD_GROUP_END with the same group id.


### PR DESCRIPTION
`MAV_CMD_DO_UPGRADE` was removed from common.xml to development.xml in #1720 .

This is proposal to delete altogether, as it does not appear to be used anywhere (at all) and there are better message designs that could be used - e.g. generic component operations including upgrade, and also capturing everything done by https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN

Not merging yet, because want final confirmation before doing so.
