### PR TITLE
Update test_and_deploy.yml - drop node 12

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install future lxml
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12', '14'] # 15 fails for some weird reason
+        node-version: ['14', '16'] # 15 fails for some weird reason
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14','15','16','17']
+        node-version: ['14','15','16','17','18']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -94,7 +94,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
       - name : Test mavlink
         run: |
           ./scripts/test.sh node

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14', '16'] # 15 fails for some weird reason
+        node-version: ['14','15','16','17']
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The node 12 tests fail due to use of optional chaining in generated code, added in node 14. This removes node 12.
I added node 16 because we should be promoting a more recent versions. Possibly even 18.

Part of fixing #2040