### PR TITLE
Deprecated GPS_INJECT_DATA

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5922,6 +5922,7 @@
       <field type="uint8_t" name="target_component">Component ID</field>
     </message>
     <message id="123" name="GPS_INJECT_DATA">
+      <deprecated since="2022-05" replaced_by="GPS_RTCM_DATA"/>
       <description>Data for injecting into the onboard GPS (used for DGPS)</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>


### PR DESCRIPTION
Was superseded by GPS_RTCM_DATA around 2017 https://github.com/mavlink/mavlink/commit/8e940ab45b10a2ea26463d55320e7f1966f372d8

As discussed in https://github.com/mavlink/mavlink/issues/1557#issuecomment-1117014996 this is not used in PX4 or ArduPilot.