### PR TITLE
DO_CHANGE_SPEED - clarify lifetime of speed setting

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1351,7 +1351,7 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="178" name="MAV_CMD_DO_CHANGE_SPEED" hasLocation="false" isDestination="false">
-        <description>Change speed and/or throttle set points.</description>
+        <description>Change speed and/or throttle set points. The value persists until it is overridden or there is a mode change.</description>
         <param index="1" label="Speed Type" minValue="0" maxValue="3" increment="1">Speed type (0=Airspeed, 1=Ground Speed, 2=Climb Speed, 3=Descent Speed)</param>
         <param index="2" label="Speed" units="m/s" minValue="-1">Speed (-1 indicates no change)</param>
         <param index="3" label="Throttle" units="%" minValue="-1">Throttle (-1 indicates no change)</param>


### PR DESCRIPTION
Clarify that the lifetime of [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED) is until over-ridden or a mode change.

This matches ArduPlane and what is expected for PX4 Plane. Discussed in https://github.com/PX4/PX4-Autopilot/issues/20159#issuecomment-1240619736 and 