### PR TITLE
Common - Opaque IDs for detecting plan changes

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5289,6 +5289,19 @@
       <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items on vehicle (on last item, sequence == total). If the autopilot stores its home location as part of the mission this will be excluded from the total. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
       <field type="uint8_t" name="mission_state" enum="MISSION_STATE" invalid="0">Mission state machine state. MISSION_STATE_UNKNOWN if state reporting not supported.</field>
       <field type="uint8_t" name="mission_mode" invalid="0">Vehicle is in a mode that can execute mission items or suspended. 0: Unknown, 1: In mission mode, 2: Suspended (not in mission mode).</field>
+      <field type="uint32_t" name="mission_id" invalid="0">Id of current on-vehicle mission plan, or 0 if IDs are not supported. GCS can use this to track changes to the mission plan type. The same value is returned on mission upload (in the MISSION_ACK).</field>
+      <field type="uint32_t" name="fence_id" invalid="0">Id of current on-vehicle fence plan, or 0 if  IDs are not supported. GCS can use this to track changes to the plan type. The same value is returned on fence upload (in the MISSION_ACK).</field>
+      <field type="uint32_t" name="rally_point" invalid="0">Id of current on-vehicle rally point plan, or 0 if IDs are not supported. GCS can use this to track changes to the mission plan type. The same value is returned on rally point upload (in the MISSION_ACK).</field>
+	    
+      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan.
+        The current id is also streamed in MISSION_CURRENT and can be used by a GCS to determine whether the plan has changed.
+        The id is calculated and returned by the mission-executing component (vehicle) following _upload_ to vehicle.
+        The only requirement on the id is that it must be different if there is any change to the on-vehicle plan type (there is no requirement that the id be globally unique).
+        0 on download from the vehicle (on download the ID is set in MISSION_COUNT).
+        0 if plan ids are not supported.
+      </field>
+
+	    
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">
       <description>Request the overall list of mission items from the system/component.</description>
@@ -5304,6 +5317,11 @@
       <field type="uint16_t" name="count">Number of mission items in the sequence</field>
       <extensions/>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan.
+        This is the same ID that was calculated and returned by the mission-executing component (vehicle) in MISSION_ACK following mission _upload_ to vehicle.
+        0 on upload to the vehicle (on upload the ID is returned in MISSION_ACK).
+        0 if plan ids are not supported.
+      </field>
     </message>
     <message id="45" name="MISSION_CLEAR_ALL">
       <description>Delete all mission items at once.</description>
@@ -5323,6 +5341,13 @@
       <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">Mission result.</field>
       <extensions/>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
+      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan.
+        The current id is also streamed in MISSION_CURRENT and can be used by a GCS to determine whether the plan has changed.
+        The id is calculated and returned by the mission-executing component (vehicle) following _upload_ to vehicle.
+        The only requirement on the id is that it must be different if there is any change to the on-vehicle plan type (there is no requirement that the id be globally unique).
+        0 on download from the vehicle (on download the ID is set in MISSION_COUNT).
+        0 if plan ids are not supported.
+      </field>
     </message>
     <message id="48" name="SET_GPS_GLOBAL_ORIGIN">
       <description>Sets the GPS coordinates of the vehicle local origin (0,0,0) position. Vehicle should emit GPS_GLOBAL_ORIGIN irrespective of whether the origin is changed. This enables transform between the local coordinate frame and the global (GPS) coordinate frame, which may be necessary when (for example) indoor and outdoor settings are connected and the MAV should move from in- to outdoor.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5289,9 +5289,9 @@
       <field type="uint16_t" name="total" invalid="UINT16_MAX">Total number of mission items on vehicle (on last item, sequence == total). If the autopilot stores its home location as part of the mission this will be excluded from the total. 0: Not supported, UINT16_MAX if no mission is present on the vehicle.</field>
       <field type="uint8_t" name="mission_state" enum="MISSION_STATE" invalid="0">Mission state machine state. MISSION_STATE_UNKNOWN if state reporting not supported.</field>
       <field type="uint8_t" name="mission_mode" invalid="0">Vehicle is in a mode that can execute mission items or suspended. 0: Unknown, 1: In mission mode, 2: Suspended (not in mission mode).</field>
