### PR TITLE
Component information protocol - move into standard

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -835,6 +835,8 @@
         <description>Parameter meta data.</description>
       </entry>
       <entry value="2" name="COMP_METADATA_TYPE_COMMANDS">
+        <wip/>
+        <!-- This value is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Meta data that specifies which commands and command parameters the vehicle supports. (WIP)</description>
       </entry>
       <entry value="3" name="COMP_METADATA_TYPE_PERIPHERALS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -846,6 +846,8 @@
         <description>Meta data for the events interface.</description>
       </entry>
       <entry value="5" name="COMP_METADATA_TYPE_ACTUATORS">
+        <wip/>
+        <!-- This value is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Meta data for actuator configuration (motors, servos and vehicle geometry) and testing.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7055,8 +7055,6 @@
       <field type="uint32_t[6]" name="link_rx_max" units="KiB/s" invalid="[UINT32_MAX]">Network capacity to the component system. A value of UINT32_MAX implies the field is unused.</field>
     </message>
     <message id="395" name="COMPONENT_INFORMATION">
-      <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>
         Component information message, which may be requested using MAV_CMD_REQUEST_MESSAGE.
         


### PR DESCRIPTION
This PR is being used to scope precisely what of the [Component Information Protocol](https://mavlink.io/en/services/component_information.html) is work in progress, and what is stable. 

@bkueng My assumption is that:
- `COMPONENT_INFORMATION` is stable (removed wip)
- `COMP_METADATA_TYPE_GENERAL` is stable
- [COMP_METADATA_TYPE_PARAMETER](https://mavlink.io/en/messages/common.html#COMP_METADATA_TYPE_PARAMETER) is stable.
- `COMP_METADATA_TYPE_COMMAND` is not stable (added wip)
- `COMP_METADATA_TYPE_ACTUATORS` is not stable (added wip).
- `COMP_METADATA_TYPE_EVENTS` is stable (added wip).

Is above correct?
For the types, by stable, I mean that the format of the schema is  under change control. You are committing not to updating it without going through a process and updating the version id. It also means that it will be assessed as part of this process - and that if it is wip I will add appropriate tagging.