### PR TITLE
remove invalid enum reference from storm32.xml

### DIFF
--- a/message_definitions/v1.0/storm32.xml
+++ b/message_definitions/v1.0/storm32.xml
@@ -10,7 +10,7 @@ Range of IDs:
 Documentation:
   STORM32 and QSHOT additions
   with mLRS additions merged
-  16. Jan. 2023
+  3. Feb. 2023
   All messages are technically WIP, but some are quite stable now.
   Quite stable means that it is in practical use, but may see extension.
   A more detailed description of the concept underlying the STORM32 and QSHOT messages can be found here:

--- a/message_definitions/v1.0/storm32.xml
+++ b/message_definitions/v1.0/storm32.xml
@@ -425,7 +425,7 @@ Documentation:
       <field type="uint16_t" name="param_count">Total number of onboard parameters.</field>
       <field type="uint16_t" name="param_index_first">Index of the first onboard parameter in this array.</field>
       <field type="uint8_t" name="param_array_len">Number of onboard parameters in this array.</field>
-      <field type="uint16_t" name="flags" display="bitmask">Flags.</field>
+      <field type="uint16_t" name="flags">Flags.</field>
       <field type="uint8_t[248]" name="packet_buf">Parameters buffer. Contains a series of variable length parameter blocks, one per parameter, with format as specifed elsewhere.</field>
     </message>
     <!-- ********** -->

--- a/message_definitions/v1.0/storm32.xml
+++ b/message_definitions/v1.0/storm32.xml
@@ -425,7 +425,7 @@ Documentation:
       <field type="uint16_t" name="param_count">Total number of onboard parameters.</field>
       <field type="uint16_t" name="param_index_first">Index of the first onboard parameter in this array.</field>
       <field type="uint8_t" name="param_array_len">Number of onboard parameters in this array.</field>
-      <field type="uint16_t" name="flags" display="bitmask" enum="PARAM_VALUE_ARRAY_FLAGS">Flags.</field>
+      <field type="uint16_t" name="flags" display="bitmask">Flags.</field>
       <field type="uint8_t[248]" name="packet_buf">Parameters buffer. Contains a series of variable length parameter blocks, one per parameter, with format as specifed elsewhere.</field>
     </message>
     <!-- ********** -->


### PR DESCRIPTION
#1941 contains an invalid enum reference that breaks generation of external libraries.

I searched for the enum definition but i couldn't find it, therefore it should be removed unless @olliw42 provides it.