### PR TITLE
New landing target messages TARGET_ABSOLUTE/RELATIVE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1158,7 +1158,7 @@
       </entry>
       <entry value="32" name="MAV_CMD_DO_FOLLOW" hasLocation="false" isDestination="false">
         <description>Begin following a target</description>
-        <param index="1" label="System ID" minValue="0" maxValue="255" increment="1">System ID (of the FOLLOW_TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode.</param>
+        <param index="1" label="System ID" minValue="0" maxValue="255" increment="1">System ID (of the TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode.</param>
         <param index="2">Reserved</param>
         <param index="3">Reserved</param>
         <param index="4" label="Altitude Mode" minValue="0" maxValue="2" increment="1">Altitude mode: 0: Keep current altitude, 1: keep altitude difference to target, 2: go to a fixed altitude above home.</param>
@@ -3590,19 +3590,28 @@
         <description>RTK basestation centered, north, east, down</description>
       </entry>
     </enum>
-    <enum name="LANDING_TARGET_TYPE">
-      <description>Type of landing target</description>
-      <entry value="0" name="LANDING_TARGET_TYPE_LIGHT_BEACON">
-        <description>Landing target signaled by light beacon (ex: IR-LOCK)</description>
+    <enum name="TARGET_TYPE">
+      <description>Type of target</description>
+      <entry value="0" name="TARGET_TYPE_LIGHT_BEACON">
+        <description>Target signaled by light beacon (ex: IR-LOCK)</description>
       </entry>
-      <entry value="1" name="LANDING_TARGET_TYPE_RADIO_BEACON">
-        <description>Landing target signaled by radio beacon (ex: ILS, NDB)</description>
+      <entry value="1" name="TARGET_TYPE_RADIO_BEACON">
+        <description>Target signaled by radio beacon (ex: ILS, NDB)</description>
       </entry>
-      <entry value="2" name="LANDING_TARGET_TYPE_VISION_FIDUCIAL">
-        <description>Landing target represented by a fiducial marker (ex: ARTag)</description>
+      <entry value="2" name="TARGET_TYPE_VISION_FIDUCIAL">
+        <description>Target represented by a fiducial marker (ex: ARTag)</description>
       </entry>
-      <entry value="3" name="LANDING_TARGET_TYPE_VISION_OTHER">
-        <description>Landing target represented by a pre-defined visual shape/feature (ex: X-marker, H-marker, square)</description>
+      <entry value="3" name="TARGET_TYPE_VISION_OTHER">
+        <description>Target represented by a pre-defined visual shape/feature (ex: X-marker, H-marker, square)</description>
+      </entry>
+    </enum>
+    <enum name="TARGET_TASK">
+      <description>Type of task associated with the target measurement</description>
+      <entry value="0" name="TARGET_TASK_FOLLOW">
+        <description>Follow the target from a given distance</description>
+      </entry>
+      <entry value="1" name="TARGET_TASK_LAND">
+        <description>Land on the target</description>
       </entry>
     </enum>
     <enum name="VTOL_TRANSITION_HEADING">
@@ -6231,19 +6240,23 @@
       <extensions/>
       <field type="int16_t" name="temperature_press_diff" units="cdegC" invalid="0">Differential pressure temperature (0, if not available). Report values of 0 (or 1) as 1 cdegC.</field>
     </message>
-    <message id="144" name="FOLLOW_TARGET">
-      <description>Current motion information from a designated system</description>
+    <message id="144" name="ABSOLUTE_TARGET">
+      <description>Current motion information from sensors on a target</description>
       <field type="uint64_t" name="timestamp" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
       <field type="float" name="alt" units="m">Altitude (MSL)</field>
-      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target velocity (0,0,0) for unknown</field>
-      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target acceleration (0,0,0) for unknown</field>
-      <field type="float[4]" name="attitude_q" invalid="[0]">(0 0 0 0 for unknown)</field>
+      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target velocity in MAV_FRAME (0,0,0) for unknown</field>
+      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target acceleration in MAV_FRAME (0,0,0) for unknown</field>
+      <field type="float[4]" name="attitude_q" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
       <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
-      <field type="float[3]" name="position_cov">eph epv</field>
+      <field type="float[2]" name="position_cov">eph epv</field>
+      <field type="float[3]" name="vel_cov" units="[m/s]^2">Variance of the target's velocity in MAV_FRAME</field>
+      <field type="float[3]" name="acc_cov" units="[m/s/s]^2">Variance of the target's acceleration in MAV_FRAME</field>
       <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
     </message>
     <message id="146" name="CONTROL_SYSTEM_STATE">
       <description>The smoothed, monotonic system state used to feed the control loops of the system.</description>
@@ -6299,8 +6312,8 @@
       <extensions/>
       <field type="uint8_t[18]" name="uid2">UID if provided by hardware (supersedes the uid field. If this is non-zero, use this field, otherwise use uid)</field>
     </message>
-    <message id="149" name="LANDING_TARGET">
-      <description>The location of a landing target. See: https://mavlink.io/en/services/landing_target.html</description>
+    <message id="149" name="RELATIVE_TARGET">
+      <description>The location of a target from an onboard sensor. See: https://mavlink.io/en/services/landing_target.html</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
@@ -6313,11 +6326,12 @@
       <field type="float" name="x" units="m">X Position of the landing target in MAV_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the landing target in MAV_FRAME</field>
       <field type="float" name="z" units="m">Z Position of the landing target in MAV_FRAME</field>
-      <field type="float[3]" name="pos_unc">Variance of landing target position in MAV_FRAME (var_x, var_y, var_z)</field>
+      <field type="float[3]" name="pos_unc" units="m^2">Variance of landing target position in MAV_FRAME (var_x, var_y, var_z)</field>
       <field type="float" name="target_yaw_unc" units="rad^2">Variance of landing target's orientation in MAV_FRAME</field>
       <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Note used if MAV_FRAME is MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
+      <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is already MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="uint8_t" name="type" enum="TARGET_TYPE">Type of landing target</field>
+      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
       <field type="uint8_t" name="position_valid" invalid="0">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
     </message>
     <!-- imported from ardupilotmega.xml (2019) -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1158,7 +1158,7 @@
       </entry>
       <entry value="32" name="MAV_CMD_DO_FOLLOW" hasLocation="false" isDestination="false">
         <description>Begin following a target</description>
-        <param index="1" label="System ID" minValue="0" maxValue="255" increment="1">System ID (of the TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode.</param>
+        <param index="1" label="System ID" minValue="0" maxValue="255" increment="1">System ID (of the FOLLOW_TARGET beacon). Send 0 to disable follow-me and return to the default position hold mode.</param>
         <param index="2">Reserved</param>
         <param index="3">Reserved</param>
         <param index="4" label="Altitude Mode" minValue="0" maxValue="2" increment="1">Altitude mode: 0: Keep current altitude, 1: keep altitude difference to target, 2: go to a fixed altitude above home.</param>
@@ -3590,28 +3590,19 @@
         <description>RTK basestation centered, north, east, down</description>
       </entry>
     </enum>
-    <enum name="TARGET_TYPE">
-      <description>Type of target</description>
-      <entry value="0" name="TARGET_TYPE_LIGHT_BEACON">
-        <description>Target signaled by light beacon (ex: IR-LOCK)</description>
+    <enum name="LANDING_TARGET_TYPE">
+      <description>Type of Landing target</description>
+      <entry value="0" name="LANDING_TARGET_TYPE_LIGHT_BEACON">
+        <description>Landing target signaled by light beacon (ex: IR-LOCK)</description>
       </entry>
-      <entry value="1" name="TARGET_TYPE_RADIO_BEACON">
-        <description>Target signaled by radio beacon (ex: ILS, NDB)</description>
+      <entry value="1" name="LANDING_TARGET_TYPE_RADIO_BEACON">
+        <description>Landing target signaled by radio beacon (ex: ILS, NDB)</description>
       </entry>
-      <entry value="2" name="TARGET_TYPE_VISION_FIDUCIAL">
-        <description>Target represented by a fiducial marker (ex: ARTag)</description>
+      <entry value="2" name="LANDING_TARGET_TYPE_VISION_FIDUCIAL">
+        <description>Landing target represented by a fiducial marker (ex: ARTag)</description>
       </entry>
-      <entry value="3" name="TARGET_TYPE_VISION_OTHER">
-        <description>Target represented by a pre-defined visual shape/feature (ex: X-marker, H-marker, square)</description>
-      </entry>
-    </enum>
-    <enum name="TARGET_TASK">
-      <description>Type of task associated with the target measurement</description>
-      <entry value="0" name="TARGET_TASK_FOLLOW">
-        <description>Follow the target from a given distance</description>
-      </entry>
-      <entry value="1" name="TARGET_TASK_LAND">
-        <description>Land on the target</description>
+      <entry value="3" name="LANDING_TARGET_TYPE_VISION_OTHER">
+        <description>Landing target represented by a pre-defined visual shape/feature (ex: X-marker, H-marker, square)</description>
       </entry>
     </enum>
     <enum name="VTOL_TRANSITION_HEADING">
@@ -6240,23 +6231,19 @@
       <extensions/>
       <field type="int16_t" name="temperature_press_diff" units="cdegC" invalid="0">Differential pressure temperature (0, if not available). Report values of 0 (or 1) as 1 cdegC.</field>
     </message>
-    <message id="144" name="ABSOLUTE_TARGET">
-      <description>Current motion information from sensors on a target</description>
+    <message id="144" name="FOLLOW_TARGET">
+      <description>Current motion information from a designated system</description>
       <field type="uint64_t" name="timestamp" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
       <field type="float" name="alt" units="m">Altitude (MSL)</field>
-      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target velocity in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target acceleration in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[4]" name="attitude_q" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
+      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target velocity (0,0,0) for unknown</field>
+      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target acceleration (0,0,0) for unknown</field>
+      <field type="float[4]" name="attitude_q" invalid="[0]">(0 0 0 0 for unknown)</field>
       <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
-      <field type="float[2]" name="position_cov">eph epv</field>
-      <field type="float[3]" name="vel_cov" units="[m/s]^2">Variance of the target's velocity in MAV_FRAME</field>
-      <field type="float[3]" name="acc_cov" units="[m/s/s]^2">Variance of the target's acceleration in MAV_FRAME</field>
+      <field type="float[3]" name="position_cov">eph epv</field>
       <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
-      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
-      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
     </message>
     <message id="146" name="CONTROL_SYSTEM_STATE">
       <description>The smoothed, monotonic system state used to feed the control loops of the system.</description>
@@ -6312,8 +6299,8 @@
       <extensions/>
       <field type="uint8_t[18]" name="uid2">UID if provided by hardware (supersedes the uid field. If this is non-zero, use this field, otherwise use uid)</field>
     </message>
-    <message id="149" name="RELATIVE_TARGET">
-      <description>The location of a target from an onboard sensor. See: https://mavlink.io/en/services/landing_target.html</description>
+    <message id="149" name="LANDING_TARGET">
+      <description>The location of a landing target. See: https://mavlink.io/en/services/landing_target.html</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
@@ -6326,12 +6313,8 @@
       <field type="float" name="x" units="m">X Position of the landing target in MAV_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the landing target in MAV_FRAME</field>
       <field type="float" name="z" units="m">Z Position of the landing target in MAV_FRAME</field>
-      <field type="float[3]" name="pos_unc" units="m^2">Variance of landing target position in MAV_FRAME (var_x, var_y, var_z)</field>
-      <field type="float" name="target_yaw_unc" units="rad^2">Variance of landing target's orientation in MAV_FRAME</field>
       <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is already MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="uint8_t" name="type" enum="TARGET_TYPE">Type of landing target</field>
-      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
+      <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
       <field type="uint8_t" name="position_valid" invalid="0">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
     </message>
     <!-- imported from ardupilotmega.xml (2019) -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6316,7 +6316,7 @@
       <field type="float[3]" name="pos_unc">Variance of landing target position in MAV_FRAME (var_x, var_y, var_z)</field>
       <field type="float" name="target_yaw_unc" units="rad^2">Variance of landing target's orientation in MAV_FRAME</field>
       <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float[4]" name="q_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Note used if MAV_FRAME is MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Note used if MAV_FRAME is MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
       <field type="uint8_t" name="position_valid" invalid="0">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7403,6 +7403,7 @@
       <field type="uint16_t" name="sequence_oldest_available">Oldest Sequence number that is still available after the sequence set in REQUEST_EVENT.</field>
       <field type="uint8_t" name="reason" enum="MAV_EVENT_ERROR_REASON">Error reason.</field>
     </message>
+    <!-- The message ids 510 and 511 are reserved for ABSOLUTE_TARGET and RELATIVE_TARGET, currently in development.xml. -->
     <message id="387" name="CANFD_FRAME">
       <description>A forwarded CANFD frame as requested by MAV_CMD_CAN_FORWARD. These are separated from CAN_FRAME as they need different handling (eg. TAO handling)</description>
       <field type="uint8_t" name="target_system">System ID.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6310,7 +6310,10 @@
       <field type="float" name="x" units="m">X Position of the landing target in MAV_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the landing target in MAV_FRAME</field>
       <field type="float" name="z" units="m">Z Position of the landing target in MAV_FRAME</field>
+      <field type="float[6]" name="pos_unc">Covariance of landing target position in MAV_FRAME (var_x, cov_xy, cov_xz, var_y, cov_yz, var_z)</field>
+      <field type="float" name="target_yaw_unc" units="rad^2">Variance of landing target's orientation in MAV_FRAME</field>
       <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_att">Quaternion of sensor's orientation from MAV_FRAME to NED (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
       <field type="uint8_t" name="position_valid" invalid="0">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -322,6 +322,9 @@
       <entry value="21" name="MAV_FRAME_LOCAL_FLU">
         <description>FLU local tangent frame (x: Forward, y: Left, z: Up) with origin fixed relative to earth. The forward axis is aligned to the front of the vehicle in the horizontal plane.</description>
       </entry>
+      <entry value="22" name="MAV_FRAME_SENSOR">
+        <description>Generic sensor frame for target observations (e.g. fiducial markers).</description>
+      </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
       <entry value="0" name="MAVLINK_DATA_STREAM_IMG_JPEG">
@@ -6310,10 +6313,10 @@
       <field type="float" name="x" units="m">X Position of the landing target in MAV_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the landing target in MAV_FRAME</field>
       <field type="float" name="z" units="m">Z Position of the landing target in MAV_FRAME</field>
-      <field type="float[6]" name="pos_unc">Covariance of landing target position in MAV_FRAME (var_x, cov_xy, cov_xz, var_y, cov_yz, var_z)</field>
+      <field type="float[3]" name="pos_unc">Variance of landing target position in MAV_FRAME (var_x, var_y, var_z)</field>
       <field type="float" name="target_yaw_unc" units="rad^2">Variance of landing target's orientation in MAV_FRAME</field>
       <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float[4]" name="q_att">Quaternion of sensor's orientation from MAV_FRAME to NED (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Note used if MAV_FRAME is MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
       <field type="uint8_t" name="position_valid" invalid="0">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -322,9 +322,6 @@
       <entry value="21" name="MAV_FRAME_LOCAL_FLU">
         <description>FLU local tangent frame (x: Forward, y: Left, z: Up) with origin fixed relative to earth. The forward axis is aligned to the front of the vehicle in the horizontal plane.</description>
       </entry>
-      <entry value="22" name="MAV_FRAME_SENSOR">
-        <description>Generic sensor frame for target observations (e.g. fiducial markers).</description>
-      </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
       <entry value="0" name="MAVLINK_DATA_STREAM_IMG_JPEG">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3591,7 +3591,7 @@
       </entry>
     </enum>
     <enum name="LANDING_TARGET_TYPE">
-      <description>Type of Landing target</description>
+      <description>Type of landing target</description>
       <entry value="0" name="LANDING_TARGET_TYPE_LIGHT_BEACON">
         <description>Landing target signaled by light beacon (ex: IR-LOCK)</description>
       </entry>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -376,8 +376,8 @@
       <field type="float[4]" name="q_target" invalid="[0]">Quaternion of the target's orientation from its body frame to the vehicle's NED frame.</field>
       <field type="float[3]" name="rates" units="rad/s" invalid="[0]">Target's roll, pitch and yaw rates</field>
       <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
-      <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in its body frame</field>
-      <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in its body frame</field>
+      <field type="float[3]" name="vel_std" units="[m/s]">Standard deviation of the target's velocity in its body frame</field>
+      <field type="float[3]" name="acc_std" units="[m/s/s]">Standard deviation of the target's acceleration in its body frame</field>
     </message>
     <!-- Target info measured by MAV's onboard sensors -->
     <message id="511" name="TARGET_RELATIVE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -302,8 +302,8 @@
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time)</field>
       <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
-      <field type="float" name="x" units="m">X Position of the target in MAV_FRAME</field>
-      <field type="float" name="y" units="m">Y Position of the target in MAV_FRAME</field>
+      <field type="float" name="x" units="m">X Position of the target in MAV_FRAME (For IR-Lock: x-axis distance from the center of image to the center of the target in units of tan(theta))</field>
+      <field type="float" name="y" units="m">Y Position of the target in MAV_FRAME (For IR-Lock: y-axis distance from the center of image to the center of the target in units of tan(theta))</field>
       <field type="float" name="z" units="m">Z Position of the target in MAV_FRAME</field>
       <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in MAV_FRAME (var_x, var_y, var_z)</field>
       <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in MAV_FRAME</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -396,8 +396,8 @@
       <field type="float" name="x" units="m">X Position of the target in TARGET_OBS_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the target in TARGET_OBS_FRAME</field>
       <field type="float" name="z" units="m">Z Position of the target in TARGET_OBS_FRAME</field>
-      <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in TARGET_OBS_FRAME (var_x, var_y, var_z)</field>
-      <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in TARGET_OBS_FRAME</field>
+      <field type="float[3]" name="pos_std" units="m">Standard deviation of the target's position in TARGET_OBS_FRAME</field>
+      <field type="float" name="yaw_std" units="rad">Standard deviation of the target's orientation in TARGET_OBS_FRAME</field>
       <field type="float[4]" name="q_target">Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -391,7 +391,7 @@
       <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in TARGET_OBS_FRAME (var_x, var_y, var_z)</field>
       <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in TARGET_OBS_FRAME</field>
       <field type="float[4]" name="q_target">Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if TARGET_OBS_FRAME is in LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -248,7 +248,10 @@
       <entry value="1" name="TARGET_OBS_FRAME_BODY_FRD">
         <description>FRD local frame aligned to the vehicle's attitude (x: Forward, y: Right, z: Down) with an origin that travels with vehicle.</description>
       </entry>
-      <entry value="2" name="TARGET_OBS_FRAME_OTHER">
+      <entry value="2" name="TARGET_OBS_FRAME_LOCAL_OFFSET_NED">
+        <description>NED local tangent frame (x: North, y: East, z: Down) with an origin that travels with vehicle.</description>
+      </entry>
+      <entry value="3" name="TARGET_OBS_FRAME_OTHER">
         <description>Other sensor frame for target observations neither in local NED nor in body FRD.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -396,8 +396,8 @@
       <field type="float" name="x" units="m">X Position of the target in TARGET_OBS_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the target in TARGET_OBS_FRAME</field>
       <field type="float" name="z" units="m">Z Position of the target in TARGET_OBS_FRAME</field>
-      <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in TARGET_OBS_FRAME</field>
-      <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in TARGET_OBS_FRAME</field>
+      <field type="float[3]" name="pos_std" units="m">Standard deviation of the target's position in TARGET_OBS_FRAME</field>
+      <field type="float" name="yaw_std" units="rad">Standard deviation of the target's orientation in TARGET_OBS_FRAME</field>
       <field type="float[4]" name="q_target">Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -240,6 +240,14 @@
         <param index="7" reserved="true" default="NaN"/>
       </entry>
     </enum>
+    <enum name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS" bitmask="true">
+      <description>These flags indicate the sensor reporting capabilities for TARGET_ABSOLUTE.</description>
+      <entry value="1" name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_POSITION"/>
+      <entry value="2" name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_VELOCITY"/>
+      <entry value="4" name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_ACCELERATION"/>
+      <entry value="8" name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_ATTITUDE"/>
+      <entry value="16" name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_RATES"/>
+    </enum>
     <enum name="TARGET_OBS_FRAME">
       <description>The frame of a target observation from an onboard sensor.</description>
       <entry value="0" name="TARGET_OBS_FRAME_LOCAL_NED">
@@ -367,12 +375,12 @@
       <description>Current motion information from sensors on a target</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
-      <field type="uint8_t" name="sensor_capabilities">bit positions for the sensor's reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT = 3, RATES = 4)</field>
+      <field type="uint8_t" name="sensor_capabilities" enum="TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS" display="bitmask">Bitmap to indicate the sensor's reporting capabilities</field>
       <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
       <field type="float" name="alt" units="m">Target's altitude (AMSL)</field>
-      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in its body frame</field>
-      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in its body frame</field>
+      <field type="float[3]" name="vel" units="m/s" invalid="[0]">Target's velocity in its body frame</field>
+      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">Linear target's acceleration in its body frame</field>
       <field type="float[4]" name="q_target" invalid="[0]">Quaternion of the target's orientation from its body frame to the vehicle's NED frame.</field>
       <field type="float[3]" name="rates" units="rad/s" invalid="[0]">Target's roll, pitch and yaw rates</field>
       <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -240,6 +240,15 @@
         <param index="7" reserved="true" default="NaN"/>
       </entry>
     </enum>
+    <enum name="TARGET_TASK">
+      <description>Type of task associated with the target measurement</description>
+      <entry value="0" name="TARGET_TASK_FOLLOW">
+        <description>Follow the target from a given distance</description>
+      </entry>
+      <entry value="1" name="TARGET_TASK_LAND">
+        <description>Land on the target</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -251,6 +260,42 @@
       <field type="float" name="param_value">Parameter value (new value if PARAM_ACCEPTED, current value otherwise)</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type.</field>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
+    </message>
+    <!-- Target info from a sensor on the target -->
+    <message id="145" name="ABSOLUTE_TARGET">
+      <description>Current motion information from sensors on a target</description>
+      <field type="uint64_t" name="timestamp" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
+      <field type="float" name="alt" units="m">Altitude (MSL)</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target velocity in MAV_FRAME (0,0,0) for unknown</field>
+      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target acceleration in MAV_FRAME (0,0,0) for unknown</field>
+      <field type="float[4]" name="attitude_q" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
+      <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
+      <field type="float[2]" name="position_cov">eph epv</field>
+      <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in MAV_FRAME</field>
+      <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in MAV_FRAME</field>
+      <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
+      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
+    </message>
+    <!-- Target info from an onboard sensor -->
+    <message id="150" name="RELATIVE_TARGET">
+      <description>The location of a target from an onboard sensor. </description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (time since system boot)</field>
+      <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float" name="x" units="m">X Position of the landing target in MAV_FRAME</field>
+      <field type="float" name="y" units="m">Y Position of the landing target in MAV_FRAME</field>
+      <field type="float" name="z" units="m">Z Position of the landing target in MAV_FRAME</field>
+      <field type="float[3]" name="pos_var" units="m^2">Variance of landing target position in MAV_FRAME (var_x, var_y, var_z)</field>
+      <field type="float" name="target_yaw_unc" units="rad^2">Variance of landing target's orientation in MAV_FRAME</field>
+      <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is already MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
+      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
+      <field type="uint8_t" name="position_valid" invalid="0">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
     </message>
     <!-- mission protocol enhancements -->
     <message id="53" name="MISSION_CHECKSUM">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -276,42 +276,6 @@
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
       <field type="uint32_t" name="checksum">CRC32 checksum of current plan for specified type.</field>
     </message>
-    <!-- Target info from a sensor on the target -->
-    <message id="145" name="ABSOLUTE_TARGET">
-      <description>Current motion information from sensors on a target</description>
-      <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time).</field>
-      <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
-      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
-      <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
-      <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
-      <field type="float" name="alt" units="m">Target's altitude (AMSL)</field>
-      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
-      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[4]" name="q_att" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
-      <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
-      <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
-      <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in MAV_FRAME</field>
-      <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in MAV_FRAME</field>
-      <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
-      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
-    </message>
-    <!-- Target info from an onboard sensor -->
-    <message id="150" name="RELATIVE_TARGET">
-      <description>The location of a target from an onboard sensor. </description>
-      <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time)</field>
-      <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
-      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
-      <field type="float" name="x" units="m">X Position of the target in MAV_FRAME (For IR-Lock: x-axis distance from the center of image to the center of the target in units of tan(theta))</field>
-      <field type="float" name="y" units="m">Y Position of the target in MAV_FRAME (For IR-Lock: y-axis distance from the center of image to the center of the target in units of tan(theta))</field>
-      <field type="float" name="z" units="m">Z Position of the target in MAV_FRAME</field>
-      <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in MAV_FRAME (var_x, var_y, var_z)</field>
-      <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in MAV_FRAME</field>
-      <field type="float[4]" name="q_att">Quaternion of the target's orientation from the target's frame to the MAV_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is already MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
-      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
-    </message>
     <message id="295" name="AIRSPEED">
       <description>Airspeed information from a sensor.</description>
       <field type="uint8_t" name="id" instance="true">Sensor ID.</field>
