### PR TITLE
WIND_COV - accuracy units are m/s

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6300,8 +6300,8 @@
       <field type="float" name="var_horiz" units="m/s">Variability of the wind in XY. RMS of a 1 Hz lowpassed wind estimate.</field>
       <field type="float" name="var_vert" units="m/s">Variability of the wind in Z. RMS of a 1 Hz lowpassed wind estimate.</field>
       <field type="float" name="wind_alt" units="m">Altitude (MSL) that this measurement was taken at</field>
-      <field type="float" name="horiz_accuracy" units="m">Horizontal speed 1-STD accuracy</field>
-      <field type="float" name="vert_accuracy" units="m">Vertical speed 1-STD accuracy</field>
+      <field type="float" name="horiz_accuracy" units="m/s">Horizontal speed 1-STD accuracy</field>
+      <field type="float" name="vert_accuracy" units="m/s">Vertical speed 1-STD accuracy</field>
     </message>
     <message id="232" name="GPS_INPUT">
       <description>GPS sensor input message.  This is a raw sensor value sent by the GPS. This is NOT the global position estimate of the system.</description>


### PR DESCRIPTION
 [WIND_COV](http://mavlink.io/en/messages/common.html#WIND_COV) (wind covariance) message set units of `horiz_accuracy` and `vert_accuracy` to `m`. However these are not covariances - they are standard deviations of the speed, so should have the same units (m/s)

This updates the units of those fields.

Fixes #1838