-      <field type="uint32_t" name="mission_id" invalid="0">Id of current on-vehicle mission plan, or 0 if IDs are not supported. GCS can use this to track changes to the mission plan type. The same value is returned on mission upload (in the MISSION_ACK).</field>
-      <field type="uint32_t" name="fence_id" invalid="0">Id of current on-vehicle fence plan, or 0 if  IDs are not supported. GCS can use this to track changes to the plan type. The same value is returned on fence upload (in the MISSION_ACK).</field>
-      <field type="uint32_t" name="rally_point" invalid="0">Id of current on-vehicle rally point plan, or 0 if IDs are not supported. GCS can use this to track changes to the mission plan type. The same value is returned on rally point upload (in the MISSION_ACK).</field>
+      <field type="uint32_t" name="mission_id" invalid="0">Id of current on-vehicle mission plan, or 0 if IDs are not supported or there is no mission loaded. GCS can use this to track changes to the mission plan type. The same value is returned on mission upload (in the MISSION_ACK).</field>
+      <field type="uint32_t" name="fence_id" invalid="0">Id of current on-vehicle fence plan, or 0 if IDs are not supported or there is no fence loaded. GCS can use this to track changes to the fence plan type. The same value is returned on fence upload (in the MISSION_ACK).</field>
+      <field type="uint32_t" name="rally_point" invalid="0">Id of current on-vehicle rally point plan, or 0 if IDs are not supported or there are no rally points loaded. GCS can use this to track changes to the rally point plan type. The same value is returned on rally point upload (in the MISSION_ACK).</field>
 
 	    
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5307,7 +5307,7 @@
       <field type="uint16_t" name="count">Number of mission items in the sequence</field>
       <extensions/>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
-      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan on download from vehicle.
+      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan (on download from vehicle).
         This field is used when downloading a plan from a vehicle to a GCS.
         0 on upload to the vehicle from GCS.
         0 if plan ids are not supported.
@@ -5333,7 +5333,7 @@
       <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">Mission result.</field>
       <extensions/>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
-      <field type="uint32_t" name="opaque_id" invalid="0">Id of new on-vehicle mission, fence, or rally point plan on upload to vehicle.
+      <field type="uint32_t" name="opaque_id" invalid="0">Id of new on-vehicle mission, fence, or rally point plan (on upload to vehicle).
         The id is calculated and returned by a vehicle when a new plan is uploaded by a GCS.
         The only requirement on the id is that it must change when there is any change to the on-vehicle plan type (there is no requirement that the id be globally unique).
         0 on download from the vehicle to the GCS (on download the ID is set in MISSION_COUNT).

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5291,7 +5291,7 @@
       <field type="uint8_t" name="mission_mode" invalid="0">Vehicle is in a mode that can execute mission items or suspended. 0: Unknown, 1: In mission mode, 2: Suspended (not in mission mode).</field>
       <field type="uint32_t" name="mission_id" invalid="0">Id of current on-vehicle mission plan, or 0 if IDs are not supported or there is no mission loaded. GCS can use this to track changes to the mission plan type. The same value is returned on mission upload (in the MISSION_ACK).</field>
       <field type="uint32_t" name="fence_id" invalid="0">Id of current on-vehicle fence plan, or 0 if IDs are not supported or there is no fence loaded. GCS can use this to track changes to the fence plan type. The same value is returned on fence upload (in the MISSION_ACK).</field>
-      <field type="uint32_t" name="rally_point" invalid="0">Id of current on-vehicle rally point plan, or 0 if IDs are not supported or there are no rally points loaded. GCS can use this to track changes to the rally point plan type. The same value is returned on rally point upload (in the MISSION_ACK).</field>
+      <field type="uint32_t" name="rally_points_id" invalid="0">Id of current on-vehicle rally point plan, or 0 if IDs are not supported or there are no rally points loaded. GCS can use this to track changes to the rally point plan type. The same value is returned on rally point upload (in the MISSION_ACK).</field>
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">
       <description>Request the overall list of mission items from the system/component.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5309,10 +5309,12 @@
       <field type="uint16_t" name="count">Number of mission items in the sequence</field>
       <extensions/>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
-      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan.
-        This is the same ID that was calculated and returned by the mission-executing component (vehicle) in MISSION_ACK following mission _upload_ to vehicle.
-        0 on upload to the vehicle (on upload the ID is returned in MISSION_ACK).
+      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan on download from vehicle.
+        This field is used when downloading a plan from a vehicle to a GCS.
+        0 on upload to the vehicle from GCS.
         0 if plan ids are not supported.
