### PR TITLE
common: added OPEN_DRONE_ID_SYSTEM_UPDATE message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7478,6 +7478,15 @@
       <field type="uint8_t" name="status" enum="MAV_ODID_ARM_STATUS">Status level indicating if arming is allowed.</field>
       <field type="char[50]" name="error">Text error message, should be empty if status is good to arm. Fill with nulls in unused portion.</field>
     </message>
+    <message id="12919" name="OPEN_DRONE_ID_SYSTEM_UPDATE">
+      <description>Update the data in the OPEN_DRONE_ID_SYSTEM message with new location information. This can be sent to update the location information for the operator when no other information in the SYSTEM message has changed. This message allows for efficient operation on radio links which have limited uplink bandwidth while meeting requirements for update frequency of the operator location.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="int32_t" name="operator_latitude" units="degE7" invalid="0">Latitude of the operator. If unknown: 0 (both Lat/Lon).</field>
+      <field type="int32_t" name="operator_longitude" units="degE7" invalid="0">Longitude of the operator. If unknown: 0 (both Lat/Lon).</field>
+      <field type="float" name="operator_altitude_geo" units="m" invalid="-1000">Geodetic altitude of the operator relative to WGS84. If unknown: -1000 m.</field>
+      <field type="uint32_t" name="timestamp" units="s">32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.</field>
+    </message>
     <message id="12920" name="HYGROMETER_SENSOR">
       <description>Temperature and humidity from hygrometer.</description>
       <field type="uint8_t" name="id" instance="true">Hygrometer ID</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7479,6 +7479,8 @@
       <field type="char[50]" name="error">Text error message, should be empty if status is good to arm. Fill with nulls in unused portion.</field>
     </message>
     <message id="12919" name="OPEN_DRONE_ID_SYSTEM_UPDATE">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Update the data in the OPEN_DRONE_ID_SYSTEM message with new location information. This can be sent to update the location information for the operator when no other information in the SYSTEM message has changed. This message allows for efficient operation on radio links which have limited uplink bandwidth while meeting requirements for update frequency of the operator location.</description>
       <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
       <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>


### PR DESCRIPTION
this is a bandwidth efficient way to update the OPEN_DRONE_ID_SYSTEM message data when there is limited uplink bandwidth. Testing on real vehicles shows that with RFD900x radios at an air data rate of 125kbit/s with OPEN_DRONE_ID messages with 1Hz update (as required by FAA RemoteID standard) that there is significant impact on the ability of the GCS to give commands to the flight controller. For example, I got a high degree of packet loss in downloading parameter pre-flight, and many/most in-flight commands failed from the GCS.
By using this message we can use the minimum required bandwidth for updating operator location while remaining FAA RemoteID standard compliant

MAVProxy implementation here: https://github.com/ArduPilot/MAVProxy/pull/1098
ArduPilot MAVLink PR: https://github.com/ArduPilot/mavlink/pull/282
ArduPilot PR: https://github.com/ArduPilot/ardupilot/pull/21435
