### PR TITLE
Extend MAV_CMD_NAV_VTOL_TAKEOFF

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1217,14 +1217,14 @@
         <param index="7" label="Altitude/Z">Altitude/Z of goal</param>
       </entry>
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF" hasLocation="true" isDestination="true">
-        <description>Takeoff from ground using VTOL mode, and transition to forward flight with specified heading. The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats,etc.).</description>
-        <param index="1">Empty</param>
+        <description>Takeoff from ground using VTOL mode, and transition to forward flight with specified heading. Upon transition completion proceed navigation according to VTOL_TAKEOFF_WAYPOINT_ROLE. The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats,etc.).</description>
+        <param index="1" label="Altitude" units="m" > Target altitude after the front transition. NAN: Transition altitude is used to define waypoint altitude. </param>
         <param index="2" label="Transition Heading" enum="VTOL_TRANSITION_HEADING">Front transition heading.</param>
-        <param index="3">Empty</param>
+        <param index="3" label="Waypoint Role" enum="VTOL_TAKEOFF_WAYPOINT_ROLE"> Role of the VTOL Takeoff Waypoint. </param>
         <param index="4" label="Yaw Angle" units="deg">Yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
-        <param index="7" label="Altitude" units="m">Altitude</param>
+        <param index="7" label="Transition Altitude" units="m">Altitude</param>
       </entry>
       <entry value="85" name="MAV_CMD_NAV_VTOL_LAND" hasLocation="true" isDestination="true">
         <description>Land using VTOL mode</description>
@@ -3606,6 +3606,18 @@
       </entry>
       <entry value="4" name="VTOL_TRANSITION_HEADING_ANY">
         <description>Use the current heading when reaching takeoff altitude (potentially facing the wind when weather-vaning is active).</description>
+      </entry>
+    </enum>
+    <enum name="VTOL_TAKEOFF_WAYPOINT_ROLE">
+      <description>Role of the VTOL Takeoff Waypoint</description>
+      <entry value="0" name="VTOL_TAKEOFF_WAYPOINT_ROLE_IGNORE_POSITION">
+        <description> Upon completion of the front transition accept the waypoint immediately.</description>
+      </entry>
+      <entry value="1" name="VTOL_TAKEOFF_WAYPOINT_ROLE_FLYTHROUGH">
+        <description> Upon completion of the front transition treat the waypoint as a standard flythrough waypoint.</description>
+      </entry>
+      <entry value="2" name="VTOL_TAKEOFF_WAYPOINT_ROLE_LOITER_ONCE">
+        <description> Upon completion of the front transition navigate to the waypoint and complete one loiter circle before accepting the waypoint.</description>
       </entry>
     </enum>
     <enum name="CAMERA_CAP_FLAGS" bitmask="true">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1218,7 +1218,7 @@
       </entry>
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF" hasLocation="true" isDestination="true">
         <description>Takeoff from ground using VTOL mode, and transition to forward flight with specified heading. Upon transition completion proceed navigation according to VTOL_TAKEOFF_WAYPOINT_ROLE. The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats,etc.).</description>
-        <param index="1" label="Altitude" units="m" > Target altitude after the front transition. NAN: Transition altitude is used to define waypoint altitude. </param>
+        <param index="1" label="Altitude" units="m">Target altitude after the transition to fixed-wing mode. NAN: Transition altitude is used to define waypoint altitude.</param>
         <param index="2" label="Transition Heading" enum="VTOL_TRANSITION_HEADING">Front transition heading.</param>
         <param index="3" label="Waypoint Role" enum="VTOL_TAKEOFF_WAYPOINT_ROLE">Role of the VTOL Takeoff Waypoint. </param>
         <param index="4" label="Yaw Angle" units="deg">Yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1218,7 +1218,7 @@
       </entry>
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF" hasLocation="true" isDestination="true">
         <description>Takeoff from ground using VTOL mode, and transition to forward flight with specified heading. Upon transition completion proceed navigation according to VTOL_TAKEOFF_WAYPOINT_ROLE. The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats,etc.).</description>
-        <param index="1" label="Altitude" units="m">Target altitude after the transition to fixed-wing mode. NAN: Transition altitude is used to define waypoint altitude.</param>
+        <param index="1" label="Climbout Altitude" units="m">Climbout altitude after the transition to fixed-wing mode. NAN: Transition altitude is used to define waypoint altitude.</param>
         <param index="2" label="Transition Heading" enum="VTOL_TRANSITION_HEADING">Front transition heading.</param>
         <param index="3" label="Waypoint Role" enum="VTOL_TAKEOFF_WAYPOINT_ROLE">Role of the VTOL Takeoff Waypoint. </param>
         <param index="4" label="Yaw Angle" units="deg">Yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
@@ -3610,13 +3610,16 @@
     </enum>
     <enum name="VTOL_TAKEOFF_WAYPOINT_ROLE">
       <description>Role of the VTOL Takeoff Waypoint</description>
