### PR TITLE
Extend WINCH_STATUS_FLAG and WINCH_ACTION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -594,7 +594,7 @@
         <description>Perform the locking sequence to relieve motor while in the fully retracted position. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="4" name="WINCH_DELIVER">
-        <description>Sequence of drop, slow down, touch down, reel up, lock. Only Action and Instance command parameters are used, others are ignored.</description>
+        <description>Sequence of drop, slow down, touch down, reel up, lock. Only action and instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="5" name="WINCH_HOLD">
         <description>Engage motor and hold current position. Only Action and Instance command parameters are used, others are ignored.</description>
@@ -602,13 +602,10 @@
       <entry value="6" name="WINCH_RETRACT">
         <description>Return the reel to the fully retracted position. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
-      <entry value="7" name="WINCH_DISENGAGE">
-        <description>Disengage clutch. Motor will become inactive. Only Action and Instance command parameters are used, others are ignored.</description>
-      </entry>
-      <entry value="8" name="WINCH_LOAD_LINE">
+      <entry value="7" name="WINCH_LOAD_LINE">
         <description>Load the reel with line. The winch will calculate the total loaded length and stop when the tension exceeds a threshold. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
-      <entry value="9" name="WINCH_ABANDON_LINE">
+      <entry value="8" name="WINCH_ABANDON_LINE">
         <description>Spool out the entire length of the line. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -581,14 +581,32 @@
     <!-- winch action enum -->
     <enum name="WINCH_ACTIONS">
       <description>Winch actions.</description>
-      <entry value="0" name="WINCH_RELAXED">
-        <description>Relax winch.</description>
+      <entry value="0" name="WINCH_ACTION_FREEWHEEL">
+        <description>Allow motor to freewheel.</description>
       </entry>
-      <entry value="1" name="WINCH_RELATIVE_LENGTH_CONTROL">
+      <entry value="1" name="WINCH_ACTION_RELATIVE_LENGTH_CONTROL">
         <description>Wind or unwind specified length of cable, optionally using specified rate.</description>
       </entry>
-      <entry value="2" name="WINCH_RATE_CONTROL">
+      <entry value="2" name="WINCH_ACTION_RATE_CONTROL">
         <description>Wind or unwind cable at specified rate.</description>
+      </entry>
+      <entry value="3" name="WINCH_ACTION_LOCK">
+        <description>Perform the locking sequence.</description>
+      </entry>
+      <entry value="4" name="WINCH_ACTION_DELIVER">
+        <description>Sequence of drop, slow down, touch down, reel up, lock.</description>
+      </entry>
+      <entry value="5" name="WINCH_ACTION_HOLD">
+        <description>Engage motor and hold current position.</description>
+      </entry>
+      <entry value="6" name="WINCH_ACTION_RETURN">
+        <description>Return the reel to the home position.</description>
+      </entry>
+      <entry value="7" name="WINCH_ACTION_DISENGAGE">
+        <description>Disengage clutch. Motor will become inactive.</description>
+      </entry>
+      <entry value="8" name="WINCH_ACTION_LOAD">
+        <description>Load the reel with line.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
@@ -4471,19 +4489,34 @@
         <description>Land in multicopter mode on reaching the landing co-ordinates (the whole landing is by "hover descent").</description>
       </entry>
     </enum>
-    <enum name="MAV_WINCH_STATUS_FLAG" bitmask="true">
+    <enum name="WINCH_STATUS_FLAG" bitmask="true">
       <description>Winch status flags used in WINCH_STATUS</description>
-      <entry value="1" name="MAV_WINCH_STATUS_HEALTHY">
+      <entry value="1" name="WINCH_STATUS_HEALTHY">
         <description>Winch is healthy</description>
       </entry>
-      <entry value="2" name="MAV_WINCH_STATUS_FULLY_RETRACTED">
+      <entry value="2" name="WINCH_STATUS_FULLY_RETRACTED">
         <description>Winch thread is fully retracted</description>
       </entry>
