### PR TITLE
gimbal: more flexible attitude messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -525,6 +525,15 @@
       <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
+      <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
+        <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+      </entry>
+      <entry value="32" name="GIMBAL_DEVICE_FLAGS_YAW_IS_BODY">
+          <description>Signals that the yaw of the quaternion and angular rates is either yaw aligned with the vehicle (YAW_IS_BODY) or absolute (YAW_IS_EARTH).</description>
+      </entry>
+      <entry value="64" name="GIMBAL_DEVICE_FLAGS_YAW_IS_EARTH">
+          <description>Signals that the yaw of the quaternion and angular rates is either yaw aligned with the vehicle (YAW_IS_BODY) or absolute (YAW_IS_EARTH).</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_FLAGS" bitmask="true">
       <description>Flags for high level gimbal manager operation The first 16 bits are identical to the GIMBAL_DEVICE_FLAGS.</description>
@@ -6911,7 +6920,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
-      <field type="float[4]" name="q" invalid="[NaN]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set, set all fields to NaN if only angular velocity should be used)</field>
+      <field type="float[4]" name="q" invalid="[NaN]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, set all fields to NaN if only angular velocity should be used). The frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_IS_EARTH or GIMBAL_DEVICE_FLAGS_YAW_IS_BODY is set. If neither are set, yaw is aligned with the Earth frame if GIMBAL_DEVICE_FLAGS_YAW_LOCK is set, and otherwise relative to body frame to uphold compatibility before the flags YAW_IS_BODY and YAW_IS_EARTH flags were introduced.</field>
       <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity, positive is rolling to the right, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity, positive is pitching up, NaN to be ignored.</field>
       <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity, positive is yawing to the right, NaN to be ignored.</field>
@@ -6919,16 +6928,24 @@
     <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal device component. The angles encoded in the quaternion are relative to absolute North if the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set (roll: positive is rolling to the right, pitch: positive is pitching up, yaw is turn to the right) or relative to the vehicle heading if the flag is not set. This message should be broadcast at a low regular rate (e.g. 10Hz).</description>
+      <description>Message reporting the status of a gimbal device. This message should be broadcasted by a gimbal device component. The angles encoded in the quaternion are relative to absolute North if the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set (roll: positive is rolling to the right, pitch: positive is pitching up, yaw is turn to the right) or relative to the vehicle heading if the flag is not set. This message should be broadcast at a low regular rate (e.g. 10Hz).
+      The frame used in the quaternion and angular_velocity fields depends on the flags.
+      Before the extension was added, the frame depended on the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK. If GIMBAL_DEVICE_FLAGS_YAW_LOCK was set, the frame would be in absolute/Earth frame, if not it would be in body/vehicle aligned frame.
+      Once the extension is added, the frame does not depend on GIMBAL_DEVICE_FLAGS_YAW_LOCK anymore but instead on the flags GIMBAL_DEVICE_FLAGS_YAW_IS_BODY or GIMBAL_DEVICE_FLAGS_YAW_IS_EARTH has to be set to signal the frame.
+      The extension basically allows a gimbal device to send its attitude in either the absolute or relative frame, and then provide the yaw offset between the frames, if known.
+  </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation, the frame is depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set)</field>
-      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (NaN if unknown)</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation), the frame is described in the message description.</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (NaN if unknown). The frame is described in the message description.</field>
       <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (NaN if unknown)</field>
       <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (NaN if unknown)</field>
       <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
+      <extensions/>
+      <field type="float" name="yaw_offset" units="rad" invalid="NaN">Yaw offset for quaternion and angular velocity from Earth/absolute to body (aligned with vehicle yaw) coordinates. If unknown, set to NaN. When used, GIMBAL_DEVICE_FLAGS_YAW_IS_BODY or GIMBAL_DEVICE_FLAGS_YAW_IS_EARTH needs to be set.</field>
+      <field type="float" name="yaw_rate_offset" units="rad/s" invalid="NaN">Yaw rate offset for quaternion and angular velocity. If unknown, set to NaN. When used, GIMBAL_DEVICE_FLAGS_YAW_IS_BODY or GIMBAL_DEVICE_FLAGS_YAW_IS_EARTH needs to be set.</field>
     </message>
     <message id="286" name="AUTOPILOT_STATE_FOR_GIMBAL_DEVICE">
       <wip/>


### PR DESCRIPTION
This is an attempt to improve the attitude setpoint and attitude status messages for gimbals, as suggested by @olliw42 in #1860.

The changes break the coupling between "locking" an angle so it stays the same relative to Earth and the setpoint used and reported to do so.

Previously, these setpoints were possible:

- Pan: gimbal orientation relative to body (in body frame)
- Lock: gimbal orientation relative to earth (in earth frame)

The changes add one more setpoint:

- Lock: gimbal orientation relative to earth (in body frame)

Concerning the attitude status output from the gimbal, it means that the a gimbal can provide the angle either body or earth frame (depending on what it has available), and provide the yaw offset between the two, if available.

This commit tries to add this without breaking existing implementations by adding two flags, and an extension.
The alternative would be to change/replace the existing messages which could lead to a difficult transition but would make the explanations and descriptions easier.