### PR TITLE
Add quickstart to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://github.com/mavlink/mavlink/workflows/Test%20and%20deploy/badge.svg)](https://github.com/mavlink/mavlink/actions?query=branch%3Amaster)
 
-## MAVLink ##
+## MAVLink
 
 MAVLink -- Micro Air Vehicle Message Marshalling Library.
 
@@ -8,7 +8,37 @@ MAVLink is a very lightweight, header-only message library for communication bet
 
 > **Tip** MAVLink is very well suited for applications with very limited communication bandwidth. Its reference implementation in C is highly optimized for resource-constrained systems with limited RAM and flash memory. It is field-proven and deployed in many products where it serves as interoperability interface between components of different manufacturers.
 
-Key Links:
+
+### QuickStart
+
+To install the minimal MAVLink environment on Ubuntu LTS 20.04 or 22.04, enter the following on a terminal:
+
+```bash
+# Dependencies
+sudo apt install python3-pip
+sudo apt install python3-lxml libxml2-utils
+
+# Clone mavlink into the directory of your choice
+git clone https://github.com/mavlink/mavlink.git --recursive
+cd mavlink
+
+# Set the PYTHONPATH environment variable to the path of the root of the cloned mavlink repository
+PYTHONPATH=$PWD
+```
+
+You can then build the MAVLink2 C-library for `message_definitions/v1.0/common.xml` from the `/mavlink` directory as shown:
+
+```bash
+python3 -m pymavlink.tools.mavgen --lang=C --wire-protocol=2.0 --output=generated/include/mavlink/v2.0 message_definitions/v1.0/common.xml
+```
+
+Instructions for using the C libraries are then covered in [Using C MAVLink Libraries (mavgen)](https://mavlink.io/en/mavgen_c/).
+
+> **Note:** [Installing the MAVLink Toolchain](https://mavlink.io/en/getting_started/installation.html) explains how to install MAVLink on other Ubuntu platforms and Windows, while [Generating MAVLink Libraries](https://mavlink.io/en/getting_started/generate_libraries.html) explains how to build MAVLink for the other programming languages [supported by the project](https://mavlink.io/en/#supported_languages).
+> The sub-topics of [Using MAVLink Libraries](https://mavlink.io/en/getting_started/use_libraries.html) explain how to use the generated libraries.
+
+## Key Links
+
 * [Documentation/Website](https://mavlink.io/en/) (mavlink.io/en/)
 * [Discussion/Support](https://mavlink.io/en/#support) (Slack)
 * [Contributing](https://mavlink.io/en/contributing/contributing.html)


### PR DESCRIPTION
There was some discussion about needing a quick start in the readme. This is clearly not a big problem for most users, but nor do I think it is harmful to provide an easy path for most users. 

Note, this does not include `future`, which is not needed on the listed platforms, or tkinter, which is optional. All that is linked to the official docs.