-      <entry value="4" name="MAV_WINCH_STATUS_MOVING">
+      <entry value="4" name="WINCH_STATUS_MOVING">
         <description>Winch motor is moving</description>
       </entry>
-      <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_ENGAGED">
-        <description>Winch clutch is engaged allowing motor to move freely</description>
+      <entry value="8" name="WINCH_STATUS_CLUTCH_ENGAGED">
+        <description>Winch clutch is engaged. Motor is active.</description>
+      </entry>
+      <entry value="16" name="WINCH_STATUS_LOCKED">
+        <description>Winch is locked by locking mechanism.</description>
+      </entry>
+      <entry value="32" name="WINCH_STATUS_DROPPING">
+        <description>Winch is dropping payload.</description>
+      </entry>
+      <entry value="64" name="WINCH_STATUS_ARRESTING">
+        <description>Winch is arresting payload descent.</description>
+      </entry>
+      <entry value="128" name="WINCH_STATUS_GROUND_SENSE">
+        <description>Winch is using torque measurements to sense the ground.</description>
+      </entry>
+      <entry value="256" name="WINCH_STATUS_RETURNING_TO_HOME">
+        <description>Winch is returning to the home position.</description>
       </entry>
     </enum>
     <enum name="MAG_CAL_STATUS">
@@ -7041,7 +7074,7 @@
       <field type="float" name="voltage" units="V" invalid="NaN">Voltage of the battery supplying the winch. NaN if unknown</field>
       <field type="float" name="current" units="A" invalid="NaN">Current draw from the winch. NaN if unknown</field>
       <field type="int16_t" name="temperature" units="degC" invalid="INT16_MAX">Temperature of the motor. INT16_MAX if unknown</field>
-      <field type="uint32_t" name="status" display="bitmask" enum="MAV_WINCH_STATUS_FLAG">Status flags</field>
+      <field type="uint32_t" name="status" display="bitmask" enum="WINCH_STATUS_FLAG">Status flags</field>
     </message>
     <message id="12900" name="OPEN_DRONE_ID_BASIC_ID">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -591,25 +591,25 @@
         <description>Wind or unwind line at specified rate.</description>
       </entry>
       <entry value="3" name="WINCH_LOCK">
-        <description>Perform the locking sequence to relieve motor while in the fully retracted position. All other command parameters are ignored.</description>
+        <description>Perform the locking sequence to relieve motor while in the fully retracted position. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="4" name="WINCH_DELIVER">
-        <description>Sequence of drop, slow down, touch down, reel up, lock. All other command parameters are ignored.</description>
+        <description>Sequence of drop, slow down, touch down, reel up, lock. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="5" name="WINCH_HOLD">
-        <description>Engage motor and hold current position. All other command parameters are ignored.</description>
+        <description>Engage motor and hold current position. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="6" name="WINCH_RETRACT">
-        <description>Return the reel to the fully retracted position. All other command parameters are ignored.</description>
+        <description>Return the reel to the fully retracted position. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="7" name="WINCH_DISENGAGE">
-        <description>Disengage clutch. Motor will become inactive. All other command parameters are ignored.</description>
+        <description>Disengage clutch. Motor will become inactive. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="8" name="WINCH_LOAD_LINE">
-        <description>Load the reel with line. The winch will calculate the total loaded length and stop when the tension exceeds a threshold. All other command parameters are ignored.</description>
+        <description>Load the reel with line. The winch will calculate the total loaded length and stop when the tension exceeds a threshold. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="9" name="WINCH_ABANDON_LINE">
-        <description>Spool out the entire length of the line. All other command parameters are ignored.</description>
+        <description>Spool out the entire length of the line. Only Action and Instance command parameters are used, others are ignored.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -591,22 +591,22 @@
         <description>Wind or unwind line at specified rate.</description>
       </entry>
       <entry value="3" name="WINCH_LOCK">
-        <description>Perform the locking sequence to relieve motor while in the fully retracted position. Only Action and Instance command parameters are used, others are ignored.</description>
+        <description>Perform the locking sequence to relieve motor while in the fully retracted position. Only action and instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="4" name="WINCH_DELIVER">
         <description>Sequence of drop, slow down, touch down, reel up, lock. Only action and instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="5" name="WINCH_HOLD">
