### PR TITLE
Jump commands - can only be used in missions

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1467,7 +1467,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="177" name="MAV_CMD_DO_JUMP" hasLocation="false" isDestination="false">
+      <entry value="177" name="MAV_CMD_DO_JUMP" hasLocation="false" isDestination="false" missionOnly="true">
         <description>Jump to the desired command in the mission list.  Repeat this action only the specified number of times</description>
         <param index="1" label="Number" minValue="0" increment="1">Sequence number</param>
         <param index="2" label="Repeat" minValue="0" increment="1">Repeat count</param>
@@ -2234,7 +2234,7 @@
         <description>Tagged jump target. Can be jumped to with MAV_CMD_DO_JUMP_TAG.</description>
         <param index="1" label="Tag" minValue="0" increment="1">Tag.</param>
       </entry>
-      <entry value="601" name="MAV_CMD_DO_JUMP_TAG" hasLocation="false" isDestination="false">
+      <entry value="601" name="MAV_CMD_DO_JUMP_TAG" hasLocation="false" isDestination="false" missionOnly="true">
         <description>Jump to the matching tag in the mission list. Repeat this action for the specified number of times. A mission should contain a single matching tag for each jump. If this is not the case then a jump to a missing tag should complete the mission, and a jump where there are multiple matching tags should always select the one with the lowest mission sequence number.</description>
         <param index="1" label="Tag" minValue="0" increment="1">Target tag to jump to.</param>
         <param index="2" label="Repeat" minValue="0" increment="1">Repeat count.</param>


### PR DESCRIPTION
This just specifies that jump commands can only be used in missions using the `missionOnly` attribute. Note that there was a lot of other churn when this was posted, but that has squashed down to just this simple change.

@peterbarker Are you OK with this? It is the first application of the attribute, that has been in the XSD for some years.
Note, there is also https://github.com/ArduPilot/pymavlink/pull/1223 that is needed to fix that up :-) 