### PR TITLE
common.xml: remove MAV_CMD_ACK

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2644,36 +2644,6 @@
         <description>Point toward of given id.</description>
       </entry>
     </enum>
-    <enum name="MAV_CMD_ACK">
-      <description>ACK / NACK / ERROR values as a result of MAV_CMDs and for mission item transmission.</description>
-      <entry value="0" name="MAV_CMD_ACK_OK">
-        <description>Command / mission item is ok.</description>
-      </entry>
-      <entry value="1" name="MAV_CMD_ACK_ERR_FAIL">
-        <description>Generic error message if none of the other reasons fails or if no detailed error reporting is implemented.</description>
-      </entry>
-      <entry value="2" name="MAV_CMD_ACK_ERR_ACCESS_DENIED">
-        <description>The system is refusing to accept this command from this source / communication partner.</description>
-      </entry>
-      <entry value="3" name="MAV_CMD_ACK_ERR_NOT_SUPPORTED">
-        <description>Command or mission item is not supported, other commands would be accepted.</description>
-      </entry>
-      <entry value="4" name="MAV_CMD_ACK_ERR_COORDINATE_FRAME_NOT_SUPPORTED">
-        <description>The coordinate frame of this command / mission item is not supported.</description>
-      </entry>
-      <entry value="5" name="MAV_CMD_ACK_ERR_COORDINATES_OUT_OF_RANGE">
-        <description>The coordinate frame of this command is ok, but he coordinate values exceed the safety limits of this system. This is a generic error, please use the more specific error messages below if possible.</description>
-      </entry>
-      <entry value="6" name="MAV_CMD_ACK_ERR_X_LAT_OUT_OF_RANGE">
-        <description>The X or latitude value is out of range.</description>
-      </entry>
-      <entry value="7" name="MAV_CMD_ACK_ERR_Y_LON_OUT_OF_RANGE">
-        <description>The Y or longitude value is out of range.</description>
-      </entry>
-      <entry value="8" name="MAV_CMD_ACK_ERR_Z_ALT_OUT_OF_RANGE">
-        <description>The Z or altitude value is out of range.</description>
-      </entry>
-    </enum>
     <enum name="MAV_PARAM_TYPE">
       <description>Specifies the datatype of a MAVLink parameter.</description>
       <entry value="1" name="MAV_PARAM_TYPE_UINT8">


### PR DESCRIPTION
This starts off looking very much like MAV_RESULT but then starts to differ

Based off the name, remove this entirely so implementers are forced to move to MAV_RESULT.


Some discussion between @hamishwillee and myself here: https://github.com/ArduPilot/mavlink/pull/307

tldr is that this is broken as an enumeration to use in an extension field as a value of zero is always "unknown".