-      <entry value="0" name="VTOL_TAKEOFF_WAYPOINT_ROLE_IGNORE_POSITION">
+      <entry value="0" name="VTOL_TAKEOFF_WAYPOINT_ROLE_DEFAULT">
+        <description>Let the flight controller decide how to treat the waypoint position. This option is there to preserve compatibility with systems relying on the previous message definition.</description>
+      </entry>
+      <entry value="1" name="VTOL_TAKEOFF_WAYPOINT_ROLE_IGNORE_POSITION">
         <description>Upon completion of the transition to fixed-wing mode accept the waypoint immediately.</description>
       </entry>
-      <entry value="1" name="VTOL_TAKEOFF_WAYPOINT_ROLE_FLYTHROUGH">
+      <entry value="2" name="VTOL_TAKEOFF_WAYPOINT_ROLE_FLYTHROUGH">
         <description>Upon completion of the transition to fixed-wing mode treat the waypoint as a standard flythrough waypoint.</description>
       </entry>
-      <entry value="2" name="VTOL_TAKEOFF_WAYPOINT_ROLE_LOITER_ONCE">
+      <entry value="3" name="VTOL_TAKEOFF_WAYPOINT_ROLE_LOITER_ONCE">
         <description>Upon completion of the transition to fixed-wing mode navigate to the waypoint and complete one loiter circle before accepting the waypoint.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3611,13 +3611,13 @@
     <enum name="VTOL_TAKEOFF_WAYPOINT_ROLE">
       <description>Role of the VTOL Takeoff Waypoint</description>
       <entry value="0" name="VTOL_TAKEOFF_WAYPOINT_ROLE_IGNORE_POSITION">
-        <description> Upon completion of the front transition accept the waypoint immediately.</description>
+        <description>Upon completion of the transition to fixed-wing mode accept the waypoint immediately.</description>
       </entry>
       <entry value="1" name="VTOL_TAKEOFF_WAYPOINT_ROLE_FLYTHROUGH">
-        <description> Upon completion of the front transition treat the waypoint as a standard flythrough waypoint.</description>
+        <description>Upon completion of the transition to fixed-wing mode treat the waypoint as a standard flythrough waypoint.</description>
       </entry>
       <entry value="2" name="VTOL_TAKEOFF_WAYPOINT_ROLE_LOITER_ONCE">
-        <description> Upon completion of the front transition navigate to the waypoint and complete one loiter circle before accepting the waypoint.</description>
+        <description>Upon completion of the transition to fixed-wing mode navigate to the waypoint and complete one loiter circle before accepting the waypoint.</description>
       </entry>
     </enum>
     <enum name="CAMERA_CAP_FLAGS" bitmask="true">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1217,7 +1217,11 @@
         <param index="7" label="Altitude/Z">Altitude/Z of goal</param>
       </entry>
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF" hasLocation="true" isDestination="true">
-        <description>Takeoff from ground using VTOL mode, and transition to forward flight with specified heading. Upon transition completion proceed navigation according to VTOL_TAKEOFF_WAYPOINT_ROLE. The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats,etc.).</description>
+        <description>
+          Takeoff from ground using VTOL mode, and transition to forward flight with specified heading.
+          Upon transition completion proceed navigation according to VTOL_TAKEOFF_WAYPOINT_ROLE.
+	  The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats, etc.).
+        </description>
         <param index="1" label="Climbout Altitude" units="m">Climbout altitude after the transition to fixed-wing mode. NAN: Transition altitude is used to define waypoint altitude.</param>
         <param index="2" label="Transition Heading" enum="VTOL_TRANSITION_HEADING">Front transition heading.</param>
         <param index="3" label="Waypoint Role" enum="VTOL_TAKEOFF_WAYPOINT_ROLE">Role of the VTOL Takeoff Waypoint. </param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1218,9 +1218,11 @@
       </entry>
       <entry value="84" name="MAV_CMD_NAV_VTOL_TAKEOFF" hasLocation="true" isDestination="true">
         <description>
