### PR TITLE
MAV_CMD_BATTERY_RESET move to common

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -262,11 +262,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="42651" name="MAV_CMD_BATTERY_RESET" hasLocation="false" isDestination="false">
-        <description>Reset battery capacity for batteries that accumulate consumed battery via integration.</description>
-        <param index="1" label="battery mask">Bitmask of batteries to reset. Least significant bit is for the first battery.</param>
-        <param index="2" label="percentage" minValue="0" maxValue="100" increment="1">Battery percentage remaining to set.</param>
-      </entry>
+      <!-- 42651 MAV_CMD_BATTERY_RESET moved to common -->
       <entry value="42700" name="MAV_CMD_DEBUG_TRAP" hasLocation="false" isDestination="false">
         <description>Issue a trap signal to the autopilot process, presumably to enter the debugger.</description>
         <param index="1">Magic number - set to 32451 to actually trap.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2542,6 +2542,11 @@
         <param index="6">Empty.</param>
         <param index="7">Empty.</param>
       </entry>
+      <entry value="42651" name="MAV_CMD_BATTERY_RESET" hasLocation="false" isDestination="false">
+        <description>Reset battery capacity for batteries that accumulate consumed battery via integration.</description>
+        <param index="1" label="battery mask">Bitmask of batteries to reset. Least significant bit is for the first battery.</param>
+        <param index="2" label="percentage" minValue="0" maxValue="100" increment="1">Battery percentage remaining to set.</param>
+      </entry>
     </enum>
     <enum name="MAV_DATA_STREAM">
       <deprecated since="2015-06" replaced_by="MESSAGE_INTERVAL"/>


### PR DESCRIPTION
This is a proposal to move the `MAV_CMD_BATTERY_RESET` command in the ArduPilot dialect to common.xml.
It is dependent on someone in PX4 agreeing this is useful and they would like to implement it.

----

Power modules are powered on boot and start measuring the consumed power. The assumption is normally that the battery is full on boot, and the remaining power will be the full battery level minus the consumed power.

This works (provided the battery is full on boot) for a single battery. However when you hotswap a battery with a full battery the  values are all immediately wrong because nothing has been consumed of the new battery.

The  `MAV_CMD_BATTERY_RESET` command in the ArduPilot dialect allows a GCS to set the remaining percentage of the battery. So you could immediately set the value back to 100%.
The command should be ignored by a smart battery, which knows its battery level and reports it accurately.

> NOTE: I am not sure how the autopilot would actually manage this. It might just immediately set the original capacity to be doubled (or whatever value is appropriate for the setting). Or it might assume a battery swap, and store the current consumed current as an offset.

The command is also used to reset fuel-based power systems, which are often set to less than 100%.