@@ -391,6 +355,42 @@
       <field type="uint8_t" name="standard_mode" enum="MAV_STANDARD_MODE">Standard mode.</field>
       <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
+    </message>
+    <!-- Target info from a sensor on the target -->
+    <message id="510" name="ABSOLUTE_TARGET">
+      <description>Current motion information from sensors on a target</description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time).</field>
+      <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
+      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
+      <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
+      <field type="float" name="alt" units="m">Target's altitude (AMSL)</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in MAV_FRAME (0,0,0) for unknown</field>
+      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in MAV_FRAME (0,0,0) for unknown</field>
+      <field type="float[4]" name="q_att" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
+      <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
+      <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
+      <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in MAV_FRAME</field>
+      <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in MAV_FRAME</field>
+      <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
+      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
+    </message>
+    <!-- Target info from an onboard sensor -->
+    <message id="511" name="RELATIVE_TARGET">
+      <description>The location of a target from an onboard sensor. </description>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time)</field>
+      <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float" name="x" units="m">X Position of the target in MAV_FRAME (For IR-Lock: x-axis distance from the center of image to the center of the target in units of tan(theta))</field>
+      <field type="float" name="y" units="m">Y Position of the target in MAV_FRAME (For IR-Lock: y-axis distance from the center of image to the center of the target in units of tan(theta))</field>
+      <field type="float" name="z" units="m">Z Position of the target in MAV_FRAME</field>
+      <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in MAV_FRAME (var_x, var_y, var_z)</field>
+      <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in MAV_FRAME</field>
+      <field type="float[4]" name="q_att">Quaternion of the target's orientation from the target's frame to the MAV_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is already MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
+      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -280,6 +280,7 @@
     <message id="145" name="ABSOLUTE_TARGET">
       <description>Current motion information from sensors on a target</description>
       <field type="uint64_t" name="timestamp" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="target_id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
