### PR TITLE
Add MAV_RESULT_COMMAND_UNSUPPORTED_MAV_FRAME

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2738,6 +2738,9 @@
       <entry value="8" name="MAV_RESULT_COMMAND_INT_ONLY">
         <description>Command is valid, but it is only accepted when sent as a COMMAND_INT (as it encodes a location in params 5, 6 and 7, and hence requires a reference MAV_FRAME).</description>
       </entry>
+      <entry value="9" name="MAV_RESULT_COMMAND_UNSUPPORTED_MAV_FRAME">
+        <description>Command is invalid because a frame is required and the specified frame is not supported.</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">
       <description>Result of mission operation (in a MISSION_ACK message).</description>


### PR DESCRIPTION
If MAV_CMD has a location where the frame is not explicitly specified this is taken from the `COMMAND_INT.frame` field. There is no way to query what frames are supported for a particular command by a particular flight stack. Many flight stacks just ignore the frame, using whatever arbitrary frame they support.

This adds a `MAV_RESULT_COMMAND_UNSUPPORTED_MAV_FRAME` to tell a user that the command may be valid, but not with the supported frame. If implemented a user could use this to determine what frames are supported. 

Note that if autopilots continue to do the very bad thing of silently just accepting any frame this will make no difference. But this is still "the right design" by any measure.
