### PR TITLE
add joystick to metadata type

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -846,6 +846,9 @@
       <entry value="5" name="COMP_METADATA_TYPE_ACTUATORS">
         <description>Meta data for actuator configuration (motors, servos and vehicle geometry) and testing.</description>
       </entry>
+      <entry value="6" name="COMP_METADATA_TYPE_JOYSTICK">
+        <description>Meta data for mavlink joystick configuration.</description>
+      </entry>
     </enum>
     <enum name="ACTUATOR_CONFIGURATION">
       <description>Actuator configuration, used to change a setting on an actuator. Component information metadata can be used to know which outputs support which commands.</description>


### PR DESCRIPTION
I would like to reserve the id 6 in the component meta data type for mavlink joysticks. The idea would be that a joystick which communicates over mavlink can report its brand, numbers of axes and buttons, etc.