### PR TITLE
message_definitions: add all_with_development.xml

### DIFF
--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -7,7 +7,8 @@
   -->
   <include>ASLUAV.xml</include>
   <include>common.xml</include>
-  <include>development.xml</include>
+  <!--To use messages from development, use all_with_development.xml-->
+  <!--<include>development.xml</include>-->
   <include>icarous.xml</include>
   <!-- matrixpilot.xml: ERROR: Duplicate message id 150 for FLEXIFUNCTION_SET (matrixpilot.xml:50) also used by SENSOR_OFFSETS (ardupilotmega.xml:1101) -->
   <!-- <include>matrixpilot.xml</include> -->

--- a/message_definitions/v1.0/all_with_development.xml
+++ b/message_definitions/v1.0/all_with_development.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<mavlink>
+  <include>all.xml</include>
+  <include>development.xml</include>
+  <messages/>
+</mavlink>


### PR DESCRIPTION
With this commit we have:
- all_with_development.xml: for development and message ID conflict checking.
- all.xml: for released software connecting to all flight stacks, e.g. QGC, MAVSDK, pymavlink.