-        <description>Engage motor and hold current position. Only Action and Instance command parameters are used, others are ignored.</description>
+        <description>Engage motor and hold current position. Only action and instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="6" name="WINCH_RETRACT">
-        <description>Return the reel to the fully retracted position. Only Action and Instance command parameters are used, others are ignored.</description>
+        <description>Return the reel to the fully retracted position. Only action and instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="7" name="WINCH_LOAD_LINE">
-        <description>Load the reel with line. The winch will calculate the total loaded length and stop when the tension exceeds a threshold. Only Action and Instance command parameters are used, others are ignored.</description>
+        <description>Load the reel with line. The winch will calculate the total loaded length and stop when the tension exceeds a threshold. Only action and instance command parameters are used, others are ignored.</description>
       </entry>
       <entry value="8" name="WINCH_ABANDON_LINE">
-        <description>Spool out the entire length of the line. Only Action and Instance command parameters are used, others are ignored.</description>
+        <description>Spool out the entire length of the line. Only action and instance command parameters are used, others are ignored.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -585,28 +585,31 @@
         <description>Allow motor to freewheel.</description>
       </entry>
       <entry value="1" name="WINCH_RELATIVE_LENGTH_CONTROL">
-        <description>Wind or unwind specified length of cable, optionally using specified rate.</description>
+        <description>Wind or unwind specified length of line, optionally using specified rate.</description>
       </entry>
       <entry value="2" name="WINCH_RATE_CONTROL">
-        <description>Wind or unwind cable at specified rate.</description>
+        <description>Wind or unwind line at specified rate.</description>
       </entry>
       <entry value="3" name="WINCH_LOCK">
-        <description>Perform the locking sequence.</description>
+        <description>Perform the locking sequence to relieve motor while in the fully retracted position. All other command parameters are ignored.</description>
       </entry>
       <entry value="4" name="WINCH_DELIVER">
-        <description>Sequence of drop, slow down, touch down, reel up, lock.</description>
+        <description>Sequence of drop, slow down, touch down, reel up, lock. All other command parameters are ignored.</description>
       </entry>
       <entry value="5" name="WINCH_HOLD">
-        <description>Engage motor and hold current position.</description>
+        <description>Engage motor and hold current position. All other command parameters are ignored.</description>
       </entry>
-      <entry value="6" name="WINCH_RETURN">
-        <description>Return the reel to the home position.</description>
+      <entry value="6" name="WINCH_RETRACT">
+        <description>Return the reel to the fully retracted position. All other command parameters are ignored.</description>
       </entry>
       <entry value="7" name="WINCH_DISENGAGE">
-        <description>Disengage clutch. Motor will become inactive.</description>
+        <description>Disengage clutch. Motor will become inactive. All other command parameters are ignored.</description>
       </entry>
-      <entry value="8" name="WINCH_LOAD">
-        <description>Load the reel with line.</description>
+      <entry value="8" name="WINCH_LOAD_LINE">
+        <description>Load the reel with line. The winch will calculate the total loaded length and stop when the tension exceeds a threshold. All other command parameters are ignored.</description>
+      </entry>
+      <entry value="9" name="WINCH_ABANDON_LINE">
+        <description>Spool out the entire length of the line. All other command parameters are ignored.</description>
       </entry>
     </enum>
     <!-- UAVCAN node health enumeration -->
@@ -2281,7 +2284,7 @@
         <description>Command to operate winch.</description>
         <param index="1" label="Instance" minValue="1" increment="1">Winch instance number.</param>
         <param index="2" label="Action" enum="WINCH_ACTIONS">Action to perform.</param>
-        <param index="3" label="Length" units="m">Length of cable to release (negative to wind).</param>
+        <param index="3" label="Length" units="m">Length of line to release (negative to wind).</param>
         <param index="4" label="Rate" units="m/s">Release rate (negative to wind).</param>
         <param index="5">Empty.</param>
         <param index="6">Empty.</param>
