### PR TITLE
common.xml: Add MAV_RESULT_COMMAND_LONG_ONLY and MAV_RESULT_COMMAND_INT_ONLY to MAV_RESULT

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2736,6 +2736,9 @@
       <entry value="6" name="MAV_RESULT_CANCELLED">
         <description>Command has been cancelled (as a result of receiving a COMMAND_CANCEL message).</description>
       </entry>
+      <entry value="7" name="MAV_RESULT_COMMAND_LONG_ONLY">
+        <description>Command is valid, but it is only accepted when sent as a COMMAND_LONG (as it has float values for params 5 and 6).</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">
       <description>Result of mission operation (in a MISSION_ACK message).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2739,6 +2739,9 @@
       <entry value="7" name="MAV_RESULT_COMMAND_LONG_ONLY">
         <description>Command is valid, but it is only accepted when sent as a COMMAND_LONG (as it has float values for params 5 and 6).</description>
       </entry>
+      <entry value="8" name="MAV_RESULT_COMMAND_INT_ONLY">
+        <description>Command is valid, but it is only accepted when sent as a COMMAND_INT (as it encodes a location in params 5, 6 and 7, and hence requires a reference MAV_FRAME).</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">
       <description>Result of mission operation (in a MISSION_ACK message).</description>


### PR DESCRIPTION
Per the descriptions on `COMMAND_INT` and `COMMAND_LONG`, certain `MAV_CMD`s should only be sent as one or the other. However, there is no mechanism for the receiving system to indicate this. The closest we can get at the moment is by using `MAV_RESULT_DENIED`, but that is ambiguous as to whether the issue is the `COMMAND_*` message or the actual parameters.

This PR adds two new entries to the `MAV_RESULT` enum, `MAV_RESULT_COMMAND_LONG_ONLY` and `MAV_RESULT_COMMAND_INT_ONLY`, to address this.