### PR TITLE
COMPONENT METADATA: translation

### DIFF
--- a/component_metadata/actuators.schema.json
+++ b/component_metadata/actuators.schema.json
@@ -94,7 +94,11 @@
         "version": {
             "description":  "Version number for the format of this file.",
             "type":         "integer",
-            "minimum":      1
+            "minimum":      2
+        },
+        "translation": {
+            "type": "object",
+            "description": "This needs to match exactly with the content of actuators.translation.json"
         },
         "show-ui-if": {
             "$ref": "#/$defs/condition",

--- a/component_metadata/actuators.translation.json
+++ b/component_metadata/actuators.translation.json
@@ -1,0 +1,94 @@
+{
+    "translation": {
+        "items": {
+            "outputs_v1": {
+                "list": {
+                    "key": "label",
+                    "items": {
+                        "subgroups": {
+                            "list": {
+                                "items": {
+                                    "parameters": {
+                                        "list": {
+                                            "key": "name",
+                                            "translate": [ "label" ]
+                                        }
+                                    },
+                                    "per-channel-parameters": {
+                                        "list": {
+                                            "key": "name",
+                                            "translate": [ "label" ]
+                                        }
+                                    },
+                                    "channels": {
+                                        "list": {
+                                            "key": "param-index",
+                                            "translate": [ "label" ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "functions_v1": {
+                "items": {
+                    "*": {
+                        "translate": [ "label" ],
+                        "items": {
+                            "note": {
+                                "translate": [ "text" ]
+                            }
+                        }
+                    }
+                }
+            },
+            "mixer_v1": {
+                "items": {
+                    "actuator-types": {
+                        "items": {
+                            "*": {
+                                "items": {
+                                    "per-item-parameters": {
+                                        "list": {
+                                            "key": "name",
+                                            "translate": [ "label" ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "config": {
+                        "list": {
+                            "key": "option",
+                            "translate": [ "title" ],
+                            "items": {
+                                "actuators": {
+                                    "list": {
+                                        "translate": [ "group-label", "item-label-prefix" ],
+                                        "items": {
+                                            "parameters": {
+                                                "list": {
+                                                    "key": "name",
+                                                    "translate": [ "label" ]
+                                                }
+                                            },
+                                            "per-item-parameters": {
+                                                "list": {
+                                                    "key": "name",
+                                                    "translate": [ "label" ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/component_metadata/parameter.schema.json
+++ b/component_metadata/parameter.schema.json
@@ -8,7 +8,11 @@
         "version": {
             "description":  "Version number for the format of this file.",
             "type":         "integer",
-            "minimum":      1
+            "minimum":      2
+        },
+        "translation": {
+            "type": "object",
+            "description": "This needs to match exactly with the content of parameter.translation.json"
         },
         "parameters": {
             "type": "array",

--- a/component_metadata/parameter.translation.json
+++ b/component_metadata/parameter.translation.json
@@ -1,0 +1,27 @@
+{
+    "translation": {
+        "items": {
+            "parameters": {
+                "list": {
+                    "key": "name",
+                    "translate": [ "shortDesc", "longDesc" ],
+                    "translate-global": ["category", "group"],
+                    "items": {
+                        "bitmask": {
+                            "list": {
+                                "key": "index",
+                                "translate": [ "description" ]
+                            }
+                        },
+                        "values": {
+                            "list": {
+                                "key": "value",
+                                "translate": [ "description" ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/component_metadata/translation.schema.json
+++ b/component_metadata/translation.schema.json
@@ -1,0 +1,94 @@
+{
+    "$id":          "https://mavlink.io/translation.schema.json",
+    "$schema":      "http://json-schema.org/draft-07/schema",
+    "description":  "Schema for translations (*.translation.json)",
+    "type":         "object",
+
+    "definitions": {
+        "items": {
+            "type": "object",
+
+            "patternProperties": {
+                "^(\\*|[0-9a-zA-Z-_]+)$": {
+                    "comment": "Select individual attributes by name, or use '*' to match all",
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "object",
+                            "$ref": "#/definitions/items"
+                        },
+                        "$ref": {
+                            "type": "string",
+                            "comment": "Reference to one of the items in $defs (see below)",
+                            "pattern": "^#/\\$defs/"
+                        },
+                        "translate": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "Object attribute to be translated. Might refer to a string or a list of strings."
+                            }
+                        },
+                        "translate-global": {
+                            "description": "Translate globally: this can be used for repeated strings, such as a category, which is then deduplicated and thus needs to be translated only once.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "description": "Object attribute to be translated. Might refer to a string or a list of strings."
+                            }
+                        },
+                        "list": {
+                            "type": "object",
+                            "properties": {
+                                "key": {
+                                    "type": "string",
+                                    "description": "Optionally specify a string/integer attribute that exists in each object of the list and uniquely identifies that object. If possible, specify a key. If not is specified, list indexes will be used (which may cause translation mismatch if elements are added/removed from the list)."
+                                },
+                                "items": {
+                                    "type": "object",
+                                    "$ref": "#/definitions/items"
+                                },
+                                "translate": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "description": "See above."
+                                    }
+                                },
+                                "translate-global": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "description": "See above."
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+
+    "properties": {
+        "translation": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "object",
+                    "$ref": "#/definitions/items"
+                },
+                "$defs": {
+                    "comment": "Custom references (for recursive definitions). The keys in this dict can be used in a '$ref' as '#/$defs/<key>'",
+                    "$ref": "#/definitions/items"
+                }
+            },
+            "required":             [ "items" ],
+            "additionalProperties": false
+        }
+    },
+    "required":             [ "translation" ]
+}


### PR DESCRIPTION
@hamishwillee this adds the translation support as discussed in https://github.com/mavlink/mavlink/issues/1656.

- Uses a summary json file with urls and modification timestamps to individual translated (and compressed) .ts files.
  I setup an example repo under https://github.com/bkueng/px4_metadata_translations. It explains the work-flow, CI integration is not done yet. @hamishwillee do you want to look into that? In particular for the CrowdIn integration.
- It's generic so new metadata types do not require GCS changes.
- Versioning: there's different approaches, probably the simplest is to use branches in the metadata repo.
- QGC implementation: https://github.com/mavlink/qgroundcontrol/pull/10522

TODO (outside of mavlink):
- CI integrations & crowdin sync
- Documentation