### PR TITLE
Extend MAV_COLLISION_ACTION enum to add MAV_COLLISION_ACTION_BRAKE.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3552,6 +3552,9 @@
       <entry value="6" name="MAV_COLLISION_ACTION_HOVER">
         <description>Aircraft to stop in place</description>
       </entry>
+      <entry value="7" name="MAV_COLLISION_ACTION_BRAKE">
+        <description>Aircraft to switch to brake mode</description>
+      </entry>
     </enum>
     <enum name="MAV_COLLISION_THREAT_LEVEL">
       <description>Aircraft-rated danger from this threat.</description>


### PR DESCRIPTION
This is in support of ADSB_AVOID improvements mentioned in the following PR:
https://github.com/ArduPilot/ardupilot/pull/24284