### PR TITLE
Add `WATER_CURRENT` and `DVL` messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7143,6 +7143,28 @@
       <field type="uint8_t" name="num_ids">number of IDs in filter list</field>
       <field type="uint16_t[16]" name="ids">filter IDs, length num_ids</field>
     </message>
+    <message id="390" name="WATER_CURRENT">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Measured water current values. Note: Actual Water current = (Vehicle Velocity - Measured Current) </description>
+      <field type="float" name="measured_current_x" units="m/s">Measured water current in X (NED) direction</field>
+      <field type="float" name="measured_current_y" units="m/s">Measured water current in Y (NED) direction</field>
+      <field type="float" name="measured_current_z" units="m/s">Measured water current in Z (NED) direction</field>
+      <field type="float" name="distance" units="m">Measurement distance from the sensor</field>
+      <field type="float" name="vehicle_velocity_x" units="m/s">Vehicle velocity when measurement was taken in X (NED)</field>
+      <field type="float" name="vehicle_velocity_y" units="m/s">Vehicle velocity when measurement was taken in Y (NED)</field>
+      <field type="float" name="vehicle_velocity_z" units="m/s">Vehicle velocity when measurement was taken in Z (NED)</field>
+    </message>
+    <message id="391" name="DVL">
+      <wip/>
+      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
+      <description>Doppler Velocity Log Sensor. Used to provide vehicle velocity </description>
+      <field type="uint8_t" name="has_lock">Has bottom lock to the floor (1 = true)</field>
+      <field type="float[16]" name="altitude_water" units="m">Vehicle altitude to the floor of body of water for each beam</field>
+      <field type="float" name="vehicle_velocity_x" units="m/s">Vehicle velocity in X (NED)</field>
+      <field type="float" name="vehicle_velocity_y" units="m/s">Vehicle velocity in Y (NED)</field>
+      <field type="float" name="vehicle_velocity_z" units="m/s">Vehicle velocity in Z (NED)</field>
+    </message>
     <!-- Rover specific messages -->
     <message id="9000" name="WHEEL_DISTANCE">
       <description>Cumulative distance traveled for each reported wheel.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7143,7 +7143,7 @@
       <field type="uint8_t" name="num_ids">number of IDs in filter list</field>
       <field type="uint16_t[16]" name="ids">filter IDs, length num_ids</field>
     </message>
-    <message id="390" name="WATER_CURRENT">
+    <message id="391" name="WATER_CURRENT">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Measured water current values. Note: Actual Water current = (Vehicle Velocity - Measured Current) </description>
@@ -7155,7 +7155,7 @@
       <field type="float" name="vehicle_velocity_y" units="m/s">Vehicle velocity when measurement was taken in Y (NED)</field>
       <field type="float" name="vehicle_velocity_z" units="m/s">Vehicle velocity when measurement was taken in Z (NED)</field>
     </message>
-    <message id="391" name="DVL">
+    <message id="392" name="DVL">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Doppler Velocity Log Sensor. Used to provide vehicle velocity </description>


### PR DESCRIPTION
There is a need for more marine-based sensors in the MAVLink standard. Some common ones are the DVL + ADCP.

ADCP measures water currents in a column of water. It can be onboard a vehicle or standalone. Measurements can be taken at a range of distances from the device. If measurements are captured from a moving vehicle the measured current **MUST** be subtracted from the vehicle velocity in order to get _actual_ current. For this I have included vehicle velocity and measured readings into the message as both are required. ADCPs are often combined with DVLs in order to get accurate vehicle velocities.

A DVL is used to track vehicle position across the seafloor. There has been prior work on this using ROS and https://www.ardusub.com/developers/dvl-integration.html and `[VISION_POSITION_DELTA](https://mavlink.io/en/messages/ardupilotmega.html#VISION_POSITION_DELTA)`. This enables EKF position updating but this message doesn't sit right with me as it's not vision tracking and it completely hides the sensor type and data from an onboard computer.

The intention for these messages is to expose the sensor data via MAVLink but also to allow DVL to contribute to positioning data.

Telemarine DVL: http://www.teledynemarine.com/Lists/Downloads/Tasman_DVL.pdf

Happy to expand these. I would also like a nice way to incorporate the sensor location (up-look vs down-look). I thought about including "Measurement Depth" in the `WATER_CURRENT` message but am still unsure on how best to tackle these as the measurement depth will be dependent on orientation of the hardware itself. For now I have omitted it.