### PR TITLE
CELLULAR_CONFIG - remove wip tagging

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6657,9 +6657,9 @@
       <field type="uint8_t" name="rx_session_pending">1: Receiving session pending, 0: No receiving session pending.</field>
     </message>
     <message id="336" name="CELLULAR_CONFIG">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Configure cellular modems. This message is re-emitted as an acknowledgement by the modem. The message may also be explicitly requested using MAV_CMD_REQUEST_MESSAGE.</description>
+      <description>Configure cellular modems.
+        This message is re-emitted as an acknowledgement by the modem.
+        The message may also be explicitly requested using MAV_CMD_REQUEST_MESSAGE.</description>
       <field type="uint8_t" name="enable_lte">Enable/disable LTE. 0: setting unchanged, 1: disabled, 2: enabled. Current setting when sent back as a response.</field>
       <field type="uint8_t" name="enable_pin">Enable/disable PIN on the SIM card. 0: setting unchanged, 1: disabled, 2: enabled. Current setting when sent back as a response.</field>
       <field type="char[16]" name="pin">PIN sent to the SIM card. Blank when PIN is disabled. Empty when message is sent back as a response.</field>


### PR DESCRIPTION
CELLULAR_CONFIG is no longer WIP as discussed in dev call. 