### PR TITLE
update instructions to install pymavlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sudo apt install python3-pip
 git clone https://github.com/mavlink/mavlink.git --recursive
 cd mavlink
 
-python3 -m pip install pymavlink/requirements.txt
+python3 -m pip install -r pymavlink/requirements.txt
 ```
 
 You can then build the MAVLink2 C-library for `message_definitions/v1.0/common.xml` from the `/mavlink` directory as shown:


### PR DESCRIPTION
update instructions to install pymavlink package instead of just its dependencies
note the instructions were broken anyway - you need the -r flag to install from a requirements file