### PR TITLE
[Discuss] MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT - redefine meaning

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2933,7 +2933,7 @@
         <description>Autopilot supports MISSION float message type.</description>
       </entry>
       <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT">
-        <description>Autopilot supports the new param float message type.</description>
+        <description>Autopilot supports the parameter protocol version 1: https://mavlink.io/en/services/parameter.html.</description>
       </entry>
       <entry value="4" name="MAV_PROTOCOL_CAPABILITY_MISSION_INT">
         <deprecated since="2020-06" replaced_by="">This flag must always be set if missions are supported, because missions must always use MISSION_ITEM_INT (rather than MISSION_ITEM, which is deprecated).</deprecated>


### PR DESCRIPTION
This is created for discussion. Don't merge until consensus has been reached.

[MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT) is unclear about what it supports. 

> Autopilot supports the new param float message type.

However there is no obvious float message type. There are messages that take floats to set and get the protocol. My strong guess is that this was originally set when the parameter protocol was created to indicate those messages, and more broadly the [parameter protocol](https://mavlink.io/en/services/parameter.html#ardupilot). It is _possible_ it means support for parameters of type `MAV_PARAM_TYPE_REAL32` - while I think ArduPilot only supports INT32 parameters. This is set by PX4 but not ArduPilot.

I have assumed here it was meant to mean "supports the parameter protocol".

Whether or not it is, I recommend that we split the parameter protocol into two versions (in docs) and add new protocol flags for them:
- v1: Ardupilot implementation that encodes the params directly in floats, leading to rounding errors. Ardupilot help confirm the differences.
- v2: PX4 version that encodes the params bytewise. Perhaps also has the mechanism to get the cache - tbd.

If it means support for `MAV_PARAM_TYPE_REAL32` we should update the docs appropriately and also add a protocol bit to indicate support for the INT32 type (though this can be assumed). Unless we have a better way to indicate the supported types?

This is first step to allowing a GCS to understand what version it is getting without having to know the autopilot. Ideally we might converge on a new version with this done. Either way though, we might end up with a useless protocol bit, but at least it will be a clearly defined useless bit :-)

Your thoughts appreciated.

DO NOT MERGE!