### PR TITLE
AVSUAS: correct MODE_M300_FORCE_AUTO_LANDING enum entry

### DIFF
--- a/message_definitions/v1.0/AVSSUAS.xml
+++ b/message_definitions/v1.0/AVSSUAS.xml
@@ -125,7 +125,7 @@
       <entry name="MODE_M300_S_SPORT" value="31">
         <description>In sport mode</description>
       </entry>
-      <entry name=" MODE_M300_FORCE_AUTO_LANDING" value="33">
+      <entry name="MODE_M300_FORCE_AUTO_LANDING" value="33">
         <description>In force auto landing mode</description>
       </entry>
       <entry name="MODE_M300_T_TRIPOD" value="38">


### PR DESCRIPTION
This space breaks pymavlink generation
