### PR TITLE
Allocate range for ras-a and indicate next free range

### DIFF
--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -34,5 +34,14 @@
     commands: 50000 - 50099
   -->
   <include>cubepilot.xml</include>
+  <!-- ras_a.xml range of IDs:
+    messages: 51000 - 52000
+    commands: 51000 - 52000
+    https://github.com/Dronecode/air-iop-definitions/blob/master/message_definitions/v1.0/ras_a.xml
+  -->
+  <!--Next range to allocate range of IDs:
+    messages: 52000 - ? < 60000
+    commands: 52000 - ? < 60000
+  -->
   <messages/>
 </mavlink>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -35,8 +35,8 @@
   -->
   <include>cubepilot.xml</include>
   <!-- ras_a.xml range of IDs:
-    messages: 51000 - 52000
-    commands: 51000 - 52000
+    messages: 51000 - 51999
+    commands: 51000 - 51999
     https://github.com/Dronecode/air-iop-definitions/blob/master/message_definitions/v1.0/ras_a.xml
   -->
   <!--Next range to allocate range of IDs:


### PR DESCRIPTION
Ras-a have agreed to restrict ids to allocated range. This chooses the free range:
    messages: 51000 - 52000
    commands: 51000 - 52000

Also added a placeholder to indicate the next free unallocated range (52000 +)