### PR TITLE
Extend cellular_status msg and add new cellular_modem_info msg for static fields

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7612,7 +7612,6 @@
       <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
       <extensions/>
-      <field type="char[9]" name="cell_tower_id" invalid="0">ID of the currently connected cell tower. NULL terminated if ID string is less than 9 chars.</field>
       <field type="uint8_t" name="band_number" invalid="0">LTE frequency band number.</field>
       <field type="float" name="band_frequency" units="MHz" invalid="0">LTE radio frequency.</field>
       <field type="uint16_t" name="arfcn" invalid="0">Absolute radio-frequency channel number.</field>
@@ -7625,6 +7624,7 @@
       <field type="uint32_t" name="link_rx_rate" units="KiB/s" invalid="0">Upload rate.</field>
       <field type="uint16_t" name="ber" invalid="0">The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>
       <field type="uint8_t" name="id" instance="true">Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
+      <field type="char[9]" name="cell_tower_id" invalid="0">ID of the currently connected cell tower. Zero-fill the unused characters at the end of the array if the ID string is less than 9 chars.</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7621,7 +7621,7 @@
       <field type="uint32_t" name="link_tx_rate" units="KiB/s" invalid="0">Download rate.</field>
       <field type="uint32_t" name="link_rx_rate" units="KiB/s" invalid="0">Upload rate.</field>
       <field type="uint16_t" name="ber" invalid="0">The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>
-      <field type="uint8_t" name="id" instance="true">Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
+      <field type="uint8_t" name="id" instance="true"  invalid="0">Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
       <field type="char[9]" name="cell_tower_id" invalid="0">ID of the currently connected cell tower. This must be NULL terminated if the length is less than 9 human-readable chars, and without the null termination (NULL) byte if the length is exactly 9 chars.</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7614,12 +7614,10 @@
       <extensions/>
       <field type="uint8_t" name="band_number" invalid="0">LTE frequency band number.</field>
       <field type="float" name="band_frequency" units="MHz" invalid="0">LTE radio frequency.</field>
-      <field type="uint16_t" name="arfcn" invalid="0">Absolute radio-frequency channel number.</field>
-      <field type="float" name="rx_level" units="dBm" invalid="0">Received signal absolute power level.</field>
+      <field type="uint16_t" name="channel_number" invalid="0">The channel number (CN). Absolute radio-frequency (ARFCN) / E-UTRA (EARFCN) / UTRA (UARFCN) / New radio (NR_CH).</field>
+      <field type="float" name="rx_level" units="dBm" invalid="0">On 3G is Received Signal Code Power (RSCP). On LTE Reference Signal Received Power (RSRP). On 5G  is New Radio Reference Signal Received Power (NR_RSRQ).</field>
       <field type="float" name="tx_level" units="dBm" invalid="0">Transmitter (modem) signal absolute power level.</field>
-      <field type="float" name="signal_to_noise" units="dBm" invalid="0">The Signal-to-Noise Ratio (SNR) is the difference between the received wireless signal and the noise floor i.e. erroneous background transmissions</field>
-      <field type="float" name="rsrp" units="dBm" invalid="0">Reference Signal Received Power</field>
-      <field type="float" name="rsrq" units="dBm" invalid="0">Reference Signal Received Quality</field>
+      <field type="float" name="rx_quality" units="dBm" invalid="0">On 3G is  Receiver quality (RxQual). On LTE is Reference Signal Received Quality (RSRQ). On 5G is New radio Reference Signal Received Quality (NR_RSRQ).</field>
       <field type="uint32_t" name="link_tx_rate" units="KiB/s" invalid="0">Download rate.</field>
       <field type="uint32_t" name="link_rx_rate" units="KiB/s" invalid="0">Upload rate.</field>
       <field type="uint16_t" name="ber" invalid="0">The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7622,7 +7622,7 @@
       <field type="uint32_t" name="link_rx_rate" units="KiB/s" invalid="0">Upload rate.</field>
       <field type="uint16_t" name="ber" invalid="0">The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>
       <field type="uint8_t" name="id" instance="true">Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
