### PR TITLE
Add the MAV_TYPE_VTOL_TILTWING aircraft type

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -142,10 +142,10 @@
       <entry value="23" name="MAV_TYPE_VTOL_TAILSITTER">
         <description>Tailsitter VTOL. Fuselage and wings orientation changes depending on flight phase: vertical for hover, horizontal for cruise. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.</description>
       </entry>
-      <!-- Entries 24/25 reserved for other VTOL airframe -->
-      <entry value="24" name="MAV_TYPE_VTOL_RESERVED4">
-        <description>VTOL reserved 4</description>
+      <entry value="24" name="MAV_TYPE_VTOL_TILTWING">
+        <description>Tiltwing VTOL. Fuselage stays horizontal in all flight phases. The whole wing, along with any attached engine, can tilt between vertical and horizontal mode.</description>
       </entry>
+      <!-- Entry 25 reserved for other VTOL airframe -->
       <entry value="25" name="MAV_TYPE_VTOL_RESERVED5">
         <description>VTOL reserved 5</description>
       </entry>


### PR DESCRIPTION
Quoting the Wikipedia article on [Tiltwing](https://en.wikipedia.org/wiki/Tiltwing):

> A tiltwing aircraft features a wing that is horizontal for conventional forward flight and rotates up for vertical takeoff and landing. It is similar to the tiltrotor design where only the propeller and engine rotate. Tiltwing aircraft are typically fully capable of VTOL operations.

I took the liberty of re-purposing `MAV_TYPE_VTOL_RESERVED4` for this aircraft type. Of course I would be totally fine with adding a new type instead.