### PR TITLE
common: extend MISSION_CURRENT

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4851,28 +4851,28 @@
         <description>NAK: NAK response</description>
       </entry>
     </enum>
-    <enum name="MISSION_FSM_STATE">
+    <enum name="MISSION_STATE">
       <description>
-        States of the mission finite state machine.
+        States of the mission state machine.
         Note that these states are independent of whether the mission is in a mode that can execute mission items or not (is suspended).
         They may not all be relevant on all vehicles.
       </description>
-      <entry value="0" name="MISSION_FSM_STATE_UNKNOWN">
+      <entry value="0" name="MISSION_STATE_UNKNOWN">
         <description>The mission status reporting is not supported.</description>
       </entry>
-      <entry value="1" name="MISSION_FSM_STATE_NO_MISSION">
+      <entry value="1" name="MISSION_STATE_NO_MISSION">
         <description>No mission on the vehicle.</description>
       </entry>
-      <entry value="2" name="MISSION_FSM_STATE_NOT_STARTED">
+      <entry value="2" name="MISSION_STATE_NOT_STARTED">
         <description>Mission has not started. This is the case after a mission has uploaded but not yet started executing.</description>
       </entry>
-      <entry value="3" name="MISSION_FSM_STATE_ACTIVE">
+      <entry value="3" name="MISSION_STATE_ACTIVE">
         <description>Mission is active, and will execute mission items when in auto mode.</description>
       </entry>
-      <entry value="4" name="MISSION_FSM_STATE_PAUSED">
+      <entry value="4" name="MISSION_STATE_PAUSED">
         <description>Mission is paused when in auto mode.</description>
       </entry>
-      <entry value="5" name="MISSION_FSM_STATE_COMPLETE">
+      <entry value="5" name="MISSION_STATE_COMPLETE">
         <description>Mission has executed all mission items.</description>
       </entry>
     </enum>
@@ -5220,8 +5220,8 @@
       <field type="uint16_t" name="seq">Sequence</field>
       <extensions/>
       <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
-      <field type="uint8_t" name="status" enum="MISSION_FSM_STATE" invalid="0">Mission finite state machine state. MISSION_FSM_STATE_UNKNOWN if state reporting not supported.</field>
-      <field type="uint8_t" name="mission mode" minValue="0" maxValue="2" increment="1" invalid="0">Vehicle is in a mode that can execute mission items (not suspended). 0: Unknown, 1: Mission mode, 2: Not in mission mode (suspended).</field>
+      <field type="uint8_t" name="mission_state" enum="MISSION_STATE" invalid="0">Mission state machine state. MISSION_STATE_UNKNOWN if state reporting not supported.</field>
+      <field type="uint8_t" name="mission_mode" minValue="0" maxValue="2" increment="1" invalid="0">Vehicle is in a mode that can execute mission items or suspended. 0: Unknown, 1: In mission mode, 2: Suspended (not in mission mode).</field>
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">
       <description>Request the overall list of mission items from the system/component.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4862,13 +4862,16 @@
       <entry value="2" name="MISSION_STATUS_ACTIVE">
         <description>The mission is running and active.</description>
       </entry>
-      <entry value="3" name="MISSION_STATUS_ACTIVE_NOT_IN_MISSION_MODE">
-        <description>The mission would be running but we're not in mission mode.</description>
+      <entry value="3" name="MISSION_STATUS_PAUSED_MANUAL">
+        <description>The mission has been paused by the a user command or by changing the flight mode.</description>
       </entry>
-      <entry value="4" name="MISSION_STATUS_PAUSED">
-        <description>The mission has been paused with autocontinue=false.</description>
+      <entry value="4" name="MISSION_STATUS_PAUSED_AUTO">
+        <description>The mission has been automatically paused due to completion of an item with autocontinue=false.</description>
       </entry>
       <entry value="5" name="MISSION_STATUS_FINISHED">
+        <description>The Mission has been finished.</description>
+      </entry>
+      <entry value="6" name="MISSION_STATUS_NO_MISSION_UPLOADED">
         <description>The Mission has been finished.</description>
       </entry>
     </enum>
@@ -5208,10 +5211,14 @@
       <field type="uint16_t" name="seq">Sequence</field>
     </message>
     <message id="42" name="MISSION_CURRENT">
-      <description>Message that announces the sequence number of the current active mission item. The MAV will fly towards this mission item.</description>
+      <description>
+        Message that announces the sequence number of the current target mission item (that the system will fly towards/execute when the mission is running).
+        This message should be streamed all the time (nominally at 1Hz).
+        This message should be emitted following a call to MAV_CMD_DO_SET_MISSION_CURRENT or SET_MISSION_CURRENT.
+      </description>
       <field type="uint16_t" name="seq">Sequence</field>
       <extensions/>
