### PR TITLE
test_and_deploy.yml - remove python 2.7 tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This removes the Python 2.7 from the test and deploy workflow. I don't think anything else is required?

Why? It's EOL and the test always fails. It's time to remove support. 

@peterbarker @auturgy @julianoes OK?