@@ -298,8 +299,8 @@
     <!-- Target info from an onboard sensor -->
     <message id="150" name="RELATIVE_TARGET">
       <description>The location of a target from an onboard sensor. </description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (time since system boot)</field>
-      <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (time since system boot)</field>
+      <field type="uint8_t" name="target_id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
       <field type="float" name="x" units="m">X Position of the landing target in MAV_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the landing target in MAV_FRAME</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -240,15 +240,6 @@
         <param index="7" reserved="true" default="NaN"/>
       </entry>
     </enum>
-    <enum name="TARGET_TASK">
-      <description>Type of task associated with the target measurement</description>
-      <entry value="0" name="TARGET_TASK_FOLLOW">
-        <description>Follow the target from a given distance</description>
-      </entry>
-      <entry value="1" name="TARGET_TASK_LAND">
-        <description>Land on the target</description>
-      </entry>
-    </enum>
     <enum name="TARGET_OBS_FRAME">
       <description>The frame of a target observation from an onboard sensor.</description>
       <entry value="0" name="LOCAL_NED">
@@ -377,15 +368,13 @@
       <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
       <field type="float" name="alt" units="m">Target's altitude (AMSL)</field>
-      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in its body frame (0,0,0) for unknown</field>
-      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in its body frame (0,0,0) for unknown</field>
-      <field type="float[4]" name="q_target" invalid="[0]">Quaternion of the target's orientation from its body frame to NED. (0 0 0 0 for unknown)</field>
-      <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
+      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in its body frame</field>
+      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in its body frame</field>
+      <field type="float[4]" name="q_target" invalid="[0]">Quaternion of the target's orientation from its body frame to NED.</field>
+      <field type="float[3]" name="rates" units="rad/s" invalid="[0]">Target's roll, pitch and yaw rates</field>
       <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
       <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in its body frame</field>
       <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in its body frame</field>
