### PR TITLE
Improve payload deploy specific messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1677,8 +1677,8 @@
         <description>Mission command to operate a gripper.</description>
         <param index="1" label="Instance" minValue="1" increment="1">Gripper instance number.</param>
         <param index="2" label="Action" enum="GRIPPER_ACTIONS">Gripper action to perform.</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
+        <param index="3" label="Timeout" units="s">Maximum time the vehicle should wait while waiting for the acknowledgement of the successful gripper action. Used for gripers with feedback sensor</param>
+        <param index="4" label="Definite Execution Time" units="s">For how long the vehicle must wait after start commanding the gripper, regardless of the acknowledgement of a successful deployment. Used for grippers without feedback sensor</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>
@@ -2356,10 +2356,10 @@
         <description>Command to operate winch.</description>
         <param index="1" label="Instance" minValue="1" increment="1">Winch instance number.</param>
         <param index="2" label="Action" enum="WINCH_ACTIONS">Action to perform.</param>
-        <param index="3" label="Length" units="m">Length of line to release (negative to wind).</param>
-        <param index="4" label="Rate" units="m/s">Release rate (negative to wind).</param>
-        <param index="5">Empty.</param>
-        <param index="6">Empty.</param>
+        <param index="3" label="Length" units="m">Length of line to release</param>
+        <param index="4" label="Rate" units="m/s">Release rate</param>
+        <param index="5" label="Timeout" units="s">Maximum time the vehicle should wait while waiting for the acknowledgement of the successful winch deployment. Used for winches with feedback sensor</param>
+        <param index="6" label="Definite Execution Time" units="s">For how long the vehicle must wait after start deploying the winch, regardless of the acknowledgement of a successful deployment. Used for winches without feedback sensor</param>
         <param index="7">Empty.</param>
       </entry>
       <!-- END of payload range (30000 to 30999) -->


### PR DESCRIPTION
## Background
This is a PR to improve the definitions of [payload specific messages](https://mavlink.io/en/services/payload.html#payload-specific-commands) that are related to payload **deployment**. Which covers:
1. [MAV_CMD_DO_GRIPPER](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GRIPPER)
2. [MAV_CMD_DO_WINCH](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_WINCH)

### Use case
This PR is needed for supporting a Missions where exact execution flow of the payload deployment actions are important.

Previous implementation which has no concept of timeout has always blindly trusted the payload deployments to work instantaneously, which is not the case in a lot of applications. The winch can get stuck, the gripper may not open in time, etc.

Also, without any time delay specifications, the previous behavior was to trigger the deployment of payload, and continue on the mission. This is not desirable since ideally, we want to be sure that we can deliver / actuate the payload precisely at a certain spot & verify that the deployment has been successful.

### Additions
With this PR, I am adding the Timeout & Definite Execution time definitions, which means the following:
1. Timeout: "Maximum time the vehicle should wait while waiting for the acknowledgement of the successful gripper action"
   - This is used for payload deployment mechanisms with feedback sensor
2. Definite Execution Time: "For how long the vehicle must wait after start commanding the gripper, regardless of the acknowledgement of a successful deployment"
   - Used for payload deployment mechanisms without feedback sensor

## Discussion