### PR TITLE
Fix spelling errors

### DIFF
--- a/component_metadata/actuators.schema.json
+++ b/component_metadata/actuators.schema.json
@@ -17,17 +17,17 @@
             "properties": {
                 "min": {
                     "type": "number",
-                    "minium": -1,
+                    "minimum": -1,
                     "maximum": 1
                 },
                 "max": {
                     "type": "number",
-                    "minium": -1,
+                    "minimum": -1,
                     "maximum": 1
                 },
                 "default": {
                     "type": "number",
-                    "minium": -1,
+                    "minimum": -1,
                     "maximum": 1
                 },
                 "default-is-nan": {

--- a/component_metadata/parameter.schema.json
+++ b/component_metadata/parameter.schema.json
@@ -28,7 +28,7 @@
                         "enum":         [ "Uint8", "Int8", "Uint16", "Int16", "Uint32", "Int32", "Float" ]
                     },
                     "shortDesc": {
-                        "description":  "Short user facing description/name for parameter. Used in UI intead of internal parameter name.",
+                        "description":  "Short user facing description/name for parameter. Used in UI instead of internal parameter name.",
                         "type":         "string",
                         "default":      "",
                         "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'." 
@@ -43,7 +43,7 @@
                         "description":  "Units for parameter value.",
                         "type":         "string",
                         "default":      "",
-                        "comment":      "A 'Known Unit' allows a GCS to convert between units like meters to feet as needed. Known Units are: 'm/meter/meter', 'vertical m' - vertical distance, 'cm/px', 'm/s', 'C' - celcius, 'm^2', 'g' - grams, 'centi-degrees', 'radians', 'norm'."
+                        "comment":      "A 'Known Unit' allows a GCS to convert between units like meters to feet as needed. Known Units are: 'm/meter/meter', 'vertical m' - vertical distance, 'cm/px', 'm/s', 'C' - celsius, 'm^2', 'g' - grams, 'centi-degrees', 'radians', 'norm'."
                     },
                     "default": {
                         "description":  "Default value for parameter.",

--- a/doc/mavlink.php
+++ b/doc/mavlink.php
@@ -57,7 +57,7 @@ else
 <br />
 
 <p>
-Messages are defined by the <a href="https://raw.github.com/mavlink/mavlink/master/message_definitions/v1.0/common.xml">common.xml</a> file. The C packing/unpacking code is generated from this specification, as well as the HTML documentaiton in the section above.<br />
+Messages are defined by the <a href="https://raw.github.com/mavlink/mavlink/master/message_definitions/v1.0/common.xml">common.xml</a> file. The C packing/unpacking code is generated from this specification, as well as the HTML documentation in the section above.<br />
 <br />
 <i>The XML displayed here is updated on every commit and therefore up-to-date.</i>
 </p>

--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -41,7 +41,7 @@ index_text="""<!-- THIS FILE IS AUTO-GENERATED (DO NOT UPDATE GITBOOK): https://
 # XML Definition Files & Dialects
 
 MAVLink definitions files can be found in [mavlink/message definitions](https://github.com/mavlink/mavlink/blob/master/message_definitions/).
-These can roughtly be divided into:
+These can roughly be divided into:
 - [Standard definitions](#standard-definitions) - core definitions shared by many flight stacks
 - [Test definitions](#test-definitions) - definitions to support testing and validation
 - [Dialects](#dialects) - *protocol-* and *vendor-specific* messages, enums and commands
@@ -54,7 +54,7 @@ The following XML definition files are considered standard/core (i.e. not dialec
 - [minimal.xml](minimal.md) - the minimum set of entities (messages, enums, MAV_CMD) required to set up a MAVLink network.
 - [standard.xml](standard.md) - the standard set of entities that are implemented by almost all flight stacks (at least 2, in a compatible way).
   This `includes` [minimal.xml](minimal.md).
-- [common.xml](../messages/common.md) - the set of entitites that have been implemented in at least one core flight stack.
+- [common.xml](../messages/common.md) - the set of entities that have been implemented in at least one core flight stack.
   This `includes` [standard.xml](minimal.md)
 
 > **Note** We are still working towards moving the truly standard entities from **common.xml** to **standard.xml**

--- a/examples/linux/mavlink_udp.c
+++ b/examples/linux/mavlink_udp.c
@@ -21,7 +21,7 @@
  qgroundcontrol are printed by this program along with the heartbeats.
  
  
- I compiled this program sucessfully on Ubuntu 10.04 with the following command
+ I compiled this program successfully on Ubuntu 10.04 with the following command
  
  gcc -I ../../pixhawk/mavlink/include -o udp-server udp-server-test.c
  

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -225,10 +225,10 @@
       </entry>
     </enum>
     <enum name="MAV_FRAME">
-      <description>Co-ordinate frames used by MAVLink. Not all frames are supported by all commands, messages, or vehicles.
+      <description>Coordinate frames used by MAVLink. Not all frames are supported by all commands, messages, or vehicles.
       
       Global frames use the following naming conventions:
-      - "GLOBAL": Global co-ordinate frame with WGS84 latitude/longitude and altitude positive over mean sea level (MSL) by default. 
+      - "GLOBAL": Global coordinate frame with WGS84 latitude/longitude and altitude positive over mean sea level (MSL) by default. 
         The following modifiers may be used with "GLOBAL":
         - "RELATIVE_ALT": Altitude is relative to the vehicle home position rather than MSL.
         - "TERRAIN_ALT": Altitude is relative to ground level rather than MSL.
@@ -273,7 +273,7 @@
       </entry>
       <entry value="8" name="MAV_FRAME_BODY_NED">
         <deprecated since="2019-08" replaced_by="MAV_FRAME_BODY_FRD"/>
-        <description>Same as MAV_FRAME_LOCAL_NED when used to represent position values. Same as MAV_FRAME_BODY_FRD when used with velocity/accelaration values.</description>
+        <description>Same as MAV_FRAME_LOCAL_NED when used to represent position values. Same as MAV_FRAME_BODY_FRD when used with velocity/acceleration values.</description>
       </entry>
       <entry value="9" name="MAV_FRAME_BODY_OFFSET_NED">
         <deprecated since="2019-08" replaced_by="MAV_FRAME_BODY_FRD"/>
@@ -3722,7 +3722,7 @@
         <description>Zoom value as proportion of full camera range (a value between 0.0 and 100.0)</description>
       </entry>
       <entry value="3" name="ZOOM_TYPE_FOCAL_LENGTH">
-        <description>Zoom value/variable focal length in milimetres. Note that there is no message to get the valid zoom range of the camera, so this can type can only be used for cameras where the zoom range is known (implying that this cannot reliably be used in a GCS for an arbitrary camera)</description>
+        <description>Zoom value/variable focal length in millimetres. Note that there is no message to get the valid zoom range of the camera, so this can type can only be used for cameras where the zoom range is known (implying that this cannot reliably be used in a GCS for an arbitrary camera)</description>
       </entry>
     </enum>
     <enum name="SET_FOCUS_TYPE">
@@ -3761,7 +3761,7 @@
         <description>Parameter failed to set</description>
       </entry>
       <entry value="3" name="PARAM_ACK_IN_PROGRESS">
-        <description>Parameter value received but not yet set/accepted. A subsequent PARAM_ACK_TRANSACTION or PARAM_EXT_ACK with the final result will follow once operation is completed. This is returned immediately for parameters that take longer to set, indicating taht the the parameter was recieved and does not need to be resent.</description>
+        <description>Parameter value received but not yet set/accepted. A subsequent PARAM_ACK_TRANSACTION or PARAM_EXT_ACK with the final result will follow once operation is completed. This is returned immediately for parameters that take longer to set, indicating that the the parameter was received and does not need to be resent.</description>
       </entry>
     </enum>
     <enum name="CAMERA_MODE">
@@ -3965,7 +3965,7 @@
         <description>SIM is required for the modem but missing</description>
       </entry>
       <entry value="3" name="CELLULAR_NETWORK_FAILED_REASON_SIM_ERROR">
-        <description>SIM is available, but not usuable for connection</description>
+        <description>SIM is available, but not usable for connection</description>
       </entry>
     </enum>
     <enum name="CELLULAR_NETWORK_RADIO_TYPE">
@@ -4595,7 +4595,7 @@
         </description>
       </entry>
       <entry value="2" name="NAV_VTOL_LAND_OPTIONS_HOVER_DESCENT">
-        <description>Land in multicopter mode on reaching the landing co-ordinates (the whole landing is by "hover descent").</description>
+        <description>Land in multicopter mode on reaching the landing coordinates (the whole landing is by "hover descent").</description>
       </entry>
     </enum>
     <enum name="MAV_WINCH_STATUS_FLAG" bitmask="true">
@@ -4631,7 +4631,7 @@
         <description>Winch is redelivering the payload. This is a failover state if the line tension goes above a threshold during RETRACTING.</description>
       </entry>
       <entry value="1024" name="MAV_WINCH_STATUS_ABANDON_LINE">
-        <description>Winch is abandoning the line and possibly payload. Winch unspools the entire calculated line length. This is a failover state from REDELIVER if the number of attemps exceeds a threshold.</description>
+        <description>Winch is abandoning the line and possibly payload. Winch unspools the entire calculated line length. This is a failover state from REDELIVER if the number of attempts exceeds a threshold.</description>
       </entry>
     </enum>
     <enum name="MAG_CAL_STATUS">
@@ -5225,7 +5225,7 @@
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
     </message>
     <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
-      <description>Sets the GPS co-ordinates of the vehicle local origin (0,0,0) position. Vehicle should emit GPS_GLOBAL_ORIGIN irrespective of whether the origin is changed. This enables transform between the local coordinate frame and the global (GPS) coordinate frame, which may be necessary when (for example) indoor and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
+      <description>Sets the GPS coordinates of the vehicle local origin (0,0,0) position. Vehicle should emit GPS_GLOBAL_ORIGIN irrespective of whether the origin is changed. This enables transform between the local coordinate frame and the global (GPS) coordinate frame, which may be necessary when (for example) indoor and outdoor settings are connected and the MAV should move from in- to outdoor.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
@@ -5234,7 +5234,7 @@
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
     </message>
     <message id="49" name="GPS_GLOBAL_ORIGIN">
-      <description>Publishes the GPS co-ordinates of the vehicle local origin (0,0,0) position. Emitted whenever a new GPS-Local position mapping is requested or set - e.g. following SET_GPS_GLOBAL_ORIGIN message.</description>
+      <description>Publishes the GPS coordinates of the vehicle local origin (0,0,0) position. Emitted whenever a new GPS-Local position mapping is requested or set - e.g. following SET_GPS_GLOBAL_ORIGIN message.</description>
       <field type="int32_t" name="latitude" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="longitude" units="degE7">Longitude (WGS84)</field>
       <field type="int32_t" name="altitude" units="mm">Altitude (MSL). Positive for up.</field>
@@ -5804,7 +5804,7 @@
     </message>
     <message id="109" name="RADIO_STATUS">
       <description>Status generated by radio and injected into MAVLink stream.</description>
-      <field type="uint8_t" name="rssi" invalid="UINT8_MAX">Local (message sender) recieved signal strength indication in device-dependent units/scale. Values: [0-254], UINT8_MAX: invalid/unknown.</field>
+      <field type="uint8_t" name="rssi" invalid="UINT8_MAX">Local (message sender) received signal strength indication in device-dependent units/scale. Values: [0-254], UINT8_MAX: invalid/unknown.</field>
       <field type="uint8_t" name="remrssi" invalid="UINT8_MAX">Remote (message receiver) signal strength indication in device-dependent units/scale. Values: [0-254], UINT8_MAX: invalid/unknown.</field>
       <field type="uint8_t" name="txbuf" units="%">Remaining free transmitter buffer space.</field>
       <field type="uint8_t" name="noise" invalid="UINT8_MAX">Local background noise level. These are device dependent RSSI values (scale as approx 2x dB on SiK radios). Values: [0-254], UINT8_MAX: invalid/unknown.</field>
@@ -5831,7 +5831,7 @@
     </message>
     <message id="113" name="HIL_GPS">
       <description>The global position, as returned by the Global Positioning System (GPS). This is
-                 NOT the global position estimate of the sytem, but rather a RAW sensor value. See message GLOBAL_POSITION_INT for the global position estimate.</description>
+                 NOT the global position estimate of the system, but rather a RAW sensor value. See message GLOBAL_POSITION_INT for the global position estimate.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
@@ -7336,7 +7336,7 @@
       <field type="uint8_t[64]" name="data">Frame data</field>
     </message>
     <message id="388" name="CAN_FILTER_MODIFY">
-      <description>Modify the filter of what CAN messages to forward over the mavlink. This can be used to make CAN forwarding work well on low bandwith links. The filtering is applied on bits 8 to 24 of the CAN id (2nd and 3rd bytes) which corresponds to the DroneCAN message ID for DroneCAN. Filters with more than 16 IDs can be constructed by sending multiple CAN_FILTER_MODIFY messages.</description>
+      <description>Modify the filter of what CAN messages to forward over the mavlink. This can be used to make CAN forwarding work well on low bandwidth links. The filtering is applied on bits 8 to 24 of the CAN id (2nd and 3rd bytes) which corresponds to the DroneCAN message ID for DroneCAN. Filters with more than 16 IDs can be constructed by sending multiple CAN_FILTER_MODIFY messages.</description>
       <field type="uint8_t" name="target_system">System ID.</field>
       <field type="uint8_t" name="target_component">Component ID.</field>
       <field type="uint8_t" name="bus">bus number</field>
@@ -7459,7 +7459,7 @@
       <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
       <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
       <field type="uint8_t[20]" name="id_or_mac">Only used for drone ID data received from other UAs. See detailed description at https://mavlink.io/en/services/opendroneid.html. </field>
-      <field type="uint8_t" name="single_message_size" units="bytes">This field must currently always be equal to 25 (bytes), since all encoded OpenDroneID messages are specificed to have this length.</field>
+      <field type="uint8_t" name="single_message_size" units="bytes">This field must currently always be equal to 25 (bytes), since all encoded OpenDroneID messages are specified to have this length.</field>
       <field type="uint8_t" name="msg_pack_size">Number of encoded messages in the pack (not the number of bytes). Allowed range is 1 - 9.</field>
       <field type="uint8_t[225]" name="messages">Concatenation of encoded OpenDroneID messages. Shall be filled with nulls in the unused portion of the field.</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -258,7 +258,7 @@
       <field type="int16_t" name="start_index">Start index for partial mission change (-1 for all items).</field>
       <field type="int16_t" name="end_index">End index of a partial mission change. -1 is a synonym for the last mission item (i.e. selects all items from start_index). Ignore field if start_index=-1.</field>
       <field type="uint8_t" name="origin_sysid">System ID of the author of the new mission.</field>
-      <field type="uint8_t" name="origin_compid" enum="MAV_COMPONENT">Compnent ID of the author of the new mission.</field>
+      <field type="uint8_t" name="origin_compid" enum="MAV_COMPONENT">Component ID of the author of the new mission.</field>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
     </message>
     <message id="53" name="MISSION_CHECKSUM">
@@ -314,7 +314,7 @@
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t[32]" name="vendor_name">Name of the component vendor</field>
       <field type="uint8_t[32]" name="model_name">Name of the component model</field>
-      <field type="char[24]" name="software_version">Sofware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
+      <field type="char[24]" name="software_version">Software version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
       <field type="char[24]" name="hardware_version">Hardware version. The version format can be custom, recommended is SEMVER 'major.minor.patch'.</field>
       <field type="uint64_t" name="capabilities" enum="MAV_PROTOCOL_CAPABILITY" display="bitmask">Component capability flags</field>
     </message>

--- a/message_definitions/v1.0/matrixpilot.xml
+++ b/message_definitions/v1.0/matrixpilot.xml
@@ -53,7 +53,7 @@
       <field type="uint8_t" name="target_component">Component ID</field>
     </message>
     <message id="151" name="FLEXIFUNCTION_READ_REQ">
-      <description>Reqest reading of flexifunction data</description>
+      <description>Request reading of flexifunction data</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="int16_t" name="read_req_type">Type of flexifunction data requested</field>
@@ -77,7 +77,7 @@
       <field type="uint16_t" name="result">result of acknowledge, 0=fail, 1=good</field>
     </message>
     <message id="155" name="FLEXIFUNCTION_DIRECTORY">
-      <description>Acknowldge sucess or failure of a flexifunction command</description>
+      <description>Acknowldge success or failure of a flexifunction command</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="directory_type">0=inputs, 1=outputs</field>
@@ -86,7 +86,7 @@
       <field type="int8_t[48]" name="directory_data">Settings data</field>
     </message>
     <message id="156" name="FLEXIFUNCTION_DIRECTORY_ACK">
-      <description>Acknowldge sucess or failure of a flexifunction command</description>
+      <description>Acknowldge success or failure of a flexifunction command</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="directory_type">0=inputs, 1=outputs</field>
@@ -95,13 +95,13 @@
       <field type="uint16_t" name="result">result of acknowledge, 0=fail, 1=good</field>
     </message>
     <message id="157" name="FLEXIFUNCTION_COMMAND">
-      <description>Acknowldge sucess or failure of a flexifunction command</description>
+      <description>Acknowldge success or failure of a flexifunction command</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="command_type">Flexifunction command type</field>
     </message>
     <message id="158" name="FLEXIFUNCTION_COMMAND_ACK">
-      <description>Acknowldge sucess or failure of a flexifunction command</description>
+      <description>Acknowldge success or failure of a flexifunction command</description>
       <field type="uint16_t" name="command_type">Command acknowledged</field>
       <field type="uint16_t" name="result">result of acknowledge</field>
     </message>
@@ -132,7 +132,7 @@
       <field type="int16_t" name="sue_magFieldEarth0">Serial UDB Extra Magnetic Field Earth 0 </field>
       <field type="int16_t" name="sue_magFieldEarth1">Serial UDB Extra Magnetic Field Earth 1 </field>
       <field type="int16_t" name="sue_magFieldEarth2">Serial UDB Extra Magnetic Field Earth 2 </field>
-      <field type="int16_t" name="sue_svs">Serial UDB Extra Number of Sattelites in View</field>
+      <field type="int16_t" name="sue_svs">Serial UDB Extra Number of Satellites in View</field>
       <field type="int16_t" name="sue_hdop">Serial UDB Extra GPS Horizontal Dilution of Precision</field>
     </message>
     <message id="171" name="SERIAL_UDB_EXTRA_F2_B">

--- a/message_definitions/v1.0/storm32.xml
+++ b/message_definitions/v1.0/storm32.xml
@@ -189,7 +189,7 @@ Documentation:
         <description>RC control. The RC input signal fed to the gimbal device exclusively controls the gimbal's orientation. Overrides RC_MIXED flag if that is also set.</description>
       </entry>
       <entry value="2048" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_RC_MIXED">
-        <description>RC control. The RC input signal fed to the gimbal device is mixed into the gimbal's orientation. Is overriden by RC_EXCLUSIVE flag if that is also set.</description>
+        <description>RC control. The RC input signal fed to the gimbal device is mixed into the gimbal's orientation. Is overridden by RC_EXCLUSIVE flag if that is also set.</description>
       </entry>
       <entry value="65535" name="MAV_STORM32_GIMBAL_DEVICE_FLAGS_NONE">
         <description>UINT16_MAX = ignore.</description>
@@ -244,7 +244,7 @@ Documentation:
     </enum>
     <enum name="MAV_STORM32_GIMBAL_MANAGER_FLAGS" bitmask="true">
       <!-- Quite stable -->
-      <description>Flags for gimbal manager operation. Used for setting and reporting, unless specified otherwise. If a setting is accepted by the gimbal manger, is reported in the STORM32_GIMBAL_MANAGER_STATUS message.</description>
+      <description>Flags for gimbal manager operation. Used for setting and reporting, unless specified otherwise. If a setting is accepted by the gimbal manager, is reported in the STORM32_GIMBAL_MANAGER_STATUS message.</description>
       <entry value="0" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_NONE">
         <description>0 = ignore.</description>
       </entry>
@@ -368,7 +368,7 @@ Documentation:
         <description>Undefined shot mode. Can be used to determine if qshots should be used or not.</description>
       </entry>
       <entry value="1" name="MAV_QSHOT_MODE_DEFAULT">
-        <description>Start normal gimbal operation. Is usally used to return back from a shot.</description>
+        <description>Start normal gimbal operation. Is usually used to return back from a shot.</description>
       </entry>
       <entry value="2" name="MAV_QSHOT_MODE_GIMBAL_RETRACT">
         <description>Load and keep safe gimbal position and stop stabilization.</description>

--- a/message_definitions/v1.0/uAvionix.xml
+++ b/message_definitions/v1.0/uAvionix.xml
@@ -93,7 +93,7 @@
       <field type="uint8_t" name="gpsOffsetLat" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT">GPS antenna lateral offset (table 2-36 of DO-282B)</field>
       <field type="uint8_t" name="gpsOffsetLon" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON">GPS antenna longitudinal offset from nose [if non-zero, take position (in meters) divide by 2 and add one] (table 2-37 DO-282B)</field>
       <field type="uint16_t" name="stallSpeed" units="cm/s">Aircraft stall speed in cm/s</field>
-      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT" display="bitmask">ADS-B transponder reciever and transmit enable flags</field>
+      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT" display="bitmask">ADS-B transponder receiver and transmit enable flags</field>
     </message>
     <message id="10002" name="UAVIONIX_ADSB_OUT_DYNAMIC">
       <description>Dynamic data used to generate ADS-B out transponder data (send at 5Hz)</description>


### PR DESCRIPTION
This PR applies automatic edits done with the following command:
codespell --summary --ignore-words-list mot,ned,parm,parms,upto --skip cmake --write-changes

Except the changes in component_metadata/actuators.schema.json all edits are done in texts means for humans, such as descriptions and comments.