### PR TITLE
MAV_CMD_VIDEO_START_CAPTURE et al change param5/6 to 0 default

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2122,8 +2122,8 @@
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
         <param index="3" label="Total Images" minValue="0" increment="1">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
         <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1. This is only valid for single-capture (param3 == 1), otherwise set to 0. Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted.</param>
-        <param index="5" reserved="true" default="NaN"/>
-        <param index="6" reserved="true" default="NaN"/>
+        <param index="5" reserved="true"/>
+        <param index="6" reserved="true"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE" hasLocation="false" isDestination="false">
@@ -2132,6 +2132,8 @@
         <param index="2" reserved="true" default="NaN"/>
         <param index="3" reserved="true" default="NaN"/>
         <param index="4" reserved="true" default="NaN"/>
+        <param index="5" reserved="true"/>
+        <param index="6" reserved="true"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="2002" name="MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE" hasLocation="false" isDestination="false">
@@ -2141,6 +2143,8 @@
         <param index="2" reserved="true" default="NaN"/>
         <param index="3" reserved="true" default="NaN"/>
         <param index="4" reserved="true" default="NaN"/>
+        <param index="5" reserved="true"/>
+        <param index="6" reserved="true"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="2003" name="MAV_CMD_DO_TRIGGER_CONTROL" hasLocation="false" isDestination="false">
@@ -2171,8 +2175,8 @@
         <param index="2" label="Status Frequency" minValue="0" units="Hz">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency)</param>
         <param index="3" reserved="true" default="NaN"/>
         <param index="4" reserved="true" default="NaN"/>
-        <param index="5" reserved="true" default="NaN"/>
-        <param index="6" reserved="true" default="NaN"/>
+        <param index="5" reserved="true"/>
+        <param index="6" reserved="true"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE" hasLocation="false" isDestination="false">
@@ -2181,8 +2185,8 @@
         <param index="2" reserved="true" default="NaN"/>
         <param index="3" reserved="true" default="NaN"/>
         <param index="4" reserved="true" default="NaN"/>
-        <param index="5" reserved="true" default="NaN"/>
-        <param index="6" reserved="true" default="NaN"/>
+        <param index="5" reserved="true"/>
+        <param index="6" reserved="true"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="2502" name="MAV_CMD_VIDEO_START_STREAMING" hasLocation="false" isDestination="false">
@@ -2229,8 +2233,8 @@
         <param index="2" label="Landing Gear Position">Landing gear position (Down: 0, Up: 1, NaN for no change)</param>
         <param index="3" reserved="true" default="NaN"/>
         <param index="4" reserved="true" default="NaN"/>
-        <param index="5" reserved="true" default="NaN"/>
-        <param index="6" reserved="true" default="NaN"/>
+        <param index="5" reserved="true"/>
+        <param index="6" reserved="true"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>
       <entry value="2600" name="MAV_CMD_CONTROL_HIGH_LATENCY" hasLocation="false" isDestination="false">


### PR DESCRIPTION
[`MAV_CMD_VIDEO_START_CAPTURE`](https://mavlink.io/en/messages/common.html#MAV_CMD_VIDEO_START_CAPTURE), [`MAV_CMD_VIDEO_STOP_CAPTURE`](https://mavlink.io/en/messages/common.html#MAV_CMD_VIDEO_STOP_CAPTURE), 
[`MAV_CMD_AIRFRAME_CONFIGURATION`](https://mavlink.io/en/messages/common.html#MAV_CMD_AIRFRAME_CONFIGURATION), 

All have param 5, 6 [reserved](https://mavlink.io/en/guide/define_xml_element.html#reserved) as `NaN`, indicating that senders should always set the values to `NaN` even if they are unused. This allows the reserved values to be resused later on for properties where "0" is an allowed value of the setting, because you would still sent `NaN` to mean "no change".

This PR changes the reserved params to have default values of 0, such that a GCS should send 0 by default for the command in param5, 6. This allows the command to be send in a COMMAND_INT by by default. We are trying to encourage that most commands should be sendable in COMMAND_INT so it becomes a kind of default, with only very few exceptions where COMMAND_LONG must be used.

I don't think there are any downsides to this:
- The commands still have reserved float params that can be used if the commands need to be extended with a float param in future.
- GCS should be sending NaN in these values now in a COMMAND long, and should change to sending 0 - both in the long and int variants. Right now though, the field is not being used. There is plenty of time, possibly unlimited time, for flight stacks to adapt. 
 - I also wouldn't be surprised if they are sending 0 instead by mistake. 
 
This fell out of discussion in https://github.com/mavlink/mavlink/pull/1992