### PR TITLE
Add Payload and Autonomy Microservice Support from Marine Dialect

### DIFF
--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -52,6 +52,9 @@
       <entry value="64" name="AUTONOMY_COMPONENT_ACOMMS">
         <description>0x40 Acomms Modem</description>
       </entry>
+      <entry value="128" name="AUTONOMY_COMPONENT_MISSION">
+        <description>0x80 Autonomy Mission</description>
+      </entry>
     </enum>
     <enum name="AUTONOMY_STATE">
       <description>Current state of the Autonomy System.</description>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -192,7 +192,7 @@
         <param index="7">Empty.</param>
       </entry> -->
       <entry value="44002" name="MAV_CMD_PAYLOAD_SET_STATE" hasLocation="false" isDestination="false">
-        <description>Set the states for the payload with the specified ID. Command will be rejected if trying to set a state not supported by the payload.</description>
+        <description>Set the states for the payload with the specified ID. Command will be rejected if trying to set a state not supported by the payload. Note that this command should always be sent as COMMAND_INT which has param5/x as int32_t rather than float.</description>
         <param index="1" label="Payload ID" minValue="0" maxValue="999" increment="1">Payload ID, 0 to apply to all Payloads in List.</param>
         <param index="2">Empty.</param>
         <param index="3">Empty.</param>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -259,6 +259,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="destination_address">Acomms message destination, 0 for broadcast.</field>
+      <field type="uint8_t" name="source_vehicle_id">Source Vehicle ID.</field>
       <field type="uint8_t" name="snippet_confidence" units="%" >Contact snippet confidence (0 to 100).</field>
       <field type="uint16_t" name="snippet_id">Contact snippet identifier. Unique for each snippet.</field>
       <field type="uint8_t" name="message_length">Length of the data transported in message.</field>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -299,13 +299,14 @@
       <field type="uint8_t" name="result" enum="PAYLOAD_LIST_RESULT">Payload List result.</field>
     </message>
     <message id="44205" name="PAYLOAD_STATUS_REQUEST">
-      <description>Request the status of the payload item with the specified payload ID. The response of the system to this message should be a PAYLOAD_STATUS message.</description>
+      <deprecated since="2022-05" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
+      <description>Request the status of the payload item with the specified payload ID. The response of the system to this message should be a PAYLOAD_STATUS message. Note: this message has been deprecated in favor of using MAV_CMD_REQUEST_MESSAGE with param1 specifiying the message ID and param2 specifying the payload ID.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="payload_id">Payload ID.</field>
     </message>
     <message id="44206" name="PAYLOAD_STATUS">
-      <description>This message is emitted as response to PAYLOAD_STATUS_REQUEST, and contains the details (ID and Type) and health and status (as bitmasks) of the specified payload.</description>
+      <description>This message is emitted as response to MAV_CMD_REQUEST_MESSAGE with param1 specifying the message ID (44206) andparam2 specifying the payload ID, and contains the details (ID and Type) and health and status (as bitmasks) of the specified payload.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="payload_id">Payload ID, 1 - N.</field>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -76,6 +76,9 @@
       <entry value="6" name="AUTONOMY_STATE_STOPPED">
         <description>Autonomy System execution stopped early.</description>
       </entry>
+      <entry value="7" name="AUTONOMY_STATE_RECOVERING">
+        <description>Autonomy System heading to recovery position.</description>
+      </entry>
     </enum>
     <enum name="PAYLOAD_TYPE">
       <description>Supported Payload types.</description>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -83,6 +83,24 @@
         <description>Autonomy System heading to recovery position.</description>
       </entry>
     </enum>
+    <enum name="VEHICLE_MODE">
+      <description>Current mode of a squad vehicle.</description>
+      <entry value="0" name="VEHICLE_MODE_DEFAULT">
+        <description>Default state, ignored.</description>
+      </entry>
+      <entry value="1" name="VEHICLE_MODE_MISSION_FAULT">
+        <description>There is a fault with the current mission.</description>
+      </entry>
+      <entry value="2" name="VEHICLE_MODE_MISSION_ABORT">
+        <description>The current mission has been aborted.</description>
+      </entry>
+      <entry value="3" name="VEHICLE_MODE_BASELINE_MISSION">
+        <description>The vehicle is executing its baseline mission.</description>
+      </entry>
+      <entry value="4" name="VEHICLE_MODE_REMOTE_MISSION">
+        <description>The vehicle is executing a remote mission.</description>
+      </entry>
+    </enum>
     <enum name="PAYLOAD_TYPE">
       <description>Supported Payload types.</description>
       <entry value="0" name="PAYLOAD_TYPE_CAMERA">

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -71,7 +71,7 @@
         <description>Autonomy System Control Suspended Temporarily.</description>
       </entry>
       <entry value="5" name="AUTONOMY_STATE_COMPLETED">
-        <description>Autonomy System execution completed succesfully.</description>
+        <description>Autonomy System execution completed successfully.</description>
       </entry>
       <entry value="6" name="AUTONOMY_STATE_STOPPED">
         <description>Autonomy System execution stopped early.</description>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -100,19 +100,19 @@
       <entry value="6" name="PAYLOAD_TYPE_FLS">
         <description>Forward Look Sonar Payload.</description>
       </entry>
-      <entry value="1001" name="PAYLOAD_TYPE_GENERIC_1">
+      <entry value="101" name="PAYLOAD_TYPE_GENERIC_1">
         <description>Generic Payload 1.</description>
       </entry>
-      <entry value="1002" name="PAYLOAD_TYPE_GENERIC_2">
+      <entry value="102" name="PAYLOAD_TYPE_GENERIC_2">
         <description>Generic Payload 2.</description>
       </entry>
-      <entry value="1003" name="PAYLOAD_TYPE_GENERIC_3">
+      <entry value="103" name="PAYLOAD_TYPE_GENERIC_3">
         <description>Generic Payload 3.</description>
       </entry>
-      <entry value="1004" name="PAYLOAD_TYPE_GENERIC_4">
+      <entry value="104" name="PAYLOAD_TYPE_GENERIC_4">
         <description>Generic Payload 4.</description>
       </entry>
-      <entry value="1005" name="PAYLOAD_TYPE_GENERIC_5">
+      <entry value="105" name="PAYLOAD_TYPE_GENERIC_5">
         <description>Generic Payload 5.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -325,7 +325,7 @@
       <field type="float" name="calculated_current_x" units="m/s">Calculated Water current in X (NED)</field>
       <field type="float" name="calculated_current_y" units="m/s">Calculated Water current in Y (NED)</field>
       <field type="float" name="calculated_current_z" units="m/s">Calculated Water current in Z (NED)</field>
-      <field type="float" name="distance" units="cm">Measurement distance from the sensor</field>
+      <field type="float" name="distance" units="m">Measurement distance from the sensor</field>
     </message>
     <message id="44301" name="DVL">
       <description>Doppler Velocity Log Sensor. Used to provide vehicle velocity.</description>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -277,7 +277,7 @@
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="source_vehicle_id">Source Vehicle ID.</field>
-      <field type="uint8_t" name="vehicle_mode">Vehicle Mode.</field>
+      <field type="uint8_t" name="vehicle_mode" enum="VEHICLE_MODE">Vehicle Mode.</field>
       <field type="int32_t" name="lat" units="degE7">Latitude, expressed</field>
       <field type="int32_t" name="lon" units="degE7">Longitude, expressed</field>
       <field type="float" name="depth" units="m">Current depth in meters positive down from the surface.</field>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -260,6 +260,7 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint32_t" name="destination_address">Acomms message destination, 0 for broadcast.</field>
       <field type="uint8_t" name="snippet_confidence" units="%" >Contact snippet confidence (0 to 100).</field>
+      <field type="uint16_t" name="snippet_id">Contact snippet identifier. Unique for each snippet.</field>
       <field type="uint8_t" name="message_length">Length of the data transported in message.</field>
       <field type="uint8_t[128]" name="message">Variable length message. The message length is defined by message_length.</field>
     </message>

