### PR TITLE
MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION - mark as reserved capability

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2996,8 +2996,8 @@
       <entry value="32768" name="MAV_PROTOCOL_CAPABILITY_MISSION_RALLY">
         <description>Autopilot supports mission rally point protocol.</description>
       </entry>
-      <entry value="65536" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION">
-        <description>Autopilot supports the requesting the FLIGHT_INFORMATION message.</description>
+      <entry value="65536" name="	MAV_PROTOCOL_CAPABILITY_RESERVED2">
+        <description>Reserved for future use.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2996,7 +2996,7 @@
       <entry value="32768" name="MAV_PROTOCOL_CAPABILITY_MISSION_RALLY">
         <description>Autopilot supports mission rally point protocol.</description>
       </entry>
-      <entry value="65536" name="	MAV_PROTOCOL_CAPABILITY_RESERVED2">
+      <entry value="65536" name="MAV_PROTOCOL_CAPABILITY_RESERVED2">
         <description>Reserved for future use.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2997,7 +2997,7 @@
         <description>Autopilot supports mission rally point protocol.</description>
       </entry>
       <entry value="65536" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION">
-        <description>Autopilot supports the flight information protocol.</description>
+        <description>Autopilot supports the requesting the FLIGHT_INFORMATION message.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">
@@ -6438,7 +6438,9 @@
       <field type="char[205]" name="file_url">URL of image taken. Either local storage or http://foo.jpg if camera provides an HTTP interface.</field>
     </message>
     <message id="264" name="FLIGHT_INFORMATION">
-      <description>Information about flight since last arming.</description>
+      <description>Information about flight since last arming.
+        This can be requested using MAV_CMD_REQUEST_MESSAGE.
+      </description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint64_t" name="arming_time_utc" units="us" invalid="0">Timestamp at arming (time since UNIX epoch) in UTC, 0 for unknown</field>
       <field type="uint64_t" name="takeoff_time_utc" units="us" invalid="0">Timestamp at takeoff (time since UNIX epoch) in UTC, 0 for unknown</field>


### PR DESCRIPTION
`MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION` indicates support for the flight information protocol but that is not documented. Looking into this, all it means is that [FLIGHT_INFORMATION](https://mavlink.io/en/messages/common.html#FLIGHT_INFORMATION) an be emitted on request, using `MAV_CMD_REQUEST_MESSAGE`

That's a waste of a capability bit. You can just send `MAV_CMD_REQUEST_MESSAGE` to determine if it is supported, which has no problematic side-effects. Further, it is just as likely that if you trust this capability bit you will be wrong. For example, I believe PX4 emits this message but does not set the bit. 

As no one sets the bit and it serves no useful purpose, I have marked it as reserved.

@auturgy @julianoes OK with this? If not I can make the text to "Autopilot supports the requesting the FLIGHT_INFORMATION message.". But I'd rather just delete it since we can without consequence.

