### PR TITLE
Fix enum value for payload battery

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3220,7 +3220,7 @@
       <entry value="3" name="MAV_BATTERY_FUNCTION_AVIONICS">
         <description>Avionics battery</description>
       </entry>
-      <entry value="4" name="MAV_BATTERY_TYPE_PAYLOAD">
+      <entry value="4" name="MAV_BATTERY_FUNCTION_PAYLOAD">
         <description>Payload battery</description>
       </entry>
     </enum>


### PR DESCRIPTION
Enum values are supposed to be prefixed by their enum name. This changes `MAV_BATTERY_TYPE_PAYLOAD` to `MAV_BATTERY_FUNCTION_PAYLOAD`. This requires a recompile for users that specifically access this item, but is non-breaking over the wire.