### PR TITLE
MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED etc - more precise

### DIFF
--- a/message_definitions/v1.0/standard.xml
+++ b/message_definitions/v1.0/standard.xml
@@ -41,13 +41,13 @@
         <description>Autopilot supports the File Transfer Protocol v1: https://mavlink.io/en/services/ftp.html.</description>
       </entry>
       <entry value="64" name="MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET">
-        <description>Autopilot supports commanding attitude offboard.</description>
+        <description>Autopilot supports the SET_ATTITUDE_TARGET message (for commanding attitude from an offboard controller).</description>
       </entry>
       <entry value="128" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED">
-        <description>Autopilot supports commanding position and velocity targets in local NED frame.</description>
+        <description>Autopilot supports the SET_POSITION_TARGET_LOCAL_NED message (for commanding position and velocity targets in local NED frame).</description>
       </entry>
       <entry value="256" name="MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT">
-        <description>Autopilot supports commanding position and velocity targets in global scaled integers.</description>
+        <description>Autopilot supports the SET_POSITION_TARGET_GLOBAL_INT message (for commanding position and velocity targets in global scaled integers).</description>
       </entry>
       <entry value="512" name="MAV_PROTOCOL_CAPABILITY_TERRAIN">
         <description>Autopilot supports terrain protocol / data handling.</description>


### PR DESCRIPTION
This updates [MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET), [MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED) and [MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT) to make it clear what exactly is supported. 

Specifically consider [MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET) , which states:

> Autopilot supports commanding attitude offboard.

You might reasonably assume that there are multiple methods (i.e. a protocol) for commanding the attitude. If you assume that then you might reasonably assume that both `SET_ATTITUDE_TARGET`, `ATTITUDE_TARGET` or some other message might be involved. 

I believe this command to be intended to mean "literally" the message is supported, following the pattern of earlier messages. Further I don't think you can assume that because `SET_ATTITUDE_TARGET` is supported the `ATTITUDE_TARGET` must also be emitted from the descriptions of the messages. So this makes it clear for the three protocol bits. In this cse:

> Autopilot supports the `SET_ATTITUDE_TARGET` message (for commanding attitude from an offboard controller)