### PR TITLE
Component Metadata: Add Frames

### DIFF
--- a/component_metadata/frames.example.json
+++ b/component_metadata/frames.example.json
@@ -1,0 +1,212 @@
+{
+    "version": 1,
+    
+    "settings": {
+        "frame_id_parameter": "SYS_AUTOSTART"
+    },
+
+    "frames_v1": [
+        {
+            "name": "multicopter",
+            "type": "group",
+            "description": "Rotary vehicles with multiple rotors to lift it's body",
+            "image": "Multirotor",
+            "subgroups": [
+                {
+                    "name": "generic multicopter",
+                    "type": "frame",
+                    "description": "Generic multicopter with customizable number of rotors",
+                    "image": "",
+                    "frame_id": 1300
+                },
+                {
+                    "name": "quadcopter",
+                    "type": "group",
+                    "description": "Multicopters with 4 rotors",
+                    "image": "Quadrotor",
+                    "subgroups": [
+                        {
+                            "name": "Holybro X500 v2",
+                            "type": "frame",
+                            "description": "Holybro's X500 V2 frame kit",
+                            "manufacturer": "Holybro",
+                            "image-custom": "holybro_x500_v2",
+                            "url": "http://www.holybro.com/product/x500-v2-kit/",
+                            "frame_id": 1313
+                        }
+                    ]
+                },
+                {
+                    "name": "hexacopter",
+                    "type": "group",
+                    "description": "Multicopters with 6 rotors",
+                    "image": "Hexarotor",
+                    "subgroups": [
+                        {
+                            "name": "Yuneec H520E Hexacopter",
+                            "type": "frame",
+                            "description": "Yuneec H520E Hexacopter with a camera & landing gear",
+                            "manufacturer": "Yuneec",
+                            "image-custom": "yuneec_h520e",
+                            "url": "https://www.conrad.ch/de/p/yuneec-h520e-speccombo-hexacopter-rtf-profi-kameraflug-mit-waermebild-orange-schwarz-2450997.html",
+                            "frame_id": 1254
+                        },
+                        {
+                            "name": "Vector Hexacopter 2.2",
+                            "type": "frame",
+                            "description": "Yuneec H520E Hexacopter with a camera & landing gear",
+                            "manufacturer": "Vision Aerial",
+                            "image-custom": "vision_vector_hexacopter",
+                            "url": "https://visionaerial.com/product/vector-hexacopter/",
+                            "frame_id": 1532
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "fixed wing",
+            "type": "group",
+            "description": "Aerial vehicles with fixed wing mounted to generate lift",
+            "image": "FixedWing",
+            "subgroups": [
+                {
+                    "name": "generic fixed wing",
+                    "type": "frame",
+                    "description": "Generic fixed wing with customizable set of actuators",
+                    "image": "",
+                    "frame_id": 1592
+                },
+                {
+                    "name": "plane a tail",
+                    "type": "group",
+                    "description": "Fixed wing with 2 ailerons, 2 flaps, a-tail, 2 a-tail actuators, throttle, wheel",
+                    "image": "FixedWingATail",
+                    "subgroups": [
+                        {
+                            "name": "Applied Aeronautics Albatross",
+                            "type": "frame",
+                            "description": "Applied Aeronautics Albatross Fixed Wing platform",
+                            "manufacturer": "Applied Aeronautics",
+                            "image-custom": "applied_aeronautics_albatross",
+                            "url": "https://www.appliedaeronautics.com/albatross-uav",
+                            "frame_id": 1212
+                        }
+                    ]
+                },
+                {
+                    "name": "simple flying wing",
+                    "type": "group",
+                    "description": "Fixed-wing with 2 aileron and 1 throttle",
+                    "image": "FixedWingFlyingWing",
+                    "subgroups": [
+                        {
+                            "name": "Generic flying wing",
+                            "type": "frame",
+                            "description": "Generic flying wing with customizable set of actuators",
+                            "manufacturer": "",
+                                                        "image-custom": "FixedWingFlyingWing",
+                            "url": "",
+                            "frame_id": 1426
+                        },
+                        {
+                            "name": "Wing wing (Z-84)",
+                            "type": "frame",
+                            "description": "Wing wing model",
+                                                        "manufacturer": "E-flite",
+                                                        "image-custom": "eflite_wing_wing",
+                            "url": "https://hobbyking.com/en_us/wing-wing-z-84-epo-845mm-kit.html?___store=en_us",
+                            "frame_id": 1426
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "vtol",
+            "type": "group",
+            "description": "Aerial vehicles with fixed wing and multicopter configuration combined",
+            "image": "VTOL",
+            "subgroups": [
+                {
+                    "name": "tiltrotor vtol",
+                    "type": "group",
+                    "description": "VTOLs with tilting rotors",
+                    "image": "VTOLTiltrotor",
+                    "subgroups": [
+                        {
+                            "name": "Convergence VTOL",
+                            "type": "frame",
+                            "description": "Famous Convergence VTOL!",
+                            "manufacturer": "E-flite",
+                            "image-custom": "convergence-vtol",
+                            "url": "https://www.horizonhobby.com/product/convergence-vtol-bnf-basic-650mm/EFL11050.html",
+                            "frame_id": 6435
+                        }
+                    ]
+                },
+                {
+                    "name": "quad tail-sitter vtol",
+                    "type": "group",
+                    "description": "VTOLs with quadcopter rotor configuration that sits on the tail when launching",
+                    "image": "VTOLQuadrotorTailsitter",
+                    "subgroups": [
+                        {
+                            "name": "Generic Quadrotor X Tailsitter",
+                            "type": "frame",
+                            "description": "Generic Quadrotor tailsitter with rotors positioned in X configuration",
+                            "manufacturer": "",
+                            "image": "VTOLQuadrotorTailsitter",
+                            "url": "",
+                            "frame_id": 5123
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "helicopter",
+            "type": "group",
+            "description": "Aerial vehicles with big rotor lifting the body",
+            "image": "Helicopter",
+            "subgroups": [
+                {
+                    "name": "generic helicopter",
+                    "type": "frame",
+                    "description": "Generic helicopter with customizable set of actuators",
+                    "image": "Helicopter",
+                    "frame_id": 4212
+                },
+                {
+                    "name": "coaxial helicopter",
+                    "type": "frame",
+                    "description": "Helicopter with coaxial rotor spinning in different directions",
+                    "image": "HelicopterCoaxial",
+                    "frame_id": 9374
+                }
+            ]
+        },
+        {
+            "name": "simulation",
+            "type": "group",
+            "description": "SIH vehicle frames for running Simulation In Hardware",
+            "image": "Simulation",
+            "subgroups": [
+                {
+                    "name": "sih quadcopter",
+                    "type": "frame",
+                    "description": "SIH quadcopter",
+                    "image": "Quadrotor",
+                    "frame_id": 1523
+                },
+                {
+                    "name": "sih fixed wing",
+                    "type": "frame",
+                    "description": "SIH fixed wing",
+                    "image": "FixedWing",
+                    "frame_id": 1523
+                }
+            ]
+        }
+    ]
+}

--- a/component_metadata/frames.schema.json
+++ b/component_metadata/frames.schema.json
@@ -1,0 +1,115 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Frames",
+    "description": "List and structure of a Frames supported by the Autopilot",
+    "type": "object",
+
+    "$defs": {
+        "imageTypes": {
+            "description": "Enum representing the image to show for the frame. Convention is to have capital letter on each new phrase",
+            "default": "Undefined",
+            "enum": [
+                "",
+                "Undefined",
+                "Simulation",
+                "Helicopter",
+                    "HelicopterCoaxial",
+                "Multirotor",
+                    "Quadrotor",
+                        "QuadrotorX", "QuadrotorH", "QuadrotorWide", 
+                    "Hexarotor",
+                "FixedWing",
+                    "FixedWingATail", "FixedWingFlyingWing",
+                "VTOL",
+                    "VTOLTiltrotor", "VTOLQuadrotorTailsitter",
+                "Boat",
+                "Rover",
+                "UUV"
+            ]
+        },
+        "frame": {
+            "type": "object",
+            "description": "A group (could be a single frame) of frames",
+
+            "properties": {
+                "type": {
+                    "enum": ["group", "frame"],
+                    "description": "Type of the frame object. If it's a group, it will include other group/frames in `subgroups` property"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "image": {
+                    "$ref": "#/$defs/imageTypes",
+                    "description": "Generic enum value (non GCS specific) representing the frame image. GCS needs to map the value to an appropriate iamge resource. If empty, GCS should use the `image` property in the parent node. If no valid image can be found in parent node, it should show `Undefined` frame image"
+                },
+                "image-custom": {
+                    "type": "string",
+                    "description": "Name of the custom image to load. GCS should have a mechanism to map the string to the appropriate image resource. So compatability with GCS is not guaranteed. It overrides the `image` property if valid"
+                },
+                "manufacturer": {
+                    "type": "string",
+                    "description": "Name of the manufacturer"
+                },
+                "url": {
+                    "type": "string",
+                    "description": "Link to the relevant material online about the frame"
+                },
+                "frame_id": {
+                    "type": "integer",
+                    "description": "ID of the frame"
+                },
+                "subgroups": {
+                    "type": "array",
+                    "description": "Sub-group of other frame / frame-groups",
+                    "items": {
+                        "$ref": "#/$defs/frame"
+                    }
+                }
+            },
+
+            "if": {
+                "properties": { "type": { "const": "group" } }
+            },
+            "then": {
+                "required": ["subgroups"]
+            },
+            "else": {
+                "description": "For frame types, frame_id must be provided",
+                "required": ["frame_id"]
+            },
+
+            "required": ["type", "name"],
+            "additionalProperties": false
+        }
+    },
+
+    "properties": {
+        "version": {
+            "type": "integer",
+            "description": "Version of the Frames JSON Schema"
+        },
+
+        "settings": {
+            "type": "object",
+            "description": "Common settings",
+            "properties": {
+                "frame_id_parameter": {
+                    "description": "Parameter name matching the Frame ID",
+                    "type": "string"
+                }
+            }
+        },
+
+        "frames_v1": {
+            "type": "array",
+            "description": "List of frames as defined in v1 spec",
+            "items": {
+                "$ref": "#/$defs/frame"
+            }
+        }
+    }
+}

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -852,6 +852,9 @@
       <entry value="5" name="COMP_METADATA_TYPE_ACTUATORS">
         <description>Meta data for actuator configuration (motors, servos and vehicle geometry) and testing.</description>
       </entry>
+      <entry value="6" name="COMP_METADATA_TYPE_FRAMES">
+        <description>Meta data for frames configuration (definition of supported frame types) and testing.</description>
+      </entry>
     </enum>
     <enum name="ACTUATOR_CONFIGURATION">
       <description>Actuator configuration, used to change a setting on an actuator. Component information metadata can be used to know which outputs support which commands.</description>


### PR DESCRIPTION
## About
This is a MAVLink part for the Airframe selection improvement project I have been working on for the last 2 weeks.

Frame metadata is meant to serve as a definite reference that can be dynamically fetched by the GCS (as done with all other component metadata), to show the frames that are actually supported.

Additionally, the frame JSON schema is defined in a way where we can structure the frames within another frame in a cascaded fashion, which enables a User-Interface workflow that wasn't possible before, which is a JSON- defined Frame selection workflow.

This is best demonstrated by the GIF below.

### Notes
For now, the JSON Schema & Examples were fetched from [this commit](https://github.com/junwoo091400/PX4-Airframe-Metadata-support/commit/75d54c40dd234959ab284604fc6c3942c909ef09) in my Qt UI repository.

This is what will eventually happen to [this](https://github.com/mavlink/qgroundcontrol/pull/10343) too I hope, as having MAVLink defined schema would make it easier for different Autopilots to agree on the format used by the QGC / Mission Planner.

### Frames metadata example
As included as part of the PR, the Frames JSON file would look something like this:

```json
{
    "version": 1,

    "settings": {
        "frame_id_parameter": "SYS_AUTOSTART"
    },

    "frames_v1": [
        {
            "name": "multicopter",
            "type": "group",
            "description": "Rotary vehicles with multiple rotors to lift it's body",
            "image": "Multirotor",
            "subgroups": [
                {
                    "name": "generic multicopter",
                    "type": "frame",
                    "description": "Generic multicopter with customizable number of rotors",
                    "image": "",
                    "frame_id": 1300
                },
                {
                    "name": "quadcopter",
                    "type": "group",
                    "description": "Multicopters with 4 rotors",
                    "image": "Quadrotor",
                    "subgroups": [
                        {
                            "name": "Holybro X500 v2",
                            "type": "frame",
                            "description": "Holybro's X500 V2 frame kit",
                            "manufacturer": "Holybro",
                            "image-custom": "holybro_x500_v2",
                            "url": "http://www.holybro.com/product/x500-v2-kit/",
                            "frame_id": 1313
                        }
                    ]
                },
                {
                    "name": "hexacopter",
                    "type": "group",
                    "description": "Multicopters with 6 rotors",
                    "image": "Hexarotor",
                    "subgroups": [
                        {
                            "name": "Yuneec H520E Hexacopter",
                            "type": "frame",
                            "description": "Yuneec H520E Hexacopter with a camera & landing gear",
                            "manufacturer": "Yuneec",
                            "image-custom": "yuneec_h520e",
                            "url": "https://www.conrad.ch/de/p/yuneec-h520e-speccombo-hexacopter-rtf-profi-kameraflug-mit-waermebild-orange-schwarz-2450997.html",
                            "frame_id": 1254
                        },
                        {
                            "name": "Vector Hexacopter 2.2",
                            "type": "frame",
                            "description": "Yuneec H520E Hexacopter with a camera & landing gear",
                            "manufacturer": "Vision Aerial",
                            "image-custom": "vision_vector_hexacopter",
                            "url": "https://visionaerial.com/product/vector-hexacopter/",
                            "frame_id": 1532
                        }
                    ]
                }
            ]
        }
    ]
}
```

### Final GCS outcome demo

![Demo](https://github.com/junwoo091400/PX4-Airframe-Metadata-support/raw/master/Frames_CompMetadata_Demo.gif)

This is from the [Qt application repository](https://github.com/junwoo091400/PX4-Airframe-Metadata-support#px4-frame-metadata-support-test-repository) linked below.

### Resources
- You can check out the progress / details of this project in the document here: https://docs.google.com/document/d/1wpGDQyJLv3AHAqMH-vxWuZ1HYksX7oq_vldEXCbxmPI/edit#
- This is a standalone Qt application that implements the Visualization / parsing of the Frames metadata, which will get ported over to QGC: https://github.com/junwoo091400/PX4-Airframe-Metadata-support

## Contents
- Added JSON schema and example file for the Frames componenet metadata

## Description
- This adds a new metadata type 'Frames' for supporting dynamically loading the supported frames from the Autopilot to the GCS
- Frame is a generic term for a previously used term `Airframe`, to inclusively bundle ground vehicle / boat / etc, not just aerial vehicles
- The Frame JSON structure is recursive, and any frame can contain many other frames in it's sub-group, which also defines the GCS user selection workflow (Starting from high level, down to low level)
- Schema also needs to be updated whenever there's a new type of a vehicle that we need to add an image for, in order to have a valid `image` Enumerator string tag
- The frames are in a list, to make sure we preserve the order, in order to deliver a consistent GCS usage experience

## TODOs
- [x] Create QGC Implementation for supporting Frames metadata: https://github.com/mavlink/qgroundcontrol/pull/10472