### PR TITLE
MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET for ACTUATOR_CONTROL_TARGET

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2982,7 +2982,7 @@
         <description>Autopilot supports terrain protocol / data handling.</description>
       </entry>
       <entry value="1024" name="MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET">
-        <description>Autopilot supports direct actuator control.</description>
+        <description>Autopilot supports the ACTUATOR_CONTROL_TARGET message.</description>
       </entry>
       <entry value="2048" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION">
         <description>Autopilot supports the flight termination command.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2981,8 +2981,8 @@
       <entry value="512" name="MAV_PROTOCOL_CAPABILITY_TERRAIN">
         <description>Autopilot supports terrain protocol / data handling.</description>
       </entry>
-      <entry value="1024" name="MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET">
-        <description>Autopilot supports the ACTUATOR_CONTROL_TARGET message.</description>
+      <entry value="1024" name="MAV_PROTOCOL_CAPABILITY_RESERVED3">
+        <description>Reserved for future use.</description>
       </entry>
       <entry value="2048" name="MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION">
         <description>Autopilot supports the flight termination command.</description>


### PR DESCRIPTION
According to archeology research by @peterbarker , `MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET` indicates support for [ACTUATOR_CONTROL_TARGET](https://mavlink.io/en/messages/common.html#ACTUATOR_CONTROL_TARGET). That is not a very useful message because it has no sysid or component id - and you would not want to broadcast this. 

There is another message one id earlier [SET_ACTUATOR_CONTROL_TARGET](https://mavlink.io/en/messages/common.html#SET_ACTUATOR_CONTROL_TARGET) that does have the id. But you couldn't rely on it being supported. 

This is not set by PX4 or ArduPilot. I'm tempted to mark it reserved as not used, because it is not useful. This change is the minimum for it not to be ambiguous.

@julianoes @auturgy OK, or should we just mark it reserved?