### PR TITLE
fix common.xml include in AVSSUAS

### DIFF
--- a/message_definitions/v1.0/AVSSUAS.xml
+++ b/message_definitions/v1.0/AVSSUAS.xml
@@ -6,7 +6,7 @@
 <!-- email contact: josh.boudreau@avss.co thomas.li@avss.co llxxgg@gmail.com-->
 <!-- mavlink messenger ID range: 60050 - 60099,  mavlink command ID range: 60050 - 60099-->
 <mavlink>
-  <include>../../message_definitions/v1.0/common.xml</include>
+  <include>common.xml</include>
   <version>2</version>
   <dialect>1</dialect>
   <enums>


### PR DESCRIPTION
4ee1eeb changed the `<include>` directive of AVSSUAS and added a directory prefix that is now useless, since all dialects were moved into the same folder.

This is causing problems with generation of external libraries.

This PR fixes the issue.