### PR TITLE
MAV_ODID_ARM_STATUS entries update to naming convention

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4355,10 +4355,10 @@
       </entry>
     </enum>
     <enum name="MAV_ODID_ARM_STATUS">
-      <entry value="0" name="MAV_ODID_GOOD_TO_ARM">
+      <entry value="0" name="MAV_ODID_ARM_STATUS_GOOD_TO_ARM">
         <description>Passing arming checks.</description>
       </entry>
-      <entry value="1" name="MAV_ODID_PRE_ARM_FAIL_GENERIC">
+      <entry value="1" name="MAV_ODID_ARM_STATUS_PRE_ARM_FAIL_GENERIC">
         <description>Generic arming failure, see error string for details.</description>
       </entry>
     </enum>


### PR DESCRIPTION
The MAV_ODID_ARM_STATUS entries did not following naming convention.
This fixes them. 

This is a breaking compile-time change, but does not break existing systems. So "OK".

@tridge @ThomasDebrunner 