### PR TITLE
common.xml: Deprecate MAV_CMD_GET_MESSAGE_INTERVAL for MAV_CMD_REQUES…

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1897,7 +1897,11 @@
         <param index="2" label="RC Type" enum="RC_TYPE">RC type.</param>
       </entry>
       <entry value="510" name="MAV_CMD_GET_MESSAGE_INTERVAL" hasLocation="false" isDestination="false">
-        <description>Request the interval between messages for a particular MAVLink message ID. The receiver should ACK the command and then emit its response in a MESSAGE_INTERVAL message.</description>
+        <deprecated since="2022-04" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+        <description>
+          Request the interval between messages for a particular MAVLink message ID.
+          The receiver should ACK the command and then emit its response in a MESSAGE_INTERVAL message.
+        </description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID</param>
       </entry>
       <entry value="511" name="MAV_CMD_SET_MESSAGE_INTERVAL" hasLocation="false" isDestination="false">


### PR DESCRIPTION
Deprecate MAV_CMD_GET_MESSAGE_INTERVAL for MAV_CMD_REQUEST_MESSAGE.

The `MESSAGE_INTERVAL` already states that you can get it it with MAV_CMD_REQUEST_MESSAGE (or MAV_CMD_GET_MESSAGE_INTERVAL) so this just deprecates the specific requestor.