### PR TITLE
Add radius to DO_REPOSITION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1442,8 +1442,8 @@
         <description>Reposition the vehicle to a specific WGS84 global position.</description>
         <param index="1" label="Speed" units="m/s" minValue="-1">Ground speed, less than 0 (-1) for default</param>
         <param index="2" label="Bitmask" enum="MAV_DO_REPOSITION_FLAGS">Bitmask of option flags.</param>
-        <param index="3">Reserved</param>
-        <param index="4" label="Yaw" units="deg">Yaw heading. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.). For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
+        <param index="3" label="Radius" units="m" minValue="0">Loiter radius around waypoint for forward-only moving vehicles (not multicopters). A value of 0 means no change in radius size. Positive values only, Yaw controls direction.</param>
+        <param index="4" label="Yaw" units="deg">Yaw heading. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.). For planes indicates loiter direction (0: clockwise, 1: counter clockwise, else: no change)</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude" units="m">Altitude</param>


### PR DESCRIPTION
Add Radius to CMD_DO_REPOSIITON for better atomic operations of control on guided commands. It uses language from the other CMD_NAV_LOITER commands.

Here's the same commit in a ArduPilot/mavlink PR: https://github.com/ArduPilot/mavlink/pull/240

I've discussed this with @WickedShell who's in favor of it.