### PR TITLE
Add MAV_CMD_SELECT_TRIGG_CAM command.

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -119,6 +119,11 @@
         <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.
           Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
+      <entry value="303" name="MAV_CMD_SELECT_TRIGG_CAM" hasLocation="false" isDestination="false">
+        <description>Select camera device and its sensor that will be used for capturing images.</description>
+        <param index="1" label="Camera device ID">Component ID of selected camera device (0 to address all cameras)</param>
+        <param index="2" label="Sensor ID">Selected sensor ID, related to stream_id field in VIDEO_STREAM_INFORMATION. (0 to address all sensors)</param>
+      </entry>
     </enum>
   </enums>
   <messages>


### PR DESCRIPTION
MAV_CMD_SELECT_TRIGG_CAM as a mission item added to the mission plan selects the camera and stream that will be used for capturing images in case where the vehicle has multiple cameras and/or camera has multiple sensors available.
