### PR TITLE
VTOL - define MAV_TYPE for belly-sitting non tiltrotor

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -136,15 +136,15 @@
       <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
         <description>Tiltrotor VTOL. Fuselage and wings stay (nominally) horizontal in all flight phases. It able to tilt (some) rotors to provide thrust in cruise flight.</description>
       </entry>
-      <!-- Entries up to 25 reserved for other VTOL airframes -->
-      <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
-        <description>VTOL reserved 2</description>
-      </entry>
-      <entry value="23" name="MAV_TYPE_VTOL_FIXEDROTOR">
+      <entry value="22" name="MAV_TYPE_VTOL_FIXEDROTOR">
         <description>VTOL with separate fixed rotors for hover and cruise flight. Fuselage and wings stay (nominally) horizontal in all flight phases.</description>
       </entry>
-      <entry value="24" name="MAV_TYPE_VTOL_TAILSITTER">
+      <entry value="23" name="MAV_TYPE_VTOL_TAILSITTER">
         <description>Tailsitter VTOL. Fuselage and wings orientation changes depending on flight phase: vertical for hover, horizontal for cruise. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.</description>
+      </entry>
+      <!-- Entries 24/25 reserved for other VTOL airframe -->
+      <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
+        <description>VTOL reserved 4</description>
       </entry>
       <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
         <description>VTOL reserved 5</description>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -128,20 +128,20 @@
         <description>Onboard companion controller</description>
       </entry>
       <entry value="19" name="MAV_TYPE_VTOL_DUOROTOR">
-        <description>Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter.</description>
+        <description>Two-rotor Tailsitter VTOL that additionally uses control surfaces in vertical operation. Note: should be named MAV_TYPE_VTOL_TAILSITTER_DUOROTOR.</description>
       </entry>
       <entry value="20" name="MAV_TYPE_VTOL_QUADROTOR">
-        <description>Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter.</description>
+        <description>Quad-rotor Tailsitter VTOL using a V-shaped quad config in vertical operation. Note: should be named MAV_TYPE_VTOL_TAILSITTER_QUADROTOR.</description>
       </entry>
       <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
-        <description>Tiltrotor VTOL</description>
+        <description>Tiltrotor VTOL. Takes off and lands on belly.</description>
       </entry>
       <!-- Entries up to 25 reserved for other VTOL airframes -->
-      <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
-        <description>VTOL reserved 2</description>
+      <entry value="22" name="MAV_TYPE_VTOL_FIXEDROTOR">
+        <description>VTOL with separate fixed rotors for hover flight. Takes off and lands on belly.</description>
       </entry>
-      <entry value="23" name="MAV_TYPE_VTOL_RESERVED3">
-        <description>VTOL reserved 3</description>
+      <entry value="23" name="MAV_TYPE_VTOL_TAILSITTER">
+        <description>Tailsitter VTOL. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.</description>
       </entry>
       <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
         <description>VTOL reserved 4</description>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -137,8 +137,8 @@
         <description>Tiltrotor VTOL. Fuselage and wings stay (nominally) horizontal in all flight phases. It able to tilt (some) rotors to provide thrust in cruise flight.</description>
       </entry>
       <!-- Entries up to 25 reserved for other VTOL airframes -->
-      <entry value="22" name="MAV_TYPE_VTOL_FIXEDROTOR">
-        <description>VTOL with separate fixed rotors for hover and cruise flight. Fuselage and wings stay (nominally) horizontal in all flight phases.</description>
+      <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
+        <description>MAV_TYPE_VTOL_FIXEDROTOR: VTOL with separate fixed rotors for hover and cruise flight. Fuselage and wings stay (nominally) horizontal in all flight phases.</description>
       </entry>
       <entry value="23" name="MAV_TYPE_VTOL_TAILSITTER">
         <description>Tailsitter VTOL. Fuselage and wings orientation changes depending on flight phase: vertical for hover, horizontal for cruise. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.</description>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -134,14 +134,14 @@
         <description>Quad-rotor Tailsitter VTOL using a V-shaped quad config in vertical operation. Note: should be named MAV_TYPE_VTOL_TAILSITTER_QUADROTOR.</description>
       </entry>
       <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
-        <description>Tiltrotor VTOL. Takes off and lands on belly.</description>
+        <description>Tiltrotor VTOL. Fuselage and wings stay (nominally) horizontal in all flight phases. It able to tilt (some) rotors to provide thrust in cruise flight.</description>
       </entry>
       <!-- Entries up to 25 reserved for other VTOL airframes -->
       <entry value="22" name="MAV_TYPE_VTOL_FIXEDROTOR">
