### PR TITLE
MAV_WINCH_STATUS_CLUTCH_ENGAGED: clarify definition

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4995,7 +4995,8 @@
         <description>Winch motor is moving</description>
       </entry>
       <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_ENGAGED">
-        <description>Winch clutch is engaged allowing motor to move freely.</description>
+        <description>Winch clutch is disengaged. The motor is moving freely and not driving the winch.
+          Note that this flag is incorrectly named ("clutch engaged" should mean that the motor is driving the winch).</description>
       </entry>
       <entry value="16" name="MAV_WINCH_STATUS_LOCKED">
         <description>Winch is locked by locking mechanism.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4995,8 +4995,7 @@
         <description>Winch motor is moving</description>
       </entry>
       <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_DISENGAGED">
-        <description>Winch clutch is disengaged. The motor is moving freely and not driving the winch.
-          .</description>
+        <description>Winch clutch is disengaged. The motor is moving freely and not driving the winch.</description>
       </entry>
       <entry value="16" name="MAV_WINCH_STATUS_LOCKED">
         <description>Winch is locked by locking mechanism.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4996,7 +4996,7 @@
       </entry>
       <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_DISENGAGED">
         <description>Winch clutch is disengaged. The motor is moving freely and not driving the winch.
-          Note that this flag is incorrectly named ("clutch engaged" should mean that the motor is driving the winch).</description>
+          .</description>
       </entry>
       <entry value="16" name="MAV_WINCH_STATUS_LOCKED">
         <description>Winch is locked by locking mechanism.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4994,7 +4994,7 @@
       <entry value="4" name="MAV_WINCH_STATUS_MOVING">
         <description>Winch motor is moving</description>
       </entry>
-      <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_ENGAGED">
+      <entry value="8" name="MAV_WINCH_STATUS_CLUTCH_DISENGAGED">
         <description>Winch clutch is disengaged. The motor is moving freely and not driving the winch.
           Note that this flag is incorrectly named ("clutch engaged" should mean that the motor is driving the winch).</description>
       </entry>


### PR DESCRIPTION
DO NOT MERGE UNLESS AGREED WITH @rmackay9 

`MAV_WINCH_STATUS_CLUTCH_ENGAGED` text was "Winch clutch is engaged allowing motor to move freely". Those things are mutually exclusive - an engaged clutch is driving the motor. 

As discussed in https://github.com/mavlink/mavlink/pull/1766#discussion_r779898408 we can't change the meaning because it is being used currently. But we can clarify what it really means and that we understand it is misnamed. 

@rmackay9 Does this work for you if I merge it now. The idea is that there is now no longer any pressure on you to change `MAV_WINCH_STATUS_CLUTCH_ENGAGED` in any kind of timely manner, or really at all if it is not possible to do safely.