### PR TITLE
{Sponsored by Intelliterra} Added MAV_CMD_DO_SET_EMERGENCY for manual emergency setting 

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1829,7 +1829,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="225" name="MAV_CMD_DO_SET_EMERGENCY" hasLocation="false" isDestination="false">
+      <entry value="225" name="MAV_CMD_ODID_SET_EMERGENCY" hasLocation="false" isDestination="false">
         <description>Used to set/unset emergency status for remote id.</description>
         <param index="1" label="Number" minValue="0" increment="1">Set/unset emergency 0: unset, 1: set</param>
         <param index="2">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1829,6 +1829,17 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+      <entry value="225" name="MAV_CMD_DO_SET_EMERGENCY" hasLocation="false" isDestination="false">
+        <description>Used to set/unset emergency status for remote id.</description>
+        <param index="1" label="Number" minValue="0" increment="1">Set/unset emergency 0: unset, 1: set</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <entry value="240" name="MAV_CMD_DO_LAST" hasLocation="false" isDestination="false">
         <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
         <param index="1">Empty</param>


### PR DESCRIPTION
Added a new MAV_CMD called MAV_CMD_DO_SET_EMERGENCY.

The purpose of this command is for operators to be able to manually set their Remote ID status to emergency from a GCS (this status is emitted from the OPEN_DRONE_ID_LOCATION message). 

An example of where this can be used is on QGroundControl. A "Declare Emergency" button exists for Remote ID but does not work since OPEN_DRONE_ID_LOCATION is handled on the PX4 side. 


The PR that I am about to add on QGroundControl utilizes this command in the "Declare Emergency" button.
The PR that I am about to add on PX4 listens for this command and sets emergency status when it is received.

As a note, I tested this on QGroundControl by making the changes to the detached head submodule and building that first, since QGC currently is not on the most recent MAVLink build. I however did also build this one successfully.


**Sponsored by Intelliterra**