### PR TITLE
common.xml DO_ORBIT command minimal values [for discussion]

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1227,7 +1227,9 @@
         <description>Start orbiting on the circumference of a circle defined by the parameters. Setting values to NaN/INT32_MAX (as appropriate) results in using defaults.</description>
         <param index="1" label="Radius" units="m">Radius of the circle. Positive: orbit clockwise. Negative: orbit counter-clockwise. NaN: Use vehicle default radius, or current radius if already orbiting.</param>
         <param index="2" label="Velocity" units="m/s">Tangential Velocity. NaN: Use vehicle default velocity, or current velocity if already orbiting.</param>
-        <param index="3" label="Yaw Behavior" enum="ORBIT_YAW_BEHAVIOUR">Yaw behavior of the vehicle.</param>
+        <param index="3" label="Yaw Behavior" enum="ORBIT_YAW_BEHAVIOUR">Yaw behavior of the vehicle.
+		  Vehicles that can independently control yaw and vehicle motion, such as multicopters, must implement ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER and ORBIT_YAW_BEHAVIOUR_RC_CONTROLLED.
+	          Vehicles that do not support independent yaw control, such as fixed-wing vehicles, must ignore this parameter.</param>
         <param index="4" label="Orbits" units="rad" minValue="0" default="0">Orbit around the centre point for this many radians (i.e. for a three-quarter orbit set 270*Pi/180). 0: Orbit forever. NaN: Use vehicle default, or current value if already orbiting.</param>
         <param index="5" label="Latitude/X">Center point latitude (if no MAV_FRAME specified) / X coordinate according to MAV_FRAME. INT32_MAX (or NaN if sent in COMMAND_LONG): Use current vehicle position, or current center if already orbiting.</param>
         <param index="6" label="Longitude/Y">Center point longitude (if no MAV_FRAME specified) / Y coordinate according to MAV_FRAME. INT32_MAX (or NaN if sent in COMMAND_LONG): Use current vehicle position, or current center if already orbiting.</param>


### PR DESCRIPTION
The orbit command can define a yaw value. 

1. The first part of this change specifies that if called on a vehicle where independent control over the yaw is specified, the command should be ignored.

   An alternative is:
   - Change default [ORBIT_YAW_BEHAVIOUR](https://mavlink.io/en/messages/common.html#ORBIT_YAW_BEHAVIOUR) to "flight stack default" and create a new option to specify centre-facing. We should perhaps do this anyway.
   - Fixed wing should then reject the command if any other value is used.
   
   I slightly prefer this for command protocol because  it allows us to use the command infrastructure to tell us a command is invalid if it sets a yaw value that doesn't make sense for the vehicle. In a mission the value either has to be ignored or pause the mission as invalid. Generally I think we use the option specified here, but I am tempted to add the "Flight stack default" anyway.
   
2. The second part is to specify a minimal set of yaw values that must be supported, if they can be supported: ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER and about ORBIT_YAW_BEHAVIOUR_RC_CONTROLLED

   I like the principle of specifying "must be supported" profiles for anything and everything as it is one way of allowing a flight stack. 
   - I am pretty sure that ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER makes sense as a minimal requirement. 
   -  Not so sure about ORBIT_YAW_BEHAVIOUR_RC_CONTROLLED - if it is I'd prefer rename to ORBIT_YAW_BEHAVIOUR_MANUAL_CONTROLLED to allow RC/Joystick and a definition that the expectation is that this be controlled by a control with positive and negative axis (e.g. joystick).

More generally though, I'm using this opportunity to reopen the can of worms that is, "what is the right way to":
- define a minimum set of supported behaviours
- discover that a flight stack says it supports those minimum set of supported behaviours
- discover other behaviours that the flight stack supports over and above the minimal set. 
- add non-breaking additional requirements in a particular ecosystem. Ideally in such a way that these are discoverable in the ecosystem.

We've discussed various options for most of these - microservices, protocol bits, test commands/modes. I think we need to keep on it. The broad reason being that you can't be a standard without mechanisms to achieve interoperability. The specific benefit to flight stacks though is that at the moment no one really knows what works and what does not.

If we do define a minimum set, how do we indicate the required options? SHould we, for example, add a "required" flag to the enum. 
