### PR TITLE
common.xml: AUTOTUNE_AXIS_YAW - fix value to correct one for bitmask

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -963,7 +963,7 @@
       <entry value="2" name="AUTOTUNE_AXIS_PITCH">
         <description>Autotune pitch axis.</description>
       </entry>
-      <entry value="3" name="AUTOTUNE_AXIS_YAW">
+      <entry value="4" name="AUTOTUNE_AXIS_YAW">
         <description>Autotune yaw axis.</description>
       </entry>
     </enum>


### PR DESCRIPTION
Fixes typo in this value found by @amilcarlucas in https://github.com/mavlink/mavlink/pull/1759/files#r777763295

No one will have implemented this yet, so I am self merging.