### PR TITLE
Add control handoff messages for multiple GCS

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -528,6 +528,7 @@
       <description>Status message indicating the currently active flight control and payload control entity.
         This message should typically be send from the system at a low frequency as well as after a control ownership change to all connected GCS. 
       </description>
+      <field type="uint8_t" name="target_system">System this messsage is meant for.</field>
       <field type="uint8_t" name="current_flight_controller" enum="CURRENT_CONTROL_ENTITY">Current flight control entity.</field>
       <field type="uint8_t" name="current_payload_controller" enum="CURRENT_CONTROL_ENTITY">Current payload control entity.</field>
     </message>
@@ -535,6 +536,7 @@
       <description>Request the flight control and/or the payload control of the target system by a GCS.
         The message can be used in a multi GCS environment. A GCS can request the control ownership of the target system. 
       </description>
+      <field type="uint8_t" name="target_system">Target system for the control request.</field>
       <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to change to own ownership.</field>
       <field type="uint8_t" name="request_priority" default="0">Priority of the control request. If the priority is higher than the priority
         of the current control entity, control is given without handoff request. 
@@ -545,6 +547,7 @@
     <message id="443" name="REQUEST_CONTROL_ACK">
       <description>Error code response of the target system to the control ownership request.
       </description>
+      <field type="uint8_t" name="target_system">System to send the Ack back.</field>
       <field type="uint8_t" name="error_code" enum="CONTROL_REQUEST_ERROR_CODE">Error code response.</field>
     </message>
     <message id="444" name="RELEASE_CONTROL">
@@ -552,12 +555,14 @@
         The message can be used in a multi GCS environment to release the control of the target system. 
         This message is ignored when the GCS is not the current active control entity of the control target.
       </description>
+      <field type="uint8_t" name="target_system">System which should release control of the sender</field>
       <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to release own ownership.</field>
     </message>
     <message id="445" name="REQUEST_HANDOFF">
       <description>Request handoff of current control entity.
         This message is send from the system to the current active control entity to request the handoff of the control target to another GCS.
       </description>
+      <field type="uint8_t" name="target_system">GCS which is currently in control and has to accept handover.</field>
       <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to handoff control ownership.</field>
       <field type="char[10]" name="requester_id">Identification of the control entity requesting ownership.</field>
       <field type="char[50]" name="reason">Reason from the control entity requesting ownership.</field>
@@ -566,6 +571,7 @@
       <description>Handoff response to handoff request. 
         This message is the response from the GCS in control to the handoff request.
       </description>
+      <field type="uint8_t" name="target_system">System which should hand over the control.</field>
       <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to handoff.</field>
       <field type="uint8_t" name="handoff_decision" enum="HANDOFF_DECISION">Control target decision.</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -348,6 +348,60 @@
         <param index="7" reserved="true"/>
       </entry>
     </enum>
+    <enum name="CURRENT_CONTROL_ENTITY">
+      <description>List of the currently active control entity.</description>
+      <entry value="0" name="CURRENT_CONTROL_ENTITY_NONE">
+        <description>Setting if no entity has control ownership.</description>
+      </entry>
+      <entry value="1" name="CURRENT_CONTROL_ENTITY_OWNER">
+        <description>Setting if the receiving GCS is the control entity.</description>
+      </entry>
+      <entry value="2" name="CURRENT_CONTROL_ENTITY_OTHER">
+        <description>Setting if a GCS other than the receiving GCS is the control entity.</description>
+      </entry>
+    </enum>
+    <enum name="CONTROL_TARGET_REQUEST">
+      <description>Selection of control target for changing ownership.</description>
+      <entry value="0" name="CONTROL_TARGET_ALL">
+        <description>Request change control ownership of both flight control and payload control.</description>
+      </entry>
+      <entry value="1" name="CONTROL_TARGET_FLIGHT">
+        <description>Request change control ownership of the flight control.</description>
+      </entry>
+      <entry value="2" name="CONTROL_TARGET_PAYLOAD">
+        <description>Request change control ownership of the payload control.</description>
+      </entry>
+    </enum>
+    <enum name="CONTROL_REQUEST_ERROR_CODE">
+      <description>Error code for the control request response.</description>
+      <entry value="0" name="CONTROL_REQUEST_PROCESSED">
+        <description>Code indicating successful processing of the request.</description>
+      </entry>
+      <entry value="1" name="CONTROL_REQUEST_DENIED">
+        <description>Error code indicating that the control request has been denied by the target system.</description>
+      </entry>
+      <entry value="2" name="CONTROL_REQUEST_HANDOFF_TIMEOUT">
+        <description>Error Code indicating timeout on the handoff request.</description>
+      </entry>
+      <entry value="3" name="CONTROL_REQUEST_DENIED_CONCURRENT">
+        <description>Error Code indicating another control request is in process.</description>
+      </entry>
+      <entry value="4" name="CONTROL_REQUEST_NO_CONTROL_AUTHORITY">
+        <description>Error Code indicating no enough authority to take control ownership.</description>
+      </entry>
+      <entry value="5" name="CONTROL_REQUEST_NO_PRIORITY_AUTHORITY">
+        <description>Error Code indicating no enough priority authority control ownership.</description>
+      </entry>
+    </enum>
+    <enum name="HANDOFF_DECISION">
+      <description>Decision of the GCS to a handoff request.</description>
+      <entry value="0" name="HANDOFF_DECISION_ACCEPT">
+        <description>Decision to accept the handoff and release control ownership.</description>
+      </entry>
+      <entry value="1" name="HANDOFF_DECISION_DENIED">
+        <description>Decision to deny the handoff request and keep control ownership.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -469,6 +523,51 @@
       <field type="uint8_t" name="standard_mode" enum="MAV_STANDARD_MODE">Standard mode.</field>
       <field type="uint8_t" name="base_mode" enum="MAV_MODE_FLAG" display="bitmask">System mode bitmap.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