--- a/message_definitions/v1.0/marine.xml
+++ b/message_definitions/v1.0/marine.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0"?>
+<mavlink>
+  <!-- XML file for the MAVLink dialect  -->
+  <include>standard.xml</include>
+  <version>0</version>
+  <dialect>0</dialect>
+  <enums>
+    <enum name="AUTONOMY_DEMAND">
+      <description>Demands to be made to the autonomy system.</description>
+      <entry value="0" name="AUTONOMY_DEMAND_DEFAULT">
+        <description>Default value, ignored.</description>
+      </entry>
+      <entry value="1" name="AUTONOMY_DEMAND_START">
+        <description>Start Autonomy System.</description>
+      </entry>
+      <entry value="2" name="AUTONOMY_DEMAND_STOP">
+        <description>Stop Autonomy System.</description>
+      </entry>
+      <entry value="3" name="AUTONOMY_DEMAND_GO_TO_RECOVERY">
+        <description>Abort Autonomy System to the Recovery Point.</description>
+      </entry>
+      <entry value="4" name="AUTONOMY_DEMAND_PAUSE">
+        <description>Pause Autonomy System.</description>
+      </entry>
+      <entry value="5" name="AUTONOMY_DEMAND_SUSPEND">
+        <description>Suspend Autonomy System Control Temporarily.</description>
+      </entry>
+      <entry value="6" name="AUTONOMY_DEMAND_RESUME">
+        <description>Resume Autonomy System.</description>
+      </entry>
+    </enum>
+    <enum name="AUTONOMY_COMPONENT" bitmask="true">
+      <description>These encode the components that can be present in an autonomy system.</description>
+      <entry value="1" name="AUTONOMY_COMPONENT_CORE">
+        <description>0x01 Autonomy System Core</description>
+      </entry>
+      <entry value="2" name="AUTONOMY_COMPONENT_ATR">
+        <description>0x02 Automated Target Recognition</description>
+      </entry>
+      <entry value="4" name="AUTONOMY_COMPONENT_SAS">
+        <description>0x04 Synthetic Aperture Sonar</description>
+      </entry>
+      <entry value="8" name="AUTONOMY_COMPONENT_MBES">
+        <description>0x08 Multi Beam Echo Sounder</description>
+      </entry>
+      <entry value="16" name="AUTONOMY_COMPONENT_FLS">
+        <description>0x10 Forward Look Sonar</description>
+      </entry>
+      <entry value="32" name="AUTONOMY_COMPONENT_CAMERA">
+        <description>0x20 Camera</description>
+      </entry>
+      <entry value="64" name="AUTONOMY_COMPONENT_ACOMMS">
+        <description>0x40 Acomms Modem</description>
+      </entry>
+    </enum>
+    <enum name="AUTONOMY_STATE">
+      <description>Current state of the Autonomy System.</description>
+      <entry value="0" name="AUTONOMY_STATE_DEFAULT">
+        <description>Default state, ignored.</description>
+      </entry>
+      <entry value="1" name="AUTONOMY_STATE_IDLE">
+        <description>System has not been started.</description>
+      </entry>
+      <entry value="2" name="AUTONOMY_STATE_EXECUTING">
+        <description>Autonomy System Executing and in control.</description>
+      </entry>
+      <entry value="3" name="AUTONOMY_STATE_PAUSED">
+        <description>Autonomy System Paused.</description>
+      </entry>
+      <entry value="4" name="AUTONOMY_STATE_SUSPENDED">
+        <description>Autonomy System Control Suspended Temporarily.</description>
+      </entry>
+      <entry value="5" name="AUTONOMY_STATE_COMPLETED">
+        <description>Autonomy System execution completed succesfully.</description>
+      </entry>
+      <entry value="6" name="AUTONOMY_STATE_STOPPED">
+        <description>Autonomy System execution stopped early.</description>
+      </entry>
+    </enum>
+    <enum name="PAYLOAD_TYPE">
+      <description>Supported Payload types.</description>
+      <entry value="0" name="PAYLOAD_TYPE_CAMERA">
+        <description>Generic Camera Payload.</description>
+      </entry>
+      <entry value="1" name="PAYLOAD_TYPE_LIDAR">
+        <description>Light Detection and Ranging Payload.</description>
+      </entry>
+      <entry value="2" name="PAYLOAD_TYPE_WINCH">
+        <description>Winch Payload.</description>
+      </entry>
+      <entry value="3" name="PAYLOAD_TYPE_ACOUSTIC_MODEM">
+        <description>Acoustic Modem Payload.</description>
+      </entry>
+      <entry value="4" name="PAYLOAD_TYPE_SAS">
+        <description>Single Aperture Sonar Payload.</description>
+      </entry>
+      <entry value="5" name="PAYLOAD_TYPE_MBES">
+        <description>Multi Beam Echo Sounder Payload.</description>
+      </entry>
+      <entry value="6" name="PAYLOAD_TYPE_FLS">
+        <description>Forward Look Sonar Payload.</description>
+      </entry>
+      <entry value="1001" name="PAYLOAD_TYPE_GENERIC_1">
+        <description>Generic Payload 1.</description>
+      </entry>
+      <entry value="1002" name="PAYLOAD_TYPE_GENERIC_2">
+        <description>Generic Payload 2.</description>
+      </entry>
+      <entry value="1003" name="PAYLOAD_TYPE_GENERIC_3">
+        <description>Generic Payload 3.</description>
+      </entry>
+      <entry value="1004" name="PAYLOAD_TYPE_GENERIC_4">
+        <description>Generic Payload 4.</description>
+      </entry>
+      <entry value="1005" name="PAYLOAD_TYPE_GENERIC_5">
+        <description>Generic Payload 5.</description>
+      </entry>
+    </enum>
+    <enum name="PAYLOAD_HEALTH">
+      <description>Flags to report health of a registered payload.</description>
+      <entry value="1" name="PAYLOAD_HEALTH_GENERIC">
+        <description>0x01 Payload Health - Generic.</description>
+      </entry>
+    </enum>
+    <enum name="PAYLOAD_STATE">
+      <description>Flags to report state of a registered payload.</description>
+      <entry value="1" name="PAYLOAD_STATE_POWERED">
+        <description>0x01 Payload State - Powered.</description>
+      </entry>
+      <entry value="2" name="PAYLOAD_STATE_ARMED">
+        <description>0x02 Payload State - Armed.</description>
+      </entry>
+      <entry value="4" name="PAYLOAD_STATE_ACTIVE">
+        <description>0x04 Payload State - Active.</description>
+      </entry>
+    </enum>
+    <enum name="PAYLOAD_LIST_RESULT">
+      <description>Results of payload discovery operation (in a PAYLOAD_LIST_ACK message).</description>
+      <entry value="0" name="PAYLOAD_LIST_ACCEPTED">
+        <description>Payload List downloaded OK</description>
+      </entry>
+      <entry value="1" name="PAYLOAD_LIST_ERROR">
+        <description>Generic error with downloading Payload List.</description>
+      </entry>
+      <entry value="2" name="PAYLOAD_LIST_REPEATED_ID">
+        <description>Multiple entries for same Payload ID in List.</description>
+      </entry>
+    </enum>
+    <!-- Additions to the MAV_SYS_STATUS_SENSOR_EXTENDED enum: -->
+    <enum name="MAV_SYS_STATUS_SENSOR_EXTENDED" bitmask="true">
+      <description>These encode the sensors whose status is sent as part of the SYS_STATUS message in the extended fields.</description>
+      <entry value="2" name="MAV_SYS_STATUS_ACOUSTIC_MODEM">
+        <description>0x02 Acoustic Modem</description>
+      </entry>
+      <entry value="4" name="MAV_SYS_STATUS_SAS">
+        <description>0x04 Single Aperture Sonar</description>
+      </entry>
+      <entry value="8" name="MAV_SYS_STATUS_MBES">
+        <description>0x08 Multi Beam Echo Sounder</description>
+      </entry>
+      <entry value="16" name="MAV_SYS_STATUS_FLS">
+        <description>0x10 Forward Look Sonar</description>
+      </entry>
+    </enum>
+    <!-- The MAV_CMD enum entries describe either: -->
+    <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
+    <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
+    <!-- ALL the entries in the MAV_CMD enum have a maximum of 7 parameters -->
+    <enum name="MAV_CMD">
+      <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries</description>
+      <entry value="44000" name="MAV_CMD_AUTONOMY_DEMAND" hasLocation="false" isDestination="false">
+        <description>Send Autonomy Demand to Autonomy System.</description>
+        <param index="1" label="Autonomy Demand"  enum="AUTONOMY_DEMAND">Autonomy Demand.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <!-- <entry value="44001" name="MAV_CMD_AUTONOMY_COMPONENT_ENABLE" hasLocation="false" isDestination="false">
+        <description>Enable the bitmask specified autonomy components (1 enable, 0 disable). Command will be rejected if trying to enable a component that is not present. </description>
+        <param index="1">Empty.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5" label="components" enum="AUTONOMY_COMPONENT">Bitmask of enabled Autonomy Components.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry> -->
+      <entry value="44002" name="MAV_CMD_PAYLOAD_SET_STATE" hasLocation="false" isDestination="false">
+        <description>Set the states for the payload with the specified ID. Command will be rejected if trying to set a state not supported by the payload.</description>
+        <param index="1" label="Payload ID" minValue="0" maxValue="999" increment="1">Payload ID, 0 to apply to all Payloads in List.</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5" label="components" enum="PAYLOAD_STATE">Bitmask of enabled Payload states.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
+      <entry value="44010" name="MAV_CMD_NAV_TRACK_START" hasLocation="true" isDestination="true">
+        <description>Navigate between two points maintaining trackline between them</description>
+        <param index="1" label="Hold" units="s" minValue="0">Hold time</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4" label="Tolerance" units="m" minValue="0">Maximum distance from track centre-line before correction is required</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+      <entry value="44011" name="MAV_CMD_NAV_TRACK_END" hasLocation="true" isDestination="true">
+        <description>Navigate between two points maintaining trackline between them</description>
+        <param index="1" label="Hold" units="s" minValue="0">Hold time</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="44001" name="AUTONOMY_STATUS">
+      <description>The state of the autonomy system.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="autonomy_components_present" enum="AUTONOMY_COMPONENT" display="bitmask" print_format="0x%04x">Bitmap showing which autonomy components are present. Value of 0: not present. Value of 1: present.</field>
+      <field type="uint32_t" name="autonomy_components_enabled" enum="AUTONOMY_COMPONENT" display="bitmask" print_format="0x%04x">Bitmap showing which autonomy components are enabled:  Value of 0: not enabled. Value of 1: enabled.</field>
+      <field type="uint32_t" name="autonomy_components_health" enum="AUTONOMY_COMPONENT" display="bitmask" print_format="0x%04x">Bitmap showing which autonomy components have an error (or are operational). Value of 0: error. Value of 1: healthy.</field>
+      <field type="uint8_t" name="system_state" enum="AUTONOMY_STATE">The Execution state of the Autonomy System.</field>
+    </message>
+    <message id="44100" name="MESSAGE_CONTACT_SNIPPET">
+      <description>Contact snippet message to be sent to specified destination, as well as confidence of contact snippet.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint32_t" name="destination_address">Acomms message destination, 0 for broadcast.</field>
+      <field type="uint8_t" name="snippet_confidence" units="%" >Contact snippet confidence (0 to 100).</field>
+      <field type="uint8_t" name="message_length">Length of the data transported in message.</field>
+      <field type="uint8_t[128]" name="message">Variable length message. The message length is defined by message_length.</field>
+    </message>
+    <message id="44101" name="MESSAGE_AUTONOMY_MISSION_STATUS">
+      <description>Autonomy System Mission Status message to be sent to specified destination.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="destination_address">Acomms message destination, 0 for broadcast.</field>
+      <field type="uint8_t" name="source_vehicle_id" invalid="UINT8_MAX">Source Vehicle ID. UINT8_MAX: field not provided.</field>
+      <field type="uint8_t" name="message_length">Length of the data transported in message.</field>
+      <field type="uint8_t[128]" name="message">Variable length message. The message length is defined by message_length.</field>
+    </message>
+    <message id="44102" name="SQUAD_VEHICLE_STATE">
+      <description>Vehicle state data recieved from another vehicle in the squad.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="source_vehicle_id">Source Vehicle ID.</field>
+      <field type="uint8_t" name="vehicle_mode">Vehicle Mode.</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude, expressed</field>
+      <field type="int32_t" name="lon" units="degE7">Longitude, expressed</field>
+      <field type="float" name="depth" units="m">Current depth in meters positive down from the surface.</field>
+      <field type="float" name="altitude" units="m">Current altitude from the terrain.</field>
+      <field type="float" name="heading" units="deg">Heading in degrees clockwise from North.</field>
+      <field type="float" name="velocity" units="m/s">Speed in meters per second.</field>
+      <field type="int8_t" name="battery_state" units="%" invalid="-1">Remaining battery energy. Values: [0-100], -1: autopilot does not estimate the remaining battery.</field>
+      <field type="uint32_t" name="vehicle_faults">Vehicle faults - defined specific to vehicle.</field>
+    </message>
+    <message id="44200" name="PAYLOAD_REQUEST_LIST">
+      <description>Request the list of registered payloads from the system/component.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+    </message>
+    <message id="44201" name="PAYLOAD_COUNT">
+      <description>Emitted as response to PAYLOAD_REQUEST_LIST, the sender can then request the details of each payload in sequence.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint16_t" name="count">Number of registered payloads</field>
+    </message>
+    <message id="44202" name="PAYLOAD_LIST_ITEM_REQUEST">
+      <description>Request the details of the payload item with the specified list position. The response of the system to this message should be a PAYLOAD_LIST_ITEM message.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="payload_list_position">Payload List Position.</field>
+    </message>
+    <message id="44203" name="PAYLOAD_LIST_ITEM">
+      <description>This message is emitted as response to PAYLOAD_REQUEST_LIST, and contains the details (ID, Type, Name) of the specified Payload.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="payload_id">Payload ID, 1 - N.</field>
+      <field type="char[16]" name="payload_name"> Payload Name.</field>
+      <field type="uint8_t" name="payload_type" enum="PAYLOAD_TYPE">Payload type.</field>
+      <field type="uint16_t" name="valid_states" enum="PAYLOAD_STATE" display="bitmask" print_format="0x%04x">Bitmap showing the valid states of the payload. Value of 0: state cannot be changed. Value of 1: state can be changed.</field>
+    </message>
+    <message id="44204" name="PAYLOAD_LIST_ACK">
+      <description>Acknowledgment message during payload handling. The type field states if this message is a positive ack (type=0) or if an error happened (type=non-zero).</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="result" enum="PAYLOAD_LIST_RESULT">Payload List result.</field>
+    </message>
+    <message id="44205" name="PAYLOAD_STATUS_REQUEST">
+      <description>Request the status of the payload item with the specified payload ID. The response of the system to this message should be a PAYLOAD_STATUS message.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="payload_id">Payload ID.</field>
+    </message>
+    <message id="44206" name="PAYLOAD_STATUS">
+      <description>This message is emitted as response to PAYLOAD_STATUS_REQUEST, and contains the details (ID and Type) and health and status (as bitmasks) of the specified payload.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="payload_id">Payload ID, 1 - N.</field>
+      <field type="uint8_t" name="payload_type" enum="PAYLOAD_TYPE">Payload type.</field>
+      <field type="uint16_t" name="payload_health" enum="PAYLOAD_HEALTH" display="bitmask" print_format="0x%04x">Bitmap showing the health of the payload. Value of 0: issue with health. Value of 1: healthy.</field>
+      <field type="uint16_t" name="payload_state" enum="PAYLOAD_STATE" display="bitmask" print_format="0x%04x">Bitmap showing the states of payload. Value of 0: state is false. Value of 1: state is true.</field>
+    </message>
+    <message id="44207" name="PAYLOAD_CHANGE">
+      <description>Broadcast on change of Payload List, specifies the change (added/removed) and ID of the payload.</description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="uint8_t" name="payload_change">Payload ID change, value 1 : ID Added, value 0 : ID Removed</field>
+      <field type="uint8_t" name="payload_id">ID of new payload added.</field>
+    </message>
+    <message id="44300" name="WATER_CURRENT">
+      <description>Water current values. Note: Calculated Water current = (Vehicle Velocity - Measured Current).</description>
+      <field type="float" name="measured_current_x" units="m/s">Raw Measured water current in X (NED) direction</field>
+      <field type="float" name="measured_current_y" units="m/s">Raw Measured water current in Y (NED) direction</field>
+      <field type="float" name="measured_current_z" units="m/s">Raw Measured water current in Z (NED) direction</field>
+      <field type="float" name="calculated_current_x" units="m/s">Calculated Water current in X (NED)</field>
+      <field type="float" name="calculated_current_y" units="m/s">Calculated Water current in Y (NED)</field>
+      <field type="float" name="calculated_current_z" units="m/s">Calculated Water current in Z (NED)</field>
+      <field type="float" name="distance" units="cm">Measurement distance from the sensor</field>
+    </message>
+    <message id="44301" name="DVL">
+      <description>Doppler Velocity Log Sensor. Used to provide vehicle velocity.</description>
+      <field type="uint8_t" name="has_lock">Boolean indicating if the DVL has bottom lock to the floor (true: 1, false: 0).</field>
+      <field type="float[16]" name="altitude_water" units="m">Vehicle altitude to the floor of body of water for each beam</field>
+      <field type="float" name="vehicle_velocity_x" units="m/s">Vehicle velocity in X (NED)</field>
+      <field type="float" name="vehicle_velocity_y" units="m/s">Vehicle velocity in Y (NED)</field>
+      <field type="float" name="vehicle_velocity_z" units="m/s">Vehicle velocity in Z (NED)</field>
+    </message>
+  </messages>
+</mavlink>


