### PR TITLE
[Discuss.] MAV_PROTOCOL_CAPABILITY_FTP - supports FTP protocol not specific message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2964,7 +2964,7 @@
         <description>Autopilot supports the new param union message type.</description>
       </entry>
       <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">
-        <description>Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.</description>
+        <description>Autopilot supports the File Transfer Protocol v1: https://mavlink.io/en/services/ftp.html.</description>
       </entry>
       <entry value="64" name="MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET">
         <description>Autopilot supports commanding attitude offboard.</description>
@@ -5620,11 +5620,12 @@
       <field type="uint16_t" name="fixed">Count of error corrected radio packets (since boot).</field>
     </message>
     <message id="110" name="FILE_TRANSFER_PROTOCOL">
-      <description>File transfer message</description>
+      <description>File transfer protocol message: https://mavlink.io/en/services/ftp.html.
+        Note that this may be used in private/non-standard FTP protocols as the data format is opaque.</description>
       <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
       <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
       <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
-      <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields.  The entire content of this block is opaque unless you understand any the encoding message_type.  The particular encoding used can be extension specific and might not always be documented as part of the mavlink specification.</field>
+      <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields. The entire content of this block is opaque unless you understand the encoding used.</field>
     </message>
     <message id="111" name="TIMESYNC">
       <description>Time synchronization message.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5620,12 +5620,11 @@
       <field type="uint16_t" name="fixed">Count of error corrected radio packets (since boot).</field>
     </message>
     <message id="110" name="FILE_TRANSFER_PROTOCOL">
-      <description>File transfer protocol message: https://mavlink.io/en/services/ftp.html.
-        Note that this may be used in private/non-standard FTP protocols as the data format is opaque.</description>
+      <description>File transfer protocol message: https://mavlink.io/en/services/ftp.html.</description>
       <field type="uint8_t" name="target_network">Network ID (0 for broadcast)</field>
       <field type="uint8_t" name="target_system">System ID (0 for broadcast)</field>
       <field type="uint8_t" name="target_component">Component ID (0 for broadcast)</field>
-      <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields. The entire content of this block is opaque unless you understand the encoding used.</field>
+      <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields. The content/format of this block is defined in https://mavlink.io/en/services/ftp.html.</field>
     </message>
     <message id="111" name="TIMESYNC">
       <description>Time synchronization message.</description>


### PR DESCRIPTION
[MAV_PROTOCOL_CAPABILITY_FTP](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY_FTP) currently says:

> Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.

This changes that to mean "supports FTP protocol v1 as documented in the devguide" (and now supported by PX4, ArduPilot, QGC, MAVSDK and possibly more). If you don't support this version you don't set it.

The justification for this is that it provides us a clear link to the actual protocol implemented by all these cases, so that if we make this better in future (please!) we have an upgrade path. We should define a bit for this, and I'd prefer it was this bit so that none of the existing systems need to do anything to be compliant. 

**Further, this removes the discussion of "opaque/private" implementations.** I don't think there are any or that they would be useful, and this is a much clearer story. I will have to make corresponding change to docs if this is accepted.

@julianoes @auturgy @LorenzMeier 