### PR TITLE
Add VELOCITY_LIMITS msg

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4927,19 +4927,6 @@
         <description>Mission has executed all mission items.</description>
       </entry>
     </enum>
-    <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-    <enum name="VELOCITY_LIMITS_MASK" bitmask="true">
-      <description>These encode velocity setpoints that are currently enabled.</description>
-      <entry value="1" name="VELOCITY_LIMITS_MASK_HORIZONTAL">
-        <description>Accept horizontal speed setpoint</description>
-      </entry>
-      <entry value="2" name="VELOCITY_LIMITS_MASK_VERTICAL">
-        <description>Accept vertical speed setpoint</description>
-      </entry>
-      <entry value="4" name="VELOCITY_LIMITS_MASK_YAW">
-        <description>Accept yaw rate setpoint</description>
-      </entry>
-    </enum>
   </enums>
   <messages>
     <message id="1" name="SYS_STATUS">
@@ -7268,15 +7255,13 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
-    <wip/>
-    <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-    <!-- TODO: Make sure the ID and naming are appropiate -->
     <message id="354" name="VELOCITY_LIMITS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
-      <field type="float" name="horizontal_speed" units="m/s">Horizontal speed in m/s</field>
-      <field type="float" name="vertical_speed" units="m/s">Vertical speed in m/s</field>
-      <field type="float" name="yaw_rate" units="rad/s">Yaw rate in rad/s</field>
-      <field type="uint8_t" name="type_mask" enum="VELOCITY_LIMITS_MASK" display="bitmask">Bitmap to indicate which velocity setpoint should be considered.</field>
+      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in local inertial north east frame. NaN: Use vehicle default speed</field>
+      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in local inertial down frame. NaN: Use vehicle default speed</field>
+      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
     </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4927,6 +4927,19 @@
         <description>Mission has executed all mission items.</description>
       </entry>
     </enum>
+    <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+    <enum name="VELOCITY_LIMITS_MASK" bitmask="true">
+      <description>These encode velocity setpoints that are currently enabled.</description>
+      <entry value="1" name="VELOCITY_LIMITS_MASK_HORIZONTAL">
+        <description>Accept horizontal speed setpoint</description>
+      </entry>
+      <entry value="2" name="VELOCITY_LIMITS_MASK_VERTICAL">
+        <description>Accept vertical speed setpoint</description>
+      </entry>
+      <entry value="4" name="VELOCITY_LIMITS_MASK_YAW">
+        <description>Accept yaw rate setpoint</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="1" name="SYS_STATUS">
@@ -7254,6 +7267,15 @@
       <field type="uint16_t" name="array_id" instance="true">Unique ID used to discriminate between arrays</field>
       <extensions/>
       <field type="float[58]" name="data">data</field>
+    </message>
+    <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+    <!-- TODO: Make sure the ID and naming are appropiate -->
+    <message id="354" name="VELOCITY_LIMITS">
+      <description>Setpoint of horizontal speed, vertical speed and yaw rate.</description>
+      <field type="float" name="horizontal_speed" units="m/s">Horizontal speed in m/s</field>
+      <field type="float" name="vertical_speed" units="m/s">Vertical speed in m/s</field>
+      <field type="float" name="yaw_rate" units="rad/s">Yaw rate in rad/s</field>
+      <field type="uint8_t" name="type_mask" enum="VELOCITY_LIMITS_MASK" display="bitmask">Bitmap to indicate which velocity setpoint should be considered.</field>
     </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7258,10 +7258,10 @@
     <message id="354" name="VELOCITY_LIMITS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
-      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
-      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
-      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
+      <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
+      <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
+      <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
+      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Field not used (ignore)</field>
     </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7268,6 +7268,7 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
+    <wip/>
     <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
     <!-- TODO: Make sure the ID and naming are appropiate -->
     <message id="354" name="VELOCITY_LIMITS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7259,8 +7259,8 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