-      <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
-      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
     </message>
     <!-- Target info from an onboard sensor -->
     <message id="511" name="TARGET_RELATIVE">
@@ -401,7 +390,6 @@
       <field type="float[4]" name="q_target">Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Not used if TARGET_OBS_FRAME is in LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
-      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -261,6 +261,21 @@
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type.</field>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
     </message>
+    <!-- mission protocol enhancements -->
+    <message id="53" name="MISSION_CHECKSUM">
+      <description>Checksum for the current mission, rally point or geofence plan, or for the "combined" plan (a GCS can use these checksums to determine if it has matching plans).
+        This message must be broadcast with the appropriate checksum following any change to a mission, geofence or rally point definition
+        (immediately after the MISSION_ACK that completes the upload sequence).
+        It may also be requested using MAV_CMD_REQUEST_MESSAGE, where param 2 indicates the plan type for which the checksum is required.
+        The checksum must be calculated on the autopilot, but may also be calculated by the GCS.
+        The checksum uses the same CRC32 algorithm as MAVLink FTP (https://mavlink.io/en/services/ftp.html#crc32-implementation).
+        The checksum for a mission, geofence or rally point definition is run over each item in the plan in seq order (excluding the home location if present in the plan), and covers the following fields (in order):
+        frame, command, autocontinue, param1, param2, param3, param4, param5, param6, param7.
+        The checksum for the whole plan (MAV_MISSION_TYPE_ALL) is calculated using the same approach, running over each sub-plan in the following order: mission, geofence then rally point.
+      </description>
+      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+      <field type="uint32_t" name="checksum">CRC32 checksum of current plan for specified type.</field>
+    </message>
     <!-- Target info from a sensor on the target -->
     <message id="145" name="ABSOLUTE_TARGET">
       <description>Current motion information from sensors on a target</description>
@@ -296,21 +311,6 @@
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
       <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
       <field type="uint8_t" name="position_valid" invalid="0">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
-    </message>
-    <!-- mission protocol enhancements -->
-    <message id="53" name="MISSION_CHECKSUM">
-      <description>Checksum for the current mission, rally point or geofence plan, or for the "combined" plan (a GCS can use these checksums to determine if it has matching plans).
-        This message must be broadcast with the appropriate checksum following any change to a mission, geofence or rally point definition
-        (immediately after the MISSION_ACK that completes the upload sequence).
-        It may also be requested using MAV_CMD_REQUEST_MESSAGE, where param 2 indicates the plan type for which the checksum is required.
-        The checksum must be calculated on the autopilot, but may also be calculated by the GCS.
-        The checksum uses the same CRC32 algorithm as MAVLink FTP (https://mavlink.io/en/services/ftp.html#crc32-implementation).
-        The checksum for a mission, geofence or rally point definition is run over each item in the plan in seq order (excluding the home location if present in the plan), and covers the following fields (in order):
-        frame, command, autocontinue, param1, param2, param3, param4, param5, param6, param7.
-        The checksum for the whole plan (MAV_MISSION_TYPE_ALL) is calculated using the same approach, running over each sub-plan in the following order: mission, geofence then rally point.
-      </description>
-      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
-      <field type="uint32_t" name="checksum">CRC32 checksum of current plan for specified type.</field>
     </message>
     <message id="295" name="AIRSPEED">
       <description>Airspeed information from a sensor.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -383,9 +383,9 @@
       <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">Linear target's acceleration in its body frame</field>
       <field type="float[4]" name="q_target" invalid="[0]">Quaternion of the target's orientation from its body frame to the vehicle's NED frame.</field>
       <field type="float[3]" name="rates" units="rad/s" invalid="[0]">Target's roll, pitch and yaw rates</field>
-      <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
-      <field type="float[3]" name="vel_std" units="[m/s]">Standard deviation of the target's velocity in its body frame</field>
-      <field type="float[3]" name="acc_std" units="[m/s/s]">Standard deviation of the target's acceleration in its body frame</field>
+      <field type="float[2]" name="position_std" units="m">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
+      <field type="float[3]" name="vel_std" units="m/s">Standard deviation of the target's velocity in its body frame</field>
+      <field type="float[3]" name="acc_std" units="m/s/s">Standard deviation of the target's acceleration in its body frame</field>
     </message>
     <!-- Target info measured by MAV's onboard sensors -->
     <message id="511" name="TARGET_RELATIVE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -249,6 +249,18 @@
         <description>Land on the target</description>
       </entry>
     </enum>
+    <enum name="TARGET_OBS_FRAME">
+      <description>The frame of a target observation from an onboard sensor.</description>
+      <entry value="0" name="LOCAL_NED">
+        <description>NED local tangent frame (x: North, y: East, z: Down) with origin fixed relative to earth.</description>
+      </entry>
+      <entry value="1" name="BODY_FRD">
+        <description>FRD local frame aligned to the vehicle's attitude (x: Forward, y: Right, z: Down) with an origin that travels with vehicle.</description>
+      </entry>
+      <entry value="2" name="GENERIC">
+        <description>Generic sensor frame for target observations not in body FRD.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -357,7 +369,7 @@
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
     </message>
     <!-- Target info from a sensor on the target -->
-    <message id="510" name="ABSOLUTE_TARGET">
+    <message id="510" name="TARGET_ABSOLUTE">
       <description>Current motion information from sensors on a target</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
@@ -365,30 +377,29 @@
       <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
       <field type="float" name="alt" units="m">Target's altitude (AMSL)</field>
-      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
-      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[4]" name="q_att" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
+      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in its body frame (0,0,0) for unknown</field>
+      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in its body frame (0,0,0) for unknown</field>
+      <field type="float[4]" name="q_target" invalid="[0]">Quaternion of the target's orientation from its body frame to NED. (0 0 0 0 for unknown)</field>
       <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
       <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
-      <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in MAV_FRAME</field>
-      <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in MAV_FRAME</field>
+      <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in its body frame</field>
+      <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in its body frame</field>
       <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
       <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
     </message>
     <!-- Target info from an onboard sensor -->
-    <message id="511" name="RELATIVE_TARGET">
+    <message id="511" name="TARGET_RELATIVE">
       <description>The location of a target from an onboard sensor. </description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time)</field>
       <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
-      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
-      <field type="float" name="x" units="m">X Position of the target in MAV_FRAME (For IR-Lock: x-axis distance from the center of image to the center of the target in units of tan(theta))</field>
-      <field type="float" name="y" units="m">Y Position of the target in MAV_FRAME (For IR-Lock: y-axis distance from the center of image to the center of the target in units of tan(theta))</field>
-      <field type="float" name="z" units="m">Z Position of the target in MAV_FRAME</field>
-      <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in MAV_FRAME (var_x, var_y, var_z)</field>
-      <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in MAV_FRAME</field>
-      <field type="float[4]" name="q_att">Quaternion of the target's orientation from the target's frame to the MAV_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is already MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="uint8_t" name="frame" enum="TARGET_OBS_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float" name="x" units="m">X Position of the target in TARGET_OBS_FRAME (For IR-Lock: x-axis distance from the center of image to the center of the target in units of tan(theta))</field>
+      <field type="float" name="y" units="m">Y Position of the target in TARGET_OBS_FRAME (For IR-Lock: y-axis distance from the center of image to the center of the target in units of tan(theta))</field>
+      <field type="float" name="z" units="m">Z Position of the target in TARGET_OBS_FRAME</field>
+      <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in TARGET_OBS_FRAME (var_x, var_y, var_z)</field>
+      <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in TARGET_OBS_FRAME</field>
+      <field type="float[4]" name="q_target">Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Not used if TARGET_OBS_FRAME is in LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
       <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -391,7 +391,7 @@
     <message id="511" name="TARGET_RELATIVE">
       <description>The location of a target measured by MAV's onboard sensors. </description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time)</field>
-      <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
+      <field type="uint8_t" name="id" instance="true">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="frame" enum="TARGET_OBS_FRAME">Coordinate frame used for following fields.</field>
       <field type="float" name="x" units="m">X Position of the target in TARGET_OBS_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the target in TARGET_OBS_FRAME</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -248,8 +248,8 @@
       <entry value="1" name="BODY_FRD">
         <description>FRD local frame aligned to the vehicle's attitude (x: Forward, y: Right, z: Down) with an origin that travels with vehicle.</description>
       </entry>
-      <entry value="2" name="GENERIC">
-        <description>Generic sensor frame for target observations not in body FRD.</description>
+      <entry value="2" name="OTHER">
+        <description>Other sensor frame for target observations neither in local NED nor in body FRD.</description>
       </entry>
     </enum>
   </enums>
@@ -364,31 +364,31 @@
       <description>Current motion information from sensors on a target</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
-      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
+      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT = 3, ATT + RATES = 4)</field>
       <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
       <field type="float" name="alt" units="m">Target's altitude (AMSL)</field>
       <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in its body frame</field>
       <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in its body frame</field>
