### PR TITLE
MAV_CMD_DO_SET_HOME - add home position roll/pitch

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1368,8 +1368,8 @@
           Note: the current home position may be emitted in a HOME_POSITION message on request (using MAV_CMD_REQUEST_MESSAGE with param1=242).
         </description>
         <param index="1" label="Use Current" minValue="0" maxValue="1" increment="1">Use current (1=use current location, 0=use specified location)</param>
-        <param index="2" label="Roll" units="deg">Roll angle (of surface). Range: -180..180 degrees. NAN or 0 means value not set. 0.01 indicates zero roll.</param>
-        <param index="3" label="Pitch" units="deg">Pitch angle (of surface). Range: -90..90 degrees. NAN or 0 means value not set. 0.01 means zero pitch.</param>
+        <param index="2" label="Roll" units="deg" minValue="-180" maxValue="180">Roll angle (of surface). Range: -180..180 degrees. NAN or 0 means value not set. 0.01 indicates zero roll.</param>
+        <param index="3" label="Pitch" units="deg" minValue="-90" maxValue="90">Pitch angle (of surface). Range: -90..90 degrees. NAN or 0 means value not set. 0.01 means zero pitch.</param>
         <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use default heading. Range: -180..180 degrees.</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1368,8 +1368,8 @@
           Note: the current home position may be emitted in a HOME_POSITION message on request (using MAV_CMD_REQUEST_MESSAGE with param1=242).      
         </description>
         <param index="1" label="Use Current" minValue="0" maxValue="1" increment="1">Use current (1=use current location, 0=use specified location)</param>
-        <param index="2" label="Roll" units="deg">Roll angle (of surface). NaN is equivalent to 0.</param>
-        <param index="3" label="Pitch" units="deg">Pitch angle (of surface). NaN is equivalent to 0.</param>
+        <param index="2" label="Roll" units="deg">Roll angle (of surface). 0 means value not set. 0.01 indicates zero roll.</param>
+        <param index="3" label="Pitch" units="deg">Pitch angle (of surface).  0 means value not set. 0.01 means zero pitch.</param>
         <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use default heading</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1368,8 +1368,8 @@
           Note: the current home position may be emitted in a HOME_POSITION message on request (using MAV_CMD_REQUEST_MESSAGE with param1=242).      
         </description>
         <param index="1" label="Use Current" minValue="0" maxValue="1" increment="1">Use current (1=use current location, 0=use specified location)</param>
-        <param index="2" label="Roll" units="deg">Roll angle (of surface). NaN to use default roll (0)</param>
-        <param index="3" label="Pitch" units="deg">Pitch angle (of surface). NaN to use default roll (0)</param>
+        <param index="2" label="Roll" units="deg">Roll angle (of surface). NaN is equivalent to 0.</param>
+        <param index="3" label="Pitch" units="deg">Pitch angle (of surface). NaN is equivalent to 0.</param>
         <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use default heading</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1365,12 +1365,12 @@
           Sets the home position to either to the current position or a specified position.
           The home position is the default position that the system will return to and land on.
           The position is set automatically by the system during the takeoff (and may also be set using this command).
-          Note: the current home position may be emitted in a HOME_POSITION message on request (using MAV_CMD_REQUEST_MESSAGE with param1=242).      
+          Note: the current home position may be emitted in a HOME_POSITION message on request (using MAV_CMD_REQUEST_MESSAGE with param1=242).
         </description>
         <param index="1" label="Use Current" minValue="0" maxValue="1" increment="1">Use current (1=use current location, 0=use specified location)</param>
-        <param index="2" label="Roll" units="deg">Roll angle (of surface). 0 means value not set. 0.01 indicates zero roll.</param>
-        <param index="3" label="Pitch" units="deg">Pitch angle (of surface).  0 means value not set. 0.01 means zero pitch.</param>
-        <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use default heading</param>
+        <param index="2" label="Roll" units="deg">Roll angle (of surface). Range: -180..180 degrees. NAN or 0 means value not set. 0.01 indicates zero roll.</param>
+        <param index="3" label="Pitch" units="deg">Pitch angle (of surface). Range: -90..90 degrees. NAN or 0 means value not set. 0.01 means zero pitch.</param>
+        <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use default heading. Range: -180..180 degrees.</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude" units="m">Altitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1368,8 +1368,8 @@
           Note: the current home position may be emitted in a HOME_POSITION message on request (using MAV_CMD_REQUEST_MESSAGE with param1=242).      
         </description>
         <param index="1" label="Use Current" minValue="0" maxValue="1" increment="1">Use current (1=use current location, 0=use specified location)</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
+        <param index="2" label="Roll" units="deg">Roll angle (of surface). NaN to use default roll (0)</param>
+        <param index="3" label="Pitch" units="deg">Pitch angle (of surface). NaN to use default roll (0)</param>
         <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use default heading</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1370,7 +1370,7 @@
         <param index="1" label="Use Current" minValue="0" maxValue="1" increment="1">Use current (1=use current location, 0=use specified location)</param>
         <param index="2" label="Roll" units="deg" minValue="-180" maxValue="180">Roll angle (of surface). Range: -180..180 degrees. NAN or 0 means value not set. 0.01 indicates zero roll.</param>
         <param index="3" label="Pitch" units="deg" minValue="-90" maxValue="90">Pitch angle (of surface). Range: -90..90 degrees. NAN or 0 means value not set. 0.01 means zero pitch.</param>
-        <param index="4" label="Yaw" units="deg">Yaw angle. NaN to use default heading. Range: -180..180 degrees.</param>
+        <param index="4" label="Yaw" units="deg" minValue="-180" maxValue="180">Yaw angle. NaN to use default heading. Range: -180..180 degrees.</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude" units="m">Altitude</param>


### PR DESCRIPTION
The vehicle outputs a quaternion of vehicle roll/pitch/yaw  in the [HOME_POSITION](https://mavlink.io/en/messages/common.html#SET_HOME_POSITION) message.
As discussed in https://github.com/mavlink/mavlink/pull/1843, the expectation is that either the quaternion outputs accurate values or NaNs for all value (even if you have a value for the yaw, you can't output it in the form of a quaternion unless you also have "some" roll and pitch value). 

The proposal here is that we allow the `MAV_CMD_DO_SET_HOME` to also specify a roll and pitch of the home position.

Note, there is no way to say "I don't know the pitch, roll" of the surface at home - if you don't know you're saying it's flat. Is that OK?
