### PR TITLE
Add HEXADECAROTOR

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -200,6 +200,12 @@
       <entry value="42" name="MAV_TYPE_WINCH">
         <description>Winch</description>
       </entry>
+      <entry value="43" name="MAV_TYPE_HEXADECAROTOR">
+        <description>Hexadecarotor</description>
+      </entry>
+      <entry value="44" name="MAV_TYPE_OCTADECAROTOR">
+        <description>Octadecarotor</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
Add 16 rotor definition for OCTA-X16 COPTER.
18 rotor to be added for VOLOCOPTER.

https://github.com/ArduPilot/ardupilot/issues/21154

HexadecaOcta ( OCTA-X16) Copter
![Screenshot from 2022-07-14 06-05-45](https://user-images.githubusercontent.com/646194/178836709-158f0cff-a16d-4b2d-b469-d0e41558ac97.png)

VOLOCOPTER:
![Screenshot from 2022-07-11 07-03-03](https://user-images.githubusercontent.com/646194/178163702-0cc06aba-03ec-493d-9b83-a40873e3e94e.png)