-      <field type="float[4]" name="q_target" invalid="[0]">Quaternion of the target's orientation from its body frame to NED.</field>
+      <field type="float[4]" name="q_target" invalid="[0]">Quaternion of the target's orientation from its body frame to the vehicle's NED frame.</field>
       <field type="float[3]" name="rates" units="rad/s" invalid="[0]">Target's roll, pitch and yaw rates</field>
       <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
       <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in its body frame</field>
       <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in its body frame</field>
     </message>
-    <!-- Target info from an onboard sensor -->
+    <!-- Target info measured by MAV's onboard sensors -->
     <message id="511" name="TARGET_RELATIVE">
-      <description>The location of a target from an onboard sensor. </description>
+      <description>The location of a target measured by MAV's onboard sensors. </description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time)</field>
       <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="frame" enum="TARGET_OBS_FRAME">Coordinate frame used for following fields.</field>
-      <field type="float" name="x" units="m">X Position of the target in TARGET_OBS_FRAME (For IR-Lock: x-axis distance from the center of image to the center of the target in units of tan(theta))</field>
-      <field type="float" name="y" units="m">Y Position of the target in TARGET_OBS_FRAME (For IR-Lock: y-axis distance from the center of image to the center of the target in units of tan(theta))</field>
+      <field type="float" name="x" units="m">X Position of the target in TARGET_OBS_FRAME</field>
+      <field type="float" name="y" units="m">Y Position of the target in TARGET_OBS_FRAME</field>
       <field type="float" name="z" units="m">Z Position of the target in TARGET_OBS_FRAME</field>
       <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in TARGET_OBS_FRAME (var_x, var_y, var_z)</field>
       <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in TARGET_OBS_FRAME</field>
       <field type="float[4]" name="q_target">Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Not used if TARGET_OBS_FRAME is in LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if TARGET_OBS_FRAME is in LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -367,7 +367,7 @@
       <description>Current motion information from sensors on a target</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