@@ -4495,7 +4498,7 @@
         <description>Winch is healthy</description>
       </entry>
       <entry value="2" name="MAV_WINCH_STATUS_FULLY_RETRACTED">
-        <description>Winch thread is fully retracted</description>
+        <description>Winch line is fully retracted</description>
       </entry>
       <entry value="4" name="MAV_WINCH_STATUS_MOVING">
         <description>Winch motor is moving</description>
@@ -4507,7 +4510,7 @@
         <description>Winch is locked by locking mechanism.</description>
       </entry>
       <entry value="32" name="MAV_WINCH_STATUS_DROPPING">
-        <description>Winch is dropping payload.</description>
+        <description>Winch is gravity dropping payload.</description>
       </entry>
       <entry value="64" name="MAV_WINCH_STATUS_ARRESTING">
         <description>Winch is arresting payload descent.</description>
@@ -4515,8 +4518,14 @@
       <entry value="128" name="MAV_WINCH_STATUS_GROUND_SENSE">
         <description>Winch is using torque measurements to sense the ground.</description>
       </entry>
-      <entry value="256" name="MAV_WINCH_STATUS_RETURNING_TO_HOME">
-        <description>Winch is returning to the home position.</description>
+      <entry value="256" name="MAV_WINCH_STATUS_RETRACTING">
+        <description>Winch is returning to the fully retracted position.</description>
+      </entry>
+      <entry value="512" name="MAV_WINCH_STATUS_REDELIVER">
+        <description>Winch is redelivering the payload. This is a failover state if the line tension goes above a threshold during RETRACTING.</description>
+      </entry>
+      <entry value="1024" name="MAV_WINCH_STATUS_ABANDON_LINE">
+        <description>Winch is abandoning the line and possibly payload. Winch unspools the entire calculated line length. This is a failover state from REDELIVER if the number of attemps exceeds a threshold.</description>
       </entry>
     </enum>
     <enum name="MAG_CAL_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -581,31 +581,31 @@
     <!-- winch action enum -->
     <enum name="WINCH_ACTIONS">
       <description>Winch actions.</description>
-      <entry value="0" name="WINCH_ACTION_FREEWHEEL">
+      <entry value="0" name="WINCH_RELAXED">
         <description>Allow motor to freewheel.</description>
       </entry>
-      <entry value="1" name="WINCH_ACTION_RELATIVE_LENGTH_CONTROL">
+      <entry value="1" name="WINCH_RELATIVE_LENGTH_CONTROL">
         <description>Wind or unwind specified length of cable, optionally using specified rate.</description>
       </entry>
-      <entry value="2" name="WINCH_ACTION_RATE_CONTROL">
+      <entry value="2" name="WINCH_RATE_CONTROL">
         <description>Wind or unwind cable at specified rate.</description>
       </entry>
-      <entry value="3" name="WINCH_ACTION_LOCK">
+      <entry value="3" name="WINCH_LOCK">
         <description>Perform the locking sequence.</description>
       </entry>
-      <entry value="4" name="WINCH_ACTION_DELIVER">
+      <entry value="4" name="WINCH_DELIVER">
         <description>Sequence of drop, slow down, touch down, reel up, lock.</description>
       </entry>
-      <entry value="5" name="WINCH_ACTION_HOLD">
+      <entry value="5" name="WINCH_HOLD">
         <description>Engage motor and hold current position.</description>
       </entry>
-      <entry value="6" name="WINCH_ACTION_RETURN">
+      <entry value="6" name="WINCH_RETURN">
         <description>Return the reel to the home position.</description>
       </entry>
-      <entry value="7" name="WINCH_ACTION_DISENGAGE">
+      <entry value="7" name="WINCH_DISENGAGE">
         <description>Disengage clutch. Motor will become inactive.</description>
       </entry>
-      <entry value="8" name="WINCH_ACTION_LOAD">
+      <entry value="8" name="WINCH_LOAD">
         <description>Load the reel with line.</description>
       </entry>
     </enum>