-      <field type="char[9]" name="cell_tower_id" invalid="0">ID of the currently connected cell tower. Zero-fill the unused characters at the end of the array if the ID string is less than 9 chars.</field>
+      <field type="char[9]" name="cell_tower_id" invalid="0">ID of the currently connected cell tower. This must be NULL terminated if the length is less than 9 human-readable chars, and without the null termination (NULL) byte if the length is exactly 9 chars.</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7611,6 +7611,20 @@
       <field type="uint16_t" name="mcc" invalid="UINT16_MAX">Mobile country code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
+      <extensions/>
+      <field type="char[9]" name="cell_tower_id" invalid="0">ID of the currently connected cell tower. NULL terminated if ID string is less than 9 chars.</field>
+      <field type="uint8_t" name="band_number" invalid="0">LTE frequency band number.</field>
+      <field type="float" name="band_frequency" units="MHz" invalid="0">LTE radio frequency.</field>
+      <field type="uint16_t" name="arfcn" invalid="0">Absolute radio-frequency channel number.</field>
+      <field type="float" name="rx_level" units="dBm" invalid="0">Received signal absolute power level.</field>
+      <field type="float" name="tx_level" units="dBm" invalid="0">Transmitter (modem) signal absolute power level.</field>
+      <field type="float" name="signal_to_noise" units="dBm" invalid="0">The Signal-to-Noise Ratio (SNR) is the difference between the received wireless signal and the noise floor i.e. erroneous background transmissions</field>
+      <field type="float" name="rsrp" units="dBm" invalid="0">Reference Signal Received Power</field>
+      <field type="float" name="rsrq" units="dBm" invalid="0">Reference Signal Received Quality</field>
+      <field type="uint32_t" name="link_tx_rate" units="KiB/s" invalid="0">Download rate.</field>
+      <field type="uint32_t" name="link_rx_rate" units="KiB/s" invalid="0">Upload rate.</field>
+      <field type="uint16_t" name="ber" invalid="0">The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>
+      <field type="uint8_t" name="id" instance="true">Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">
       <description>Status of the Iridium SBD link.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7621,7 +7621,7 @@
       <field type="uint32_t" name="link_tx_rate" units="KiB/s" invalid="0">Download rate.</field>
       <field type="uint32_t" name="link_rx_rate" units="KiB/s" invalid="0">Upload rate.</field>
       <field type="uint16_t" name="ber" invalid="0">The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>
-      <field type="uint8_t" name="id" instance="true"  invalid="0">Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
+      <field type="uint8_t" name="id" instance="true" invalid="0">Cellular instance number. Indexed from 1. Matches index in corresponding CELLULAR_MODEM_INFORMATION message.</field>
       <field type="char[9]" name="cell_tower_id" invalid="0">ID of the currently connected cell tower. This must be NULL terminated if the length is less than 9 human-readable chars, and without the null termination (NULL) byte if the length is exactly 9 chars.</field>
     </message>
     <message id="335" name="ISBD_LINK_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7607,7 +7607,7 @@
       <field type="uint8_t" name="status" enum="CELLULAR_STATUS_FLAG">Cellular modem status</field>
       <field type="uint8_t" name="failure_reason" enum="CELLULAR_NETWORK_FAILED_REASON">Failure reason when status in in CELLULAR_STATUS_FLAG_FAILED</field>
       <field type="uint8_t" name="type" enum="CELLULAR_NETWORK_RADIO_TYPE">Cellular network radio type: gsm, cdma, lte...</field>
-      <field type="uint8_t" name="quality" invalid="UINT8_MAX">Signal quality in percent. If unknown, set to UINT8_MAX</field>
+      <field type="uint8_t" name="quality" invalid="UINT8_MAX">Signal quality in percent. May be used for Received Signal Strength Indicator (RSSI). If unknown, set to UINT8_MAX</field>
       <field type="uint16_t" name="mcc" invalid="UINT16_MAX">Mobile country code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="mnc" invalid="UINT16_MAX">Mobile network code. If unknown, set to UINT16_MAX</field>
       <field type="uint16_t" name="lac" invalid="0">Location area code. If unknown, set to 0</field>
