### PR TITLE
pymavlink: update submodule

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This should fix the node CI tests.

This includes https://github.com/ArduPilot/pymavlink/pull/752.