### PR TITLE
Add post-landed behavior setting for NAV_LAND command

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1086,8 +1086,8 @@
       <entry value="21" name="MAV_CMD_NAV_LAND" hasLocation="true" isDestination="true">
         <description>Land at location.</description>
         <param index="1" label="Abort Alt" units="m">Minimum target altitude if landing is aborted (0 = undefined/use system default).</param>
-        <param index="2" label="Land Mode" enum="PRECISION_LAND_MODE">Precision land mode.</param>
-        <param index="3">Empty.</param>
+        <param index="2" label="Precision land Mode" enum="PRECISION_LAND_MODE">Precision land mode.</param>
+        <param index="3" label="Post landed behavior" enum="POST_LAND_BEHAVIOR">Behavior after being landed (do auto-disarm? or continue onto next mission item? etc.)</param>
         <param index="4" label="Yaw Angle" units="deg">Desired yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
         <param index="5" label="Latitude">Latitude.</param>
         <param index="6" label="Longitude">Longitude.</param>
@@ -3986,6 +3986,12 @@
       </entry>
       <entry value="2" name="PRECISION_LAND_MODE_REQUIRED">
         <description>Use precision landing, searching for beacon if not found when land command accepted (land normally if beacon cannot be found).</description>
+      </entry>
+    </enum>
+    <enum name="POST_LAND_BEHAVIOR" bitmask="true">
+      <description>Configuration for post-landed behavior (bitmask)</description>
+      <entry value="1" name="POST_LAND_BEHAVIOR_DONT_DISARM">
+        <description>Don't disarm automatically after landing (e.g. when the vehicle should land and takeoff automatically to continue mission)</description>
       </entry>
     </enum>
     <!-- parachute action enum -->


### PR DESCRIPTION
## Context
With a recent PR in [PX4-Autopilot](https://github.com/PX4/PX4-Autopilot/pull/19659), which **introduced the possibility to plan a mission where the vehicle lands & takes off and continues to the next mission item**, whereas previously the vehicle would've disarmed and wouldn't continue the mission, the following behavioral change was introduced:

![image](https://user-images.githubusercontent.com/4668506/168588748-6516e457-7ec5-4073-8f9c-c76534e17716.gif)
GIF from the PR

### Use case that was affected
Let's imagine you are a operator of a simple package delivery service in Hawaii.

You want to plan a mission of package delivery from the bottom of the mountain, to the top, land, and then make it return to launch. The mission flow until now has been something like this:
1. Operator triggers the start of the mission
2. Drone reaches the top of the mountain, lands
3. Drone disarms itself
4. Operator takes the package out of the drone
5. Operator triggers 'mission continue'
6. Drone comes back to the launch

However, with the new change, it would look like this (only step 3 ~ 5 affected)
3. **Drone doesn't disarm and idles (keeps spinning the propeller)**
4. Operator is suprised as to why the drone didn't disarm
5. Drone takes-off, then flies back to the launch

## Solution
The fact that vehicle disarms after landing has been useful in a lot of cases including the example but as well as doing a battery hot-swap (for long-range missions). And until now that was a reasonable assumption. However, with the use cases like package delivery (where the vehicle lands, places the package, then resumes the mission automatically), this assumption doesn't always hold true.

So I would like to propose specifying the **"Post Land" behavior** in the NAV_LAND command as the Mission item. With this change, without exclusively setting the Bit 1 to indicate "Don't disarm", the vehicle automatically disarming after landing behavior would be preserved.

And if the bit is set, the auto-continue in the middle of the mission would be supported as well (which would make the land-amid-mission PR more feature-complete).

## Other
Thank you :wink: Open for feedbacks!