### PR TITLE
all.xml: Add message/command ranges for other dialects

### DIFF
--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -63,8 +63,8 @@
     commands: 52000 - 52099
   -->
   <!--Next range to allocate range of IDs:
-    messages: 52100 - 52100 < 60000
-    commands: 52100 - 52199 < 60000
+    messages: 52100 - 52100 (< 60000)
+    commands: 52100 - 52199 (< 60000)
   -->
   <messages/>
 </mavlink>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -34,7 +34,7 @@
   <!-- uAvionix.xml range of IDs:
     messages: 10001-10999
     commands: ? - ?
-  -->  
+  -->
   <include>uAvionix.xml</include>
   <!-- storm32.xml range of IDs:
     messages: 60000 - 60049

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -13,7 +13,6 @@
   <!-- common.xml range of IDs:
     messages: 300 - 10000
     commands: 0 - 39999
-  
     Note: entities imported from other dialects may fall outside these ranges.    
   -->
   <include>common.xml</include>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -1,13 +1,25 @@
 <?xml version="1.0"?>
 <mavlink>
+  <!-- ardupilotmega.xml range of IDs:
+    messages: 11000 - 11999
+    commands: 42000 - 42999
+  -->
   <include>ardupilotmega.xml</include>
   <!-- ASLUAV.xml range of IDs:
     messages: 8000 - 8999
     commands: 40001 - 41999
   -->
   <include>ASLUAV.xml</include>
+  <!-- common.xml range of IDs:
+    messages: 300 - 10000
+    commands: 0 - 39999
+  -->
   <include>common.xml</include>
   <include>development.xml</include>
+  <!-- icarous.xml range of IDs:
+    messages: 42000 - 42999
+    commands: ? - ?
+  -->
   <include>icarous.xml</include>
   <!-- matrixpilot.xml: ERROR: Duplicate message id 150 for FLEXIFUNCTION_SET (matrixpilot.xml:50) also used by SENSOR_OFFSETS (ardupilotmega.xml:1101) -->
   <!-- <include>matrixpilot.xml</include> -->
@@ -18,6 +30,10 @@
   <include>standard.xml</include>
   <include>test.xml</include>
   <include>ualberta.xml</include>
+  <!-- uAvionix.xml range of IDs:
+    messages: 10001-10999
+    commands: ? - ?
+  -->  
   <include>uAvionix.xml</include>
   <!-- storm32.xml range of IDs:
     messages: 60000 - 60049
@@ -45,8 +61,8 @@
     commands: 52000 - 52099
   -->
   <!--Next range to allocate range of IDs:
-    messages: 52100 - ? < 60000
-    commands: 52100 - ? < 60000
+    messages: 52100 - 52100 < 60000
+    commands: 52100 - 52199 < 60000
   -->
   <messages/>
 </mavlink>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -13,6 +13,8 @@
   <!-- common.xml range of IDs:
     messages: 300 - 10000
     commands: 0 - 39999
+  
+    Note: entities imported from other dialects may fall outside these ranges.    
   -->
   <include>common.xml</include>
   <include>development.xml</include>


### PR DESCRIPTION
This adds additional range information to all.xml. I'd rather have this in the files themselves, but good to have an overview.

This is from https://mavlink.io/en/guide/define_xml_element.html and by inspection.

@peterbarker OK?
