### PR TITLE
Command int long fixes

### DIFF
--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -133,7 +133,8 @@
       <xsl:apply-templates select="wip" />
       <p><a href="#mav_commands">[Command]</a><xsl:value-of select="description" /> </p> <!-- mavlink_comment -->
       <xsl:if test='@hasLocation = "true" or @isDestination = "true"'>
-        <p>Send in COMMAND_INT for commands that specify a position, if supported by your flight stack (frame of reference cannot be set in COMMAND_LONG, and lat/lon in param 5/6 are less precise if sent in floats).</p>
+        <p>Send this command in a COMMAND_INT (if supported by your flight stack), as it specifies positional information.
+        If sent in a COMMAND_LONG, no frame of reference can be set, and lat/lon values in param 5/6 are less precise.</p>
       </xsl:if>
 
    <table class="sortable">

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -132,7 +132,9 @@
       <xsl:apply-templates select="deprecated" />
       <xsl:apply-templates select="wip" />
       <p><a href="#mav_commands">[Command]</a><xsl:value-of select="description" /> </p> <!-- mavlink_comment -->
-
+      <xsl:if test='@hasLocation = "true" or @isDestination = "true"'>
+        <p>Send in COMMAND_INT (not COMMAND_LONG).</p>
+      </xsl:if>
 
    <table class="sortable">
    <thead>

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -133,7 +133,7 @@
       <xsl:apply-templates select="wip" />
       <p><a href="#mav_commands">[Command]</a><xsl:value-of select="description" /> </p> <!-- mavlink_comment -->
       <xsl:if test='@hasLocation = "true" or @isDestination = "true"'>
-        <p>Send in COMMAND_INT (not COMMAND_LONG).</p>
+        <p>Send in COMMAND_INT for commands that specify a position, if supported by your flight stack (frame of reference cannot be set in COMMAND_LONG, and lat/lon in param 5/6 are less precise if sent in floats).</p>
       </xsl:if>
 
    <table class="sortable">


### PR DESCRIPTION
Following on from discussion in #1982, this updates docs generator to add a note to any command that has either `hasDestination=true` or `isDestingation=true` attribute. This renders as a line at the end of the description like this:

![image](https://github.com/mavlink/mavlink/assets/5368500/418ccc26-a362-4dea-ac4f-59fbcce230b5)

Are we OK with the text? More questions to follow; they wouldn't block this, but would result in follow on work.

FYI @sypaq-nexton @peterbarker 