### PR TITLE
Gimbal Device: Adding handling of absolute/relative yaw

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -462,6 +462,9 @@
       <entry value="2048" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
         <description>Gimbal device supports yawing/panning infinetely (e.g. using slip disk).</description>
       </entry>
+      <entry value="4096" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_YAW_IN_EARTH_FRAME">
+        <description>Gimbal device supports yaw angles and angular velocities relative to North (earth frame). This usually requires support by an autopilot via AUTOPILOT_STATE_FOR_GIMBAL_DEVICE. Support can go on and off during runtime, which is reported by the flag GIMBAL_DEVICE_FLAGS_CAN_ACCEPT_YAW_IN_EARTH_FRAME.</description>
+      </entry>
       <entry value="8192" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RC_INPUTS">
         <description>Gimbal device supports radio control inputs as an alternative input for controlling the gimbal orientation.</description>
       </entry>
@@ -527,6 +530,15 @@
       </entry>
       <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
         <description>Lock yaw angle to absolute angle relative to North (not relative to vehicle). If this flag is set, the yaw angle and z component of angular velocity are relative to North (earth frame, x-axis pointing North), else they are relative to the vehicle heading (vehicle frame, earth frame rotated so that the x-axis is pointing forward).</description>
+      </entry>
+      <entry value="32" name="GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME">
+        <description>Yaw angle and z component of angular velocity are relative to the vehicle heading (vehicle frame, earth frame rotated such that the x-axis is pointing forward).</description>
+      </entry>
+      <entry value="64" name="GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME">
+        <description>Yaw angle and z component of angular velocity are relative to North (earth frame, x-axis is pointing North).</description>
+      </entry>
+      <entry value="128" name="GIMBAL_DEVICE_FLAGS_ACCEPTS_YAW_IN_EARTH_FRAME">
+        <description>Gimbal device can accept yaw angle inputs relative to North (earth frame). This flag is only for reporting (attempts to set this flag are ignored).</description>
       </entry>
       <entry value="256" name="GIMBAL_DEVICE_FLAGS_RC_EXCLUSIVE">
         <description>The gimbal orientation is set exclusively by the RC signals feed to the gimbal's radio control inputs. MAVLink messages for setting the gimbal orientation (GIMBAL_DEVICE_SET_ATTITUDE) are ignored.</description>
@@ -6922,28 +6934,56 @@
     <message id="284" name="GIMBAL_DEVICE_SET_ATTITUDE">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Low level message to control a gimbal device's attitude. This message is to be sent from the gimbal manager to the gimbal device component. Angles and rates can be set to NaN according to use case.</description>
+      <description>Low level message to control a gimbal device's attitude. 
+	  This message is to be sent from the gimbal manager to the gimbal device component. 
+	  The quaternion and angular velocities can be set to NaN according to use case. 
+	  For the angles encoded in the quaternion and the angular velocities holds: 
+	  If the flag GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME is set, then they are relative to the vehicle heading (vehicle frame). 
+	  If the flag GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME is set, then they are relative to absolute North (earth frame). 
+	  If neither of these flags are set, then (for backwards compatibility) it holds: 
+	  If the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set, then they are relative to absolute North (earth frame), 
+	  else they are relative to the vehicle heading (vehicle frame). 
+	  Setting both GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME and GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME is not allowed. 
+	  These rules are to ensure backwards compatibility. 
+	  New implementations should always set either GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME or GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Low level gimbal flags.</field>
-      <field type="float[4]" name="q" invalid="[NaN]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation). The frame depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set. Set fields to NaN to be ignored (only angular velocity should be used).</field>
-      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (positive: rolling to the right). NaN to be ignored.</field>
-      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (positive: pitching up). NaN to be ignored.</field>
-      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: yawing to the right). NaN to be ignored.</field>
+      <field type="float[4]" name="q" invalid="[NaN]">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation). The frame is described in the message description. Set fields to NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (positive: rolling to the right). The frame is described in the message description. NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (positive: pitching up). The frame is described in the message description. NaN to be ignored.</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: yawing to the right). The frame is described in the message description. NaN to be ignored.</field>
     </message>
     <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Message reporting the status of a gimbal device. This message should be broadcast by a gimbal device component at a low regular rate (e.g. 5 Hz). The angles encoded in the quaternion and the angular velocities are relative to North if the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set or relative to the vehicle heading if the flag is not set.</description>
