### PR TITLE
common.xml: exclude any stored home location from MISSION_CURRENT.total

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5274,7 +5274,7 @@
       </description>
       <field type="uint16_t" name="seq">Sequence</field>
       <extensions/>
-      <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items on vehicle.  If the autopilot stores its home location as part of the mission this should be excluded from the total. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
+      <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items on vehicle (on last item, sequence == total). If the autopilot stores its home location as part of the mission this will be excluded from the total. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
       <field type="uint8_t" name="mission_state" enum="MISSION_STATE" invalid="0">Mission state machine state. MISSION_STATE_UNKNOWN if state reporting not supported.</field>
       <field type="uint8_t" name="mission_mode" invalid="0">Vehicle is in a mode that can execute mission items or suspended. 0: Unknown, 1: In mission mode, 2: Suspended (not in mission mode).</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5274,7 +5274,7 @@
       </description>
       <field type="uint16_t" name="seq">Sequence</field>
       <extensions/>
-      <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
+      <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items on vehicle.  If the autopilot stores its home location as part of the mission this should be excluded from the total. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
       <field type="uint8_t" name="mission_state" enum="MISSION_STATE" invalid="0">Mission state machine state. MISSION_STATE_UNKNOWN if state reporting not supported.</field>
       <field type="uint8_t" name="mission_mode" invalid="0">Vehicle is in a mode that can execute mission items or suspended. 0: Unknown, 1: In mission mode, 2: Suspended (not in mission mode).</field>
     </message>


### PR DESCRIPTION
ArduPilot stores its home location in slot-0.

Before this change, in the case you have that home location and a single waypoint uploaded ArduPilot would report a total of 2 - but when running the mission towards this single waypoint would report going to waypoint 1.  This is contrary to expectations of the user, so exclude slot 0 from the count.

@hamishwillee please discuss but don't merge just yet?  See https://github.com/ArduPilot/ardupilot/pull/23230
