### PR TITLE
component_info: re-use protocol capabilities

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -120,33 +120,6 @@
           Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
       </entry>
     </enum>
-    <enum name="COMPONENT_CAP_FLAGS1" bitmask="true">
-      <description>Component capability flags 1 (Bitmap)</description>
-      <entry value="1" name="COMPONENT_CAP_FLAGS1_PARAM">
-        <description>Component has parameters, and supports the parameter protocol (PARAM messages).</description>
-      </entry>
-      <entry value="2" name="COMPONENT_CAP_FLAGS1_PARAM_EXT">
-        <description>Component has parameters, and supports the extended parameter protocol (PARAM_EXT messages).</description>
-      </entry>
-      <entry value="4" name="COMPONENT_CAP_FLAGS1_COMPONENT_INFORMATION">
-        <description>Component supports the component information protocol.</description>
-      </entry>
-      <entry value="8" name="COMPONENT_CAP_FLAGS1_GIMBAL_V2">
-        <description>Component supports the gimbal v2 protocol.</description>
-      </entry>
-      <entry value="16" name="COMPONENT_CAP_FLAGS1_MAVLINK_FTP">
-        <description>Component supports the MAVLink FTP protocol.</description>
-      </entry>
-      <entry value="32" name="COMPONENT_CAP_FLAGS1_EVENTS_INTERFACE">
-        <description>Component supports the events interface protocol.</description>
-      </entry>
-      <entry value="64" name="COMPONENT_CAP_FLAGS1_CAMERA">
-        <description>Component supports the camera v1 protocol.</description>
-      </entry>
-      <entry value="128" name="COMPONENT_CAP_FLAGS1_CAMERA_V2">
-        <description>Component supports the camera v2 protocol.</description>
-      </entry>
-    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -207,7 +180,7 @@
       <field type="uint8_t[32]" name="model_name">Name of the component model</field>
       <field type="char[24]" name="software_version">Sofware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
       <field type="char[24]" name="hardware_version">Hardware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
-      <field type="uint64_t" name="component_cap_flags1" enum="COMPONENT_CAP_FLAGS1" display="bitmask">Component capability flags 1 (this is called 1, so that number 2 could be added in the future).</field>
+      <field type="uint64_t" name="capabilities" enum="MAV_PROTOCOL_CAPABILITY" display="bitmask">Component capability flags</field>
     </message>
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>


### PR DESCRIPTION
I think it might make sense to re-use the existing capability flags from AUTOPILOT_VERSION also for COMPONENT_INFORMATION_BASICS. Otherwise, we have weird parallel flags that conflict with the existing ones.

If/when we run out of these 64 flags, we can extend both messages, AUTOPILOT_VERSION, and COMPONENT_INFORMATION_BASICS with another 64 bits of MAV_PROTOCOL_CAPABILITY_2.

@hamishwillee,@olliw42, @auturgy what do you think? Good idea or bad idea?