### PR TITLE
isAltitude, hasLocation, isDestination discussion and application

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1645,7 +1645,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="191" name="MAV_CMD_DO_GO_AROUND" altitudeOnly="true">
+      <entry value="191" name="MAV_CMD_DO_GO_AROUND" hasLocation="false" isDestination="false">
         <description>Mission command to safely abort an autonomous landing.</description>
         <param index="1" label="Altitude" units="m">Altitude</param>
         <param index="2">Empty</param>
@@ -1715,7 +1715,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="198" name="MAV_CMD_DO_SET_ROI_SYSID">
+      <entry value="198" name="MAV_CMD_DO_SET_ROI_SYSID" hasLocation="false" isDestination="false">
         <description>Mount tracks system with specified system ID. Determination of target vehicle position may be done with GLOBAL_POSITION_INT or any other means. This command can be sent to a gimbal manager but not to a gimbal device. A gimbal device is not to react to this message.</description>
         <param index="1" label="System ID" minValue="1" maxValue="255" increment="1">System ID</param>
         <param index="2" label="Gimbal device ID">Component ID of gimbal device to address (or 1-6 for non-MAVLink gimbal), 0 for all gimbal device components. Send command multiple times for more than one gimbal (but not all gimbals).</param>
@@ -2102,7 +2102,7 @@
         <param index="6">Reserved</param>
         <param index="7">Reserved</param>
       </entry>
-      <entry value="420" name="MAV_CMD_INJECT_FAILURE">
+      <entry value="420" name="MAV_CMD_INJECT_FAILURE" hasLocation="false" isDestination="false">
         <description>Inject artificial failure for testing purposes. Note that autopilots should implement an additional protection before accepting this command such as a specific param setting.</description>
         <param index="1" label="Failure unit" enum="FAILURE_UNIT">The unit which is affected by the failure.</param>
         <param index="2" label="Failure type" enum="FAILURE_TYPE">The type how the failure manifests itself.</param>
@@ -2606,7 +2606,7 @@
         <param index="7">Reserved</param>
       </entry>
       <!-- from ardupilotmega.xml (hence ID is in that range) -->
-      <entry value="42006" name="MAV_CMD_FIXED_MAG_CAL_YAW">
+      <entry value="42006" name="MAV_CMD_FIXED_MAG_CAL_YAW" hasLocation="false" isDestination="false">
         <description>Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location.</description>
         <param index="1" label="Yaw" units="deg">Yaw of vehicle in earth frame.</param>
         <param index="2" label="CompassMask">CompassMask, 0 for all.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1645,7 +1645,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="191" name="MAV_CMD_DO_GO_AROUND" hasLocation="false" isDestination="false">
+      <entry value="191" name="MAV_CMD_DO_GO_AROUND" altitudeOnly="true">
         <description>Mission command to safely abort an autonomous landing.</description>
         <param index="1" label="Altitude" units="m">Altitude</param>
         <param index="2">Empty</param>


### PR DESCRIPTION
This discussion evolved quite considerably. The resolution is that hasLocation and isDestination only apply to the param5,6,7 values, and should be applied that way. This now updates just a few MAV_CMD that don't meet this case.


----

[`MAV_CMD_DO_GO_AROUND`](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GO_AROUND) has an altitude with units in metres but no specified frame.

While I suspect that most flight stacks would assume this to be AMSL because they should have a barometer, but some might have terrain info, rangefinder, or assume AGL from home. If sent in a COMMAND_LONG the frame is ambiguous.

For discussion, this adds a new attribute `hasAltitude` that should be applied to any item where `hasLocation` and `isDestination` are `false` but there is an altitude setting that does not have a fixed and specified frame.
This is needed so we can auto-add notes to indicate what command this should be sent in.

Initially I intended to change the attributes `hasLocation` and `isDestination` from false to true, which would allow me to auto-add a note that the command should be send in COMMAND_INT.

However @sypaq-nexton had a reasonable question - should `hasLocation` and `isDestination` only apply to things that have a position in the ground plane (like lat/lon).
The answer is yes. `isDestination` was invented so a GCS could identify waypoints for drawing lines through automatically. If we apply this to things without a location, the GCS might screw up rendering. 
I don't know for sure, but I suspect that `hasLocation` might have similar semantics.

1. Does adding this make sense.
2. Does adding it only if the other attributes make sense, or is it better to add it to everything that has an altitude, including those that have location. 
3. You probably only add it if the frame is fixed in the description. The only case you would want it would be if param 5/6 was used for altitude. We would avoid this, so I think we don't add it for those cases.

Falls out of discussion in https://github.com/mavlink/mavlink/pull/1992

@julianoes @auturgy Opinions? If you agree I will update XSD.