-      <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT = 3, ATT + RATES = 4)</field>
+      <field type="uint8_t" name="sensor_capabilities">bit positions for the sensor's reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT = 3, RATES = 4)</field>
       <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
       <field type="float" name="alt" units="m">Target's altitude (AMSL)</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -279,7 +279,7 @@
     <!-- Target info from a sensor on the target -->
     <message id="145" name="ABSOLUTE_TARGET">
       <description>Current motion information from sensors on a target</description>
-      <field type="uint64_t" name="timestamp" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint8_t" name="target_id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
       <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
@@ -299,7 +299,7 @@
     <!-- Target info from an onboard sensor -->
     <message id="150" name="RELATIVE_TARGET">
       <description>The location of a target from an onboard sensor. </description>
-      <field type="uint64_t" name="timestamp" units="us">Timestamp (time since system boot)</field>
+      <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time)</field>
       <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
       <field type="float" name="x" units="m">X Position of the target in MAV_FRAME</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -282,36 +282,35 @@
       <field type="uint64_t" name="timestamp" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="target_id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
-      <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
-      <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
-      <field type="float" name="alt" units="m">Altitude (MSL)</field>
+      <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
+      <field type="float" name="alt" units="m">Target's altitude (AMSL)</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
-      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target velocity in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target acceleration in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[4]" name="attitude_q" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
+      <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in MAV_FRAME (0,0,0) for unknown</field>
+      <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in MAV_FRAME (0,0,0) for unknown</field>
+      <field type="float[4]" name="q_target_att" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
       <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
