### PR TITLE
MAV_PROTOCOL_CAPABILITY_PARAM_UNION - never implemented

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2960,8 +2960,8 @@
       <entry value="8" name="MAV_PROTOCOL_CAPABILITY_COMMAND_INT">
         <description>Autopilot supports COMMAND_INT scaled integer message type.</description>
       </entry>
-      <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_UNION">
-        <description>Autopilot supports the new param union message type.</description>
+      <entry value="16" name="MAV_PROTOCOL_CAPABILITY_RESERVED1">
+        <description>Reserved for future use.</description>
       </entry>
       <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">
         <description>Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.</description>


### PR DESCRIPTION
[MAV_PROTOCOL_CAPABILITY_PARAM_UNION](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY_PARAM_UNION) was described as :

> Autopilot supports the new param union message type.

- There does not appear to be any message that might conceivably be this "param union" message.
- There is no mention or appearance it on search of mavlink/mavlink, other than this issue raised by OllieW #1153 which I should have properly addressed at the time.
- Grep shows this bit is not set in the PX4 or ArduPilot codebase.

My assumption is that whatever it was intended for never happened. Now I could just deprecate this, but I think it can actually be safely reused. I have therefore indicated that in this change.

@auturgy @julianoes You OK with this?