+      <description>Message reporting the status of a gimbal device. 
+	  This message should be broadcast by a gimbal device component at a low regular rate (e.g. 5 Hz). 
+	  For the angles encoded in the quaternion and the angular velocities holds: 
+	  If the flag GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME is set, then they are relative to the vehicle heading (vehicle frame). 
+	  If the flag GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME is set, then they are relative to absolute North (earth frame). 
+	  If neither of these flags are set, then (for backwards compatibility) it holds: 
+	  If the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set, then they are relative to absolute North (earth frame), 
+	  else they are relative to the vehicle heading (vehicle frame). 
+	  Other conditions of the flags are not allowed. 
+	  The quaternion and angular velocities in the other frame can be calculated from delta_yaw and delta_yaw_velocity as 
+	  q_earth = q_delta_yaw * q_vehicle and w_earth = w_delta_yaw_velocity + w_vehicle (if not NaN).
+	  If neither the GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME nor the GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME flag is set, 
+	  then (for backwards compatibility) the data in the delta_yaw and delta_yaw_velocity fields are to be ignored.
+	  New implementations should always set either GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME or GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME, 
+	  and always should set delta_yaw and delta_yaw_velocity either to the proper value or NaN.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint16_t" name="flags" enum="GIMBAL_DEVICE_FLAGS">Current gimbal flags set.</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation). The frame depends on whether the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is set.</field>
-      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (positive: rolling to the right). The frame is as for the quaternion. NaN if unknown.</field>
-      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (positive: pitching up). The frame is as for the quaternion. NaN if unknown.</field>
-      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: yawing to the right). The frame is as for the quaternion. NaN if unknown.</field>
-      <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure).</field>
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation). The frame is described in the message description.</field>
+      <field type="float" name="angular_velocity_x" units="rad/s" invalid="NaN">X component of angular velocity (positive: rolling to the right). The frame is described in the message description. NaN if unknown.</field>
+      <field type="float" name="angular_velocity_y" units="rad/s" invalid="NaN">Y component of angular velocity (positive: pitching up). The frame is described in the message description. NaN if unknown.</field>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: yawing to the right). The frame is described in the message description. NaN if unknown.</field>
+      <field type="uint32_t" name="failure_flags" display="bitmask" enum="GIMBAL_DEVICE_ERROR_FLAGS">Failure flags (0 for no failure)</field>
+      <extensions/>
+      <field type="float" name="delta_yaw" units="rad" invalid="NAN">Yaw angle relating the quaternions in earth and body frames (see message description). NaN if unknown.</field>
+      <field type="float" name="delta_yaw_velocity" units="rad/s" invalid="NAN">Yaw angular velocity relating the angular velocities in earth and body frames (see message description). NaN if unknown.</field>
     </message>
     <message id="286" name="AUTOPILOT_STATE_FOR_GIMBAL_DEVICE">
       <wip/>
@@ -6961,6 +7001,8 @@
       <field type="float" name="feed_forward_angular_velocity_z" units="rad/s" invalid="NaN">Feed forward Z component of angular velocity (positive: yawing to the right). NaN to be ignored. This is to indicate if the autopilot is actively yawing.</field>
       <field type="uint16_t" name="estimator_status" enum="ESTIMATOR_STATUS_FLAGS" display="bitmask">Bitmap indicating which estimator outputs are valid.</field>
       <field type="uint8_t" name="landed_state" enum="MAV_LANDED_STATE" invalid="MAV_LANDED_STATE_UNDEFINED">The landed state. Is set to MAV_LANDED_STATE_UNDEFINED if landed state is unknown.</field>
+      <extensions/>
+      <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity in NED (North, East, Down). NaN if unknown.</field>
     </message>
     <message id="287" name="GIMBAL_MANAGER_SET_PITCHYAW">
       <wip/>


### PR DESCRIPTION
This is the third of a sequence of four PRs, which are intended to finally get the looming changes with regards to the gimbal device protocol merged. These are of two kinds: handling of yaw absolute and relative, and handling of RC signals.

The four PRs are:
1. https://github.com/mavlink/mavlink/pull/1911
2. https://github.com/mavlink/mavlink/pull/1912
3. https://github.com/mavlink/mavlink/pull/1914
4. https://github.com/mavlink/mavlink/pull/1913

The additions to the gimbal device flags and messages have been discussed and agreed to before in
- https://github.com/mavlink/mavlink/issues/1860 "Yet another effort towards unified gimbal device messages"
- https://github.com/mavlink/mavlink/pull/1885 "gimbal: more flexible attitude messages"

see especially https://github.com/mavlink/mavlink/issues/1860#issuecomment-1189939693, https://github.com/mavlink/mavlink/issues/1860#issuecomment-1204714314

These PRs are intended to weed out the little kinks which were remaining.

The four PRs can technically each be merged for itself, but depend on each other, i.e., should not merged at all but in the proper sequence, and they will require rebasing to do so. However, I have done them spearately so you can better see what changes are there. Hopefully that's an appropriate approach.