@@ -4489,33 +4489,33 @@
         <description>Land in multicopter mode on reaching the landing co-ordinates (the whole landing is by "hover descent").</description>
       </entry>
     </enum>
-    <enum name="WINCH_STATUS_FLAG" bitmask="true">
+    <enum name="MAV_WINCH_STATUS_FLAG" bitmask="true">
       <description>Winch status flags used in WINCH_STATUS</description>
-      <entry value="1" name="WINCH_STATUS_HEALTHY">
+      <entry value="1" name="MAV_WINCH_STATUS_HEALTHY">
         <description>Winch is healthy</description>
       </entry>
-      <entry value="2" name="WINCH_STATUS_FULLY_RETRACTED">
+      <entry value="2" name="MAV_WINCH_STATUS_FULLY_RETRACTED">
         <description>Winch thread is fully retracted</description>
       </entry>
-      <entry value="4" name="WINCH_STATUS_MOVING">
+      <entry value="4" name="MAV_WINCH_STATUS_MOVING">
         <description>Winch motor is moving</description>
       </entry>
-      <entry value="8" name="WINCH_STATUS_CLUTCH_ENGAGED">
+      <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_ENGAGED">
         <description>Winch clutch is engaged. Motor is active.</description>
       </entry>
-      <entry value="16" name="WINCH_STATUS_LOCKED">
+      <entry value="16" name="MAV_WINCH_STATUS_LOCKED">
         <description>Winch is locked by locking mechanism.</description>
       </entry>
-      <entry value="32" name="WINCH_STATUS_DROPPING">
+      <entry value="32" name="MAV_WINCH_STATUS_DROPPING">
         <description>Winch is dropping payload.</description>
       </entry>
-      <entry value="64" name="WINCH_STATUS_ARRESTING">
+      <entry value="64" name="MAV_WINCH_STATUS_ARRESTING">
         <description>Winch is arresting payload descent.</description>
       </entry>
-      <entry value="128" name="WINCH_STATUS_GROUND_SENSE">
+      <entry value="128" name="MAV_WINCH_STATUS_GROUND_SENSE">
         <description>Winch is using torque measurements to sense the ground.</description>
       </entry>
-      <entry value="256" name="WINCH_STATUS_RETURNING_TO_HOME">
+      <entry value="256" name="MAV_WINCH_STATUS_RETURNING_TO_HOME">
         <description>Winch is returning to the home position.</description>
       </entry>
     </enum>
@@ -7074,7 +7074,7 @@
       <field type="float" name="voltage" units="V" invalid="NaN">Voltage of the battery supplying the winch. NaN if unknown</field>
       <field type="float" name="current" units="A" invalid="NaN">Current draw from the winch. NaN if unknown</field>
       <field type="int16_t" name="temperature" units="degC" invalid="INT16_MAX">Temperature of the motor. INT16_MAX if unknown</field>
-      <field type="uint32_t" name="status" display="bitmask" enum="WINCH_STATUS_FLAG">Status flags</field>
+      <field type="uint32_t" name="status" display="bitmask" enum="MAV_WINCH_STATUS_FLAG">Status flags</field>
     </message>
     <message id="12900" name="OPEN_DRONE_ID_BASIC_ID">
       <wip/>


### PR DESCRIPTION
- Added additional flags to `status` of the **WINCH_STATUS** message. 
- Added additional actions to the **WINCH_ACTIONS** enum for the **MAV_CMD_DO_WINCH** command.
- Renamed **MAV_WINCH_STATUS_*** to **WINCH_STATUS_*** and actions **WINCH_*** to **WINCH_ACTION_***

This PR is specifically to enable support for a smart winch which implements the new winch status flags and actions. I worked with @julianoes on this solution as to avoid using custom messages/commands in our product. The only quirk with this solution is that states are being encoded into the field meant for status flags, which aren't quite the same thing (states are mutually exclusive while flags are not) -- but I feel this is only a minor flaw. 