### PR TITLE
Auto generate docs for reserved params if explicitly specified

### DIFF
--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -189,7 +189,7 @@
         <xsl:if test='@label'>: <xsl:value-of select="@label" /></xsl:if>
         </td> <!-- mission_param -->
 
-        <td><xsl:value-of select="." />
+        <td><xsl:if test='@reserved = "true"'>Reserved (set to <xsl:if test='@default'><xsl:value-of select="@default" /></xsl:if><xsl:if test='not(@default)'>0</xsl:if>)</xsl:if><xsl:value-of select="." />
          <xsl:if test='@decimalPlaces'><br /><strong>GCS display settings:</strong>
             <xsl:if test='@label'><em>Label:</em> <xsl:value-of select="@label" />, </xsl:if>
             <xsl:if test='@decimalPlaces'><em>decimalPlaces:</em> <xsl:value-of select="@decimalPlaces" /></xsl:if>


### PR DESCRIPTION
The definition file format allows you to specify that [parameters are reserved](https://mavlink.io/en/guide/define_xml_element.html#reserved) and have a default value like this:
```xml
<param index="3" reserved="true" default="NaN" />
```

This change adds docs for the parameter like `Reserved (set to NaN)` for the above, where reserved is set to to true. 

Note, that if _no parameter_ is defined for a particular index, MAVLink defines this to mean the same as
```xml
<param index="3" reserved="true" default="0" />
```
This works properly for generated libraries but not for the docs - the parameter will simply be omitted from the docs. The reason is that the generator uses XSLT to process nodes. IF there is no node, then nothing is done.