### PR TITLE
Is it worth qualifying "telemetry" or "published", and if so how?

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5668,7 +5668,7 @@
       <field type="int16_t" name="temperature_press_diff" units="cdegC" invalid="0">Differential pressure temperature (0, if not available). Report values of 0 (or 1) as 1 cdegC.</field>
     </message>
     <message id="30" name="ATTITUDE">
-      <description>The attitude in the aeronautical frame (right-handed, Z-down, Y-right, X-front, ZYX, intrinsic).</description>
+      <description>Attitude telemetry in the aeronautical frame (right-handed, Z-down, Y-right, X-front, ZYX, intrinsic).</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="roll" units="rad">Roll angle (-pi..+pi)</field>
       <field type="float" name="pitch" units="rad">Pitch angle (-pi..+pi)</field>
@@ -5678,7 +5678,7 @@
       <field type="float" name="yawspeed" units="rad/s">Yaw angular speed</field>
     </message>
     <message id="31" name="ATTITUDE_QUATERNION">
-      <description>The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
+      <description>Attitude telemetry in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation)</field>
       <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation)</field>
@@ -5691,7 +5691,7 @@
       <field type="float[4]" name="repr_offset_q" invalid="[0]">Rotation offset by which the attitude quaternion and angular speed vector should be rotated for user display (quaternion with [w, x, y, z] order, zero-rotation is [1, 0, 0, 0], send [0, 0, 0, 0] if field not supported). This field is intended for systems in which the reference attitude may change during flight. For example, tailsitters VTOLs rotate their reference attitude by 90 degrees between hover mode and fixed wing mode, thus repr_offset_q is equal to [1, 0, 0, 0] in hover mode and equal to [0.7071, 0, 0.7071, 0] in fixed wing mode.</field>
     </message>
     <message id="32" name="LOCAL_POSITION_NED">
-      <description>The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
+      <description>Filtered local position telemetry (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="float" name="x" units="m">X Position</field>
       <field type="float" name="y" units="m">Y Position</field>


### PR DESCRIPTION
Had a question the other day where someone was trying to send the ATTITUDE message as a setter - i.e. as though from some external estimator. The message looks like this:

```
<message id="30" name="ATTITUDE">
      <description>The attitude in the aeronautical frame (right-handed, Z-down, Y-right, X-front, ZYX, intrinsic).</description>
```

We have a convention for setters to name them SET_Xxxxx. Is that enough? My thinking here is we could easily do:

```
<message id="30" name="ATTITUDE">
      <description>Attitude telemetry in the aeronautical frame (right-handed, Z-down, Y-right, X-front, ZYX, intrinsic).</description>
```

Other options might be to be explicit,

```
      <description>Gets attitude in the aeronautical frame (right-handed, Z-down, Y-right, X-front, ZYX, intrinsic).
      <description>Sets attitude in the aeronautical frame (right-handed, Z-down, Y-right, X-front, ZYX, intrinsic).
```

or use attributes:

```
<message id="30" name="ATTITUDE" get="true">
<message id="30" name="SET_ATTITUDE" set="true">
```

Any opinions. Not a huge deal IMO.

