### PR TITLE
MAV_CMD_SET_MESSAGE_INTERVAL - default interval may be 0

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1937,7 +1937,7 @@
       <entry value="511" name="MAV_CMD_SET_MESSAGE_INTERVAL" hasLocation="false" isDestination="false">
         <description>Set the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM.</description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID</param>
-        <param index="2" label="Interval" units="us" minValue="-1" increment="1">The interval between two messages. Set to -1 to disable and 0 to request default rate.</param>
+        <param index="2" label="Interval" units="us" minValue="-1" increment="1">The interval between two messages. -1: disable. 0: request default rate (which may be zero).</param>
         <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address of message stream (if message has target address fields). 0: Flight-stack default (recommended), 1: address of requestor, 2: broadcast.</param>
       </entry>
       <entry value="512" name="MAV_CMD_REQUEST_MESSAGE" hasLocation="false" isDestination="false">


### PR DESCRIPTION
MAV_CMD_SET_MESSAGE_INTERVAL can be used to set a default interval. This update makes it clear that the default interval might be 0 (and probably will be if the message isn't streaming when this is first sent).

This is to reduce the minor risk that someone will call the method expecting default to mean "some sensible non-zero value"; if the value is not streaming then the sensible default value is zero.

As discussed with @peterbarker .