### PR TITLE
Add ability to specify axis to autotune

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -952,6 +952,21 @@
         <description>Servo 16</description>
       </entry>
     </enum>
+    <enum name="AUTOTUNE_AXIS">
+      <description>Enable axes that will be tuned via autotuning. Used in MAV_CMD_DO_AUTOTUNE_ENABLE.</description>
+      <entry value="0" name="AUTOTUNE_AXIS_DEFAULT">
+        <description>Flight stack tunes axis according to its default settings.</description>
+      </entry>
+      <entry value="1" name="AUTOTUNE_AXIS_ROLL">
+        <description>Autotune roll axis.</description>
+      </entry>
+      <entry value="2" name="AUTOTUNE_AXIS_PITCH">
+        <description>Autotune pitch axis.</description>
+      </entry>
+      <entry value="3" name="AUTOTUNE_AXIS_YAW">
+        <description>Autotune yaw axis.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -1599,7 +1614,7 @@
       <entry value="212" name="MAV_CMD_DO_AUTOTUNE_ENABLE" hasLocation="false" isDestination="false">
         <description>Enable/disable autotune.</description>
         <param index="1" label="Enable" minValue="0" maxValue="1" increment="1">Enable (1: enable, 0:disable).</param>
-        <param index="2">Empty.</param>
+        <param index="2" label="Axis" enum="AUTOTUNE_AXIS">Specify which axis are autotuned. 0 indicates autopilot default settings.</param>
         <param index="3">Empty.</param>
         <param index="4">Empty.</param>
         <param index="5">Empty.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -952,7 +952,7 @@
         <description>Servo 16</description>
       </entry>
     </enum>
-    <enum name="AUTOTUNE_AXIS">
+    <enum name="AUTOTUNE_AXIS" bitmask="true">
       <description>Enable axes that will be tuned via autotuning. Used in MAV_CMD_DO_AUTOTUNE_ENABLE.</description>
       <entry value="0" name="AUTOTUNE_AXIS_DEFAULT">
         <description>Flight stack tunes axis according to its default settings.</description>


### PR DESCRIPTION
Flight stacks routinely allow autotuning of specific axis. Both PX4 and ArduPilot support this (for FW only) using parameters. This PR allows a GCS to set the relevant axis to tune without having to know what those axis are - essentially making it easier for a GCS to support an unknown flight stack.

Note that the default value of 0 means "do whatever you would normally do". A receiving system that has not been upgraded to understand the value should reject non-zero values with an error "as standard", but it may not. Either way though, in this case the specific axes setting will be ignored.


## Current autotune implementations

The command simply enables and disables autotuning.

[ArduPilot implements](https://ardupilot.org/plane/docs/automatic-tuning-with-autotune.html#automatic-tuning-with-autotune) as a FW mode (only). 
- The command puts the flight stack into autotune mode.
- The user flies in the mode and inject steps using transmitter.
- The tuning system steadily improves the flight characteristics. 
- When user is happy that flight is good they exit the mode. 
- There is no concept here of progress or automation. The GCS only needs to know about turning it on. The normal mode information in heartbeat shows that the mode has changed - though the GCS needs to know about this mode.

[PX4 implements](http://docs.px4.io/master/en/config/autotune.html#auto-tuning) as a long running command in the current altitude controlled/stabilized mode for both MC and FW. 
- The flight stack injects appropriate movement and then tunes. 
- Process is more or less fixed in length and ends (by default) with test for FW and in flight application of new params, and landing for MC where values then applied.
- Therefore this is an automated process with an end. 

## Suggestions for further improvement?

I'd welcome suggestions for ways to make it possible for a GCS to implement this for an unknown flight stack.

I don't think there is one at the "command level" because the approaches used by PX4 and ArduPilot are fundamentally different. We can't mandate a long running command be used (even if we wanted to) because this makes no sense for ArduPilot's implementation.

What we might do is provide additional a  [MAV_PROTOCOL_CAPABILITY](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY) hint to the autopilot about the way that autotune has been implemented. So define:
- [MAV_PROTOCOL_CAPABILITY_AUTOTUNE_LRC](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY) - Autotune is implemented as an automated process using a long running command.
- [MAV_PROTOCOL_CAPABILITY_AUTOTUNE_MODE](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY) - Autotune has been implemented as a standard mode (and define a standard mode for this, assuming one can be agreed). 

Any other ideas?