### This PR: Adding handling of absolute/relative yaw

This is propbably the most "difficult" PR among the four, given that the abs/real yaw topic produced the most discussion and that it's also where things got stuck again.

The PR here is essentially @julianoes attempt https://github.com/mavlink/mavlink/pull/1885, with the kinks worked out, some additions, a hopefully complete definiton of the things, and maybe some language changes.

As part of the discussion in https://github.com/mavlink/mavlink/issues/1860 it was concluded that the revision 
- should be achieved via extensions to the messages
- should be backwards compatible, in all directions, old-old, new-old, old-new, and new-new.

These two requirements essentially rule out all the other suggestions, which may be simpler and cleaner, and leaves us with the approach to add two flags to indicate the frame for yaw (which is exactly what @julianoes' PR was also doing).

With this given, let's go through the various changes made in this PR:

#### 1. It adds the two flags GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME and GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME. 

These are to indicate which frame is used for yaw in the messages GIMBAL_DEVICE_SET_ATTITUDE and GIMBAL_DEVICE_ATTITUDE_STATUS. One needs them in order to break with the current apporach there the frame is linked to the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK, which however was identified to be too restrictive. One may think one can do it with only one flag, but this would violate backwards compatibility. Hence two flags are needed. The descriptions hopefully explain their usage.

Just as a memo, there is actually a migration path towards there these flags can be deprecated in some future:
- Today, in order to achieve full back wards compatibility, one should set GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME if the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK is not set, and set GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME if the flag GIMBAL_DEVICE_FLAGS_YAW_LOCK  is set.
- In a next step, i.e. a next version round of the implementations, the implementations could go towards always setting  GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME, but never setting GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME. This would much simplify the usage of the messages, compared to the slight hoops necessary for now.
- In a last step, i.e. yet another next version round, bith flags would become obsolete. 

#### 2. The extensions delta_yaw and delta_yaw_velocity are added to the message GIMBAL_DEVICE_ATTITUDE_STATUS. 

These are to allow the conversion from one frame to the other with the data given in the main body of the message. The message descriptions hopefully precisely define the relation ships. In order to ensure back wards compatibility, some definition is required to distinguish and handle the case delta_yaw=delta_yaw_velocity=0, which means no extension provided, from other cases.

#### 3. The cap flag GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_YAW_IN_EARTH_FRAME is added. 
 
It might be that one can find a set of definitions such that this flag is not needed, it however seems to be an obvious good idea, to just tell straight forwardly. So far this would have been achieved by setting the flag GIMBAL_DEVICE_CAP_FLAGS_HAS_YAW_LOCK, i.e., if this flag was set one would have concluded that the gimbal must also be able to handle absolute yaw. Since we broke with this correlation however, we want to have a new respective cap flag. Not in @julianeous attempt, but should be an obvious addition.

#### 4. The flag GIMBAL_DEVICE_FLAGS_ACCEPTS_YAW_IN_EARTH_FRAME is added. 

This is a new one. It allows to achieve two things:
- first, it resolves a potential race condition at startup, which goes as follows: The gimbal first needs to receive AUTOPILOT_STATE_FOR_GIMBAL_DEVICE before it can decide if it can support absolute yaw, however the capabilities would be usually requested very early on. The only way out currently would be for the gimbal device to NOT send the capabilities or to nack such requests until it eventually has gotten the AUTOPILOT_STATE_FOR_GIMBAL_DEVICE messages, with the estimator flags set as needed. In short, the gimbal device discovery would have to be postponed until the autopilot has achieved position lock (or similar). With the suggested flags, the gimbal device could immediately respond to capability requests, but could indicate to a gimbal manager that it can't yet use yaw in earth frame features.
- second, it well can happen that during operation e.g. position lock is lost, and that the gimbal cannot do the yaw earth frame things for the period of time there this error condition exists.

One could instead of adding this flag add a further condition to the ERROR_FLAGS enum. This would bode well with the second situation, I however didn't considered this because I always ened up with something which didn't look natural to me. E.g., if a gimbal just would not support yaw earth frame, there would be always a flag raised in the error flags, although nothing went wrong. I.e., erroflags == 0 would not mean no error anymore.

#### 5. The extension "angular_velocity_z" was added to the AUTOPILOT_STATE_FOR_GIMBAL_DEVICE message. 

This is also a new one, and in fact corrects for an omission which should not have occured. Without that data, the gimbal cannot translate the angular velocities from earth to vehicle and vice versa. This means that it e.g. cannot achieve a steady rotation around z when the control is in earth frame, i.e., the camera would wiggle then the vehicle would wiggle.


Olli :)




