### PR TITLE
common: add FOCUS_TYPE_AUTO

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3611,6 +3611,15 @@
       <entry value="3" name="FOCUS_TYPE_METERS">
         <description>Focus value in metres. Note that there is no message to get the valid focus range of the camera, so this can type can only be used for cameras where the range is known (implying that this cannot reliably be used in a GCS for an arbitrary camera).</description>
       </entry>
+      <entry value="4" name="FOCUS_TYPE_AUTO">
+        <description>Focus automatically.</description>
+      </entry>
+      <entry value="5" name="FOCUS_TYPE_AUTO_SINGLE">
+        <description>Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.</description>
+      </entry>
+      <entry value="6" name="FOCUS_TYPE_AUTO_CONTINUOUS">
+        <description>Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.</description>
+      </entry>
     </enum>
     <enum name="PARAM_ACK">
       <description>Result from PARAM_EXT_SET message (or a PARAM_SET within a transaction).</description>


### PR DESCRIPTION
The current SET_FOCUS_TYPEs are mainly useful for controlling the camera focus via remote control (FOCUS_TYPE_STEP or FOCUS_TYPE_CONTINUOUS) or for specific control of the focus (FOCUS_TYPE_METERS). With this PR we are adding some auto focus types, which most of the modern cameras have:

- FOCUS_TYPE_AUTO: Full automatic focus
- FOCUS_TYPE_SINGLE (aka AF-S): Good for still pictures
- FOCUS_TYPE_CONTINUOUS (aka AF-C): Good for dynamic scenes