@@ -7617,7 +7617,7 @@
       <field type="uint16_t" name="channel_number" invalid="0">The channel number (CN). Absolute radio-frequency (ARFCN) / E-UTRA (EARFCN) / UTRA (UARFCN) / New radio (NR_CH).</field>
       <field type="float" name="rx_level" units="dBm" invalid="0">On 3G is Received Signal Code Power (RSCP). On LTE Reference Signal Received Power (RSRP). On 5G  is New Radio Reference Signal Received Power (NR_RSRQ).</field>
       <field type="float" name="tx_level" units="dBm" invalid="0">Transmitter (modem) signal absolute power level.</field>
-      <field type="float" name="rx_quality" units="dBm" invalid="0">On 3G is  Receiver quality (RxQual). On LTE is Reference Signal Received Quality (RSRQ). On 5G is New radio Reference Signal Received Quality (NR_RSRQ).</field>
+      <field type="float" name="rx_quality" units="dBm" invalid="0">On 3G is Receiver Quality (RxQual). On LTE is Reference Signal Received Quality (RSRQ). On 5G is New radio Reference Signal Received Quality (NR_RSRQ).</field>
       <field type="uint32_t" name="link_tx_rate" units="KiB/s" invalid="0">Download rate.</field>
       <field type="uint32_t" name="link_rx_rate" units="KiB/s" invalid="0">Upload rate.</field>
       <field type="uint16_t" name="ber" invalid="0">The bit error rate (BER) is determined by comparing the erroneous bits received with the total number of bits received. It is a ratio.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -415,10 +415,10 @@
       <field type="uint8_t" name="id" instance="true">Modem instance number. Indexed from 1. Matches index in corresponding CELLULAR_STATUS message.</field>
       <field type="uint64_t" name="imei" invalid="NULL">Unique Modem International Mobile Equipment Identity Number.</field>
       <field type="uint64_t" name="imsi" invalid="NULL">Current SIM International mobile subscriber identity.</field>
-      <field type="char[10]" name="modem_id" invalid="[0]">Unique id for modem. Zero-fill unused characters at the end of the array if the string is less than 10 chars.</field>
-      <field type="char[20]" name="iccid" invalid="[0]">Integrated Circuit Card Identification Number of SIM Card.</field>
-      <field type="char[24]" name="firmware" invalid="[0]">The firmware version installed on the modem. Zero-fill unused characters at the end of the array if the string is less than 24 chars. The format is not intended for display.</field>
-      <field type="char[50]" name="modem_model" invalid="[0]">Modem model name. Zero-fill unused characters at the end of the array if the string is less than 50 chars.</field>
+      <field type="char[10]" name="modem_id" invalid="[0]">Unique id for modem. This must be NULL terminated if the length is less than 10 human-readable chars, and without the null termination (NULL) byte if the length is exactly 10 chars.</field>
+      <field type="char[20]" name="iccid" invalid="[0]">Integrated Circuit Card Identification Number of SIM Card.  This must be NULL terminated if the length is less than 20 human-readable chars, and without the null termination (NULL) byte if the length is exactly 20 chars.</field>
+      <field type="char[24]" name="firmware" invalid="[0]">The firmware version installed on the modem. This must be NULL terminated if the length is less than 24 human-readable chars, and without the null termination (NULL) byte if the length is exactly 24 chars. The format is not intended for display.</field>
+      <field type="char[50]" name="modem_model" invalid="[0]">Modem model name.  This must be NULL terminated if the length is less than 50 human-readable chars, and without the null termination (NULL) byte if the length is exactly 50 chars.</field>
     </message>
     <message id="361" name="FIGURE_EIGHT_EXECUTION_STATUS">
       <wip/>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -416,9 +416,9 @@
       <field type="uint64_t" name="imei" invalid="NULL">Unique Modem International Mobile Equipment Identity Number.</field>
       <field type="uint64_t" name="iccid" invalid="NULL">Integrated Circuit Card Identification Number of SIM Card.</field>
       <field type="uint64_t" name="imsi" invalid="NULL">Current SIM International mobile subscriber identity.</field>