-          Takeoff from ground using VTOL mode, and transition to forward flight with specified heading.
-          Upon transition completion proceed navigation according to VTOL_TAKEOFF_WAYPOINT_ROLE.
-	  The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats, etc.).
+          Takeoff from ground vertically in VTOL mode.
+          Transition to forward flight with the specified heading at the transition altitude (param7).
+          Further navigation depends on the value of param3 (VTOL_TAKEOFF_WAYPOINT_ROLE).
+          It might immediately complete after the transition, fly to the waypoint defined by params 5, 6, 1 and then complete, or some other action.
+	  The command should be ignored by vehicles that don't support both VTOL and fixed-wing flight (multicopters, boats, etc.).
         </description>
         <param index="1" label="Climbout Altitude" units="m">Climbout altitude after the transition to fixed-wing mode. NAN: Transition altitude is used to define waypoint altitude.</param>
         <param index="2" label="Transition Heading" enum="VTOL_TRANSITION_HEADING">Front transition heading.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1220,7 +1220,7 @@
         <description>Takeoff from ground using VTOL mode, and transition to forward flight with specified heading. Upon transition completion proceed navigation according to VTOL_TAKEOFF_WAYPOINT_ROLE. The command should be ignored by vehicles that dont support both VTOL and fixed-wing flight (multicopters, boats,etc.).</description>
         <param index="1" label="Altitude" units="m" > Target altitude after the front transition. NAN: Transition altitude is used to define waypoint altitude. </param>
         <param index="2" label="Transition Heading" enum="VTOL_TRANSITION_HEADING">Front transition heading.</param>
-        <param index="3" label="Waypoint Role" enum="VTOL_TAKEOFF_WAYPOINT_ROLE"> Role of the VTOL Takeoff Waypoint. </param>
+        <param index="3" label="Waypoint Role" enum="VTOL_TAKEOFF_WAYPOINT_ROLE">Role of the VTOL Takeoff Waypoint. </param>
         <param index="4" label="Yaw Angle" units="deg">Yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>


### PR DESCRIPTION
**Motivation**
MAV_CMD_NAV_VTOL_TAKEOFF is used to command a VTOL to takeoff from the ground vertically and transition to fixed wing flight via the specified heading. What happens after the transition is not well defined and typically different flight controller implementations did what they considered the "correct" thing to do.
In PX4 the current behavior is to treat the VTOL takeoff waypoint as a standard 3D waypoint once the vehicle transitioned to fixed wing flight. In Ardupilot (please correct me if I'm wrong) the 3D position of the waypoint is ignored once the vehicle transitioned to fixed wing flight.
A ground station like QGC cannot really display any meaningful predicted path if it does not know about the specifics of the implementation.

This is an attempt to extend the definition of MAV_CMD_NAV_VTOL_TAKEOFF in order to allow different behaviors of the vehicle after the transition to fixed wing flight.

**Details**

1) Add an altitude field which (together with lat/lon fields) fully defines the 3D location of the waypoint. This altitude is NOT the same as the transition altitude as those two measures don't necessarily need to be the same. Some use cases/air frames require low transition altitudes but a higher climbout altitude. Generally you want to transition as low as possible to conserve energy but you want to loiter high enough to clear potential obstacles.

2) Define VTOL_TAKEOFF_WAYPOINT_ROLE enum which specifies the role of the 3D vtol takeoff waypoint.
This enum describes what exactly the vehicle will do after the transition to fixed wing flight has completed and what needs to happen in order for the MAV_CMD_NAV_VTOL_TAKEOFF to be considered "reached".

- Option VTOL_TAKEOFF_WAYPOINT_ROLE_IGNORE_POSITION

The way-point's only use is to define a transition direction if required by the "Transition Heading" parameter. Other than that the location does not serve any other purpose since the vehicle does not need to reach the position.

- Option VTOL_TAKEOFF_WAYPOINT_ROLE_FLYTHROUGH

Other than potentially defining a transition direction ("Transition Heading") the waypoint is treated as a "standard" waypoint which needs to be "reached" by the vehicle according to the measures implemented by the flight controller (acceptance radius).
This option is useful to obtain a predictable flight path.

- Option VTOL_TAKEOFF_WAYPOINT_ROLE_LOITER_ONCE

The same as VTOL_TAKEOFF_WAYPOINT_ROLE_FLYTHROUGH, however, instead of just reaching the waypoint, the vehicle needs to complete one full loiter circle at the waypoint location. The radius and direction are given by vehicle defaults.
This option is useful to accelerate convergence of wind estimation. This can be very important for vehicle relying on synthetic airspeed computation. It's also useful in cases where there are no other navigation commands following immediately (e.g. VTOL takeoff commanded by the user directly instead of being commanded as part of a mission) since then the vehicle is loitering at a known position and does not needs any immediate action.

Here is an attempt to sketch out the different options:
![vtol_takeoff_extension](https://user-images.githubusercontent.com/7610489/183900215-015af547-979e-4e52-a19d-6dfa9f5f1b95.jpg)


**Other comments**
The intent is to extend the message in such a way that it does not break existing implementations. This should be given by the fact that the proposal makes user to the two empty fields and does not alter any existing fields.

**Related Links**
https://github.com/PX4/PX4-Autopilot/issues/15645
https://github.com/mavlink/qgroundcontrol/issues/8221
Example implementation in QGroundControl:
https://github.com/mavlink/qgroundcontrol/pull/10123

**Alternatives**
- one might argue that the behavior after the transition should always be defined by a consecutive waypoint and the implementation goes beyond the scope of the VTOL takeoff
