### PR TITLE
minimal: Add MAV_STATE_REBOOT_REQUIRED in MAV_STATE

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -283,6 +283,9 @@
       <entry value="8" name="MAV_STATE_FLIGHT_TERMINATION">
         <description>System is terminating itself.</description>
       </entry>
+      <entry value="9" name="MAV_STATE_REBOOT_REQUIRED">
+        <description>System needs to be rebooted. Used for new settings to take effect or to restart initial state.</description>
+      </entry>
     </enum>
     <enum name="MAV_COMPONENT">
       <description>Component ids (values) for the different types and instances of onboard hardware/software that might make up a MAVLink system (autopilot, cameras, servos, GPS systems, avoidance systems etc.).


### PR DESCRIPTION
The idea is for the vehicle to inform the GCS that a reboot is required, right now there are palliative methods like parameter metadata, but that does not work when the GCS is restarted or a second computer connects to the vehicle. The vehicle should be able to inform the GCS that a reboot is required. 