+        The current on-vehicle plan ids are streamed in `MISSION_CURRENT`, allowing a GCS to determine if any part of the plan has changed and needs to be re-uploaded.
+        The ids are recalculated by the vehicle when any part of the on-vehicle plan changes (when a new plan is uploaded, the vehicle returns the new id to the GCS in MISSION_ACK).
       </field>
     </message>
     <message id="45" name="MISSION_CLEAR_ALL">
@@ -5333,12 +5335,12 @@
       <field type="uint8_t" name="type" enum="MAV_MISSION_RESULT">Mission result.</field>
       <extensions/>
       <field type="uint8_t" name="mission_type" enum="MAV_MISSION_TYPE">Mission type.</field>
-      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan.
-        The current id is also streamed in MISSION_CURRENT and can be used by a GCS to determine whether the plan has changed.
-        The id is calculated and returned by the mission-executing component (vehicle) following _upload_ to vehicle.
-        The only requirement on the id is that it must be different if there is any change to the on-vehicle plan type (there is no requirement that the id be globally unique).
-        0 on download from the vehicle (on download the ID is set in MISSION_COUNT).
+      <field type="uint32_t" name="opaque_id" invalid="0">Id of new on-vehicle mission, fence, or rally point plan on upload to vehicle.
+        The id is calculated and returned by a vehicle when a new plan is uploaded by a GCS.
+        The only requirement on the id is that it must change when there is any change to the on-vehicle plan type (there is no requirement that the id be globally unique).
+        0 on download from the vehicle to the GCS (on download the ID is set in MISSION_COUNT).
         0 if plan ids are not supported.
+        The current on-vehicle plan ids are streamed in `MISSION_CURRENT`, allowing a GCS to determine if any part of the plan has changed and needs to be re-uploaded.
       </field>
     </message>
     <message id="48" name="SET_GPS_GLOBAL_ORIGIN">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5292,8 +5292,6 @@
       <field type="uint32_t" name="mission_id" invalid="0">Id of current on-vehicle mission plan, or 0 if IDs are not supported or there is no mission loaded. GCS can use this to track changes to the mission plan type. The same value is returned on mission upload (in the MISSION_ACK).</field>
       <field type="uint32_t" name="fence_id" invalid="0">Id of current on-vehicle fence plan, or 0 if IDs are not supported or there is no fence loaded. GCS can use this to track changes to the fence plan type. The same value is returned on fence upload (in the MISSION_ACK).</field>
       <field type="uint32_t" name="rally_point" invalid="0">Id of current on-vehicle rally point plan, or 0 if IDs are not supported or there are no rally points loaded. GCS can use this to track changes to the rally point plan type. The same value is returned on rally point upload (in the MISSION_ACK).</field>
-
-	    
     </message>
     <message id="43" name="MISSION_REQUEST_LIST">
       <description>Request the overall list of mission items from the system/component.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5292,14 +5292,6 @@
       <field type="uint32_t" name="mission_id" invalid="0">Id of current on-vehicle mission plan, or 0 if IDs are not supported. GCS can use this to track changes to the mission plan type. The same value is returned on mission upload (in the MISSION_ACK).</field>
       <field type="uint32_t" name="fence_id" invalid="0">Id of current on-vehicle fence plan, or 0 if  IDs are not supported. GCS can use this to track changes to the plan type. The same value is returned on fence upload (in the MISSION_ACK).</field>
       <field type="uint32_t" name="rally_point" invalid="0">Id of current on-vehicle rally point plan, or 0 if IDs are not supported. GCS can use this to track changes to the mission plan type. The same value is returned on rally point upload (in the MISSION_ACK).</field>
-	    
-      <field type="uint32_t" name="opaque_id" invalid="0">Id of current on-vehicle mission, fence, or rally point plan.
-        The current id is also streamed in MISSION_CURRENT and can be used by a GCS to determine whether the plan has changed.
-        The id is calculated and returned by the mission-executing component (vehicle) following _upload_ to vehicle.
-        The only requirement on the id is that it must be different if there is any change to the on-vehicle plan type (there is no requirement that the id be globally unique).
-        0 on download from the vehicle (on download the ID is set in MISSION_COUNT).
-        0 if plan ids are not supported.
-      </field>
 
 	    
     </message>


### PR DESCRIPTION
This PR proposes a mechanism (for discussion) for determining whether part of an on-vehicle plan type (mission, fence, rally points) have changed, so that a GCS can upload the changed plan, or more importantly choose _not_ to upload a plan that it already has.

