### PR TITLE
Add MAV_CMD_DO_PRECISION_HOLD

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1187,13 +1187,13 @@
       </entry>
       <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="true" isDestination="true">
         <description>
-          Vehicle moves to specified location (lat/lon/alt) and engages Precision Hold mode (NaN/INT32_MAX may be used to set the current location when the message is received).
-          If it gets LANDING_TARGET messages for the indicated landing target it: adjusts its horizontal position to align precisely above the target, adjusts its altitude to the Hold altitude (param3), and then holds the position. 
+          Vehicle moves to location (if specified) and descends above a target. It will hold its position above the target at a fixed distance, specified in the param "Hold distance".
+          If it gets LANDING_TARGET messages for the indicated landing target it: adjusts its horizontal position to align precisely above the target, descends to above the target, and then hold the position at "Hold distance" from the target.
           If the specified target is not found the vehicle holds the specified lat/lon/alt and enters normal Position Hold mode (the timeout for entering position hold is flight-stack specific).
         </description>
-        <param index="1" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found the vehicle will use normal Position Hold mode.</param>
+        <param index="1" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found the vehicle will use normal Position Hold mode. 0 to use first target found.</param>
         <param index="2" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
-        <param index="3" label="Hold altitude" units="m">Altitude above target to hold position. Set to NaN to use current altitude as the Hold altitude.</param>
+        <param index="3" label="Hold distance" units="m">Distance above target to hold position. NaN to use current altitude.</param>
         <param index="4">Empty</param>
         <param index="5" label="Latitude/X">Latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current latitude.</param>
         <param index="6" label="Longitude/Y">Longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current longitude.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1185,7 +1185,7 @@
         <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. INT32_MAX (or NaN if sent in COMMAND_LONG): Use current vehicle position, or current center if already orbiting.</param>
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
-      <entry value="35" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="false" isDestination="false">
+      <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="false" isDestination="false">
         <description>Enable or disable a Precision Hold which allows the vehicle to hover precisely above a target.</description>
         <param index="1" label="Enable">Enable or disable Precision Hold.</param>
         <param index="2" label="Target number">The ID of the target if multiple targets are present.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1186,11 +1186,11 @@
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
       <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="true" isDestination="true">
-        <description>Vehicle moves to specified location and enables or disables Precision Hold mode which allows the vehicle to hover precisely above a LANDING_TARGET. If any of the 3 fields Latitude/Longitude/Altitude are NAN the current position will be used instead.</description>
-        <param index="1" label="Enable">Enable or disable Precision Hold.</param>
-        <param index="2" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found, the lowest ID target available will be used.</param>
-        <param index="3" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
-        <param index="4" label="Height above target" units="m">Set to zero to maintain current altitude.</param>
+        <description>Vehicle moves to specified location and engages Precison Hold mode which allows the vehicle to hover precisely above a LANDING_TARGET. If Latitude/Longitude are FLT_MAX (COMMAND_LONG) or INT32_MAX (COMMAND_INT) the current position will be used instead. If Altitude is FLT_MAX (COMMAND_LONG) or INT32_MAX (COMMAND_INT) the current altitude will be used instead </description>
+        <param index="1" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found the vehicle will use normal Position Hold mode.</param>
+        <param index="2" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
+        <param index="3" label="Height above target" units="m">Set to NaN to maintain current altitude.</param>
+        <param index="4">Empty</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude">Altitude</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1187,19 +1187,17 @@
       </entry>
       <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="true" isDestination="true">
         <description>
-          Vehicle moves to specified location (lat/lon/alt) and engages Precision Hold mode.
-          If it gets LANDING_TARGET messages for the indicated landing target it adjusts its horizontal position to align precisely above the target (and maintains altitude).
+          Vehicle moves to specified location (lat/lon/alt) and engages Precision Hold mode (NaN/INT32_MAX may be used to set the current location when the message is received).
+          If it gets LANDING_TARGET messages for the indicated landing target it: adjusts its horizontal position to align precisely above the target, adjusts its altitude to the Hold altitude (param3), and then holds the position. 
           If the specified target is not found the vehicle holds the specified lat/lon/alt and enters normal Position Hold mode (the timeout for entering position hold is flight-stack specific).
-          If Latitude/Longitude are NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) the current position will be used.
-          If Altitude is NaN the vehicle altitude when the message is received will be used.
         </description>
         <param index="1" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found the vehicle will use normal Position Hold mode.</param>
         <param index="2" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
-        <param index="3" label="Height above target" units="m">Set to NaN to maintain current altitude.</param>
+        <param index="3" label="Hold altitude" units="m">Altitude above target to hold position. Set to NaN to use current altitude as the Hold altitude.</param>
         <param index="4">Empty</param>
