### PR TITLE
Positional NAV command - test wording of scaling recommendation

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1087,8 +1087,8 @@
         <param index="2" label="Accept Radius" units="m" minValue="0">Acceptance radius (if the sphere with this radius is hit, the waypoint counts as reached)</param>
         <param index="3" label="Pass Radius" units="m">0 to pass through the WP, if &gt; 0 radius to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
         <param index="4" label="Yaw" units="deg">Desired yaw angle at waypoint (rotary wing). NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
-        <param index="5" label="Latitude">Latitude. Multiply degree value by 1E7 if sent in COMMAND_INT (recommended).</param>
-        <param index="6" label="Longitude">Longitude. Multiply degree value by 1E7 if sent in COMMAND_INT (recommended).</param>
+        <param index="5" label="Latitude">Latitude. Multiply degree value by 1E7 if sent in COMMAND_INT (recommended for greater precision).</param>
+        <param index="6" label="Longitude">Longitude. Multiply degree value by 1E7 if sent in COMMAND_INT (recommended for greater precision).</param>
         <param index="7" label="Altitude" units="m">Altitude</param>
       </entry>
       <entry value="17" name="MAV_CMD_NAV_LOITER_UNLIM" hasLocation="true" isDestination="true">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1087,8 +1087,8 @@
         <param index="2" label="Accept Radius" units="m" minValue="0">Acceptance radius (if the sphere with this radius is hit, the waypoint counts as reached)</param>
         <param index="3" label="Pass Radius" units="m">0 to pass through the WP, if &gt; 0 radius to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control.</param>
         <param index="4" label="Yaw" units="deg">Desired yaw angle at waypoint (rotary wing). NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
-        <param index="5" label="Latitude">Latitude</param>
-        <param index="6" label="Longitude">Longitude</param>
+        <param index="5" label="Latitude">Latitude. Multiply degree value by 1E7 if sent in COMMAND_INT (recommended).</param>
+        <param index="6" label="Longitude">Longitude. Multiply degree value by 1E7 if sent in COMMAND_INT (recommended).</param>
         <param index="7" label="Altitude" units="m">Altitude</param>
       </entry>
       <entry value="17" name="MAV_CMD_NAV_LOITER_UNLIM" hasLocation="true" isDestination="true">


### PR DESCRIPTION
Generally if you're sending lat/lon in a MAV_CMD then using COMMAND_INT is better, as it offers greater precision.
I propose to make this clear in every command where this applies. 
This PR tests the wording in one case before rolling it out more widely.

@peterbarker OK?

Following on from discussion in https://github.com/ArduPilot/MAVProxy/pull/1149