This replaces the `MISSION_CHECKSUM` which is being removed in https://github.com/mavlink/mavlink/pull/2010.

## Overview

Plan upload/download can consume quite a lot of bandwidth, especially for large missions.
Currently ground stations upload the vehicle plan every time they connect, even if they already have a matching plan. Further, if a second ground station or companion updates the plan on a vehicle, there is no reliable way for other ground stations to know that they have to update.

The ideal solution for this problem is for vehicles and ground stations to have a common way of calculating a representation of the plan (such as a checksum) and for the vehicle to publish its current representation. That way the ground station could always know if it has the current plan. Unfortunately the shared-representation approach is flawed because the vehicle will commonly not store a precise match to the GCS version - parameters that are invalid on the vehicle might not be stored, and other values might be stored as some kind of rounded value.

We're therefore limited to solutions where the ID representing a mission must be shared between a vehicle and GCS on upload and then published for all other vehicles. This allows a GCS that has uploaded a mission to know that it does not have to re-update, and for other GCS to know that they do. 

This proposal does not require it to be a globally unique UUID, though that might be handy for systems that want to manage missions. 

In theory this ID could just iterate for more than the likely number of missions uploaded between vehicle reboots (or several reboots?). It might be a checksum or UUID.

The id might be set by the Vehicle or a GCS. This PR currently defines a proposal for the first case, but both options are discussed here.

## Vehicle supplies ID on upload (see PR)

Proposed solution :
- During [upload of a mission, fence, or rally point to the vehicle](https://mavlink.io/en/services/mission.html#uploading_mission) the vehicle calculate and returns an `opaque_id` to the GCS in the final `MISSION_ACK` (the value is set to 0 on download to GCS). This is the current id for the particular plan type.
- Vehicle publishes the opaque id for the mission, fence and rally points in the `MISSON_CURRENT`
- During [download from vehicle](https://mavlink.io/en/services/mission.html#download_mission) the opaque id is set in the `MISSION_COUNT`.  Note that a round-tripped downloaded mission might not look the same as the original mission that was uploaded from a GCS, but it has the same on-vehicle characteristic. 
- The id for each plan type is a unit32.

With this 
- A GCS uploading a plan will have the matching value in MISSION_CURRENT - so no reupload
- Any other GCS will have a mismatch following upload of a new mission. After reuploading the mismatched plan-part it will match.
- An ArduPilot FTP based plan upload could work with this by setting the unique ID to the FTP file checksum. If they are all in the same file, they could all be set to the same value.

Open questions/concerns
- Should we just suggest the opaque ids iterate?
  - The only requirement is that a GCS seeing the emitted number knows that it doesn't match the current value.
  - So we might use a uInt_8 for this and iterate on each change. 
  - The only problem case would be if a GCS had a mission and disconnected, then the vehicle had 256 ish new missions and end up with the same value. In this case the GCS would choose not to re-upload.
  - But you might well argue that uint_16 was sufficient.
  - In the case of an ArduPilot FTP this would still work - the FTP would have to trigger an iteration.
  - What is the argument "against".
- Do we need separate ids for each plan part?
  - The "for" argument is that if a rally point changes you can upload that separately without having to upload a mission.
  - I guess the "against" is that it means 3 uint_32 added to the MISSION_CURRENT rather than one. 
  - Is it worth it? I think so - a mission might be hundreds of items.
  - And these ids could be smaller if we just iterate the number.

- Is uint32 the right size?
  - if we are allowing CRCs or various UID calculations, what's the best data size for this.


## GCS supplies ID on upload.

An alternative is that 
- GCS supplies the id of the current mission plan on upload, and gets it back on download in a field added to MISSION_COUNT (note, fewer fields, as you don't need it in both ACK and COUNT)
- Values emitted from MISSION_CURRENT
- Id has to be different from current mission. It couldn't reliably be iterated so would have to be calculated. It would therefore be better off being bigger - might be a UUID or a CHECKSUM.

With this 
- A GCS uploading a plan will have the matching values in MISSION_CURRENT. Reupload not triggered
- Any other GCS will have a mismatch following upload of a new mission. After reuploading the mismatched plan-part it will match. 
- An ArduPilot FTP based plan upload could again be required to use the checksum.

The main difference between the two approaches is that for the GCS you probably have to have a bigger ID because you can't reliably iterate (I don't think). The benefit is that the  MISSION_COUNT changes are simpler, and occur early in the mission upload/download - so systems that for some reason don't get the ACK will still get the value.




