### PR TITLE
Fix c_library_vX build order

### DIFF
--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -60,12 +60,22 @@ rm -rf $CLIBRARY_PATH/*
 
 # generate new c headers
 echo -e "\0033[34mStarting to generate c headers\0033[0m\n"
-generate_headers development $1
-generate_headers ardupilotmega $1
-generate_headers matrixpilot $1
+generate_headers all $1
 generate_headers test $1
+generate_headers storm32 $1
+generate_headers ardupilotmega $1
+generate_headers csAirLink $1
+generate_headers uAvionix $1
+generate_headers cubepilot $1
+generate_headers ualberta $1
+generate_headers paparazzi $1
 generate_headers ASLUAV $1
+generate_headers matrixpilot $1
+generate_headers python_array_test $1
+generate_headers development $1
 generate_headers standard $1
+generate_headers common $1
+generate_headers minimal $1
 mkdir -p $CLIBRARY_PATH/message_definitions
 cp message_definitions/v1.0/* $CLIBRARY_PATH/message_definitions/.
 echo -e "\0033[34mFinished generating c headers\0033[0m\n"

--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -73,8 +73,8 @@ generate_headers ASLUAV $1
 generate_headers matrixpilot $1
 generate_headers python_array_test $1
 generate_headers development $1
-generate_headers standard $1
 generate_headers common $1
+generate_headers standard $1
 generate_headers minimal $1
 mkdir -p $CLIBRARY_PATH/message_definitions
 cp message_definitions/v1.0/* $CLIBRARY_PATH/message_definitions/.


### PR DESCRIPTION
This attempts to fix the build order of the prebuilt MAVLink libraries.

The order in which things are built matters. This is due to a bug in mavgen, which means that if there are any shared enum values then they only only appear the top level library that is built.
In practise this means that if you build `ardupilotmega.xml` then `ardupilotmega/ardupilotmega.h` will contain the `mav_cmd` definitions, and `common/common.h` (which is nested) will not.

To ensure that every level of library is correct you therefore need to build top level libraries first, and then any libraries that they nest. In other words, ensure that the last time a library is built, is when it the top level library. 

This is the order to get the entire library, including everything in all.xml. IOt shows what is included by the file, and what the file includes (in brackets). So libraries must be build after all XML that includes them.
Essentially this should mostly work as long as common, standard, minimal are built in that order, after everything that includes common.xml.

```
all - incl everything ()
test - no incl (all)
storm32 - incl ardupilotmega (all)
ardupilotmega  - (all, storm32)
csAirLink - no incl - (ardupilotmega)
icarous - no incl (ardupilotmega, all)
uAvionix.xml - incl common (all, ardupilotmega)
cubepilot.xml - incl common (all, ardupilotmega)
ualberta - incl common (all)
paparazzi - incl common ()
ASLUAV - incl common (all)
matrixpilot - incl common ()
python_array_test - incl common (all)
development - incl common (all)
common - incl standard (all, ardupilotmega, ualberta, uAvionix, cubepilot, asluav, AVSSUAS, development, matrixpilot, paparazzi, python_array_test )
standard - incl minimal (common, all)
minimal - no imports (standard)
```

I tested this by building this library and then comparing to all, ardupilotmega, common, minimal as built independently. 
With this order the XML is identical except for the hashes. Since these only matter for identifying the top level file and are not affected by overlaying, that does not matter.

FYI @bkueng 
