### PR TITLE
development: add command to configure SiK radio

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -336,6 +336,17 @@
         <param index="6" reserved="true" default="0"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
+      <entry value="550" name="MAV_CMD_SET_AT_S_PARAM" hasLocation="false" isDestination="false">
+        <description>Allows setting an AT S command of an SiK radio.
+        </description>
+        <param index="1" label="Radio instance">The radio instance, one-based, 0 for all.</param>
+        <param index="2" label="Index">The Sx index, e.g. 3 for S3 which is NETID.</param>
+        <param index="3" label="Value">The value to set it to, e.g. default 25 for NETID</param>
+        <param index="4" reserved="true"/>
+        <param index="5" reserved="true"/>
+        <param index="6" reserved="true"/>
+        <param index="7" reserved="true"/>
+      </entry>
     </enum>
   </enums>
   <messages>


### PR DESCRIPTION
This is a command that allows to set AT parameters of SiK radios connected to a drone.

For example, this can be used to set the ID of a radio allowing it to be paired to another ground radio. This can be used for configuration at initial setup but also during a mission to specifically swap to a new ground radio.

More details on the possible configuration options can be found in:
https://ardupilot.org/copter/docs/common-3dr-radio-advanced-configuration-and-technical-information.html#using-the-at-command-set
https://docs.px4.io/main/en/data_links/sik_radio.html

For PX4, this would replace the existing ID configuration using a parameter which does not have proper feedback.