-      <field type="uint16_t" name="total">Total number of mission items</field>
+      <field type="uint16_t" name="total">Total number of mission items. 0 if no mission is present on the vehicle.</field>
       <field type="uint8_t" name="status" enum="MISSION_STATUS">Mission status</field>
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5220,7 +5220,7 @@
       <field type="uint16_t" name="seq">Sequence</field>
       <extensions/>
       <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
-      <field type="uint8_t" name="status" enum="MISSION_FSM_STATE">Mission finite state machine state. MISSION_FSM_STATE_UNKNOWN if state reporting not supported.</field>
+      <field type="uint8_t" name="status" enum="MISSION_FSM_STATE" invalid="0">Mission finite state machine state. MISSION_FSM_STATE_UNKNOWN if state reporting not supported.</field>
       <field type="uint8_t" name="mission mode" minValue="0" maxValue="2" increment="1" invalid="0">Vehicle is in a mode that can execute mission items (not suspended). 0: Unknown, 1: Mission mode, 2: Not in mission mode (suspended).</field>
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4862,11 +4862,11 @@
       <entry value="2" name="MISSION_STATUS_ACTIVE">
         <description>The mission is running and active.</description>
       </entry>
-      <entry value="3" name="MISSION_STATUS_PAUSED_MANUAL">
-        <description>The mission has been paused by the a user command or by changing the flight mode.</description>
+      <entry value="3" name="MISSION_STATUS_PAUSED_MODE_CHANGE">
+        <description>The mission has been paused by changing the flight mode.</description>
       </entry>
       <entry value="4" name="MISSION_STATUS_PAUSED_AUTO">
-        <description>The mission has been automatically paused due to completion of an item with autocontinue=false.</description>
+        <description>The mission has been paused in mission mode. For example, automatically paused due to completion of an item with autocontinue=false.</description>
       </entry>
       <entry value="5" name="MISSION_STATUS_FINISHED">
         <description>The Mission has been finished.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4851,28 +4851,29 @@
         <description>NAK: NAK response</description>
       </entry>
     </enum>
-    <enum name="MISSION_STATUS">
-      <description>Status of a mission.</description>
-      <entry value="0" name="MISSION_STATUS_UNKNOWN">
-        <description>The mission status is not supported.</description>
+    <enum name="MISSION_FSM_STATE">
+      <description>
+        States of the mission finite state machine.
+        Note that these states are independent of whether the mission is in a mode that can execute mission items or not (is suspended).
+        They may not all be relevant on all vehicles.
+      </description>
+      <entry value="0" name="MISSION_FSM_STATE_UNKNOWN">
+        <description>The mission status reporting is not supported.</description>
       </entry>
-      <entry value="1" name="MISSION_STATUS_NOT_STARTED">
-        <description>The mission has not been started yet. This is the case after upload when there is no active mission.</description>
+      <entry value="1" name="MISSION_FSM_STATE_NO_MISSION">
+        <description>No mission on the vehicle.</description>
       </entry>
-      <entry value="2" name="MISSION_STATUS_ACTIVE">
-        <description>The mission is running and active.</description>
+      <entry value="2" name="MISSION_FSM_STATE_NOT_STARTED">
+        <description>Mission has not started. This is the case after a mission has uploaded but not yet started executing.</description>
       </entry>
-      <entry value="3" name="MISSION_STATUS_PAUSED_MODE_CHANGE">
-        <description>The mission has been paused by changing the flight mode.</description>
+      <entry value="3" name="MISSION_FSM_STATE_ACTIVE">
+        <description>Mission is active, and will execute mission items when in auto mode.</description>
       </entry>
-      <entry value="4" name="MISSION_STATUS_PAUSED_AUTO">
-        <description>The mission has been paused in mission mode. For example, automatically paused due to completion of an item with autocontinue=false.</description>
+      <entry value="4" name="MISSION_FSM_STATE_PAUSED">
+        <description>Mission is paused when in auto mode.</description>
       </entry>
-      <entry value="5" name="MISSION_STATUS_FINISHED">
-        <description>The Mission has been finished.</description>
-      </entry>
-      <entry value="6" name="MISSION_STATUS_NO_MISSION_UPLOADED">
-        <description>There is no mission on the vehicle.</description>
+      <entry value="5" name="MISSION_FSM_STATE_COMPLETE">
+        <description>Mission has executed all mission items.</description>
       </entry>
     </enum>
   </enums>
