### PR TITLE
Mission item - document values for autocontinue

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5160,7 +5160,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the mission item completes.</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the item completes (after which it can be restarted using MAV_CMD_DO_PAUSE_CONTINUE or MAV_CMD_OVERRIDE_GOTO).</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
@@ -5419,7 +5419,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the mission item completes.</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true.Set false to pause mission after the item completes (after which it can be restarted using MAV_CMD_DO_PAUSE_CONTINUE or MAV_CMD_OVERRIDE_GOTO).</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5160,7 +5160,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the item completes (after which it can be restarted using MAV_CMD_DO_PAUSE_CONTINUE or MAV_CMD_OVERRIDE_GOTO).</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the item completes (after which it can be restarted using MAV_CMD_DO_PAUSE_CONTINUE).</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
@@ -5419,7 +5419,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true.Set false to pause mission after the item completes (after which it can be restarted using MAV_CMD_DO_PAUSE_CONTINUE or MAV_CMD_OVERRIDE_GOTO).</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the item completes (after which it can be restarted using MAV_CMD_DO_PAUSE_CONTINUE).</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5184,7 +5184,7 @@
       <description>
         Set the mission item with sequence number seq as the current item and emit MISSION_CURRENT (whether or not the mission number changed).
         The system will continue to this mission item on the shortest path, skipping any intermediate mission items.
-        If the mission is paused, the system will continue to the new item after it is restarted.
+        If the mission is paused, the mission may need to be restarted before continuing to the new item.
       </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5181,11 +5181,7 @@
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
     </message>
     <message id="41" name="MISSION_SET_CURRENT">
-      <description>
-        Set the mission item with sequence number seq as the current item and emit MISSION_CURRENT (whether or not the mission number changed).
-        The system will continue to this mission item on the shortest path, skipping any intermediate mission items.
-        If the mission is paused, it may need to be resumed before continuing.
-      </description>
+      <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="seq">Sequence</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5182,7 +5182,7 @@
     </message>
     <message id="41" name="MISSION_SET_CURRENT">
       <description>
-        Set the mission item with sequence number seq as the current item.
+        Set the mission item with sequence number seq as the current item and emit MISSION_CURRENT (whether or not the mission number changed).
         The system will continue to this mission item on the shortest path, skipping any intermediate mission items.
         If the mission is paused, the system will continue to the new item after it is restarted.
       </description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5160,7 +5160,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the item completes (after which it can be restarted using MAV_CMD_DO_PAUSE_CONTINUE).</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the item completes.</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
@@ -5184,7 +5184,7 @@
       <description>
         Set the mission item with sequence number seq as the current item.
         The system will continue to this mission item on the shortest path, skipping any intermediate mission items.
-        If the mission is paused, the system will continue to the new item after it is restarted (MAV_CMD_DO_PAUSE_CONTINUE).
+        If the mission is paused, the system will continue to the new item after it is restarted.
       </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
@@ -5423,7 +5423,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the item completes (after which it can be restarted using MAV_CMD_DO_PAUSE_CONTINUE).</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the item completes.</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5184,7 +5184,7 @@
       <description>
         Set the mission item with sequence number seq as the current item and emit MISSION_CURRENT (whether or not the mission number changed).
         The system will continue to this mission item on the shortest path, skipping any intermediate mission items.
-        If the mission is paused, it may need to be restarted before continuing.
+        If the mission is paused, it may need to be resumed before continuing.
       </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5184,7 +5184,7 @@
       <description>
         Set the mission item with sequence number seq as the current item and emit MISSION_CURRENT (whether or not the mission number changed).
         The system will continue to this mission item on the shortest path, skipping any intermediate mission items.
-        If the mission is paused, the mission may need to be restarted before continuing to the new item.
+        If the mission is paused, it may need to be restarted before continuing.
       </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5181,7 +5181,11 @@
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
     </message>
     <message id="41" name="MISSION_SET_CURRENT">
-      <description>Set the mission item with sequence number seq as current item. This means that the MAV will continue to this mission item on the shortest path (not following the mission items in-between).</description>
+      <description>
+        Set the mission item with sequence number seq as the current item.
+        The system will continue to this mission item on the shortest path, skipping any intermediate mission items.
+        If the mission is paused, the system will continue to the new item after it is restarted (MAV_CMD_DO_PAUSE_CONTINUE).
+      </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="seq">Sequence</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5160,7 +5160,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the mission item completes.</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>
@@ -5419,7 +5419,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the waypoint.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the waypoint.</field>
       <field type="uint8_t" name="current">false:0, true:1</field>
-      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint</field>
+      <field type="uint8_t" name="autocontinue">Autocontinue to next waypoint. 0: false, 1: true. Set false to pause mission after the mission item completes.</field>
       <field type="float" name="param1">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2">PARAM2, see MAV_CMD enum</field>
       <field type="float" name="param3">PARAM3, see MAV_CMD enum</field>


### PR DESCRIPTION
Autocontinue field can be set true or false. If true when the mission item is "achieved" it will start executing the next item. If false, it will pause until explicitly commanded to proceed using MAV_CMD_DO_PAUSE_CONTINUE or MAV_CMD_OVERRIDE_GOTO.

This makes it clear how the command should be used - since it wasn't clear what values would cause what behaviour.