-        <description>VTOL with separate fixed rotors for hover flight. Takes off and lands on belly.</description>
+        <description>VTOL with separate fixed rotors for hover and cruise flight. Fuselage and wings stay (nominally) horizontal in all flight phases.</description>
       </entry>
       <entry value="23" name="MAV_TYPE_VTOL_TAILSITTER">
-        <description>Tailsitter VTOL. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.</description>
+        <description>Tailsitter VTOL. Fuselage and wings orientation changes depending on flight phase: vertical for hover, horizontal for cruise. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.</description>
       </entry>
       <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
         <description>VTOL reserved 4</description>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -138,13 +138,13 @@
       </entry>
       <!-- Entries up to 25 reserved for other VTOL airframes -->
       <entry value="22" name="MAV_TYPE_VTOL_RESERVED2">
-        <description>MAV_TYPE_VTOL_FIXEDROTOR: VTOL with separate fixed rotors for hover and cruise flight. Fuselage and wings stay (nominally) horizontal in all flight phases.</description>
+        <description>VTOL reserved 2</description>
       </entry>
-      <entry value="23" name="MAV_TYPE_VTOL_TAILSITTER">
+      <entry value="23" name="MAV_TYPE_VTOL_FIXEDROTOR">
+        <description>VTOL with separate fixed rotors for hover and cruise flight. Fuselage and wings stay (nominally) horizontal in all flight phases.</description>
+      </entry>
+      <entry value="24" name="MAV_TYPE_VTOL_TAILSITTER">
         <description>Tailsitter VTOL. Fuselage and wings orientation changes depending on flight phase: vertical for hover, horizontal for cruise. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.</description>
-      </entry>
-      <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
-        <description>VTOL reserved 4</description>
       </entry>
       <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
         <description>VTOL reserved 5</description>


### PR DESCRIPTION
There is no MAV_TYPE for the vehicle known as a quadplane or standard vtol - a vehicle that takes off and lands on its belly, which has fixed separate rotors for vertical flight.  Commonly `MAV_TYPE_VTOL_RESERVED2` has been used for this.

This PR un-reserves `MAV_TYPE_VTOL_RESERVED2` (22) replacing with:
>  `MAV_TYPE_VTOL_FIXEDROTOR` - VTOL with separate fixed rotors for hover flight. Takes off and lands on belly.

While doing this I realised that naming is pretty adhoc, so I propose a naming convention: 
- `MAV_TYPE_VTOL_<TYPE>[_ROTORS]`, where:
  - `TYPE`: TAILSITTER | FIXEDROTOR | TILTROTOR:
  - `ROTORS` is string for numbers of "propulsion units" - rotors, fans, whatever.
    This is optional - my assumption is that a GCS doesn't do anything special based on the number of rotors. If it did you define a more specific type by adding a string like "DUOROTOR"

Due to this I have also replaced `MAV_TYPE_VTOL_RESERVED3` (23) with:
> `MAV_TYPE_VTOL_TAILSITTER` - Tailsitter VTOL. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.


Assumptions/Questions:
- For rotors I have assumed a string like "DUOROTOR" is better than "DUO" - so `MAV_TYPE_VTOL_TAILSITTER_DUOROTOR` 
- The main thing about the VTOL types is that it tells a GCS how to orient UI elements/horizon in the different states. So "really" you only need to know TAIL or BELLY orientation. BUT this is more scalable and in line with current types.
- There are two existing frames `VTOL MAV_TYPE_VTOL_DUOROTOR` and `MAV_TYPE_VTOL_QUADROTOR` that should be named `MAV_TYPE_VTOL_TAILSITTER_QUAD`/`MAV_TYPE_VTOL_TAILSITTER_DUO` or  `MAV_TYPE_VTOL_TAILSITTER_QUAD`/`MAV_TYPE_VTOL_TAILSITTER_QUADROTOR`. I assume that it would break too much to change them.

@meee1 @DonLakeFlyer As GCS authors, does this make sense to you? My assumption is basically GSC uses the MAV_TYPE for GCS layout based on the vehicle, and primarily the thing of interest is the orientation of the vehicle. 
The change for you guys would be configuring the UI on MAV_TYPE_VTOL_FIXEDROTOR and accepting MAV_TYPE_VTOL_TAILSITTER as a proxy for either or MAV_TYPE_VTOL_TAILSITTER_DUO or MAV_TYPE_VTOL_QUADROTOR.

FYI @sfuhrer @auturgy @julianoes 
