### PR TITLE
common.xml:TIMESYNC docs and extensions

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5828,9 +5828,20 @@
       <field type="uint8_t[251]" name="payload">Variable length payload. The length is defined by the remaining message length when subtracting the header and other fields. The content/format of this block is defined in https://mavlink.io/en/services/ftp.html.</field>
     </message>
     <message id="111" name="TIMESYNC">
-      <description>Time synchronization message.</description>
-      <field type="int64_t" name="tc1">Time sync timestamp 1</field>
-      <field type="int64_t" name="ts1">Time sync timestamp 2</field>
+      <description>
+        Time synchronization message.
+        The message is used for both timesync requests and responses.
+        The request is sent with `ts1=requesting component timestamp` and `tc1=0`, and may be broadcast or targeted to a specific system/component.
+        The response is sent with `ts1=requesting component timestamp` (mirror back unchanged), and `tc1=responding component timestamp`, with the `target_system` and `target_component` set to ids of the original request.
+        Systems can determine if they are receiving a request or response based on the value of `tc`.
+        If the response has `target_system==target_component==0` the remote system has not been updated to use the component IDs and cannot reliably timesync.
+        Timestamps are UNIX Epoch time or time since system boot in nanoseconds (the timestamp format can be inferred by checking for the magnitude of the number; generally it doesn't matter as only the offset are used).
+      </description>
+      <field type="int64_t" name="tc1" units="ns">Time sync timestamp 1. Request: 0. Response: Timestamp of remote system.</field>
+      <field type="int64_t" name="ts1" units="ns">Time sync timestamp 2. Request: Timestamp of request. Response: Timestamp of request (mirrored).</field>
+      <extensions/>
+      <field type="uint8_t" name="target_system">Target system id. Request: 0 (broadcast) or id of specific system. Response must contain system id of the requesting component.</field>
+      <field type="uint8_t" name="target_component">Target component id. Request: 0 (broadcast) or id of specific component. Response must contain component id of the requesting component.</field>
     </message>
     <message id="112" name="CAMERA_TRIGGER">
       <description>Camera-IMU triggering and synchronisation message.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5834,7 +5834,7 @@
         The request is sent with `ts1=requesting component timestamp` and `tc1=0`, and may be broadcast or targeted to a specific system/component.
         The response is sent with `ts1=requesting component timestamp` (mirror back unchanged), and `tc1=responding component timestamp`, with the `target_system` and `target_component` set to ids of the original request.
         Systems can determine if they are receiving a request or response based on the value of `tc`.
-        If the response has `target_system==target_component==0` the remote system has not been updated to use the component IDs and cannot reliably timesync.
+        If the response has `target_system==target_component==0` the remote system has not been updated to use the component IDs and cannot reliably timesync; the requestor may report an error.
         Timestamps are UNIX Epoch time or time since system boot in nanoseconds (the timestamp format can be inferred by checking for the magnitude of the number; generally it doesn't matter as only the offset are used).
       </description>
       <field type="int64_t" name="tc1" units="ns">Time sync timestamp 1. Request: 0. Response: Timestamp of remote system.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5831,14 +5831,15 @@
       <description>
         Time synchronization message.
         The message is used for both timesync requests and responses.
-        The request is sent with `ts1=requesting component timestamp` and `tc1=0`, and may be broadcast or targeted to a specific system/component.
-        The response is sent with `ts1=requesting component timestamp` (mirror back unchanged), and `tc1=responding component timestamp`, with the `target_system` and `target_component` set to ids of the original request.
+        The request is sent with `ts1=syncing component timestamp` and `tc1=0`, and may be broadcast or targeted to a specific system/component.
+        The response is sent with `ts1=syncing component timestamp` (mirror back unchanged), and `tc1=responding component timestamp`, with the `target_system` and `target_component` set to ids of the original request.
         Systems can determine if they are receiving a request or response based on the value of `tc`.
         If the response has `target_system==target_component==0` the remote system has not been updated to use the component IDs and cannot reliably timesync; the requestor may report an error.
-        Timestamps are UNIX Epoch time or time since system boot in nanoseconds (the timestamp format can be inferred by checking for the magnitude of the number; generally it doesn't matter as only the offset are used).
+        Timestamps are UNIX Epoch time or time since system boot in nanoseconds (the timestamp format can be inferred by checking for the magnitude of the number; generally it doesn't matter as only the offset is used).
+        The message sequence is repeated numerous times with results being filtered/averaged to estimate the offset.
       </description>
-      <field type="int64_t" name="tc1" units="ns">Time sync timestamp 1. Request: 0. Response: Timestamp of remote system.</field>
-      <field type="int64_t" name="ts1" units="ns">Time sync timestamp 2. Request: Timestamp of request. Response: Timestamp of request (mirrored).</field>
+      <field type="int64_t" name="tc1" units="ns">Time sync timestamp 1. Syncing: 0. Responding: Timestamp of responding component.</field>
+      <field type="int64_t" name="ts1" units="ns">Time sync timestamp 2. Timestamp of syncing component (mirrored in response).</field>
       <extensions/>
       <field type="uint8_t" name="target_system">Target system id. Request: 0 (broadcast) or id of specific system. Response must contain system id of the requesting component.</field>
       <field type="uint8_t" name="target_component">Target component id. Request: 0 (broadcast) or id of specific component. Response must contain component id of the requesting component.</field>


### PR DESCRIPTION
This adds documentation to the TIMESYNC message including information about timestamp units (ns) and format, and the message sequence.

As discussed in https://github.com/mavlink/mavlink-devguide/pull/433 the original message was broadcast. That means that,  in the case that there might be multiple components requesting timesync, it is not possible to tell if a response is to a particular request. 
ArduPilot encode the system id in the request timestamp (ts1), which is perfectly "safe". However this is not 100% reliable because it is more common to sync multiple _components_ within a single system, so you still can't be sure if a response is intended for a particular component.

Therefore this adds extension fields for `target_system` and `target_component`, which allows robust determination of the intended recipient, and timesyncing to specific targets (eliminating unwanted respones).

@peterbarker @auturgy @julianoes FYI - TBD.