### PR TITLE
Gimbal Device: Add error flag no gimbal manager

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -571,7 +571,7 @@
         <description>There is an error with the gimbal power source.</description>
       </entry>
       <entry value="32" name="GIMBAL_DEVICE_ERROR_FLAGS_MOTOR_ERROR">
-        <description>There is an error with the gimbal motor's.</description>
+        <description>There is an error with the gimbal motors.</description>
       </entry>
       <entry value="64" name="GIMBAL_DEVICE_ERROR_FLAGS_SOFTWARE_ERROR">
         <description>There is an error with the gimbal's software.</description>
@@ -580,7 +580,10 @@
         <description>There is an error with the gimbal's communication.</description>
       </entry>
       <entry value="256" name="GIMBAL_DEVICE_ERROR_FLAGS_CALIBRATION_RUNNING">
-        <description>Gimbal is currently calibrating.</description>
+        <description>Gimbal device is currently calibrating.</description>
+      </entry>
+      <entry value="512" name="GIMBAL_DEVICE_ERROR_FLAGS_NO_MANAGER">
+        <description>Gimbal device is not assigned to a gimbal manager.</description>
       </entry>
     </enum>
     <!-- gripper action enum -->


### PR DESCRIPTION
This adds a flag to the gimbal device error flags which indicates that the gimbal device is not assigned to a gimbal manger.

This is useful to check/see if the system is healthy (operational). It is not strictly an error, like calibration is not strictly an error, but like calibration it is a mal condition. Note that gimbal devices must not be used except by the gimbal manager, which implies that there must be such a gimbal manager and that the gimbal device must have discovered its gimbal manager.

Such as flag is also in the storm32.xml protocol, and was found to be useful.

