### PR TITLE
Tell git to ignore the doc/messages folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 tags
 doc/html
+doc/messages
 doc/*.log
 .DS_Store
 build*


### PR DESCRIPTION
When I build the docs locally these show up in git. This is to prevent that happening.