### PR TITLE
ardupilotmega: add nav_attitude_time command

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -291,6 +291,16 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+      <entry value="42703" name="MAV_CMD_NAV_ATTITUDE_TIME" hasLocation="false" isDestination="false">
+        <description>Maintain an attitude for a specified time.</description>
+        <param index="1" label="time" units="s">Time to maintain specified attitude and climb rate</param>
+        <param index="2" label="roll" units="deg">Roll angle in degrees (positive is lean right, negative is lean left)</param>
+        <param index="3" label="pitch" units="deg">Pitch angle in degrees (positive is lean back, negative is lean forward)</param>
+        <param index="4" label="yaw" units="deg">Yaw angle</param>
+        <param index="5" label="climb_rate" units="m/s">Climb rate</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <entry value="43000" name="MAV_CMD_GUIDED_CHANGE_SPEED" hasLocation="false" isDestination="false">
         <description>Change flight speed at a given rate. This slews the vehicle at a controllable rate between it's previous speed and the new one. (affects GUIDED only. Outside GUIDED, aircraft ignores these commands. Designed for onboard companion-computer command-and-control, not normally operator/GCS control.)</description>
         <param index="1" label="speed type" enum="SPEED_TYPE">Airspeed or groundspeed.</param>


### PR DESCRIPTION
This adds a new ArduPilot specific NAV_ATTITUDE_TIME command which allows the user to specify an attitude they would like the vehicle to maintain for a specified period of time during.  This can be useful if a user wants to, for example, specify that a copter should drift with the wind for 10 seconds (they could set roll, pitch and climb_rate arguments to zero).

This has [already been merged into the AP specific mavlink](https://github.com/ArduPilot/mavlink/pull/272) but if there's interest in other teams using this message I'm happy to move it to common.xml instead.

This has been tested successfully in SITL using AP.