+    </message>
+    <message id="441" name="CONTROL_STATUS">
+      <description>Status message indicating the currently active flight control and payload control entity.
+        This message should typically be send from the system at a low frequency as well as after a control ownership change to all connected GCS. 
+      </description>
+      <field type="uint8_t" name="current_flight_controller" enum="CURRENT_CONTROL_ENTITY">Current flight control entity.</field>
+      <field type="uint8_t" name="current_payload_controller" enum="CURRENT_CONTROL_ENTITY">Current payload control entity.</field>
+    </message>
+    <message id="442" name="REQUEST_CONTROL">
+      <description>Request the flight control and/or the payload control of the target system by a GCS.
+        The message can be used in a multi GCS environment. A GCS can request the control ownership of the target system. 
+      </description>
+      <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to change to own ownership.</field>
+      <field type="uint8_t" name="request_priority" default="0">Priority of the control request. If the priority is higher than the priority
+        of the current control entity, control is given without handoff request. 
+        The priority request should be authenticated on the target system before granting this privilegs. Default value of 0.</field>
+      <field type="char[10]" name="requester_id">Identification of the control entity requesting ownership.</field>
+      <field type="char[50]" name="reason">Reason for taking ownership.</field>
+    </message>
+    <message id="443" name="REQUEST_CONTROL_ACK">
+      <description>Error code response of the target system to the control ownership request.
+      </description>
+      <field type="uint8_t" name="error_code" enum="CONTROL_REQUEST_ERROR_CODE">Error code response.</field>
+    </message>
+    <message id="444" name="RELEASE_CONTROL">
+      <description>Release the previously aquired control. 
+        The message can be used in a multi GCS environment to release the control of the target system. 
+        This message is ignored when the GCS is not the current active control entity of the control target.
+      </description>
+      <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to release own ownership.</field>
+    </message>
+    <message id="445" name="REQUEST_HANDOFF">
+      <description>Request handoff of current control entity.
+        This message is send from the system to the current active control entity to request the handoff of the control target to another GCS.
+      </description>
+      <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to handoff control ownership.</field>
+      <field type="char[10]" name="requester_id">Identification of the control entity requesting ownership.</field>
+      <field type="char[50]" name="reason">Reason from the control entity requesting ownership.</field>
+    </message>
+    <message id="446" name="HANDOFF_RESPOND">
+      <description>Handoff response to handoff request. 
+        This message is the response from the GCS in control to the handoff request.
+      </description>
+      <field type="uint8_t" name="control_target" enum="CONTROL_TARGET_REQUEST">Control target to handoff.</field>
+      <field type="uint8_t" name="handoff_decision" enum="HANDOFF_DECISION">Control target decision.</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
### Problem to Solve

In a multi GCS environment, only on GCS should be able to control the system. All other GCS should only act as observers. As an observer, you can still receive telemetry and payload stream, get the parameters and the mission, but cannot command the vehicle and change the parameters and mission. In order to set which GCS is in control, new message sets needs to be created.

### Proposed solution

The control handoff sub process in mavlink consists of requesting the control of the target system in a multi GCS environment requesting independently the flight control and/or the payload control. These service can be used in place of [CHANGE_OPERATOR_CONTROL](https://mavlink.io/en/messages/common.html#CHANGE_OPERATOR_CONTROL) and [CHANGE_OPERATOR_CONTROL_ACK](https://mavlink.io/en/messages/common.html#CHANGE_OPERATOR_CONTROL_ACK) messages. The process covers:

- The request of control from a GCS
- A handoff relay request from the system, if another GCS is in control
- A periodic status message defining the current GCS in control

The proposed solution for the control handoff subprocess is detailed as:

#### REQUEST_CONTROL

This message is used to request control of the target system from a GCS. The GCS is able to define the control target being the flight control and/or the payload control. It can further specify a text Id as a string identifying the GCS and give a reason for taking over control. This messages can be relayed to the GCS currently in control to get additional information as to why the control has to be handed over. If no GCS is currently in control, the request is accepted immediately, else, a handoff request to the current GCS in control is send.
Further, a request priority can be given. If the priority is higher than the priority of the GCS currently in control, the control is given over directly without additional request of the current GCS in control. This is used to be able to take the control by force.
Note that the system should check that a GCS has the necessary permission to make a priority request.

#### REQUEST_CONTROL_ACK

This message is used to give a feedback from the target system to the requesting GCS. It can detail as to why a request has been denied. To avoid diverging information, only the control_status should be check if the GCS is really in control.

#### CONTROL_STATUS

This message defines the currently in active controller for the flight control and payload control. This message is sent periodically and when a change in the current controller happened.

#### REQUEST_HANDOFF

This message is used from the target system when a control request is received but another GCS is already in control. It asks the GCS in control to hand over the control to the requesting GCS. it relays the requester id and reason such that the GCS in control can decide if he wants to hando ver the control

#### HANDOFF_RESPOND

This message is used from the current GCS in control to send it's decision for the handoff request.

#### RELEASE_CONTROL

This message can be used when a GCS wants to release the control of the flight and/or the payload control. If the control is released, the current controller is set to none in the target system.

A communication diagram is shown here:
[Mavlink_distributed_GCS.drawio.pdf](https://github.com/mavlink/mavlink/files/10734670/Mavlink_distributed_GCS.drawio.pdf)