### PR TITLE
minimal: add `MAV_TYPE`  `MAV_TYPE_GENERIC_MULTIROTOR`

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -200,6 +200,9 @@
       <entry value="42" name="MAV_TYPE_WINCH">
         <description>Winch</description>
       </entry>
+      <entry value="43" name="MAV_TYPE_GENERIC_MULTIROTOR">
+        <description>Generic multirotor that does not fit into a specific type or whose type is unknown</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
GCS's typically use `MAV_TYPE` to tailor the interface to a specific vehicle type, if the vehicle has not yet been configured, or has a unusual type that does not fall in to the provided types the existing `TYPE_GENERIC` is not specific enough to give the GCS a clue about what sort of vehicle it is. 

https://github.com/ArduPilot/ardupilot/pull/22658, https://github.com/ArduPilot/ardupilot/issues/22657

On AP this can happen during initial setup when the frame class is not setup. Or if a frame type is setup that falls outside of the given types, one could use scripting to setup a vehicle with 5 rotors for example.  