### PR TITLE
Rename and document parameter encoding protocol bits.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2962,8 +2962,10 @@
           Note that MISSION_ITEM is deprecated, and autopilots should use MISSION_INT instead.
         </description>
       </entry>
-      <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT">
-        <description>Autopilot supports the new param float message type.</description>
+      <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST">
+        <description>Parameter protocol uses C-cast of parameter values to set the param_value (float) fields: https://mavlink.io/en/services/parameter.html#parameter-encoding.
+          Note that either this flag or MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE should be set if the parameter protocol is supported.
+        </description>
       </entry>
       <entry value="4" name="MAV_PROTOCOL_CAPABILITY_MISSION_INT">
         <description>Autopilot supports MISSION_ITEM_INT scaled integer message type.
@@ -2973,8 +2975,10 @@
       <entry value="8" name="MAV_PROTOCOL_CAPABILITY_COMMAND_INT">
         <description>Autopilot supports COMMAND_INT scaled integer message type.</description>
       </entry>
-      <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_UNION">
-        <description>Autopilot supports the new param union message type.</description>
+      <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE">
+        <description>Parameter protocol uses byte-wise encoding of parameter values into param_value (float) fields: https://mavlink.io/en/services/parameter.html#parameter-encoding.
+          Note that either this flag or MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE should be set if the parameter protocol is supported.
+        </description>
       </entry>
       <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">
         <description>Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.</description>


### PR DESCRIPTION
Parameter values may be of many types, e.g. int32. These are sent by the parameter protocol in message fields of type `float` either cast directly into the float or byte-wise encoded in the "underlying data" of the float. 

These two approaches are incompatible, and there is no way to infer which is being used. For this kind of thing the normal approach is to use a protocol bit.

As discussed in the dev call [20220216](https://github.com/mavlink/mavlink/wiki/20220216-Dev-Meeting) this PR proposes to use `MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE` and `MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST` for this purpose, renamed from `MAV_PROTOCOL_CAPABILITY_PARAM_UNION` and `MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT` respectively. This will allow a GCS to detect the encoding used without having to know the flight stack. It will also immediately make it possible to document both approaches as valid, and give a reasonable path for ArduPilot to move to byte-wise encoding if desired.

Note
- The bits aren't set by either flight stack. There is no cost to changing their name as these values should not be being read or set by anyone (because it wasn't clear what they were for).

After this we will have to:
- Update the docs with new names in this draft PR - https://github.com/mavlink/mavlink-devguide/pull/436/files
- Get known flight stacks to emit these bits