### PR TITLE
common.xml: Add ZOOM_TYPE_HORIZONTAL_FOV to CAMERA_ZOOM_TYPE enum

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3753,6 +3753,9 @@
       <entry value="3" name="ZOOM_TYPE_FOCAL_LENGTH">
         <description>Zoom value/variable focal length in millimetres. Note that there is no message to get the valid zoom range of the camera, so this can type can only be used for cameras where the zoom range is known (implying that this cannot reliably be used in a GCS for an arbitrary camera)</description>
       </entry>
+      <entry value="4" name="ZOOM_TYPE_HORIZONTAL_FOV">
+        <description>Zoom value as horizontal field of view in degrees.</description>
+      </entry>
     </enum>
     <enum name="SET_FOCUS_TYPE">
       <description>Focus types for MAV_CMD_SET_CAMERA_FOCUS</description>


### PR DESCRIPTION
Allow the user to specify the camera zoom level as a horizontal field-of-view (HFOV) value. The primary use case for this is for systems with two cameras (with different lens/sensor combinations) where you want the two captured images to be the same.