### PR TITLE
Add radius to DO_REPOSITION v2

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1449,7 +1449,7 @@
         <description>Reposition the vehicle to a specific WGS84 global position.</description>
         <param index="1" label="Speed" units="m/s" minValue="-1">Ground speed, less than 0 (-1) for default</param>
         <param index="2" label="Bitmask" enum="MAV_DO_REPOSITION_FLAGS">Bitmask of option flags.</param>
-        <param index="3">Reserved</param>
+        <param index="3" label="Radius" units="m">Loiter radius for planes. Positive values only, direction is controlled by Yaw value. A value of zero or NaN is ignored. </param>
         <param index="4" label="Yaw" units="deg">Yaw heading. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.). For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>


### PR DESCRIPTION
This replaces https://github.com/mavlink/mavlink/pull/1787

Add radius, and a bit flag to utilize it, to DO_REPOSITION so it's much more useful for planes in guided modes

See https://github.com/ArduPilot/mavlink/pull/240 for a matching Ardupilot/mavlink PR