### PR TITLE
Update ardupilotmega.xml - delete SPEED_TYPE

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -23,10 +23,6 @@
       <entry value="0" name="HEADING_TYPE_COURSE_OVER_GROUND"/>
       <entry value="1" name="HEADING_TYPE_HEADING"/>
     </enum>
-    <enum name="SPEED_TYPE">
-      <entry value="0" name="SPEED_TYPE_AIRSPEED"/>
-      <entry value="1" name="SPEED_TYPE_GROUNDSPEED"/>
-    </enum>
     <!-- ardupilot specific MAV_CMD_* commands -->
     <enum name="MAV_CMD">
       <!-- 200 to 214 used by common.xml -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3464,7 +3464,7 @@
       <entry value="0" name="SPEED_TYPE_AIRSPEED">
         <description>Airspeed</description>
       </entry>
-      <entry value="1" name="SPEED_TYPE_GROUND_SPEED">
+      <entry value="1" name="SPEED_TYPE_GROUNDSPEED">
         <description>Groundspeed</description>
       </entry>
       <entry value="2" name="SPEED_TYPE_CLIMB_SPEED">


### PR DESCRIPTION
We added SPEED_TYPE to common.xml and got no errors in building ... but we are now and it appears to be because this is already defined in ardupilotmega.xml.

I've removed from ardupilot. The values are the same for the existing value, but common defines extra values and uses SPEED_TYPE_GROUND_SPEED rather than SPEED_TYPE_GROUNDSPEED. I have modified that here to match the deleted APM stuff too.

@peterbarker @auturgy - OK?

This is what is in common. 

```
    <enum name="SPEED_TYPE">
      <description>Speed setpoint types used in MAV_CMD_DO_CHANGE_SPEED</description>
      <entry value="0" name="SPEED_TYPE_AIRSPEED">
        <description>Airspeed</description>
      </entry>
      <entry value="1" name="SPEED_TYPE_GROUND_SPEED">
        <description>Groundspeed</description>
      </entry>
      <entry value="2" name="SPEED_TYPE_CLIMB_SPEED">
        <description>Climb speed</description>
      </entry>
      <entry value="3" name="SPEED_TYPE_DESCENT_SPEED">
        <description>Descent speed</description>
      </entry>
    </enum>
    ```