### PR TITLE
MAV_TYPE_VTOL _DUOROTOR and _QUADROTOR renamed to new format

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -127,11 +127,11 @@
       <entry value="18" name="MAV_TYPE_ONBOARD_CONTROLLER">
         <description>Onboard companion controller</description>
       </entry>
-      <entry value="19" name="MAV_TYPE_VTOL_DUOROTOR">
-        <description>Two-rotor Tailsitter VTOL that additionally uses control surfaces in vertical operation. Note: should be named MAV_TYPE_VTOL_TAILSITTER_DUOROTOR.</description>
+      <entry value="19" name="MAV_TYPE_VTOL_TAILSITTER_DUOROTOR">
+        <description>Two-rotor Tailsitter VTOL that additionally uses control surfaces in vertical operation. Note, value previously named MAV_TYPE_VTOL_DUOROTOR.</description>
       </entry>
-      <entry value="20" name="MAV_TYPE_VTOL_QUADROTOR">
-        <description>Quad-rotor Tailsitter VTOL using a V-shaped quad config in vertical operation. Note: should be named MAV_TYPE_VTOL_TAILSITTER_QUADROTOR.</description>
+      <entry value="20" name="MAV_TYPE_VTOL_TAILSITTER_QUADROTOR">
+        <description>Quad-rotor Tailsitter VTOL using a V-shaped quad config in vertical operation. Note: value previously named MAV_TYPE_VTOL_QUADROTOR.</description>
       </entry>
       <entry value="21" name="MAV_TYPE_VTOL_TILTROTOR">
         <description>Tiltrotor VTOL. Fuselage and wings stay (nominally) horizontal in all flight phases. It able to tilt (some) rotors to provide thrust in cruise flight.</description>


### PR DESCRIPTION
This PR update the names of the enum values:
 - `MAV_TYPE_VTOL_DUOROTOR` to `MAV_TYPE_VTOL_TAILSITTER_DUOROTOR`
- `MAV_TYPE_VTOL_QUADROTOR` to `MAV_TYPE_VTOL_TAILSITTER_QUADROTOR`

This update matches the values to the naming convention discussed in https://github.com/mavlink/mavlink/pull/1808#issue-1157921604 

The change follows on from #1808 and in particular the discussion https://github.com/mavlink/mavlink/pull/1808/files#r823318681

It is in a separate PR because anyone who uses these values will need to update their code on next build with new library. Note however that code that is not rebuilt will continue to work (the change is forward compatible. 