### PR TITLE
minimal: try to make component ID less confusing

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -690,7 +690,7 @@
         <description>Component handling TUNNEL messages (e.g. vendor specific GUI of a component).</description>
       </entry>
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
-        <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID. Instead, such commands must be sent with target_component=MAV_COMP_ID_ALL and the target component may use any appropriate component id.</deprecated>
+        <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID. Instead, system commands should be sent with target_component=MAV_COMP_ID_ALL allowing the target component to use any appropriate component id.</deprecated>
         <description>Deprecated, don't use. Previously indicated component for handling system messages (e.g. to ARM, takeoff, etc.). Instead, such commands must be sent with target_component=MAV_COMP_ID_ALL and the target component may use any appropriate component id.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -691,7 +691,7 @@
       </entry>
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
         <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID.</deprecated>
-        <description>Component for handling system messages (e.g. to ARM, takeoff, etc.).</description>
+        <description>Deprecated, don't use. Previously indicated component for handling system messages (e.g. to ARM, takeoff, etc.). Instead, such commands must be sent with target_component=MAV_COMP_ID_ALL and the target component may use any appropriate component id.</description>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -691,7 +691,7 @@
       </entry>
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
         <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID. Instead, system commands should be sent with target_component=MAV_COMP_ID_ALL allowing the target component to use any appropriate component id.</deprecated>
-        <description>Deprecated, don't use. Previously indicated component for handling system messages (e.g. to ARM, takeoff, etc.). Instead, such commands must be sent with target_component=MAV_COMP_ID_ALL and the target component may use any appropriate component id.</description>
+        <description>Deprecated, don't use. Component for handling system messages (e.g. to ARM, takeoff, etc.).</description>
       </entry>
     </enum>
   </enums>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -690,7 +690,7 @@
         <description>Component handling TUNNEL messages (e.g. vendor specific GUI of a component).</description>
       </entry>
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
-        <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID.</deprecated>
+        <deprecated since="2018-11" replaced_by="MAV_COMP_ID_ALL">System control does not require a separate component ID. Instead, such commands must be sent with target_component=MAV_COMP_ID_ALL and the target component may use any appropriate component id.</deprecated>
         <description>Deprecated, don't use. Previously indicated component for handling system messages (e.g. to ARM, takeoff, etc.). Instead, such commands must be sent with target_component=MAV_COMP_ID_ALL and the target component may use any appropriate component id.</description>
       </entry>
     </enum>


### PR DESCRIPTION
This is my attempt to avoid some confusion around MAV_COMP_ID_SYSTEM_CONTROL. Essentially, it shouldn't be used anymore.

Replacing it with MAV_COMP_ID_ALL only makes sense as a target though, and not as a source.

@hamishwillee let me know what you think. I had someone confused about this the other day but I can't remember the specifics. What I do remember is making a todo to make it less confusing, and this is my attempt to do so.