### PR TITLE
common - un-WIP gimbal messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6939,8 +6939,6 @@
       <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity, positive is yawing to the right, NaN to be ignored.</field>
     </message>
     <message id="283" name="GIMBAL_DEVICE_INFORMATION">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE. The maximum angles and rates are the limits by hardware. However, the limits by software used are likely different/smaller and dependent on mode/settings/etc..</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="char[32]" name="vendor_name">Name of the gimbal vendor.</field>
@@ -6959,8 +6957,6 @@
       <field type="float" name="yaw_max" units="rad" invalid="NaN">Maximum hardware yaw angle (positive: to the right, negative: to the left). NAN if unknown.</field>
     </message>
     <message id="284" name="GIMBAL_DEVICE_SET_ATTITUDE">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Low level message to control a gimbal device's attitude. 
 	  This message is to be sent from the gimbal manager to the gimbal device component. 
 	  The quaternion and angular velocities can be set to NaN according to use case. 
@@ -6982,8 +6978,6 @@
       <field type="float" name="angular_velocity_z" units="rad/s" invalid="NaN">Z component of angular velocity (positive: yawing to the right). The frame is described in the message description. NaN to be ignored.</field>
     </message>
     <message id="285" name="GIMBAL_DEVICE_ATTITUDE_STATUS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Message reporting the status of a gimbal device. 
 	  This message should be broadcast by a gimbal device component at a low regular rate (e.g. 5 Hz). 
 	  For the angles encoded in the quaternion and the angular velocities holds: 
@@ -7013,8 +7007,6 @@
       <field type="float" name="delta_yaw_velocity" units="rad/s" invalid="NAN">Yaw angular velocity relating the angular velocities in earth and body frames (see message description). NaN if unknown.</field>
     </message>
     <message id="286" name="AUTOPILOT_STATE_FOR_GIMBAL_DEVICE">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Low level message containing autopilot state relevant for a gimbal device. This message is to be sent from the autopilot to the gimbal device component. The data of this message are for the gimbal device's estimator corrections, in particular horizon compensation, as well as indicates autopilot control intentions, e.g. feed forward angular control in the z-axis.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>


### PR DESCRIPTION
With ArduPilot implementing these too, and some manufacturers, presumably time to remove the WIP tagging.

Any issues I should be aware of? I.e. something that no one has implemented that should remain WIP?

@julianoes Service docs indicate `MAV_CMD_DO_GIMBAL_MANAGER_TRACK_RECTANGLE` but I think you guys decided that was camera API `MAV_CMD_CAMERA_TRACK_RECTANGLE` right? 

@julianoes @olliw42 @rmackay9 @auturgy FYI Suggestions, feedback, welcome.