### PR TITLE
common.xml: deprecate SET_HOME_POSITION message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6243,6 +6243,7 @@
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <message id="243" name="SET_HOME_POSITION">
+      <deprecated since="2022-02" replaced_by="MAV_CMD_DO_SET_HOME">This message is being superseded by MAV_CMD_DO_SET_HOME.  Using the command protocols allows a GCS to detect setting of the home position has failed.</deprecated>
       <description>The position the system will return to and land on. The position is set automatically by the system during the takeoff in case it was not explicitly set by the operator before or after. The global and local positions encode the position in the respective coordinate frames, while the q parameter encodes the orientation of the surface. Under normal conditions it describes the heading and terrain slope, which can be used by the aircraft to adjust the approach. The approach 3D vector describes the point to which the system should fly in normal flight mode and then perform a landing sequence along the vector.</description>
       <field type="uint8_t" name="target_system">System ID.</field>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>


### PR DESCRIPTION
MAVProxy doesn't use this.

MissionPlanner doesn't use this.

QGroundControl doesn't use this

PX4Firmware doesn't use this.

apm_planner2 doesn't use this(!)

The command equivalent, MAV_CMD_DO_SET_HOME allows for the command to be
rejected, so everyone can save flash by removing support for this
message.