-      <field type="float[2]" name="position_cov">eph epv</field>
+      <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
       <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in MAV_FRAME</field>
       <field type="float[3]" name="acc_var" units="[m/s/s]^2">Variance of the target's acceleration in MAV_FRAME</field>
       <field type="uint64_t" name="custom_state">button states or switches of a tracker device</field>
-      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
+      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
     </message>
     <!-- Target info from an onboard sensor -->
     <message id="150" name="RELATIVE_TARGET">
       <description>The location of a target from an onboard sensor. </description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (time since system boot)</field>
-      <field type="uint8_t" name="target_id">The ID of the target if multiple targets are present</field>
+      <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
-      <field type="float" name="x" units="m">X Position of the landing target in MAV_FRAME</field>
-      <field type="float" name="y" units="m">Y Position of the landing target in MAV_FRAME</field>
-      <field type="float" name="z" units="m">Z Position of the landing target in MAV_FRAME</field>
-      <field type="float[3]" name="pos_var" units="m^2">Variance of landing target position in MAV_FRAME (var_x, var_y, var_z)</field>
-      <field type="float" name="target_yaw_unc" units="rad^2">Variance of landing target's orientation in MAV_FRAME</field>
-      <field type="float[4]" name="q">Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float" name="x" units="m">X Position of the target in MAV_FRAME</field>
+      <field type="float" name="y" units="m">Y Position of the target in MAV_FRAME</field>
+      <field type="float" name="z" units="m">Z Position of the target in MAV_FRAME</field>
+      <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in MAV_FRAME (var_x, var_y, var_z)</field>
+      <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in MAV_FRAME</field>
+      <field type="float[4]" name="q">Quaternion of the target's orientation from the target's frame to the MAV_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is already MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
-      <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of landing target</field>
-      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target measurement (e.g. follow or land)</field>
-      <field type="uint8_t" name="position_valid" invalid="0">Boolean indicating whether the position fields (x, y, z, q, type) contain valid target position information (valid: 1, invalid: 0). Default is 0 (invalid).</field>
+      <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
+      <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>
     </message>
     <message id="295" name="AIRSPEED">
       <description>Airspeed information from a sensor.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -396,8 +396,8 @@
       <field type="float" name="x" units="m">X Position of the target in TARGET_OBS_FRAME</field>
       <field type="float" name="y" units="m">Y Position of the target in TARGET_OBS_FRAME</field>
       <field type="float" name="z" units="m">Z Position of the target in TARGET_OBS_FRAME</field>
-      <field type="float[3]" name="pos_std" units="m">Standard deviation of the target's position in TARGET_OBS_FRAME</field>
-      <field type="float" name="yaw_std" units="rad">Standard deviation of the target's orientation in TARGET_OBS_FRAME</field>
+      <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in TARGET_OBS_FRAME</field>
+      <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in TARGET_OBS_FRAME</field>
       <field type="float[4]" name="q_target">Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -280,7 +280,7 @@
     <message id="145" name="ABSOLUTE_TARGET">
       <description>Current motion information from sensors on a target</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp (UNIX epoch time).</field>
-      <field type="uint8_t" name="target_id">The ID of the target if multiple targets are present</field>
+      <field type="uint8_t" name="id">The ID of the target if multiple targets are present</field>
       <field type="uint8_t" name="est_capabilities">bit positions for tracker reporting capabilities (POS = 0, VEL = 1, ACCEL = 2, ATT + RATES = 3)</field>
       <field type="int32_t" name="lat" units="degE7">Target's latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Target's longitude (WGS84)</field>
