### PR TITLE
Support a return to default speed for DO_CHANGE_SPEED

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1353,7 +1353,7 @@
       <entry value="178" name="MAV_CMD_DO_CHANGE_SPEED" hasLocation="false" isDestination="false">
         <description>Change speed and/or throttle set points.</description>
         <param index="1" label="Speed Type" minValue="0" maxValue="3" increment="1">Speed type (0=Airspeed, 1=Ground Speed, 2=Climb Speed, 3=Descent Speed)</param>
-        <param index="2" label="Speed" units="m/s" minValue="-1">Speed (-1 indicates no change)</param>
+        <param index="2" label="Speed" units="m/s" minValue="-1">Speed (-1 indicates no change, -2 indicates return to default vehicle speed)</param>
         <param index="3" label="Throttle" units="%" minValue="-1">Throttle (-1 indicates no change)</param>
         <param index="4" reserved="true" default="0"/>
         <param index="5" reserved="true" default="0"/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1353,8 +1353,8 @@
       <entry value="178" name="MAV_CMD_DO_CHANGE_SPEED" hasLocation="false" isDestination="false">
         <description>Change speed and/or throttle set points.</description>
         <param index="1" label="Speed Type" minValue="0" maxValue="3" increment="1">Speed type (0=Airspeed, 1=Ground Speed, 2=Climb Speed, 3=Descent Speed)</param>
-        <param index="2" label="Speed" units="m/s" minValue="-1">Speed (-1 indicates no change, -2 indicates return to default vehicle speed)</param>
-        <param index="3" label="Throttle" units="%" minValue="-1">Throttle (-1 indicates no change)</param>
+        <param index="2" label="Speed" units="m/s" minValue="-2">Speed (-1 indicates no change, -2 indicates return to default vehicle speed)</param>
+        <param index="3" label="Throttle" units="%" minValue="-2">Throttle (-1 indicates no change, -2 indicates return to default vehicle throttle value)</param>
         <param index="4" reserved="true" default="0"/>
         <param index="5" reserved="true" default="0"/>
         <param index="6" reserved="true" default="0"/>


### PR DESCRIPTION
DO_CHANGE_SPEED is useful for temporarily overriding flight speeds, but when you are done with an override the only way I can see to either know the default tuned speed (which means reading vehicle parameters/have specific flight controller knowledge), or to change flight modes and then change back, and hope that your flight controller chooses to reset the target speed (which might just be an ArduPilot undocumented behavior). These are obviously both terrible solutions, because one requires specific knowledge about the flight stack, the other requires undocumented behaviour, requires more commands to be sent, and can result in changing more then desired.

This just adds a special case of -2 to be resume the default tuned value for the speed, allowing a very easy end to any speed override. An ArduPilot proposed implementation is available here: https://github.com/ArduPilot/ardupilot/pull/20541