### PR TITLE
Component Information Basics: add camera cap flag

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -141,7 +141,10 @@
         <description>Component supports the events interface protocol.</description>
       </entry>
       <entry value="64" name="COMPONENT_CAP_FLAGS1_CAMERA">
-        <description>Component supports the camera protocol.</description>
+        <description>Component supports the camera v1 protocol.</description>
+      </entry>
+      <entry value="128" name="COMPONENT_CAP_FLAGS1_CAMERA_v2">
+        <description>Component supports the camera v2 protocol.</description>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -143,7 +143,7 @@
       <entry value="64" name="COMPONENT_CAP_FLAGS1_CAMERA">
         <description>Component supports the camera v1 protocol.</description>
       </entry>
-      <entry value="128" name="COMPONENT_CAP_FLAGS1_CAMERA_v2">
+      <entry value="128" name="COMPONENT_CAP_FLAGS1_CAMERA_V2">
         <description>Component supports the camera v2 protocol.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -140,6 +140,9 @@
       <entry value="32" name="COMPONENT_CAP_FLAGS1_EVENTS_INTERFACE">
         <description>Component supports the events interface protocol.</description>
       </entry>
+      <entry value="64" name="COMPONENT_CAP_FLAGS1_CAMERA">
+        <description>Component supports the camera protocol.</description>
+      </entry>
     </enum>
   </enums>
   <messages>


### PR DESCRIPTION
title says it

if there is a gimbal v2 protocol flag there should be also a camera protocol flag, shouldn't it?