### PR TITLE
Common should depend on standard and not visa versa

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <mavlink>
-  <include>minimal.xml</include>
+  <include>standard.xml</include>
   <version>3</version>
   <dialect>0</dialect>
   <enums>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <mavlink>
-  <!-- XML file for prototyping definitions for standard.xml  -->
-  <include>standard.xml</include>
+  <!-- XML file for prototyping definitions for common.xml -->
+  <include>common.xml</include>
   <version>0</version>
   <dialect>0</dialect>
   <enums>

--- a/message_definitions/v1.0/standard.xml
+++ b/message_definitions/v1.0/standard.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <mavlink>
   <!-- MAVLink standard messages -->
-  <include>common.xml</include>
+  <include>minimal.xml</include>
   <dialect>0</dialect>
-  <!-- use common.xml enums -->
+  <!-- use minimal.xml enums -->
   <enums/>
-  <!-- use common.xml messages -->
+  <!-- use minimal.xml messages -->
   <messages/>
 </mavlink>


### PR DESCRIPTION
There are three core XML definition files that comprise the standard; at time of writing everything else is a dialect. The meaning of these is (at least historically):
- `minimal.xml`: The minimal set of XML definitions needed to have a functioning mavlink network. 
- `standard.xml`: The set of XML definitions that are "standard". The expectation is that these definitions are supported by at least two flight stacks in a compatible way. You could reasonably hope that most flight stacks would support them.
- `common.xml`: A library of definitions; a flight stack does not have to support these definitions, but if it supports the kind of functionality it must use the definitions from the library.

This is still a logical and desirable setup, albeit the descriptions do not precisely describe the content:

- standard.xml is empty other than to import common.xml. This is incorrect because it implies "everything in common is standard".
- common.xml contains some functionality that has not been agreed to be "library worthy". Those definitions should be in the flight stack dialect. (common is supposed to be a "path for standardization")

We'd like to move towards standard.xml being truly standard. This PR changes the order of inclusion to reflect this:

- From: **standard.xml > common.xml > minimal.xml**.
- To: **common.xml > standard.xml > minimal.xml**.

Following this step, we could start moving things that are really in multiple stacks across to standard.xml.

A few thoughts/questions:
- This would break any system that depends on standard.xml, as it will no longer pick up common.xml. Do we know of any system that uses standard directly? - PX4 and ArduPilot do not.
- This will increase the level of nesting by one for ArduPilot and PX4. The toolchain current nests to 5 levels (based on a flag). I believe there is no risk at a toolchain level of missing definitions because ardupilot will still pick up minimal.xml at 4 levels.

What testing do we need to do on this?

@auturgy @peterbarker @julianoes @dagar 