### PR TITLE
MAV_CMD_NAV_PUNCTUAL_WAYPOINT - Adding support for punctual waypoint commands

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2422,6 +2422,16 @@
         <param index="7">User defined</param>
       </entry>
       <!-- END of user range (31000 to 31999) -->
+      <entry value="26009" name="MAV_CMD_NAV_PUNCTUAL_WAYPOINT" hasLocation="true" isDestination="true">
+        <description>Navigate to a location at certain time.</description>
+        <param index="1" label="Delta Time" units="s" minValue="-1" increment="1">Delta time in seconds (-1 to enable time-of-day fields)</param>
+        <param index="2" label="Hour" minValue="-1" maxValue="23" increment="1">hour (24h format, UTC, -1 to ignore)</param>
+        <param index="3" label="Minute" minValue="-1" maxValue="59" increment="1">minute (24h format, UTC, -1 to ignore)</param>
+        <param index="4" label="Second" minValue="-1" maxValue="59" increment="1">second (24h format, UTC, -1 to ignore)</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
     </enum>
     <enum name="MAV_DATA_STREAM">
       <deprecated since="2015-06" replaced_by="MESSAGE_INTERVAL"/>


### PR DESCRIPTION
Hi.

This is my PR to support punctual waypoint commands to MAVLink enabled vehicles.
The reason behind that is I was working on the ArduPilot codebase to support punctual navigation to a certain waypoint but there were no related MAVLink commands.

This command is something like a mix-up of MAV_CMD_NAV_WAYPOINT and MAV_CMD_NAV_DELAY but instead of delaying to go to a certain waypoint, I would like to navigate to a waypoint at a certain time.

For example, if the first field (delta time) is set to an integer value > 0, the vehicle will try to be at the specified location (param 5, 6, and 7) exactly after delta time seconds neither earlier nor later.

If the first field (delta time) is set to -1, then UTC fields (param 2, 3, and 4) will be enabled and the vehicle will try to be at the specified location (param 5, 6, and 7) exactly at the specified time neither earlier nor later (Hour:Minute:Second).

If the first field (delta time) is set to 0, vehicle will go to this location like MAV_CMD_NAV_WAYPOINT.

Firstly I will implement this in GUIDED mode but later I will add support to this command in AUTO mode (of ArduPilot).