### PR TITLE
common: remove option for relative speed change

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1313,10 +1313,10 @@
         <param index="1" label="Speed Type" minValue="0" maxValue="3" increment="1">Speed type (0=Airspeed, 1=Ground Speed, 2=Climb Speed, 3=Descent Speed)</param>
         <param index="2" label="Speed" units="m/s" minValue="-1">Speed (-1 indicates no change)</param>
         <param index="3" label="Throttle" units="%" minValue="-1">Throttle (-1 indicates no change)</param>
-        <param index="4">Reserved, no longer used, set to 0</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
+        <param index="4" reserved="true" default="0" />
+        <param index="5" reserved="true" default="0" />
+        <param index="6" reserved="true" default="0" />
+        <param index="7" reserved="true" default="0" />
       </entry>
       <entry value="179" name="MAV_CMD_DO_SET_HOME" hasLocation="true" isDestination="false">
         <description>Changes the home location either to the current location or a specified location.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1313,7 +1313,7 @@
         <param index="1" label="Speed Type" minValue="0" maxValue="3" increment="1">Speed type (0=Airspeed, 1=Ground Speed, 2=Climb Speed, 3=Descent Speed)</param>
         <param index="2" label="Speed" units="m/s" minValue="-1">Speed (-1 indicates no change)</param>
         <param index="3" label="Throttle" units="%" minValue="-1">Throttle (-1 indicates no change)</param>
-        <param index="4" label="Relative" minValue="0" maxValue="1" increment="1">0: absolute, 1: relative</param>
+        <param index="4">Reserved, no longer used, set to 0</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1313,10 +1313,10 @@
         <param index="1" label="Speed Type" minValue="0" maxValue="3" increment="1">Speed type (0=Airspeed, 1=Ground Speed, 2=Climb Speed, 3=Descent Speed)</param>
         <param index="2" label="Speed" units="m/s" minValue="-1">Speed (-1 indicates no change)</param>
         <param index="3" label="Throttle" units="%" minValue="-1">Throttle (-1 indicates no change)</param>
-        <param index="4" reserved="true" default="0" />
-        <param index="5" reserved="true" default="0" />
-        <param index="6" reserved="true" default="0" />
-        <param index="7" reserved="true" default="0" />
+        <param index="4" reserved="true" default="0"/>
+        <param index="5" reserved="true" default="0"/>
+        <param index="6" reserved="true" default="0"/>
+        <param index="7" reserved="true" default="0"/>
       </entry>
       <entry value="179" name="MAV_CMD_DO_SET_HOME" hasLocation="true" isDestination="false">
         <description>Changes the home location either to the current location or a specified location.</description>


### PR DESCRIPTION
This removes the functionality to do a speed change in a relative way (e.g. 5 m/s slower) rather than an absolute way (10 m/s).

This option in param4 had been [added in 2016](https://github.com/mavlink/mavlink/commit/320f616179d5088ce3a37147aa79a81d07ea848a) but neither implemented in PX4 nor ArduPilot from what I can tell.

While this option might be a good idea, there is - at this point - no safe option to add the functionality. If we were to start using the
option, then it might not work correctly if the autopilot does not actually check param4.

Additionally to the fact that we can't start using it, the API is also odd in that a negative speed (or at least -1) is generally ignored, so a relative change that is slower (negative) would likely not work either.

I think the safe bet is to reserve this to 0, and add a new command for relative changes, if required.