### PR DESCRIPTION
This has been in development for over a year and is currently operational on underwater vehicles (UUVs) like the popular [Remus vehicle from Hydroid.](https://en.wikipedia.org/wiki/REMUS_(AUV)) It's stable enough now we have decided to present the changes upstream.

This is version **v22.08.01**

There are also matching functional implementations in MAVSDK which are also in operation on both vehicle-side and autonomy-control side.

> UUVs tend to operate in very comms limited environments (no RF / limited acoustic comms). As with most robots they have an on-board "autopilot" or "front-seat" that controls low-level vehicle movement (Control Fins to set Heading, Control Motor to Set Speed etc). They also often run a generic Autonomy system on an additional "back-seat" computer, which accepts high-level commands and breaks them down for the front-seat vehicle to consume (Scan this point, Scan this area etc.)
> 
> Typically each vehicle manufacturer creates their own bespoke interface to allow external-control from an autonomy system, we are pushing to standardise this approach with an open standard.
> 
> We are using MAVLink now as our vehicle interface for this Autonomy <-> Frontseat link and have been working with vehicle manufacturers have MAVLink integrated as a "frontseat" control interface.

The things of note are:

- **Generic Vehicle Payload Registering, Status and Control**
  - Ability to add/swap/remove/enable/disable/pause generic external sensors, sonar, sidescan, FLS, etc.
- **Support for External Autonomy Systems** - Components, Health, State and Control
  - These autonomy systems run on a companion computer and issue MAVLINK commands to the vehicle front-seat controller.
- Water current, DVL (Doppler Velocity Logger)
  -  Domain specific environment monitoring
- Various assorted messages for information sharing between squads. 

# Payload Microservice

The Payload Microservice is used to discover, configure and control `Payloads<Payload>` (which could be sensors, actuators or other connected components) registered on a `MAVLink` system.

You can use this Microservice to:

>   - Retrieve a list of all Payloads on the system
>   - Retrieve the status of a single Payload
>   - Receive updates on newly registered Payloads
>   - Control Payload state

It is expected that the AutoPilot maintains a list of registered Payloads, containing for each:

>   - ID
>       - Any number in the range \(1 - UINT8\_MAX\)
>       - **Must be unique** in reguards to the other Payload IDs
>   - Type
>       - Must be one of the values defined in the `PAYLOAD_TYPE` enum
>   - States
>       - The states that the Payload can be set to
>       - 16 byte bitmask corresponding to the `PAYLOAD_STATE` enum
>   - Health
>       - The Payload health
>       - 16 byte bitmask corresponding to the `PAYLOAD_HEALTH` enum
>   - State
>       - The the current states of the vehicle
>       - 16 byte bitmask corresponding to the `PAYLOAD_STATE` enum
>   - Name
>       - *Optional*
>       - Maximum length of `16` characters

A system can use the Payload Microservice to request details about the Payloads on the MAVLink system and to configure said Payloads.

When an external system enables a Payload it will set the Payload state to:

  - PAYLOAD\_STATE\_POWERED = true
  - PAYLOAD\_STATE\_ARMED = true
  - PAYLOAD\_STATE\_ACTIVE = true

When a Payload is disabled, An external system will set the Payload state to:

  - PAYLOAD\_STATE\_POWERED = true
  - PAYLOAD\_STATE\_ARMED = false
  - PAYLOAD\_STATE\_ACTIVE = false

In order to request a `PAYLOAD_STATUS` from the AutoPilot, A system will
send a [MAV\_CMD\_REQUEST\_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) with:

  - <span class="title-ref">Param 1</span> set to `44206` (the Message
    ID of `PAYLOAD_STATUS`)
  - <span class="title-ref">Param 2</span> set to the Payload ID of the
    Payload being enquired about

For a list of the enumerations used in the payload messages, please see `payload-enum-summary`.

The AutoPilot also needs to respect the implementation details layed out in `payload-microservice-operation-exceptions`.

##### Workflows

`payload_discovery_process` below shows the communication sequence external systems use to retrieve the list of registered Payloads from the `AutoPilot` (assuming all operations succeed).
![payload_list_request](https://github.com/mavlink/mavlink/assets/1307881/4b7109c5-cb42-4fd7-a899-41a216b60b7d)
> Payload Discovery Operation

In more detail, the sequence of operations is:

1.  Autonomy sends a `PAYLOAD_REQUEST_LIST` to start the discovery and
    download process
      - Autonomy will wait for a specific length of time for a
        `PAYLOAD_COUNT` response from the AutoPilot. If no response is
        received during that time, Autonomy will re-send the
        <span class="title-ref">PAYLOAD\_REQUEST\_LIST</span> message.
2.  The AutoPilot receives the message and responds with a
    `PAYLOAD_COUNT` where the <span class="title-ref">count</span> field
    is the number of registered payloads
3.  Autonomy sends a `PAYLOAD_LIST_ITEM_REQUEST` for the first list item
    ( `list position = 0`)
      - Autonomy will wait for a specific length of time for a
        `PAYLOAD_LIST_ITEM_REQUEST` response from the AutoPilot. If no
        response is received during that time, Autonomy will re-send the
        `PAYLOAD_LIST_ITEM_REQUEST` message.
4.  The AutoPilot receives the `PAYLOAD_LIST_ITEM_REQUEST` message and
    responds with the requested Payload details via a
    `PAYLOAD_LIST_ITEM` message
5.  Autonomy and AutoPilot repeat steps 3 and 4 until Autonomy has the
    deatils of all Payloads
6.  After receiving the details of the last Payload, Autonomy responds
    with a single `PAYLOAD_LIST_ACK` with the
    <span class="title-ref">type</span> field set to
    `PAYLOAD_LIST_ACCEPTED` (see the `PAYLOAD_LIST_RESULT` enum) to
    indicate Payload discovery success
7.  The AutoPilot receives the `PAYLOAD_LIST_ACK` containing
    `PAYLOAD_LIST_ACCEPTED` and understands the operation to be
    complete.

**List request errors are considered unrecoverable see `payload-microservice-errors` for details on how to handle errors.**

`payload_status_update` below shows the communication sequence that autonomy follows to request the status of a registered Payload.

Autonomy sends a [MAV\_CMD\_REQUEST\_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) message with the ID of the Payload it wants the status of (`IDX`) to the AutoPilot. The AutoPilot then responds with a `PAYLOAD_STATUS` message containing the Type, Health and Status of the Payload.

![payload_status_update](https://github.com/mavlink/mavlink/assets/1307881/311ede0d-11eb-4294-be0b-d977c17b2fd5)
> Payload Status Update Operation

The diagram below shows the communication sequence Autonomy uses to change the State of a registered Payload. The `MAV_CMD_PAYLOAD_SET_STATE` message is used to set the State of a Payload using a bitmask corresponding to the `PAYLOAD_STATE` enum, where the bits are set to `1` to indicate the state is `true` and `0` to indicate the state is `false`.

As part of the Payload discovery process, the valid States that can be set for each Payload are specified in the `PAYLOAD_LIST_ITEM` message. If trying to set a unsupported state on a payload (e.g. setting `Armed=true` on a Payload that only has <span class="title-ref">Powered</span> as a valid state), then the `MAV_CMD_PAYLOAD_SET_STATE` command should be rejected by the AutoPilot with a [COMMAND\_ACK](https://mavlink.io/en/messages/common.html#COMMAND_ACK) with a [MAV\_RESULT](https://mavlink.io/en/messages/common.html#MAV_RESULT) of `MAV_RESULT_DENIED`.

If the <span class="title-ref">id</span> field in the `MAV_CMD_PAYLOAD_SET_STATE` command sent by Autonomy is `0`, the AutoPilot must apply the state change to all registered Payloads for which it is a valid option. If a Payload ID that is not registered is specified in the command, it should be rejected by sending a
[COMMAND\_ACK](https://mavlink.io/en/messages/common.html#COMMAND_ACK) with a [MAV\_RESULT](https://mavlink.io/en/messages/common.html#MAV_RESULT) of `MAV_RESULT_DENIED`.

If AutoPilot successfully handles the command, a [COMMAND\_ACK](https://mavlink.io/en/messages/common.html#COMMAND_ACK) message should be sent back to Autonomy with a [MAV\_RESULT](https://mavlink.io/en/messages/common.html#MAV_RESULT) of `MAV_RESULT_ACCEPTED` followed by AutoPilot sending a `PAYLOAD_STATUS` message containing the updated Payload State.

![payload_state_control](https://github.com/mavlink/mavlink/assets/1307881/b6fd6cfe-c8c8-47a6-9d1c-abcd317b6c2c)

> Payload State Control Operation

When a Payload is added or removed to the AutoPilot's Payload list, a `PAYLOAD_CHANGE` message needs to be broadcast in order to inform all connected Companion Computers (including Autonomy) of the change, specifying the Payload ID that was affected and whether it has been added or removed.

If the update was about a new Payload, the Companion Computers may subsequently sent a
[MAV\_CMD\_REQUEST\_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE)
message to obtain details of the new Payload.

![payload_list_change](https://github.com/mavlink/mavlink/assets/1307881/17d10844-99e3-46b2-82d2-a44f27c7f45e)

# Autonomy Microservice

The Autonomy Microservice allows the `AutoPilot` to set Autonomy execution state, for control handover, and to monitor the state of Autonomy. The various `MAVLink Messages` used in the Autonomy Microservice are detailed in `Autonomy Message Table`.

| Message                   | ID      | Direction            | Description                      |
| ------------------------- | ------- | -------------------- | -------------------------------- |
| `MAV_CMD_AUTONOMY_DEMAND` | \#44000 | AutoPilot to Autonomy | Send Autonomy Demand to Autonomy. |
| `AUTONOMY_STATUS`         | \#44001 | Autonomy to AutoPilot | The state of Autonomy.            |

Messages used by the Autonomy Microservice

Central to the Autonomy Microservice is a state machine representing the autonomy system's execution state. numref:<span class="title-ref">autonomy\_state\_diagram</span> shows this state machine, where:

  - **Each state** is defined in the `AUTONOMY_STATE` enum (sent from
    Autonomy to the AutoPilot via the `AUTONOMY_STATUS` message).

  - **Each transition** is defined in the `AUTONOMY_DEMAND` enum (sent
    from the AutoPilot to Autonomy via the `MAV_CMD_AUTONOMY_DEMAND`
    message).

![autonomy_state_diagram](https://github.com/mavlink/mavlink/assets/1307881/32b1bbb0-f51a-43fd-ae0f-16e57c215cc0)

The Autopilot **MUST** send a `Stop` or `Pause` command to Autonomy whenever it takes forcible control of the system.

In addition to providing an overall system state, the `AUTONOMY_STATUS` message also provides status bitmaps for a number of sub-components. Autonomy provides status for the following components:

  - `AUTONOMY_COMPONENT_CORE`
  - `AUTONOMY_COMPONENT_ATR`
  - `AUTONOMY_COMPONENT_MISSION`

Status bits for all other components are not used by Autonomy and set to zero.

##### Health Reporting

`Component Health Descriptions` describes in further detail what each
health flag reported by `AUTONOMY_STATUS` indicates.

| Autonomy Component           | Health Description                                                                                                                                                    |
| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `AUTONOMY_COMPONENT_CORE`    | When health is reported as true for this component, it indicates that Autonomy has initialized successfully.                                                           |
| `AUTONOMY_COMPONENT_ATR`     | When health is reported as true for this component, it indicates that Autonomy's Embedded ATR component has initialized successfully and is ready for data processing. |
| `AUTONOMY_COMPONENT_MISSION` | When health is reported as true for this component, it indicates that Autonomy has a valid mission plan loaded and is ready for launch.                                |

Autonomy Component Health

##### Workflows

`autonomy_request_state` below shows the communication sequence
AutoPilot needs to follow to get the status of Autonomy.

Autonomy responds to the
[MAV\_CMD\_REQUEST\_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE)
command (see `Command Types
Table`) sent by the AutoPilot with a `AUTONOMY_STATUS` message
containing the presence, state and health of the components present on
the Autonomy system, and the current execution state of the system.

![autonomy_request_status](https://github.com/mavlink/mavlink/assets/1307881/b448648c-b9b4-472f-b09f-290f98e6f49c)
> Request Autonomy State Process

`autonomy_send_autonomy_demand` below shows the communication sequence
when the AutoPilot sends a `MAV_CMD_AUTONOMY_DEMAND` containing an
`AUTONOMY_DEMAND` to Autonomy.

Autonomy responds with a
[COMMAND\_ACK](https://mavlink.io/en/messages/common.html#COMMAND_ACK)
and a `AUTONOMY_STATUS` message as stated in
`payload-microservice-errors`.

![autonomy_send_autonomy_demand](https://github.com/mavlink/mavlink/assets/1307881/cc62df6e-049f-4cfc-ad85-6a412e7f063e)
> Send Autonomy Demand Process

#### Additional MAVLink Messages 

In addition to the messages already detailed in the various `MAVLink
Microservices`,

  - `MESSAGE_CONTACT_SNIPPET`
  - `MESSAGE_AUTONOMY_MISSION_STATUS`
  - `SQUAD_VEHICLE_STATE`

Also see the following enumerations:

  - `MAV_SYS_STATUS_SENSOR_EXTENDED`

#### External Communications

For integrations where all external communications (acoustic, RF etc.) for a vehicle are handled entirely by the `AutoPilot`:

  - Autonomy will forward all outgoing communication it wishes to send to
    the AutoPilot
  - The AutoPilot must send Autonomy incoming communications

| Message                           | ID    | Direction            | Description                                                   |
| --------------------------------- | ----- | -------------------- | ------------------------------------------------------------- |
| `MESSAGE_CONTACT_SNIPPET`         | 44100 | Autonomy to AutoPilot | Forward message containing details of an ATR Contact Snippet. |
| `MESSAGE_AUTONOMY_MISSION_STATUS` | 44101 | Bidirectional        | Forward message containing the status of the Autonomy Mission  |

Autonomy will provide the following metadata to define how the AutoPilot should handle the communication:

  - <span class="title-ref">destination\_address</span> - The ID of the
    external target of the communication, or `0` for broadcast
  - <span class="title-ref">message\_length</span> - The length of the
    communication to be sent (32 bytes by default)
  - <span class="title-ref">snippet\_confidence</span> - Only used by
    `MESSAGE_CONTACT_SNIPPET`, to be used by the AutoPilot to sort the
    order of the stored snippets

AutoPilot must provide the following metadata when sending a `MESSAGE_AUTONOMY_MISSION_STATUS` to Autonomy:

  - <span class="title-ref">source\_vehicle\_id</span> - The ID of the
    external source of the communication

**ALL** `MESSAGE_CONTACT_SNIPPET` messages received by the AutoPilot should be sent in the order they were received; while only the most recent `MESSAGE_AUTONOMY_MISSION_STATUS` should be sent.

It is expected that the AutoPilot will forward any incoming Mission Status communications to Autonomy using the `MESSAGE_AUTONOMY_MISSION_STATUS` message.

If sending outgoing communications over a limited medium, such as acoustic, it is expected that the AutoPilot uses the type of outgoing communication to determine the sending priority.

If the AutoPilot receives telemetry, vehicle state or fault updates from other vehicles in the squad via acoustic of other communications, these must be forwarded to Autonomy using the `SQUAD_VEHICLE_STATE` message.

# APPENDIX 1

## Messages (Marine)

### MAVLink Type Enumerations

#### AUTONOMY\_DEMAND

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) Demands
that can be made to an autonomy system.

| Value | Field Name                         | Description                                  |
| ----- | ---------------------------------- | -------------------------------------------- |
| 0     | AUTONOMY\_DEMAND\_DEFAULT          | Default value, ignored.                      |
| 1     | AUTONOMY\_DEMAND\_START            | Start Autonomy System.                       |
| 2     | AUTONOMY\_DEMAND\_STOP             | Stop Autonomy System.                        |
| 3     | AUTONOMY\_DEMAND\_GO\_TO\_RECOVERY | Abort Autonomy System to the Recovery Point. |
| 4     | AUTONOMY\_DEMAND\_PAUSE            | Pause Autonomy System.                       |
| 5     | AUTONOMY\_DEMAND\_SUSPEND          | Suspend Autonomy System Control Temporarily. |
| 6     | AUTONOMY\_DEMAND\_RESUME           | Resume Autonomy System.                      |

#### AUTONOMY\_COMPONENT

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) These
encode the components that can be present in an autonomy system.

| Value | Field Name                   | Description                       |
| ----- | ---------------------------- | --------------------------------- |
| 1     | AUTONOMY\_COMPONENT\_CORE    | 0x01 Autonomy System Core         |
| 2     | AUTONOMY\_COMPONENT\_ATR     | 0x02 Automated Target Recognition |
| 4     | AUTONOMY\_COMPONENT\_SAS     | 0x04 Synthetic Aperture Sonar     |
| 8     | AUTONOMY\_COMPONENT\_MBES    | 0x08 Multi Beam Echo Sounder      |
| 16    | AUTONOMY\_COMPONENT\_FLS     | 0x10 Forward Look Sonar           |
| 32    | AUTONOMY\_COMPONENT\_CAMERA  | 0x20 Camera                       |
| 64    | AUTONOMY\_COMPONENT\_ACOMMS  | 0x40 Acomms Modem                 |
| 128   | AUTONOMY\_COMPONENT\_MISSION | 0x80 Autonomy Mission             |

#### AUTONOMY\_STATE

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) Describes
the states an autonomy system can be in.

| Value | Field Name                  | Description                                       |
| ----- | --------------------------- | ------------------------------------------------- |
| 0     | AUTONOMY\_STATE\_DEFAULT    | Default state, ignored.                           |
| 1     | AUTONOMY\_STATE\_IDLE       | System has not been started.                      |
| 2     | AUTONOMY\_STATE\_EXECUTING  | Autonomy System Executing and in control.         |
| 3     | AUTONOMY\_STATE\_PAUSED     | Autonomy System execution paused.                 |
| 4     | AUTONOMY\_STATE\_SUSPENDED  | Autonomy System Control Suspended Temporarily.    |
| 5     | AUTONOMY\_STATE\_COMPLETED  | Autonomy System execution completed successfully. |
| 6     | AUTONOMY\_STATE\_STOPPED    | Autonomy System execution stopped early.          |
| 7     | AUTONOMY\_STATE\_RECOVERING | Autonomy System heading to recovery position.     |

#### MAV\_SYS\_STATUS\_SENSOR\_EXTENDED

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) Extends the
common
[MAV\_SYS\_STATUS\_SENSOR](https://mavlink.io/en/messages/common.html#MAV_SYS_STATUS_SENSOR)
enum.

| Value | Field Name                         | Description                                             |
| ----- | ---------------------------------- | ------------------------------------------------------- |
| 1     | MAV\_SYS\_STATUS\_RECOVERY\_SYSTEM | 0x01 Recovery system (parachute, balloon, retracts etc) |
| 2     | MAV\_SYS\_STATUS\_ACOUSTIC\_MODEM  | 0x02 Acoustic Modem                                     |
| 4     | MAV\_SYS\_STATUS\_SAS              | 0x04 Single Aperture Sonar                              |
| 8     | MAV\_SYS\_STATUS\_MBES             | 0x08 Multi Beam Echo Sounder                            |
| 16    | MAV\_SYS\_STATUS\_FLS              | 0x10 Forward Look Sonar                                 |

#### PAYLOAD\_TYPE

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) Defines the
various types of `Payloads<Payload>` that can be available on the
MAVLink system.

| Value | Field Name                     | Description                         |
| ----- | ------------------------------ | ----------------------------------- |
| 0     | PAYLOAD\_TYPE\_CAMERA          | Generic Camera Payload              |
| 1     | PAYLOAD\_TYPE\_LIDAR           | Light Detection and Ranging Payload |
| 2     | PAYLOAD\_TYPE\_WINCH           | Winch Payload                       |
| 3     | PAYLOAD\_TYPE\_ACOUSTIC\_MODEM | Acoustic Modem Payload              |
| 4     | PAYLOAD\_TYPE\_SAS             | Single Aperture Sonar Payload       |
| 5     | PAYLOAD\_TYPE\_MBES            | Multi Beam Echo Sounder Payload     |
| 6     | PAYLOAD\_TYPE\_FLS             | Forward Look Sonar Payload          |
| 101   | PAYLOAD\_TYPE\_GENERIC\_1      | Generic Payload 1                   |
| 102   | PAYLOAD\_TYPE\_GENERIC\_2      | Generic Payload 2                   |
| 103   | PAYLOAD\_TYPE\_GENERIC\_3      | Generic Payload 3                   |
| 104   | PAYLOAD\_TYPE\_GENERIC\_4      | Generic Payload 4                   |
| 105   | PAYLOAD\_TYPE\_GENERIC\_5      | Generic Payload 5                   |

#### PAYLOAD\_HEALTH

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) These
define the operational health a `Payload` can be in.

| Value | Field Name               | Description                   |
| ----- | ------------------------ | ----------------------------- |
| 1     | PAYLOAD\_HEALTH\_GENERIC | 0x01 Payload Health - Generic |

#### PAYLOAD\_STATE

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) These
define the states a `Payload` can be in.

| Value | Field Name              | Description                  |
| ----- | ----------------------- | ---------------------------- |
| 1     | PAYLOAD\_STATE\_POWERED | 0x01 Payload State - Powered |
| 2     | PAYLOAD\_STATE\_ARMED   | 0x02 Payload State - Armed   |
| 4     | PAYLOAD\_STATE\_ACTIVE  | 0x04 Payload State - Active  |

#### PAYLOAD\_LIST\_RESULT

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) These
define the results of a payload discovery operation.

| Value | Field Name                  | Description                                  |
| ----- | --------------------------- | -------------------------------------------- |
| 0     | PAYLOAD\_LIST\_ACCEPTED     | Payload List downloaded OK                   |
| 1     | PAYLOAD\_LIST\_ERROR        | Generic error with downloading Payload List  |
| 2     | PAYLOAD\_LIST\_REPEATED\_ID | Multiple entries for same Payload ID in List |

#### VEHICLE\_MODE

[\[Enum\]](https://mavlink.io/en/messages/common.html#enums) Vehicle
Mode.

| Value | Field Name                       | Description                                    |
| ----- | -------------------------------- | ---------------------------------------------- |
| 0     | VEHICLE\_MODE\_DEFAULT           | Default state, ignored.                        |
| 1     | VEHICLE\_MODE\_MISSION\_FAULT    | There is a fault with the current mission.     |
| 2     | VEHICLE\_MODE\_MISSION\_ABORT    | The current mission has been aborted.          |
| 3     | VEHICLE\_MODE\_BASELINE\_MISSION | The vehicle is executing its baseline mission. |
| 4     | VEHICLE\_MODE\_REMOTE\_MISSION   | THe vehicle is executing a remote mission.     |

### MAVLink Commands ([MAV\_CMD](https://mavlink.io/en/messages/common.html#mav_commands))

<div class="note">

<div class="admonition-title">

Note

</div>

MAVLink commands
([MAV\_CMD](https://mavlink.io/en/messages/common.html#mav_commands))
and messages are different\! These commands define the values of up to 7
parameters that are packaged INSIDE specific messages used in the
Mission Protocol and Command Protocol. Use commands for actions in
missions or if you need acknowledgment and/or retry logic from a
request. Otherwise use messages.

</div>

#### MAV\_CMD\_AUTONOMY\_DEMAND (\#44000)

[\[Command\]](https://mavlink.io/en/messages/common.html#mav_commands)
Send autonomy demands to a `Companion Computer`.

| Parameter (:Label) | Units | Values           | Description     |
| ------------------ | ----- | ---------------- | --------------- |
| 1: Autonomy Demand | N/A   | AUTONOMY\_DEMAND | Autonomy Demand |
| 2                  | N/A   | N/A              | Empty           |
| 3                  | N/A   | N/A              | Empty           |
| 4                  | N/A   | N/A              | Empty           |
| 5                  | N/A   | N/A              | Empty           |
| 6                  | N/A   | N/A              | Empty           |
| 7                  | N/A   | N/A              | Empty           |

#### MAV\_CMD\_PAYLOAD\_SET\_STATE (\#44002)

[\[Command\]](https://mavlink.io/en/messages/common.html#mav_commands)
Set the states for the payload with the specified ID.

Command will be rejected if trying to set a state not supported by the
payload.

<div class="note">

<div class="admonition-title">

Note

</div>

This command should always be sent as
<span class="title-ref">COMMAND\_INT</span> which has:

  - <span class="title-ref">Param 5/x</span> as int32\_t rather than
    float

</div>

| Parameter (:Label) | Units | Values                     | Description                                    |
| ------------------ | ----- | -------------------------- | ---------------------------------------------- |
| 1: Payload ID      | N/A   | min: 0 max:999 increment:1 | Payload ID, 0 to apply to all Payloads in List |
| 2                  | N/A   | N/A                        | Empty                                          |
| 3                  | N/A   | N/A                        | Empty                                          |
| 4                  | N/A   | N/A                        | Empty                                          |
| 5: components      | N/A   | PAYLOAD\_STATE             | Bitmask of enabled Payload states              |
| 6                  | N/A   | N/A                        | Empty                                          |
| 7                  | N/A   | N/A                        | Empty                                          |

### MAVLink Messages

#### AUTONOMY\_STATUS (\#44001)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages) Used
to specify the state of an autonomy system.

<table>
<caption>AUTONOMY_STATUS</caption>
<thead>
<tr class="header">
<th>Field Name</th>
<th>Default Value</th>
<th>Type</th>
<th>Units</th>
<th>Description</th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td>target_system</td>
<td>N/A</td>
<td>uint8_t</td>
<td>N/A</td>
<td>System ID</td>
</tr>
<tr class="even">
<td>target_component</td>
<td>N/A</td>
<td>uint8_t</td>
<td>N/A</td>
<td>Component ID</td>
</tr>
<tr class="odd">
<td>autonomy_components_present</td>
<td>N/A</td>
<td>uint32_t</td>
<td>MAV_AUTONOMY_COMPONENT</td>
<td>A 32 bit bitmap corresponding to the <code class="interpreted-text" data-role="ref">AUTONOMY_COMPONENT&lt;AUTONOMY_COMPONENT&gt;</code> enum, showing which autonomy components are present on the <code class="interpreted-text" data-role="term">MAVLink</code> system:
<ul>
<li>Value of <code>0</code> if not present</li>
<li>Value of <code>1</code> if present</li>
</ul></td>
</tr>
<tr class="even">
<td>autonomy_components_enabled</td>
<td>N/A</td>
<td>uint32_t</td>
<td>MAV_AUTONOMY_COMPONENT</td>
<td>A 32 bit bitmap corresponding to the <code class="interpreted-text" data-role="ref">AUTONOMY_COMPONENT&lt;AUTONOMY_COMPONENT&gt;</code> enum, showing which autonomy components are enabled:
<ul>
<li>Value of <code>0</code> if not enabled</li>
<li>Value of <code>1</code> if enabled</li>
</ul></td>
</tr>
<tr class="odd">
<td>autonomy_components_health</td>
<td>N/A</td>
<td>uint32_t</td>
<td>MAV_AUTONOMY_COMPONENT</td>
<td>A 32 bit bitmap corresponding to the <code class="interpreted-text" data-role="ref">AUTONOMY_COMPONENT&lt;AUTONOMY_COMPONENT&gt;</code> enum, showing which autonomy components have an error (or are operational):
<ul>
<li>Value of <code>0</code> if it has an error</li>
<li>Value of <code>1</code> if it is healthy</li>
</ul></td>
</tr>
<tr class="even">
<td>system_state</td>
<td>N/A</td>
<td>uint8_t</td>
<td><code class="interpreted-text" data-role="ref">AUTONOMY_STATE&lt;AUTONOMY_COMPONENT&gt;</code></td>
<td>The current execution state of the Autonomy system.</td>
</tr>
</tbody>
</table>

#### MESSAGE\_CONTACT\_SNIPPET (\#44100)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages)
Contact snippet message to be sent to specified destination with message
priority, as well as confidence of contact snippet.

| Field Name           | Default Value | Type            | Units | Description                                                                |
| -------------------- | ------------- | --------------- | ----- | -------------------------------------------------------------------------- |
| target\_system       | N/A           | uint8\_t        | N/A   | System ID                                                                  |
| target\_component    | N/A           | uint8\_t        | N/A   | Component ID                                                               |
| destination\_address | N/A           | uint8\_t        | N/A   | Acomms message destination, 0 for broadcast.                               |
| snippet\_confidence  | N/A           | uint8\_t        | %     | Contact snippet confidence (0 to 100).                                     |
| snippet\_id          | N/A           | uint16\_t       | N/A   | Contact snippet identifier. Unique for each snippet across all contacts    |
| source\_vehicle\_id  | N/A           | uint8\_t        | N/A   | Source Vehicle ID. UINT8\_MAX: field not provided.                         |
| message\_length      | N/A           | uint8\_t        | N/A   | Length of the data transported in message                                  |
| message              | N/A           | uint8\_t\[128\] | N/A   | Variable length message. The message length is defined by message\_length. |

#### MESSAGE\_AUTONOMY\_MISSION\_STATUS (\#44101)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages)
Autonomy System Mission Status message to be sent to specified
destination.

| Field Name           | Default Value | Type            | Units | Description                                                                |
| -------------------- | ------------- | --------------- | ----- | -------------------------------------------------------------------------- |
| target\_system       | N/A           | uint8\_t        | N/A   | System ID                                                                  |
| target\_component    | N/A           | uint8\_t        | N/A   | Component ID                                                               |
| destination\_address | N/A           | uint8\_t        | N/A   | Acomms message destination, 0 for broadcast.                               |
| source\_vehicle\_id  | N/A           | uint8\_t        | N/A   | Source Vehicle ID. UINT8\_MAX: field not provided.                         |
| message\_length      | N/A           | uint8\_t        | N/A   | Length of the data transported in message                                  |
| message              | N/A           | uint8\_t\[128\] | N/A   | Variable length message. The message length is defined by message\_length. |

#### SQUAD\_VEHICLE\_STATE (\#44102)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages)
Vehicle state data recieved from another vehicle in the squad.

| Field Name          | Default Value | Type     | Units                  | Description                                                                                         |
| ------------------- | ------------- | -------- | ---------------------- | --------------------------------------------------------------------------------------------------- |
| target\_system      | N/A           | uint8\_t | N/A                    | System ID                                                                                           |
| target\_component   | N/A           | uint8\_t | N/A                    | Component ID                                                                                        |
| source\_vehicle\_id | N/A           | uint8\_t | N/A                    | Source Vehicle ID.                                                                                  |
| vehicle\_mode       | N/A           | uint8\_t | N/A                    | Current vehicle mode. See `VEHICLE_MODE` for allowed values.                                        |
| lat                 | N/A           | int32\_t | Decimal Degrees \* 1e7 | Latitude, expressed                                                                                 |
| lon                 | N/A           | int32\_t | Decimal Degrees \* 1e7 | Longitude, expressed                                                                                |
| depth               | N/A           | float    | m                      | Current depth in meters positive down from the surface.                                             |
| altitude            | N/A           | float    | m                      | Current altitude from the terrain                                                                   |
| heading             | N/A           | float    | degrees                | Heading in degrees clockwise from North.                                                            |
| velocity            | N/A           | float    | m/s                    | Speed in meters per second.                                                                         |
| battery\_state      | N/A           | uint8\_t | %                      | Remaining battery energy. Values: \[0-100\], -1: AutoPilot does not estimate the remaining battery. |
| vehicle\_faults     | N/A           | int32\_t | N/A                    | Vehicle faults - defined specific to vehicle.                                                       |

#### PAYLOAD\_REQUEST\_LIST (\#44200)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages) Used
to request the list of registered Payloads from the AutoPilot.

| Field Name        | Default Value | Type     | Units | Description  |
| ----------------- | ------------- | -------- | ----- | ------------ |
| target\_system    | N/A           | uint8\_t | N/A   | System ID    |
| target\_component | N/A           | uint8\_t | N/A   | Component ID |

#### PAYLOAD\_COUNT (\#44201)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages) This
message is emitted as response to `PAYLOAD_REQUEST_LIST`. The `Companion
Computer` can then request the individual payload item based on the
knowledge of the total number of `Payloads<Payload>`.

| Field Name        | Default Value | Type      | Units | Description                   |
| ----------------- | ------------- | --------- | ----- | ----------------------------- |
| target\_system    | N/A           | uint8\_t  | N/A   | System ID                     |
| target\_component | N/A           | uint8\_t  | N/A   | Component ID                  |
| count             | N/A           | uint16\_t | N/A   | Number of registered payloads |

#### PAYLOAD\_LIST\_ITEM\_REQUEST (\#44202)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages)
Request the status of the Payload with the specified Payload ID.

| Field Name              | Default Value | Type     | Units | Description           |
| ----------------------- | ------------- | -------- | ----- | --------------------- |
| target\_system          | N/A           | uint8\_t | N/A   | System ID             |
| target\_component       | N/A           | uint8\_t | N/A   | Component ID          |
| payload\_list\_position | N/A           | uint8\_t | N/A   | Payload List position |

#### PAYLOAD\_LIST\_ITEM (\#44203)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages)
Description of a single `Payload`.

| Field Name        | Default Value | Type                       | Units | Description       |
| ----------------- | ------------- | -------------------------- | ----- | ----------------- |
| target\_system    | N/A           | uint8\_t                   | N/A   | System ID         |
| target\_component | N/A           | uint8\_t                   | N/A   | Component ID      |
| payload\_id       | N/A           | uint8\_t                   | N/A   | Payload ID, 1 - N |
| payload\_name     | N/A           | char\[16\]                 | N/A   | Payload Name      |
| payload\_type     | N/A           | PAYLOAD\_TYPE              | N/A   | Payload Type      |
| valid\_states     | N/A           | uint16\_t - PAYLOAD\_STATE | N/A   | Payload Type      |

#### PAYLOAD\_LIST\_ACK (\#44204)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages)
Acknowledgment Message from a `Companion Computer` upon receiving all
<span class="title-ref">PAYLOAD\_LIST\_ITEM</span> Messages.

| Field Name        | Default Value | Type                  | Units | Description         |
| ----------------- | ------------- | --------------------- | ----- | ------------------- |
| target\_system    | N/A           | uint8\_t              | N/A   | System ID           |
| target\_component | N/A           | uint8\_t              | N/A   | Component ID        |
| result            | N/A           | PAYLOAD\_LIST\_RESULT | N/A   | Payload List result |

#### PAYLOAD\_STATUS (\#44206)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages) This
message is emitted as response to
<span class="title-ref">MAV\_CMD\_REQUEST\_MESSAGE</span> messages with
<span class="title-ref">Param 1</span> specifying the message ID
(`44206`) and <span class="title-ref">Param 2</span> specifying the
payload ID. This message contains the details (ID and Type) and health
and status (as bitmasks) of the specified payload.

| Field Name        | Default Value | Type          | Units           | Description              |
| ----------------- | ------------- | ------------- | --------------- | ------------------------ |
| target\_system    | N/A           | uint8\_t      | N/A             | System ID                |
| target\_component | N/A           | uint8\_t      | N/A             | Component ID             |
| payload\_id       | N/A           | uint8\_t      | N/A             | Payload ID, 1 - N        |
| payload\_type     | N/A           | PAYLOAD\_TYPE | N/A             | Payload Type             |
| payload\_health   | N/A           | uint16\_t     | PAYLOAD\_HEALTH | Payload Health (bitmask) |
| payload\_state    | N/A           | uint16\_t     | PAYLOAD\_STATE  | Payload State (bitmask)  |

#### PAYLOAD\_CHANGE (\#44207)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages)
Notification that a `Payload` has been added or removed from the MAVLink
system.

| Field Name        | Default Value | Type     | Units                | Description       |
| ----------------- | ------------- | -------- | -------------------- | ----------------- |
| target\_system    | N/A           | uint8\_t | N/A                  | System ID         |
| target\_component | N/A           | uint8\_t | N/A                  | Component ID      |
| payload\_change   | N/A           | uint8\_t | 1: Added, 0: Removed | Payload ID change |
| payload\_id       | N/A           | uint8\_t | N/A                  | Payload ID (1-N)  |

#### WATER\_CURRENT (\#44300)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages) Water
current values.

<div class="note">

<div class="admonition-title">

Note

</div>

Calculated Water current = (Vehicle Velocity - Measured Current).

</div>

| Field Name             | Default Value | Type  | Units | Description                                     |
| ---------------------- | ------------- | ----- | ----- | ----------------------------------------------- |
| measured\_current\_x   | N/A           | float | m/s   | Raw Measured water current in X (NED) direction |
| measured\_current\_y   | N/A           | float | m/s   | Raw Measured water current in Y (NED) direction |
| measured\_current\_z   | N/A           | float | m/s   | Raw Measured water current in Z (NED) direction |
| calculated\_current\_x | N/A           | float | m/s   | Calculated Water current in X (NED)             |
| calculated\_current\_y | N/A           | float | m/s   | Calculated Water current in Y (NED)             |
| calculated\_current\_z | N/A           | float | m/s   | Calculated Water current in Z (NED)             |
| distance               | N/A           | float | m     | Measurement distance from the sensor            |

#### DVL (\#44301)

[\[Message\]](https://mavlink.io/en/messages/common.html#messages)
Doppler Velocity Log Sensor. Used to provide vehicle velocity.

| Field Name           | Default Value | Type        | Units | Description                                                                     |
| -------------------- | ------------- | ----------- | ----- | ------------------------------------------------------------------------------- |
| has\_lock            | N/A           | uint8\_t    | N/A   | Boolean indicating if the DVL has bottom lock to the floor (true: 1, false: 0). |
| altitude\_water      | N/A           | float\[16\] | m     | Vehicle altitude to the floor of body of water for each beam                    |
| vehicle\_velocity\_x | N/A           | float       | m/s   | Vehicle velocity in X (NED)                                                     |
| vehicle\_velocity\_y | N/A           | float       | m/s   | Vehicle velocity in Y (NED)                                                     |
| vehicle\_velocity\_z | N/A           | float       | m/s   | Vehicle velocity in Z (NED)                                                     |


# APPENDIX 2

## Autonomy Protocol

The autonomy microservice is used by `AutoPilots<AutoPilot>` to get
information about `Companion Computers<Companion Computer>` that provide
autonomy. It also allows AutoPilots to configure the state of autonomy
systems.

Full definitions can be found in
[marine.xml](https://github.com/mavlinkmarine/mavlink/blob/v22.08/message_definitions/v1.0/marine.xml).

## Message/Enum Summary

| Message                   | Description                       |
| ------------------------- | --------------------------------- |
| `MAV_CMD_AUTONOMY_DEMAND` | Send a demand to autonomy system. |
| `AUTONOMY_STATUS`         | The state of the autonomy system. |

Autonomy Protocol Message Summary

| Message              | Description                                                            |
| -------------------- | ---------------------------------------------------------------------- |
| `AUTONOMY_DEMAND`    | Demands to be made to the autonomy system.                             |
| `AUTONOMY_COMPONENT` | These encode the components that can be present in an autonomy system. |
| `AUTONOMY_STATE`     | Current state of the Autonomy System.                                  |

Autonomy Protocol Enum Summary

## Operation Exceptions

### Timeouts and Retires

A timeout should be set for all messages that require a response. If the
expected response is not received before the timeout then the message
must be resent. If no response is received after a number of retries
then the client must cancel the operation and return to a clean state as
it was before the initial message was sent.

The recommended timeout values before resending, and the number of
retries are:

  - Timeout (default): `1500 ms`
  - Retries (max): `5`

### Errors/Completion

On acceptance of a `MAV_CMD_AUTONOMY_DEMAND`, the autonomy component
must respond with a <span class="title-ref">COMMAND\_ACK</span> message
with a `MAV_RESULT_ACCEPTED` <span class="title-ref">MAV\_RESULT</span>
and then it must publish a `AUTONOMY_STATUS` message containing the
updated execution state.

If a command is received by the autonomy component when it is not in a
state to carry it out, the resulting
<span class="title-ref">COMMAND\_ACK</span> must contain the
`MAV_RESULT_TEMPORARILY_REJECTED`
<span class="title-ref">MAV\_RESULT</span>.

If a command is received by the autonomy component when would constitute
an invalid state transition (for example if the autonomy sytem does not
allow a `AUTONOMY_DEMAND_START` when the current execution mode is
`AUTONOMY_STATE_EXECUTING`), then the autonomy system should continue in
its current state, rejecting the new one, and send a resulting
<span class="title-ref">COMMAND\_ACK</span> containing the
`MAV_RESULT_DENIED` <span class="title-ref">MAV\_RESULT</span>.

# APPENDIX 3

## Payload Protocol

The payload microservice is used by `Companion Computers<Companion
Computer>` to get information about `Payloads<Payload>` from the
AutoPilot. It also allows Companion Computers to configure Payloads via
the AutoPilot.

Full definitions can be found in
[marine.xml](https://github.com/mavlinkmarine/mavlink/blob/v22.08/message_definitions/v1.0/marine.xml).

## Message/Enum Summary

<table>
<caption>Payload Protocol Message Summary</caption>
<thead>
<tr class="header">
<th>Message</th>
<th>Description</th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td><code class="interpreted-text" data-role="ref">PAYLOAD_REQUEST_LIST</code></td>
<td>Used to request the list of registered Payloads from the AutoPilot.</td>
</tr>
<tr class="even">
<td><code class="interpreted-text" data-role="ref">PAYLOAD_COUNT</code></td>
<td>Emitted as response to <span class="title-ref">PAYLOAD_REQUEST_LIST</span></td>
</tr>
<tr class="odd">
<td><code class="interpreted-text" data-role="ref">PAYLOAD_LIST_ITEM_REQUEST</code></td>
<td>Request the status of the Payload with the specified Payload ID.</td>
</tr>
<tr class="even">
<td><code class="interpreted-text" data-role="ref">PAYLOAD_LIST_ITEM</code></td>
<td>This message is emitted as response to <code class="interpreted-text" data-role="ref">PAYLOAD_LIST_ITEM_REQUEST</code>.</td>
</tr>
<tr class="odd">
<td><code class="interpreted-text" data-role="ref">PAYLOAD_LIST_ACK</code></td>
<td>Acknowledgment Message from a Companion Computer upon receiving all <code class="interpreted-text" data-role="ref">PAYLOAD_LIST_ITEM</code> Messages.</td>
</tr>
<tr class="even">
<td><code class="interpreted-text" data-role="ref">PAYLOAD_STATUS</code></td>
<td><p>Emitted as response to <span class="title-ref">MAV_CMD_REQUEST_MESSAGE</span> with <span class="title-ref">Param 1</span> set to <code>44206</code>.</p>
<p>It contains the ID, Type, Health and State of the Payload specified in <span class="title-ref">Param 2</span> of the <span class="title-ref">MAV_CMD_REQUEST_MESSAGE</span> Message.</p></td>
</tr>
<tr class="odd">
<td><code class="interpreted-text" data-role="ref">PAYLOAD_CHANGE</code></td>
<td>Notification that a Payload has been added or removed from the MAVLink system.</td>
</tr>
<tr class="even">
<td><code class="interpreted-text" data-role="ref">MAV_CMD_PAYLOAD_SET_STATE</code></td>
<td>Put the Payload with the specified ID into the given state.</td>
</tr>
</tbody>
</table>

| Message               | Description                                              |
| --------------------- | -------------------------------------------------------- |
| `PAYLOAD_TYPE`        | List of supported payload types and generic placeholders |
| `PAYLOAD_HEALTH`      | Flags to report health of a registered payload           |
| `PAYLOAD_STATE`       | Flags to report state of a registered payload            |
| `PAYLOAD_LIST_RESULT` | Results of payload discovery operation                   |

Payload Protocol Enum Summary

## Operation Exceptions

### Timeouts and Retires

A timeout should be set for all messages that require a response. If the
expected response is not received before the timeout then the message
must be resent. If no response is received after a number of retries
then the client must cancel the operation and return to a clean state as
it was before the initial message was sent.

The recommended timeout values before resending, and the number of
retries are:

  - Timeout (default): `1500 ms`
  - Timeout (payload items): `250 ms`
  - Retries (max): `5`

### Errors/Completion

On successful completion of a payload list exchange the participant that
made the initial `PAYLOAD_REQUEST_LIST`, will send a `PAYLOAD_LIST_ACK`
messages with a <span class="title-ref">result</span> value of
`PAYLOAD_LIST_ACCEPTED` (see the `PAYLOAD_LIST_RESULT` enum).

Any other value in the <span class="title-ref">result</span> field of
the `PAYLOAD_LIST_ACK` message indicates an error. Both participants in
the exchange must reset themselves to the state they were in before the
initial `PAYLOAD_REQUEST_LIST` message, and the initiator must ignore
any information it received during the erronious list exchange.

