### PR TITLE
fix typo MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3053,7 +3053,7 @@
       </entry>
       <entry value="16" name="MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE">
         <description>Parameter protocol uses byte-wise encoding of parameter values into param_value (float) fields: https://mavlink.io/en/services/parameter.html#parameter-encoding.
-          Note that either this flag or MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE should be set if the parameter protocol is supported.
+          Note that either this flag or MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST should be set if the parameter protocol is supported.
         </description>
       </entry>
       <entry value="32" name="MAV_PROTOCOL_CAPABILITY_FTP">


### PR DESCRIPTION
Fixes copy paste typo described here https://github.com/mavlink/mavlink/pull/1799#discussion_r994348458