### PR TITLE
Gimbal Device: Adding RC handling

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -529,10 +529,10 @@
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
       </entry>
       <entry value="256" name="GIMBAL_DEVICE_FLAGS_RC_EXCLUSIVE">
-        <description>The gimbal orientation is set exclusively by the rc signals feed to the gimbal's radio control inputs. MAVLink messages for setting the gimbal orientation (GIMBAL_DEVICE_SET_ATTITUDE) are ignored.</description>
+        <description>The gimbal orientation is set exclusively by the RC signals feed to the gimbal's radio control inputs. MAVLink messages for setting the gimbal orientation (GIMBAL_DEVICE_SET_ATTITUDE) are ignored.</description>
       </entry>
       <entry value="512" name="GIMBAL_DEVICE_FLAGS_RC_MIXED">
-        <description>The gimbal orientation is determined by combining/mixing the rc signals feed to the gimbal's radio control inputs and the MAVLink messages for setting the gimbal orientation (GIMBAL_DEVICE_SET_ATTITUDE). How these two controls are combined or mixed is not defined by the protocol but is up to the implementation.</description>
+        <description>The gimbal orientation is determined by combining/mixing the RC signals feed to the gimbal's radio control inputs and the MAVLink messages for setting the gimbal orientation (GIMBAL_DEVICE_SET_ATTITUDE). How these two controls are combined or mixed is not defined by the protocol but is up to the implementation.</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_FLAGS" bitmask="true">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -462,6 +462,9 @@
       <entry value="2048" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
         <description>Gimbal device supports yawing/panning infinetely (e.g. using slip disk).</description>
       </entry>
+      <entry value="8192" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RC_INPUTS">
+        <description>Gimbal device supports radio control inputs as an alternative input for controlling the gimbal orientation.</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_CAP_FLAGS" bitmask="true">
       <description>Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_DEVICE_CAP_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>
@@ -524,6 +527,12 @@
       </entry>
       <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to drone). If this flag is set, the quaternion is in the Earth frame with the x-axis pointing North (yaw absolute). If this flag is not set, the quaternion frame is in the Earth frame rotated so that the x-axis is pointing forward (yaw relative to vehicle).</description>
+      </entry>
+      <entry value="256" name="GIMBAL_DEVICE_FLAGS_RC_EXCLUSIVE">
+        <description>The gimbal orientation is set exclusively by the rc signals feed to the gimbal's radio control inputs. MAVLink messages for setting the gimbal orientation (GIMBAL_DEVICE_SET_ATTITUDE) are ignored.</description>
+      </entry>
+      <entry value="512" name="GIMBAL_DEVICE_FLAGS_RC_MIXED">
+        <description>The gimbal orientation is determined by combining/mixing the rc signals feed to the gimbal's radio control inputs and the MAVLink messages for setting the gimbal orientation (GIMBAL_DEVICE_SET_ATTITUDE). How these two controls are combined or mixed is not defined by the protocol but is up to the implementation.</description>
       </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_FLAGS" bitmask="true">


### PR DESCRIPTION
This is the fourth of a sequence of four PRs, which are intended to finally get the looming changes with regards to the gimbal device protocol merged. These are of two kinds: handling of yaw absolute and relative, and handling of RC signals.

The four PRs are:
1. https://github.com/mavlink/mavlink/pull/1911
2. https://github.com/mavlink/mavlink/pull/1912
3. https://github.com/mavlink/mavlink/pull/1914
4. https://github.com/mavlink/mavlink/pull/1913

The additions to the gimbal device flags and messages have been discussed and agreed to before in
- https://github.com/mavlink/mavlink/issues/1860 "Yet another effort towards unified gimbal device messages"
- https://github.com/mavlink/mavlink/pull/1885 "gimbal: more flexible attitude messages"

see especially https://github.com/mavlink/mavlink/issues/1860#issuecomment-1189939693, https://github.com/mavlink/mavlink/issues/1860#issuecomment-1204714314

These PRs are intended to weed out the little kinks which were remaining.

The four PRs can technically each be merged for itself, but depend on each other, i.e., should not merged at all but in the proper sequence, and they will require rebasing to do so. However, I have done them spearately so you can better see what changes are there. Hopefully that's an appropriate approach.

### This PR: Adding RC handling

This PR adds two flags to allow RC input handling. This was discussed at length in https://github.com/mavlink/mavlink/issues/1860, and agreed to, see https://github.com/mavlink/mavlink/issues/1860#issuecomment-1189939693. This PR should hence be non-controversial, except of naming and language maybe.

_**Note**_: There are gaps in the enums, these areas are for the other yaw-related gimbal device flags from the 3rd PR. So, this PR should not be merged before the 3rd is merged, or needs to be modified.

Olli :)