### PR TITLE
remove pymavlink files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,17 +9,8 @@ install*
 .nfs*
 share/
 __pycache__
-pymavlink/generator/C/
-pymavlink/generator/C/
-pymavlink/generator/python/
-pymavlink/generator/python/
 apidocs/
-pymavlink/generator/message_definitions
 *.swp
-pymavlink/dialects/
-pymavlink/MANIFEST
-pymavlink/dist
-pymavlink.egg-info/
 .pydevproject
 .project
 .ropeproject


### PR DESCRIPTION
These are more properly managed within the pymavlink repository