### PR TITLE
development.xml - remove mission_checksum

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -398,21 +398,6 @@
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Parameter type.</field>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
     </message>
-    <!-- mission protocol enhancements -->
-    <message id="53" name="MISSION_CHECKSUM">
-      <description>Checksum for the current mission, rally point or geofence plan, or for the "combined" plan (a GCS can use these checksums to determine if it has matching plans).
-        This message must be broadcast with the appropriate checksum following any change to a mission, geofence or rally point definition
-        (immediately after the MISSION_ACK that completes the upload sequence).
-        It may also be requested using MAV_CMD_REQUEST_MESSAGE, where param 2 indicates the plan type for which the checksum is required.
-        The checksum must be calculated on the autopilot, but may also be calculated by the GCS.
-        The checksum uses the same CRC32 algorithm as MAVLink FTP (https://mavlink.io/en/services/ftp.html#crc32-implementation).
-        The checksum for a mission, geofence or rally point definition is run over each item in the plan in seq order (excluding the home location if present in the plan), and covers the following fields (in order):
-        frame, command, autocontinue, param1, param2, param3, param4, param5, param6, param7.
-        The checksum for the whole plan (MAV_MISSION_TYPE_ALL) is calculated using the same approach, running over each sub-plan in the following order: mission, geofence then rally point.
-      </description>
-      <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
-      <field type="uint32_t" name="checksum">CRC32 checksum of current plan for specified type.</field>
-    </message>
     <message id="295" name="AIRSPEED">
       <description>Airspeed information from a sensor.</description>
       <field type="uint8_t" name="id" instance="true">Sensor ID.</field>


### PR DESCRIPTION
This PR removes MISSION_CHECKSUM .

MISSION_CHECKSUM is supposed to provide a checksum of various parts of the plan. The theory is that a ground station can calculate the same checksum for its current plan and therefore know if it has the current fence, mission, rally points. 

Unfortunately the theory is flawed because flight stacks do not necessarily store all the data in the original mission.

Replaced the functionality by https://github.com/mavlink/mavlink/pull/2012