### PR TITLE
common.xml: Event had miss-named target component/system fields

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6823,8 +6823,8 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Event message. Each new event from a particular component gets a new sequence number. The same message might be sent multiple times if (re-)requested. Most events are broadcast, some can be specific to a target component (as receivers keep track of the sequence for missed events, all events need to be broadcast. Thus we use destination_component instead of target_component).</description>
-      <field type="uint8_t" name="destination_component">Component ID</field>
-      <field type="uint8_t" name="destination_system">System ID</field>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="id">Event ID (as defined in the component metadata)</field>
       <field type="uint32_t" name="event_time_boot_ms" units="ms">Timestamp (time since system boot when the event happened).</field>
       <field type="uint16_t" name="sequence">Sequence number.</field>


### PR DESCRIPTION
@bkueng The EVENT message used `destination_component` and `destination_system` but MAVLink expects the values to be `target_system` and `target_component` - otherwise you'd have to write special code just for events to know whether the event is for this system/component. It also breaks routing.

This will break compatibility for the message. 