-      <field type="char[10]" name="modem_id" invalid="[0]">Unique id for modem. Field is NULL terminated if string is less than 10 chars.</field>
-      <field type="char[24]" name="firmware" invalid="[0]">The firmware version installed on the modem. Field is NULL terminated if string is less than 24 chars. The format is not intended for display.</field>
-      <field type="char[50]" name="modem_model" invalid="[0]">Modem model name. Field is NULL terminated if string is less than 50 chars.</field>
+      <field type="char[10]" name="modem_id" invalid="[0]">Unique id for modem. Zero-fill unused characters at the end of the array if the string is less than 10 chars.</field>
+      <field type="char[24]" name="firmware" invalid="[0]">The firmware version installed on the modem. Zero-fill unused characters at the end of the array if the string is less than 24 chars. The format is not intended for display.</field>
+      <field type="char[50]" name="modem_model" invalid="[0]">Modem model name. Zero-fill unused characters at the end of the array if the string is less than 50 chars.</field>
     </message>
     <message id="361" name="FIGURE_EIGHT_EXECUTION_STATUS">
       <wip/>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -410,6 +410,16 @@
       <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
       <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: No limit applied</field>
     </message>
+    <message id="337" name="CELLULAR_MODEM_INFORMATION">
+      <description>Cellular modem device information. This contains static information about a modem and should be sent at low rate. Note that the dynamic information about the connection is provided in an associated CELLULAR_STATUS message.</description>
+      <field type="uint8_t" name="id" instance="true">Modem instance number. Indexed from 1. Matches index in corresponding CELLULAR_STATUS message.</field>
+      <field type="uint64_t" name="imei" invalid="NULL">Unique Modem International Mobile Equipment Identity Number.</field>
+      <field type="uint64_t" name="iccid" invalid="NULL">Integrated Circuit Card Identification Number of SIM Card.</field>
+      <field type="uint64_t" name="imsi" invalid="NULL">Current SIM International mobile subscriber identity.</field>
+      <field type="char[10]" name="modem_id" invalid="[0]">Unique id for modem. Field is NULL terminated if string is less than 10 chars.</field>
+      <field type="char[24]" name="firmware" invalid="[0]">The firmware version installed on the modem. Field is NULL terminated if string is less than 24 chars. The format is not intended for display.</field>
+      <field type="char[50]" name="modem_model" invalid="[0]">Modem model name. Field is NULL terminated if string is less than 50 chars.</field>
+    </message>
     <message id="361" name="FIGURE_EIGHT_EXECUTION_STATUS">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -414,9 +414,9 @@
       <description>Cellular modem device information. This contains static information about a modem and should be sent at low rate. Note that the dynamic information about the connection is provided in an associated CELLULAR_STATUS message.</description>
       <field type="uint8_t" name="id" instance="true">Modem instance number. Indexed from 1. Matches index in corresponding CELLULAR_STATUS message.</field>
       <field type="uint64_t" name="imei" invalid="NULL">Unique Modem International Mobile Equipment Identity Number.</field>
-      <field type="uint64_t" name="iccid" invalid="NULL">Integrated Circuit Card Identification Number of SIM Card.</field>
       <field type="uint64_t" name="imsi" invalid="NULL">Current SIM International mobile subscriber identity.</field>
       <field type="char[10]" name="modem_id" invalid="[0]">Unique id for modem. Zero-fill unused characters at the end of the array if the string is less than 10 chars.</field>
+      <field type="char[20]" name="iccid" invalid="[0]">Integrated Circuit Card Identification Number of SIM Card.</field>
       <field type="char[24]" name="firmware" invalid="[0]">The firmware version installed on the modem. Zero-fill unused characters at the end of the array if the string is less than 24 chars. The format is not intended for display.</field>
       <field type="char[50]" name="modem_model" invalid="[0]">Modem model name. Zero-fill unused characters at the end of the array if the string is less than 50 chars.</field>
     </message>


### PR DESCRIPTION
- expand fields and allow multiple instances and add new msg for static cellular_info

## PRs
 * Proto: [Add cellular status and cellular_modem_info #309](https://github.com/mavlink/MAVSDK-Proto/pull/309)
 * MAVSDK: [Add cellular status and cellular_modem_info #1960](https://github.com/mavlink/MAVSDK/pull/1960)
 * MAVSDK-Python: [Add cellular status and cellular_modem_info #546](https://github.com/mavlink/MAVSDK-Python/pull/546)
