### PR TITLE
Param protocol bits: revert float, move c_style

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2969,10 +2969,9 @@
           Note that MISSION_ITEM is deprecated, and autopilots should use MISSION_INT instead.
         </description>
       </entry>
-      <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST">
-        <description>Parameter protocol uses C-cast of parameter values to set the param_value (float) fields: https://mavlink.io/en/services/parameter.html#parameter-encoding.
-          Note that either this flag or MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE should be set if the parameter protocol is supported.
-        </description>
+      <entry value="2" name="MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT">
+        <deprecated since="2022-03" replaced_by="MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST"/>
+        <description>Autopilot supports the new param float message type.</description>
       </entry>
       <entry value="4" name="MAV_PROTOCOL_CAPABILITY_MISSION_INT">
         <description>Autopilot supports MISSION_ITEM_INT scaled integer message type.
@@ -3022,6 +3021,11 @@
       </entry>
       <entry value="65536" name="MAV_PROTOCOL_CAPABILITY_RESERVED2">
         <description>Reserved for future use.</description>
+      </entry>
+      <entry value="131072" name="MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST">
+        <description>Parameter protocol uses C-cast of parameter values to set the param_value (float) fields: https://mavlink.io/en/services/parameter.html#parameter-encoding.
+          Note that either this flag or MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE should be set if the parameter protocol is supported.
+        </description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">


### PR DESCRIPTION
This change
- moves `MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST` from id `2` to id `131072` 
- reverts the value of id `2` to `MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT` (changed in #1799) and marks it deprecated.

The change in #1799 was made under the incorrect assumption that `MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT` was not set by any flight stack and hence could be renamed and documented to properly explain its meaning - i.e. parameter values are encoded using a C-cast.

In fact BOTH PX4 and ArduPilot set this. What this means is that ID2 cannot be used for `MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST` because a false signal would be sent by PX4 in old versions, which defeats the purpose.

As neither PX4 or ArduPilot have updated yet, this is an urgent fix to update the signals correctly. Things that support `MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT` and continue to emit it, but it has no real meaning. 

@julianoes @auturgy I will to merge this "immediately". OK?