@@ -288,7 +288,7 @@
       <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
       <field type="float[3]" name="vel" units="m/s" invalid="[0]">target's velocity in MAV_FRAME (0,0,0) for unknown</field>
       <field type="float[3]" name="acc" units="m/s/s" invalid="[0]">linear target's acceleration in MAV_FRAME (0,0,0) for unknown</field>
-      <field type="float[4]" name="q_target_att" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
+      <field type="float[4]" name="q_att" invalid="[0]">Quaternion of the target's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is MAV_FRAME_LOCAL_NED). (0 0 0 0 for unknown)</field>
       <field type="float[3]" name="rates" invalid="[0]">(0 0 0 for unknown)</field>
       <field type="float[2]" name="position_std" units="[m]">Standard deviation of horizontal (eph) and vertical (epv) position errors</field>
       <field type="float[3]" name="vel_var" units="[m/s]^2">Variance of the target's velocity in MAV_FRAME</field>
@@ -307,7 +307,7 @@
       <field type="float" name="z" units="m">Z Position of the target in MAV_FRAME</field>
       <field type="float[3]" name="pos_var" units="m^2">Variance of the target's position in MAV_FRAME (var_x, var_y, var_z)</field>
       <field type="float" name="yaw_var" units="rad^2">Variance of the target's orientation in MAV_FRAME</field>
-      <field type="float[4]" name="q">Quaternion of the target's orientation from the target's frame to the MAV_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
+      <field type="float[4]" name="q_att">Quaternion of the target's orientation from the target's frame to the MAV_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="float[4]" name="q_sensor_att">Quaternion of the sensor's orientation from MAV_FRAME to vehicle-carried NED. (Not used if MAV_FRAME is already MAV_FRAME_LOCAL_NED) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
       <field type="uint8_t" name="task" enum="TARGET_TASK">Type of task associated with the target observation (e.g. FOLLOW or LAND)</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -242,13 +242,13 @@
     </enum>
     <enum name="TARGET_OBS_FRAME">
       <description>The frame of a target observation from an onboard sensor.</description>
-      <entry value="0" name="LOCAL_NED">
+      <entry value="0" name="TARGET_OBS_FRAME_LOCAL_NED">
         <description>NED local tangent frame (x: North, y: East, z: Down) with origin fixed relative to earth.</description>
       </entry>
-      <entry value="1" name="BODY_FRD">
+      <entry value="1" name="TARGET_OBS_FRAME_BODY_FRD">
         <description>FRD local frame aligned to the vehicle's attitude (x: Forward, y: Right, z: Down) with an origin that travels with vehicle.</description>
       </entry>
-      <entry value="2" name="OTHER">
+      <entry value="2" name="TARGET_OBS_FRAME_OTHER">
         <description>Other sensor frame for target observations neither in local NED nor in body FRD.</description>
       </entry>
     </enum>


### PR DESCRIPTION
This pull request extends the [LANDING_TARGET](https://mavlink.io/en/services/landing_target.html) message to include position and orientation uncertainties in order to properly fuse the landing target estimations in a Kalman filter https://github.com/PX4/PX4-Autopilot/pull/20653. It also adds the sensor's orientation at the moment of the observation, which is necessary if there is processing time (e.g. detect fiducial marker) between the observation and the message being sent. Finally, it extends the [MAV_FRAME](https://mavlink.io/en/messages/common.html#MAV_FRAME) message to allow for generic sensor frames. This allows to properly handle the [LANDING_TARGET](https://mavlink.io/en/services/landing_target.html) message: 

- if MAV_FRAME == MAV_FRAME_LOCAL_NED, the target is directly sent to the precision landing algorithm.
- if MAV_FRAME == MAV_FRAME_SENSOR, the target is sent to the Kalman filter which will rotate it into vehicle-carried NED using the sensor's orientation `q_sensor_att`. The estimation is then sent to the precision landing algorithm.
- Otherwise: the target is sent to the Kalman filter which will rotate it into vehicle-carried NED using: 
    - `q_sensor_att` if filled 
    - the current attitude of the drone (properly transformed into MAV_FRAME). 
   
Changes: 

- Added position and orientation uncertainties to the [LANDING_TARGET](https://mavlink.io/en/services/landing_target.html) message
- Added sensor's orientation at the moment of the observation to the [LANDING_TARGET](https://mavlink.io/en/services/landing_target.html) message
- Extended the [MAV_FRAME](https://mavlink.io/en/messages/common.html#MAV_FRAME) message to allow for generic sensor frames

Please let me know if there are any further modifications needed.

Update: 

We currently have two main tasks using targets: 
1. following a target with the message "FOLLOW_TARGET" 
2. landing on a target with the message "LANDING_TARGET." 

However, the main difference between these messages is not the task, but rather the physical location of the sensor used. [FOLLOW_TARGET](https://mavlink.io/en/messages/common.html#FOLLOW_TARGET) reports observations from a **sensor on the target** (e.g. GPS or IMUs), while [LANDING_TARGET](https://mavlink.io/en/services/landing_target.html) reports observations from an **onboard sensor** (e.g. vision-based fiducial marker detection or irlock beacon detection). One might want to follow a target using a fiducial marker (LANDING_TARGET msg). Inversely, one might want to land on a target with a GPS attached (FOLLOW_TARGET msg). Each message should thus be usable independently of the task. Additionally, the new target estimator allows to fuse several measurements such as GPS, fiducial markers and irlock beacons in a Kalman Filter to estimate the target's state (for static and moving targets) https://github.com/PX4/PX4-Autopilot/pull/20653. The same filter class can then be used for precision landing and the target following tasks, reinforcing the idea that both messages should be used in parallel.

Proposed changes: 
1. "LANDING_TARGET" becomes "RELATIVE_TARGET" (for onboard sensors such as fiducial markers, irlock beacons, etc.)
2. "FOLLOW_TARGET" becomes "ABSOLUTE_TARGET" (for sensors on the target such as GPS, IMUs, etc.). 
3. Both "RELATIVE_TARGET" and "ABSOLUTE_TARGET" have a "TARGET_TASK" field, which can either be "TARGET_TASK_FOLLOW" or "TARGET_TASK_LAND," depending on the task at hand.

Additionally, adding a [MAV_FRAME](https://mavlink.io/en/messages/common.html#MAV_FRAME) field to the ABSOLUTE_TARGET msg allows for measurements to be entered in the target's frame and use the `quaternion` field to rotate it to the navigation NED frame, making the message less confusing.