### PR TITLE
Air-Link: Added messages for connections to air-link modules

### DIFF
--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -39,9 +39,14 @@
     commands: 51000 - 51999
     https://github.com/Dronecode/air-iop-definitions/blob/master/message_definitions/v1.0/ras_a.xml
   -->
+  <include>csAirLink.xml</include>
+  <!-- csAirLink.xml range of IDs:
+    messages: 52000 - 52099
+    commands: 52000 - 52099
+  -->
   <!--Next range to allocate range of IDs:
-    messages: 52000 - ? < 60000
-    commands: 52000 - ? < 60000
+    messages: 52100 - ? < 60000
+    commands: 52100 - ? < 60000
   -->
   <messages/>
 </mavlink>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -5,6 +5,7 @@
   <include>uAvionix.xml</include>
   <include>icarous.xml</include>
   <include>cubepilot.xml</include>
+  <include>csAirLink.xml</include>
   <dialect>2</dialect>
   <!-- Note that ArduPilot-specific messages should use the command id range from 150 to 250, to leave plenty of room for growth of common.xml If you prototype a message here, then you should consider if it is general enough to move into common.xml later -->
   <enums>

--- a/message_definitions/v1.0/csAirLink.xml
+++ b/message_definitions/v1.0/csAirLink.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- ClearSky Air-Link contact info:          -->
+  <!-- company URL: https://air-link.space/     -->
+  <!-- email contact: drone@air-link.space      -->
+  <!-- mavlink ID range: 52000 - 52099          -->
+  <version>3</version>
+  <enums>
+    <enum name="AIRLINK_AUTH_RESPONSE_TYPE">
+      <entry value="0" name="AIRLINK_ERROR_LOGIN_OR_PASS">
+        <description>Login or password error</description>
+      </entry>
+      <entry value="1" name="AIRLINK_AUTH_OK">
+        <description>Auth successful</description>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="52000" name="AIRLINK_AUTH">
+      <description>Authorization package</description>
+      <field type="char[50]" name="login">Login</field>
+      <field type="char[50]" name="password">Password</field>
+    </message>
+    <message id="52001" name="AIRLINK_AUTH_RESPONSE">
+      <description>Response to the authorization request</description>
+      <field type="uint8_t" name="resp_type" enum="AIRLINK_AUTH_RESPONSE_TYPE">Response type</field>
+    </message>
+  </messages>
+</mavlink>


### PR DESCRIPTION
Hi. I am adding the ability to connect ground stations with Qgroundcontrol and MissionPlanner software to [AirLink lte modules](https://ardupilot.org/plane/docs/common-airlink-telemetry.html). Adding changes to master will help speed up the work.