### PR TITLE
Added "shortest way" as an option for yaw direction in MAV_CONDITION_YAW

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -759,7 +759,7 @@
                     <param index="1">target angle: [0-360], 0 is north</param>
                     <param index="2">speed during yaw change:[deg per second]</param>
                     <param index="3">direction: negative: counter clockwise, 0: shortest way, positive: clockwise [-1,0,1]</param>
-                    <param index="4">relative offset or absolute angle: [ 1,0]</param>
+                    <param index="4">relative offset or absolute angle: [1,0]</param>
                     <param index="5">Empty</param>
                     <param index="6">Empty</param>
                     <param index="7">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -758,7 +758,7 @@
                     <description>Reach a certain target angle.</description>
                     <param index="1">target angle: [0-360], 0 is north</param>
                     <param index="2">speed during yaw change:[deg per second]</param>
-                    <param index="3">direction: negative: counter clockwise, positive: clockwise [-1,1]</param>
+                    <param index="3">direction: negative: counter clockwise, 0: shortest way, positive: clockwise [-1,0,1]</param>
                     <param index="4">relative offset or absolute angle: [ 1,0]</param>
                     <param index="5">Empty</param>
                     <param index="6">Empty</param>


### PR DESCRIPTION
We should absolutely have a "shortest way" turn.
As-is, any imperfection in desired YAW since the last YAW command, risk an almost 360°turn.
Flying side-looking radar, we used [MAV_CMD_CONDITION_YAW](https://mavlink.io/en/messages/common.html#MAV_CMD_CONDITION_YAW) after each WP set to 120° right turn, if the desired heading is set to 120° at a moment when the actual heading is 120.01°... there will be a 359.99° turn to the right.

Having the option for "shortest way" - the usual way a copter turns during the execution of waypoints, is kind of mandatory.

