### PR TITLE
new message radio_status_extensions in development

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -187,5 +187,14 @@
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot).
         The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
+    <message id="420" name="RADIO_STATUS_EXTENSIONS">
+      <description>Additional information on link status for digital radios.</description>
+      <field type="uint8_t" name="rssi" units="dB">Recieved signal strength indication in decibels.</field>
+      <field type="uint8_t" name="snr" units="dB">Signal to noise ratio in decibels.</field>
+      <field type="uint8_t" name="mcs_index">Modulation Coding Scheme index. This index uniquely describes the combination of number of spatial streams, modulation type and coding scheme.</field>
+      <field type="uint8_t" name="number_spatial_streams">Number of spatial streams.</field>
+      <field type="uint8_t" name="queue_size">Number of packets in buffer.</field>
+      <field type="uint8_t" name="air_time" units="%">Percentage of time the radio is transmitting.</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
The [RADIO_STATUS](https://mavlink.io/en/messages/common.html#RADIO_STATUS) message contains the RSSI, however digital radios often provide additional information on the link status such as:

- SNR: signal to noise ratio [dB]
- MCS index: which Modulation Coding Scheme is being used
- NSS: number of spatial streams
- Queue size: packets waiting to be sent
- Air time: percentage of the time the radio is transmitting [%]

which can be useful when performing e.g. range tests.

Example data:
![image](https://user-images.githubusercontent.com/86957734/142756697-8009ba32-5a12-40c0-a668-d3b96d6cef18.png)