-      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in local inertial north east frame. NaN: Use vehicle default speed</field>
-      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in local inertial down frame. NaN: Use vehicle default speed</field>
+      <field type="float" name="horizontal_velocity_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
+      <field type="float" name="vertical_velocity_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME LOCAL. NaN: Use vehicle default speed</field>
       <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Use vehicle default rate</field>
     </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7255,14 +7255,6 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
-    <message id="354" name="VELOCITY_LIMITS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
-      <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
-      <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
-      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Field not used (ignore)</field>
-    </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7272,7 +7272,7 @@
     <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
     <!-- TODO: Make sure the ID and naming are appropiate -->
     <message id="354" name="VELOCITY_LIMITS">
-      <description>Setpoint of horizontal speed, vertical speed and yaw rate.</description>
+      <description>Temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. This message should be streamed at 1Hz while the lower limits apply. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
       <field type="float" name="horizontal_speed" units="m/s">Horizontal speed in m/s</field>
       <field type="float" name="vertical_speed" units="m/s">Vertical speed in m/s</field>
       <field type="float" name="yaw_rate" units="rad/s">Yaw rate in rad/s</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -442,7 +442,7 @@
     <message id="355" name="VELOCITY_LIMITS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Current limits for horizontal speed, vertical speed and yaw rate.</description>
+      <description>Current limits for horizontal speed, vertical speed and yaw rate, as set by SET_VELOCITY_LIMITS.</description>
       <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
       <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
       <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: No limit applied</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -432,7 +432,10 @@
     <message id="354" name="SET_VELOCITY_LIMITS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Set temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
+      <description>Set temporary maximum limits for horizontal speed, vertical speed and yaw rate.
+        The consumer must stream the current limits in VELOCITY_LIMITS at 1 Hz or more (when limits are being set).
+        The consumer should latch the limits until a new limit is received or the mode is changed.
+      </description>
       <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
       <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
       <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -429,6 +429,22 @@
       <field type="uint16_t" name="data_rate" units="MiB/s">WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.</field>
       <field type="uint8_t" name="security" enum="WIFI_NETWORK_SECURITY">WiFi network security type.</field>
     </message>
+    <message id="354" name="SET_VELOCITY_LIMITS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Set temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
+      <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
+      <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
+      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Field not used (ignore)</field>
+    </message>
+    <message id="355" name="VELOCITY_LIMITS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Current limits for horizontal speed, vertical speed and yaw rate.</description>
+      <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
+      <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
+      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: No limit applied</field>
+    </message>
     <message id="361" name="FIGURE_EIGHT_EXECUTION_STATUS">
       <wip/>
       <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -237,14 +237,14 @@
       </entry>
       <entry value="32" name="MAV_BATTERY_STATUS_FLAGS_REQUIRES_SERVICE">
         <description>
-          Battery requires service (not safe to fly). 
+          Battery requires service (not safe to fly).
           This is set at vendor discretion.
           It is likely to be set for most faults, and may also be set according to a maintenance schedule (such as age, or number of recharge cycles, etc.).
         </description>
       </entry>
       <entry value="64" name="MAV_BATTERY_STATUS_FLAGS_BAD_BATTERY">
         <description>
-          Battery is faulty and cannot be repaired (not safe to fly). 
+          Battery is faulty and cannot be repaired (not safe to fly).
           This is set at vendor discretion.
           The battery should be disposed of safely.
         </description>
@@ -433,6 +433,8 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Set temporary limits for horizontal speed, vertical speed and yaw rate to slow down the vehicle from the default configuration during operation. The consumer implements a timeout and returns to default limits in case the stream is lost. Accelerations are automatically adjusted accordingly.</description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
       <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
       <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
       <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Field not used (ignore)</field>


### PR DESCRIPTION
This pr is part of a work which aims to enable "slow mode" on a vehicle. This mode allows to scale down the vehicle's velocities by limiting the maximum values. It is useful in scenarios such as: EASA 3m/s velocity limit, camera zooming. Corresponding work can be found [here](https://github.com/PX4/PX4-Autopilot/pull/21790)
The velocity_limits message consists of: 
 * ~horizontal velocity limit~ horizontal speed limit
 * ~vertical velocity limit~ vertical speed limit 
 * yaw rate limit