-        <param index="5" label="Latitude/X">Latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME</param>
-        <param index="6" label="Longitude/Y">Longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME</param>
-        <param index="7" label="Altitude/Z">Altitude (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME</param>
+        <param index="5" label="Latitude/X">Latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current latitude.</param>
+        <param index="6" label="Longitude/Y">Longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current longitude.</param>
+        <param index="7" label="Altitude/Z">Altitude (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN to use current altitude.</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1186,12 +1186,12 @@
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
       <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="false" isDestination="false">
-        <description>Enable or disable a Precision Hold which allows the vehicle to hover precisely above a target.</description>
+        <description>Enable or disable a Precision Hold which allows the vehicle to hover precisely above a LANDING_TARGET.</description>
         <param index="1" label="Enable">Enable or disable Precision Hold.</param>
         <param index="2" label="Target number">The ID of the target if multiple targets are present.</param>
         <param index="3" label="Staionary">Set to 1 if the target is expected to remain stationary. The vehicle should not follow the target if it moves.</param>
         <param index="4" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
-        <param index="5" label="Height above target">Set to zero to maintain current altitude.</param>
+        <param index="5" label="Height above target" units="m">Set to zero to maintain current altitude.</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1186,7 +1186,13 @@
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
       <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="true" isDestination="true">
-        <description>Vehicle moves to specified location and engages Precison Hold mode which allows the vehicle to hover precisely above a LANDING_TARGET. If Latitude/Longitude are FLT_MAX (COMMAND_LONG) or INT32_MAX (COMMAND_INT) the current position will be used instead. If Altitude is FLT_MAX (COMMAND_LONG) or INT32_MAX (COMMAND_INT) the current altitude will be used instead </description>
+        <description>
+          Vehicle moves to specified location (lat/lon/alt) and engages Precision Hold mode.
+          If it gets LANDING_TARGET messages for the indicated landing target it adjusts its horizontal position to align precisely above the target (and maintains altitude).
+          If the specified target is not found the vehicle holds the specified lat/lon/alt and enters normal Position Hold mode (the timeout for entering position hold is flight-stack specific).
+          If Latitude/Longitude are NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) the current position will be used.
+          If Altitude is NaN the vehicle altitude when the message is received will be used.
+        </description>
         <param index="1" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found the vehicle will use normal Position Hold mode.</param>
         <param index="2" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
         <param index="3" label="Height above target" units="m">Set to NaN to maintain current altitude.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1186,8 +1186,14 @@
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
       <entry value="35" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="false" isDestination="false">
-        <description>Initiate a precision hold at the current position and maintain a distance above a target.</description>
-        <param index="1" label="Height above target">Set to zero to maintain current altitude</param>
+        <description>Enable or disable a Precision Hold. Optional Latitude/Longitude and distance above target.</description>
+        <param index="1" label="Enable">Enable or disable Precision Hold.</param>
+        <param index="2" label="Height above target">Set to zero to maintain current altitude.</param>
+        <param index="3" label="Target number">The ID of the target if multiple targets are present.</param>
+        <param index="4" label="Staionary">Set to 1 if the target is expected to remain stationary. The vehicle should not follow the target if it moves.</param>
+        <param index="5" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
+        <param index="6" label="Latitude">Latitude to travel to before initiating Precision Hold. Set to NAN to use current position.</param>
+        <param index="7" label="Longitude">Longitude to travel to before initiating Precision Hold. Set to NAN to use current position.</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1185,6 +1185,10 @@
         <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. INT32_MAX (or NaN if sent in COMMAND_LONG): Use current vehicle position, or current center if already orbiting.</param>
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
+      <entry value="35" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="false" isDestination="false">
+        <description>Initiate a precision hold at the current position and maintain a distance above a target.</description>
+        <param index="1" label="Height above target">Set to zero to maintain current altitude</param>
+      </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>
         <description>Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicle's control system to control the vehicle attitude and the attitude of various sensors such as cameras.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1185,13 +1185,15 @@
         <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. INT32_MAX (or NaN if sent in COMMAND_LONG): Use current vehicle position, or current center if already orbiting.</param>
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
-      <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="false" isDestination="false">
-        <description>Enable or disable a Precision Hold which allows the vehicle to hover precisely above a LANDING_TARGET.</description>
+      <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="true" isDestination="true">
+        <description>Vehicle moves to specified location and enables or disables Precision Hold mode which allows the vehicle to hover precisely above a LANDING_TARGET. If any of the 3 fields Latitude/Longitude/Altitude are NAN the current position will be used instead.</description>
         <param index="1" label="Enable">Enable or disable Precision Hold.</param>
         <param index="2" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found, the lowest ID target available will be used.</param>
-        <param index="3" label="Stationary">Set to 1 if the target is expected to remain stationary. The vehicle should not follow the target if it moves.</param>
-        <param index="4" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
-        <param index="5" label="Height above target" units="m">Set to zero to maintain current altitude.</param>
+        <param index="3" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
+        <param index="4" label="Height above target" units="m">Set to zero to maintain current altitude.</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude">Altitude</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1197,9 +1197,9 @@
         <param index="2" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
         <param index="3" label="Height above target" units="m">Set to NaN to maintain current altitude.</param>
         <param index="4">Empty</param>
-        <param index="5" label="Latitude">Latitude</param>
-        <param index="6" label="Longitude">Longitude</param>
-        <param index="7" label="Altitude">Altitude</param>
+        <param index="5" label="Latitude/X">Latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME</param>
+        <param index="6" label="Longitude/Y">Longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME</param>
+        <param index="7" label="Altitude/Z">Altitude (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1198,7 +1198,7 @@
         <param index="3" label="Hold altitude" units="m">Altitude above target to hold position. NaN to hold at current altitude.</param>
         <param index="4">Empty</param>
         <param index="5" label="Initial Latitude/X">Latitude before entering Position Hold mode (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current latitude.</param>
-        <param index="6" label="Longitude/Y">Longitude before entering Position Hold mode (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current longitude.</param>
+        <param index="6" label="Initial Longitude/Y">Longitude before entering Position Hold mode (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current longitude.</param>
         <param index="7" label="Initial Altitude/Z">Altitude before entering Position Hold mode (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN to use current altitude.</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1188,8 +1188,8 @@
       <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="false" isDestination="false">
         <description>Enable or disable a Precision Hold which allows the vehicle to hover precisely above a LANDING_TARGET.</description>
         <param index="1" label="Enable">Enable or disable Precision Hold.</param>
-        <param index="2" label="Target number">The ID of the target if multiple targets are present.</param>
-        <param index="3" label="Staionary">Set to 1 if the target is expected to remain stationary. The vehicle should not follow the target if it moves.</param>
+        <param index="2" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found, the lowest ID target available will be used.</param>
+        <param index="3" label="Stationary">Set to 1 if the target is expected to remain stationary. The vehicle should not follow the target if it moves.</param>
         <param index="4" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
         <param index="5" label="Height above target" units="m">Set to zero to maintain current altitude.</param>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1187,7 +1187,7 @@
       </entry>
       <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="true" isDestination="true">
         <description>
-          Precision hold precisely over the 3d position defined in a particular LANDING_TARGET message (param1) at a hold altitude (param3) relative to the target.
+          Precision hold over the 3d position defined in a particular LANDING_TARGET message (param1) at a hold altitude (param3) relative to the target.
           The vehicle first moves to the initial location (param5, 6, 7) and then engages Precision Hold mode (Set initial location to NaN/INT32_MAX to engage Precision Hold at the current position).
           The vehicle waits at the initial location for LANDING_TARGET messages with the indicated id (param1).
           If found, it then aligns with the horizontal position defined in the LANDING_TARGET at a target-relative altitude specified in the Hold altitude field (param3).

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1187,17 +1187,19 @@
       </entry>
       <entry value="36" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="true" isDestination="true">
         <description>
-          Vehicle moves to location (if specified) and descends above a target. It will hold its position above the target at a fixed distance, specified in the param "Hold distance".
-          If it gets LANDING_TARGET messages for the indicated landing target it: adjusts its horizontal position to align precisely above the target, descends to above the target, and then hold the position at "Hold distance" from the target.
-          If the specified target is not found the vehicle holds the specified lat/lon/alt and enters normal Position Hold mode (the timeout for entering position hold is flight-stack specific).
+          Precision hold precisely over the 3d position defined in a particular LANDING_TARGET message (param1) at a hold altitude (param3) relative to the target.
+          The vehicle first moves to the initial location (param5, 6, 7) and then engages Precision Hold mode (Set initial location to NaN/INT32_MAX to engage Precision Hold at the current position).
+          The vehicle waits at the initial location for LANDING_TARGET messages with the indicated id (param1).
+          If found, it then aligns with the horizontal position defined in the LANDING_TARGET at a target-relative altitude specified in the Hold altitude field (param3).
+          If the specified target is not found within a timeout the vehicle enters normal Position Hold mode and holds its current position (the timeout is flight-stack specific).
         </description>
-        <param index="1" label="Target number">The ID of the target (LANDING_TARGET.target_num) if multiple targets are present. If the specified target is not found the vehicle will use normal Position Hold mode. 0 to use first target found.</param>
+        <param index="1" label="Target number">The ID of the target (LANDING_TARGET.target_num). 0 to use first target found. If the specified target is not found the vehicle will use normal Position Hold mode.</param>
         <param index="2" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
-        <param index="3" label="Hold distance" units="m">Distance above target to hold position. NaN to use current altitude.</param>
+        <param index="3" label="Hold altitude" units="m">Altitude above target to hold position. NaN to hold at current altitude.</param>
         <param index="4">Empty</param>
-        <param index="5" label="Latitude/X">Latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current latitude.</param>
-        <param index="6" label="Longitude/Y">Longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current longitude.</param>
-        <param index="7" label="Altitude/Z">Altitude (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN to use current altitude.</param>
+        <param index="5" label="Initial Latitude/X">Latitude before entering Position Hold mode (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current latitude.</param>
+        <param index="6" label="Longitude/Y">Longitude before entering Position Hold mode (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. NaN (COMMAND_LONG) or INT32_MAX (COMMAND_INT) to use current longitude.</param>
+        <param index="7" label="Initial Altitude/Z">Altitude before entering Position Hold mode (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN to use current altitude.</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1186,14 +1186,12 @@
         <param index="7" label="Altitude/Z">Center point altitude (MSL) (if no MAV_FRAME specified) / Z coordinate according to MAV_FRAME. NaN: Use current vehicle altitude.</param>
       </entry>
       <entry value="35" name="MAV_CMD_DO_PRECISION_HOLD" hasLocation="false" isDestination="false">
-        <description>Enable or disable a Precision Hold. Optional Latitude/Longitude and distance above target.</description>
+        <description>Enable or disable a Precision Hold which allows the vehicle to hover precisely above a target.</description>
         <param index="1" label="Enable">Enable or disable Precision Hold.</param>
-        <param index="2" label="Height above target">Set to zero to maintain current altitude.</param>
-        <param index="3" label="Target number">The ID of the target if multiple targets are present.</param>
-        <param index="4" label="Staionary">Set to 1 if the target is expected to remain stationary. The vehicle should not follow the target if it moves.</param>
-        <param index="5" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
-        <param index="6" label="Latitude">Latitude to travel to before initiating Precision Hold. Set to NAN to use current position.</param>
-        <param index="7" label="Longitude">Longitude to travel to before initiating Precision Hold. Set to NAN to use current position.</param>
+        <param index="2" label="Target number">The ID of the target if multiple targets are present.</param>
+        <param index="3" label="Staionary">Set to 1 if the target is expected to remain stationary. The vehicle should not follow the target if it moves.</param>
+        <param index="4" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>
+        <param index="5" label="Height above target">Set to zero to maintain current altitude.</param>
       </entry>
       <entry value="80" name="MAV_CMD_NAV_ROI" hasLocation="true" isDestination="false">
         <deprecated since="2018-01" replaced_by="MAV_CMD_DO_SET_ROI_*"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1191,7 +1191,7 @@
           The vehicle first moves to the initial location (param5, 6, 7) and then engages Precision Hold mode (Set initial location to NaN/INT32_MAX to engage Precision Hold at the current position).
           The vehicle waits at the initial location for LANDING_TARGET messages with the indicated id (param1).
           If found, it then aligns with the horizontal position defined in the LANDING_TARGET at a target-relative altitude specified in the Hold altitude field (param3).
-          If the specified target is not found within a timeout the vehicle enters normal Position Hold mode and holds its current position (the timeout is flight-stack specific).
+          If the specified target is not found within a (flight-stack specific) timeout the vehicle enters normal Position Hold mode and holds its current position.
         </description>
         <param index="1" label="Target number">The ID of the target (LANDING_TARGET.target_num). 0 to use first target found. If the specified target is not found the vehicle will use normal Position Hold mode.</param>
         <param index="2" label="Use Heading">Set to 1 if the drone should align it's heading with the target heading.</param>


### PR DESCRIPTION
This adds an additional MAV_CMD to initiate what I am dubbing a "Precision Hold". This is exactly the same thing as Precision Land except instead of landing the vehicle will control XY (and Z if specified) to hover precisely above a target. Ardupilot already has something similar called [Precision Loiter](https://ardupilot.org/copter/docs/precision-landing-with-irlock.html). I chose the term Hold because Loiter usually implies fixed wing aircraft and this feature cannot be used with a fixed wing. I've already implemented this in a fork of PX4 and will merge into upstream once there's proper mavlink support.

We must look at what already exists for the mavlink [Landing Target protocol](https://mavlink.io/en/services/landing_target.html) and [LANDING_TARGET](https://mavlink.io/en/services/landing_target.html) message.

**Minimum requirements of the command**
- Specify whether we wish to enable or disable the Precison Hold behavior
- Specify which target to use if multiple targets are present
- Specify a height offset above target to maintain or use current altitude
- Specify if the vehicle should follow the target if it moves
- Specify if the vehicle should align its heading with the target heading

I chose to exclude optional Latitude/Longitude since this would make the command coordinate based, which would then require an Altitude in AMSL and makes the command more complex to use in missions (as well as we are limited to 7 parameters -- Altitude would make it 8)