### PR TITLE
Gimbal manager: Add gimbal device flags to low word of gimbal manager flags

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -507,6 +507,12 @@
       <entry value="2048" name="GIMBAL_MANAGER_CAP_FLAGS_SUPPORTS_INFINITE_YAW">
         <description>Based on GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_INFINITE_YAW.</description>
       </entry>
+      <entry value="4096" name="GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_YAW_IN_EARTH_FRAME">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_SUPPORTS_YAW_IN_EARTH_FRAME.</description>
+      </entry>
+      <entry value="8192" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RC_INPUTS">
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_RC_INPUTS.</description>
+      </entry>
       <entry value="65536" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
         <description>Gimbal manager supports to point to a local position.</description>
       </entry>
@@ -550,19 +556,34 @@
     <enum name="GIMBAL_MANAGER_FLAGS" bitmask="true">
       <description>Flags for high level gimbal manager operation The first 16 bits are identical to the GIMBAL_DEVICE_FLAGS.</description>
       <entry value="1" name="GIMBAL_MANAGER_FLAGS_RETRACT">
-        <description>Based on GIMBAL_DEVICE_FLAGS_RETRACT</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_RETRACT.</description>
       </entry>
       <entry value="2" name="GIMBAL_MANAGER_FLAGS_NEUTRAL">
-        <description>Based on GIMBAL_DEVICE_FLAGS_NEUTRAL</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_NEUTRAL.</description>
       </entry>
       <entry value="4" name="GIMBAL_MANAGER_FLAGS_ROLL_LOCK">
-        <description>Based on GIMBAL_DEVICE_FLAGS_ROLL_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_ROLL_LOCK.</description>
       </entry>
       <entry value="8" name="GIMBAL_MANAGER_FLAGS_PITCH_LOCK">
-        <description>Based on GIMBAL_DEVICE_FLAGS_PITCH_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_PITCH_LOCK.</description>
       </entry>
       <entry value="16" name="GIMBAL_MANAGER_FLAGS_YAW_LOCK">
-        <description>Based on GIMBAL_DEVICE_FLAGS_YAW_LOCK</description>
+        <description>Based on GIMBAL_DEVICE_FLAGS_YAW_LOCK.</description>
+      </entry>
+      <entry value="32" name="GIMBAL_MANAGER_FLAGS_YAW_IN_VEHICLE_FRAME">
+        <description>Based on GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME.</description>
+      </entry>
+      <entry value="64" name="GIMBAL_MANAGER_FLAGS_YAW_IN_EARTH_FRAME">
+        <description>Based on GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME.</description>
+      </entry>
+      <entry value="128" name="GIMBAL_MANAGER_FLAGS_ACCEPTS_YAW_IN_EARTH_FRAME">
+        <description>Based on GIMBAL_DEVICE_FLAGS_ACCEPTS_YAW_IN_EARTH_FRAME.</description>
+      </entry>
+      <entry value="256" name="GIMBAL_MANAGER_FLAGS_RC_EXCLUSIVE">
+        <description>Based on GIMBAL_DEVICE_FLAGS_RC_EXCLUSIVE.</description>
+      </entry>
+      <entry value="512" name="GIMBAL_MANAGER_FLAGS_RC_MIXED">
+        <description>Based on GIMBAL_DEVICE_FLAGS_RC_MIXED.</description>
       </entry>
     </enum>
     <enum name="GIMBAL_DEVICE_ERROR_FLAGS" bitmask="true">


### PR DESCRIPTION
The lower 16 bits of the gimbal manager flags and cap flags are supposed to coincide the gimbal device flags and cap flags. This PR aligns the manager flags & cap flags with the recent additions to the gimbal device flags & cap flags. I have also added .'s in the descriptions of the gimbal manager flags, as it's so in the descriptions of the gimbal manager cap flags.