@@ -5218,8 +5219,9 @@
       </description>
       <field type="uint16_t" name="seq">Sequence</field>
       <extensions/>
-      <field type="uint16_t" name="total">Total number of mission items. 0 if no mission is present on the vehicle.</field>
-      <field type="uint8_t" name="status" enum="MISSION_STATUS">Mission status</field>
+      <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
+      <field type="uint8_t" name="status" enum="MISSION_FSM_STATE">Mission finite state machine state. MISSION_FSM_STATE_UNKNOWN if state reporting not supported.</field>
+      <field type="uint8_t" name="mission mode" minValue="0" maxValue="2" increment="1">Vehicle is in a mode that can execute mission items (not suspended). 0: Unknown, 1: Mission mode, 2: Not in mission mode (suspended).</field>
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">
       <description>Request the overall list of mission items from the system/component.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4851,6 +4851,27 @@
         <description>NAK: NAK response</description>
       </entry>
     </enum>
+    <enum name="MISSION_STATUS">
+      <description>Status of a mission.</description>
+      <entry value="0" name="MISSION_STATUS_UNKNOWN">
+        <description>The mission status is not supported.</description>
+      </entry>
+      <entry value="1" name="MISSION_STATUS_NOT_STARTED">
+        <description>The mission has not been started yet. This is the case after upload when there is no active mission.</description>
+      </entry>
+      <entry value="2" name="MISSION_STATUS_ACTIVE">
+        <description>The mission is running and active.</description>
+      </entry>
+      <entry value="3" name="MISSION_STATUS_ACTIVE_NOT_IN_MISSION_MODE">
+        <description>The mission would be running but we're not in mission mode.</description>
+      </entry>
+      <entry value="4" name="MISSION_STATUS_PAUSED">
+        <description>The mission has been paused with autocontinue=false.</description>
+      </entry>
+      <entry value="5" name="MISSION_STATUS_FINISHED">
+        <description>The Mission has been finished.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="1" name="SYS_STATUS">
@@ -5189,6 +5210,9 @@
     <message id="42" name="MISSION_CURRENT">
       <description>Message that announces the sequence number of the current active mission item. The MAV will fly towards this mission item.</description>
       <field type="uint16_t" name="seq">Sequence</field>
+      <extensions/>
+      <field type="uint16_t" name="total">Total number of mission items</field>
+      <field type="uint8_t" name="status" enum="MISSION_STATUS">Mission status</field>
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">
       <description>Request the overall list of mission items from the system/component.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4872,7 +4872,7 @@
         <description>The Mission has been finished.</description>
       </entry>
       <entry value="6" name="MISSION_STATUS_NO_MISSION_UPLOADED">
-        <description>The Mission has been finished.</description>
+        <description>There is no mission on the vehicle.</description>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5221,7 +5221,7 @@
       <extensions/>
       <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
       <field type="uint8_t" name="status" enum="MISSION_FSM_STATE">Mission finite state machine state. MISSION_FSM_STATE_UNKNOWN if state reporting not supported.</field>
-      <field type="uint8_t" name="mission mode" minValue="0" maxValue="2" increment="1">Vehicle is in a mode that can execute mission items (not suspended). 0: Unknown, 1: Mission mode, 2: Not in mission mode (suspended).</field>
+      <field type="uint8_t" name="mission mode" minValue="0" maxValue="2" increment="1" invalid="0">Vehicle is in a mode that can execute mission items (not suspended). 0: Unknown, 1: Mission mode, 2: Not in mission mode (suspended).</field>
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">
       <description>Request the overall list of mission items from the system/component.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5221,7 +5221,7 @@
       <extensions/>
       <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
       <field type="uint8_t" name="mission_state" enum="MISSION_STATE" invalid="0">Mission state machine state. MISSION_STATE_UNKNOWN if state reporting not supported.</field>
-      <field type="uint8_t" name="mission_mode" minValue="0" maxValue="2" increment="1" invalid="0">Vehicle is in a mode that can execute mission items or suspended. 0: Unknown, 1: In mission mode, 2: Suspended (not in mission mode).</field>
+      <field type="uint8_t" name="mission_mode" invalid="0">Vehicle is in a mode that can execute mission items or suspended. 0: Unknown, 1: In mission mode, 2: Suspended (not in mission mode).</field>
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">
       <description>Request the overall list of mission items from the system/component.</description>


### PR DESCRIPTION
The message MISSION_CURRENT is a bit limited as it sends the current mission item sequence but no context.

My proposition would be to include the total as well as the status of an ongoing mission.

Related to https://github.com/mavlink/mavlink/pull/1868.