### PR TITLE
Minimal.xml - MAV_STATE - add failsafe to affected states

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -275,16 +275,16 @@
         <description>System is active and might be already airborne. Motors are engaged.</description>
       </entry>
       <entry value="5" name="MAV_STATE_CRITICAL">
-        <description>System is in a non-normal flight mode. It can however still navigate.</description>
+        <description>System is in a non-normal flight mode (failsafe). It can however still navigate.</description>
       </entry>
       <entry value="6" name="MAV_STATE_EMERGENCY">
-        <description>System is in a non-normal flight mode. It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
+        <description>System is in a non-normal flight mode (failsafe). It lost control over parts or over the whole airframe. It is in mayday and going down.</description>
       </entry>
       <entry value="7" name="MAV_STATE_POWEROFF">
         <description>System just initialized its power-down sequence, will shut down now.</description>
       </entry>
       <entry value="8" name="MAV_STATE_FLIGHT_TERMINATION">
-        <description>System is terminating itself.</description>
+        <description>System is terminating itself (failsafe or commanded).</description>
       </entry>
     </enum>
     <enum name="MAV_COMPONENT">


### PR DESCRIPTION
As discussed in https://github.com/mavlink/mavlink/wiki/20230607-Dev-Meeting a consumer should be able to monitor for vehicle being in a non-normal failsafe state by looking at the MAV_STATE in the heartbeat. What this does is add a note that the critical/emergency states "failsafe" so that this comes up if someone is searching for the term in the mavlink docs - I tried to find something and missed this. 