### PR TITLE
Re-use param index 3 for Fence Action

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2333,7 +2333,7 @@
         </description>
         <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count</param>
         <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group, must be the same for all points in each polygon</param>
-        <param index="3">Reserved</param>
+        <param index="3" label="Fence Action" minValue="0" increment="1">Action the vehicle will take when the fence is breached.</param>
         <param index="4">Reserved</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
@@ -2344,7 +2344,7 @@
         </description>
         <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count</param>
         <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
+        <param index="3" label="Fence Action" minValue="0" increment="1">Action the vehicle will take when the fence is breached.</param>
         <param index="4">Reserved</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
@@ -2355,7 +2355,7 @@
         </description>
         <param index="1" label="Radius" units="m">Radius.</param>
         <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group</param>
-        <param index="3">Reserved</param>
+        <param index="3" label="Fence Action" minValue="0" increment="1">Action the vehicle will take when the fence is breached.</param>
         <param index="4">Reserved</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
@@ -2366,7 +2366,7 @@
         </description>
         <param index="1" label="Radius" units="m">Radius.</param>
         <param index="2">Reserved</param>
-        <param index="3">Reserved</param>
+        <param index="3" label="Fence Action" minValue="0" increment="1">Action the vehicle will take when the fence is breached.</param>
         <param index="4">Reserved</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>


### PR DESCRIPTION
This PR is connected to: https://github.com/mavlink/mavlink/issues/2043

It adds the option to use `index param 3` for sending fence action, so each geofence can have its breach action. 

Feasibility development was done and with these changes, we can have multiple steps of breaching actions. One useful example is a case where the vehicle flies uncontrollably outside the last fence we can terminate the vehicle, to prevent the vehicle from entering a forbidden area, etc.
![image](https://github.com/mavlink/mavlink/assets/10188706/0c7cbdd4-fee8-41ad-8955-9c89880e5bbc)



