### PR TITLE
MAV_CMD_RUN_PREARM_CHECKS - capture intent better

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1882,7 +1882,7 @@
           This allows preflight checks to be run on demand, which may be useful on systems that normally run them at low rate, or which do not trigger checks when the armable state might have changed.
           This command should should return MAV_RESULT_ACCEPTED if it is able to run the checks.
           The results of the checks are usually then reported in SYS_STATUS messages (this is system-specific).
-          The command should return MAV_RESULT_TEMPORARILY_REJECTED if the system is armed.
+          The command should return MAV_RESULT_TEMPORARILY_REJECTED if the system is already armed.
         </description>
       </entry>
       <entry value="405" name="MAV_CMD_ILLUMINATOR_ON_OFF" hasLocation="false" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1878,7 +1878,12 @@
         <param index="2" label="Force" minValue="0" maxValue="21196" increment="21196">0: arm-disarm unless prevented by safety checks (i.e. when landed), 21196: force arming/disarming (e.g. allow arming to override preflight checks and disarming in flight)</param>
       </entry>
       <entry value="401" name="MAV_CMD_RUN_PREARM_CHECKS" hasLocation="false" isDestination="false">
-        <description>Instructs system to run pre-arm checks. This command should return MAV_RESULT_TEMPORARILY_REJECTED in the case the system is armed, otherwise MAV_RESULT_ACCEPTED. Note that the return value from executing this command does not indicate whether the vehicle is armable or not, just whether the system has successfully run/is currently running the checks.  The result of the checks is reflected in the SYS_STATUS message.</description>
+        <description>Instructs a target system to run pre-arm checks.
+          This allows preflight checks to be run on demand, which may be useful on systems that normally run them at low rate, or which do not trigger checks when the armable state might have changed.
+          This command should should return MAV_RESULT_ACCEPTED if it is able to run the checks.
+          The results of the checks are usually then reported in SYS_STATUS messages (this is system-specific).
+          The command should return MAV_RESULT_TEMPORARILY_REJECTED if the system is armed.
+        </description>
       </entry>
       <entry value="405" name="MAV_CMD_ILLUMINATOR_ON_OFF" hasLocation="false" isDestination="false">
         <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1880,7 +1880,7 @@
       <entry value="401" name="MAV_CMD_RUN_PREARM_CHECKS" hasLocation="false" isDestination="false">
         <description>Instructs a target system to run pre-arm checks.
           This allows preflight checks to be run on demand, which may be useful on systems that normally run them at low rate, or which do not trigger checks when the armable state might have changed.
-          This command should should return MAV_RESULT_ACCEPTED if it is able to run the checks.
+          This command should should return MAV_RESULT_ACCEPTED if it will run the checks.
           The results of the checks are usually then reported in SYS_STATUS messages (this is system-specific).
           The command should return MAV_RESULT_TEMPORARILY_REJECTED if the system is already armed.
         </description>


### PR DESCRIPTION
This attempts to better capture a comment from @MaEtUgR in https://github.com/mavlink/mavlink/pull/1651#issuecomment-1150885749 that he wasn't entirely clear that MAV_CMD_RUN_PREARM_CHECKS  was needed for the case where prearm checks are run at fairly low rate, or not run when things happen that might cause the armable state to change.

What I've done is added that information. I also noted that SYS_STATUS is one way the results might be reported. MAVLink doesn't actually specify anything about this, but PX4 will doubtless use EVENTS in future (and I suspect ArduPilot may too).

@MaEtUgR @peterbarker is this acceptable?
