### PR TITLE
Master pr/camera info gimbal associated

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6715,7 +6715,8 @@
       <field type="uint32_t" name="flags" enum="CAMERA_CAP_FLAGS" display="bitmask">Bitmap of camera capability flags.</field>
       <field type="uint16_t" name="cam_definition_version">Camera definition version (iteration).  Use 0 if not known.</field>
       <field type="char[140]" name="cam_definition_uri">Camera definition URI (if any, otherwise only basic functions will be available). HTTP- (http://) and MAVLink FTP- (mavlinkftp://) formatted URIs are allowed (and both must be supported by any GCS that implements the Camera Protocol). The definition file may be xz compressed, which will be indicated by the file extension .xml.xz (a GCS that implements the protocol must support decompressing the file). The string needs to be zero terminated.  Use a zero-length string if not known.</field>
-      <field type="uint8_t" name="gimbal_device_id" invalid="0">If this camera is associated with a gimbal, this field is the gimbal device id, following MAVLink Gimbal Protocol v2. The id is the component id of the gimbal device, or 1-6 reserved for non mavlink gimbals ). Use 0 if no gimbal is associated with the camera.</field>
+      <extensions/>
+      <field type="uint8_t" name="gimbal_device_id" invalid="0">Gimbal id of a gimbal associated with this camera. This is the component id of the gimbal device, or 1-6 for non mavlink gimbals. Use 0 if no gimbal is associated with the camera.</field>
     </message>
     <message id="260" name="CAMERA_SETTINGS">
       <description>Settings of a camera. Can be requested with a MAV_CMD_REQUEST_MESSAGE command.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6715,6 +6715,7 @@
       <field type="uint32_t" name="flags" enum="CAMERA_CAP_FLAGS" display="bitmask">Bitmap of camera capability flags.</field>
       <field type="uint16_t" name="cam_definition_version">Camera definition version (iteration).  Use 0 if not known.</field>
       <field type="char[140]" name="cam_definition_uri">Camera definition URI (if any, otherwise only basic functions will be available). HTTP- (http://) and MAVLink FTP- (mavlinkftp://) formatted URIs are allowed (and both must be supported by any GCS that implements the Camera Protocol). The definition file may be xz compressed, which will be indicated by the file extension .xml.xz (a GCS that implements the protocol must support decompressing the file). The string needs to be zero terminated.  Use a zero-length string if not known.</field>
+      <field type="uint8_t" name="gimbal_device_id" invalid="0">If this camera is associated with a gimbal, this field is the gimbal device id, following MAVLink Gimbal Protocol v2. The id is the component id of the gimbal device, or 1-6 reserved for non mavlink gimbals ). Use 0 if no gimbal is associated with the camera.</field>
     </message>
     <message id="260" name="CAMERA_SETTINGS">
       <description>Settings of a camera. Can be requested with a MAV_CMD_REQUEST_MESSAGE command.</description>


### PR DESCRIPTION
Following #2006 issue. This commit adds a new field to CAMERA_INFORMATION to link it to a gimbal device. 

I think the convention should follow the same logic as gimbal device id, which is 1-6 for non mavlink gimbals ( gimbals devices "simulated" by an autopilot ) and the rest of the numbers should be interpreted as component ID, for gimbal devices that are actually an independent mavlink system.

I am not that familiar with mavlink, so I am not sure if this way it is all right, in the sense of how to present it so the message is trimmed if we are not using this field, please let me know if it needs to be fixed.