### PR TITLE
MAV_CMD_FIXED_MAG_CAL_YAW - help clarify frame and location

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2402,7 +2402,7 @@
         <param index="7">Reserved</param>
       </entry>
       <!-- from ardupilotmega.xml (hence ID is in that range) -->
-      <entry value="42006" name="MAV_CMD_FIXED_MAG_CAL_YAW" hasLocation="false" isDestination="false">
+      <entry value="42006" name="MAV_CMD_FIXED_MAG_CAL_YAW">
         <description>Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location.</description>
         <param index="1" label="Yaw" units="deg">Yaw of vehicle in earth frame.</param>
         <param index="2" label="CompassMask">CompassMask, 0 for all.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2402,7 +2402,7 @@
         <param index="7">Reserved</param>
       </entry>
       <!-- from ardupilotmega.xml (hence ID is in that range) -->
-      <entry value="42006" name="MAV_CMD_FIXED_MAG_CAL_YAW" hasLocation="true" isDestination="false">
+      <entry value="42006" name="MAV_CMD_FIXED_MAG_CAL_YAW" hasLocation="false" isDestination="false">
         <description>Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location.</description>
         <param index="1" label="Yaw" units="deg">Yaw of vehicle in earth frame.</param>
         <param index="2" label="CompassMask">CompassMask, 0 for all.</param>


### PR DESCRIPTION
`MAV_CMD_FIXED_MAG_CAL_YAW` has latitude and longitude specified in param 3, 4, rather than 5, 6 by convention. This means that the values must be sent in a float and will be less precise than they might be.

1. Does lack of precision matter? My assumption is "no" - this is just used for getting WMM field tables which won't be granular to metres.
2. Does not having a frame specified matter? I mean, should we add "Global (WGS84) coordinate frame" is used by default?
3. Is it worth duplicating these in param 5, 6 to follow convention? We could add a note to suggest flight stacks send values in both, and param 5, 6 values be used if set, in order to eventually have a consistent command. Reason not to is "hassle" and also that 0 is a valid value. I think we should do it.

Following on from discussion in https://github.com/mavlink/mavlink/pull/1992

- This is tagged as `hasLocation="true"`. Just to be clear, does it matter if the location is in the wrong place/should we only apply this to cases where it is in the right place? I kind of think we should only apply to things in the right place for `hasLocation` and `isLocation`. My reason is that the convention is used by GCS - so if they assume those locations based on this tag, they will be broken.

Upshot, I think this change is "good". But not sure if any need for the others.