### PR TITLE
development: add setter/getters for torque and thrust setpoints

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -553,5 +553,37 @@
       <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
     </message>
+    <message id="150" name="SET_TORQUE_SETPOINT">
+      <description>Set the (normalized) torque setpoint in body frame</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float" name="x">Torque setpoint around x in MAV_FRAME</field>
+      <field type="float" name="y">Torque setpoint around y in MAV_FRAME</field>
+      <field type="float" name="z">Torque setpoint around z in MAV_FRAME</field>
+    </message>
+    <message id="151" name="GET_TORQUE_SETPOINT">
+      <description>Get the (normalized) torque setpoint in body frame</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float" name="x">Torque setpoint around x in MAV_FRAME</field>
+      <field type="float" name="y">Torque setpoint around y in MAV_FRAME</field>
+      <field type="float" name="z">Torque setpoint around z in MAV_FRAME</field>
+    </message>
+    <message id="152" name="SET_THRUST_SETPOINT">
+      <description>Set the (normalized) thrust setpoint in body frame</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float" name="x">thrust setpoint around x in MAV_FRAME</field>
+      <field type="float" name="y">thrust setpoint around y in MAV_FRAME</field>
+      <field type="float" name="z">thrust setpoint around z in MAV_FRAME</field>
+    </message>
+    <message id="153" name="GET_THRUST_SETPOINT">
+      <description>Get the (normalized) thrust setpoint in body frame</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="frame" enum="MAV_FRAME">Coordinate frame used for following fields.</field>
+      <field type="float" name="x">thrust setpoint around x in MAV_FRAME</field>
+      <field type="float" name="y">thrust setpoint around y in MAV_FRAME</field>
+      <field type="float" name="z">thrust setpoint around z in MAV_FRAME</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
On PX4 we removed support for [SET_ACTUATOR_CONTROL_TARGET](https://mavlink.io/en/messages/common.html#SET_ACTUATOR_CONTROL_TARGET) and [ACTUATOR_CONTROL_TARGET](https://mavlink.io/en/messages/common.html#ACTUATOR_CONTROL_TARGET) in https://github.com/PX4/PX4-Autopilot/pull/20837. Reason is that we now have clean interfaces into the mixer (allocator), that doesn't go through the legacy "actuator_controls" anymore. 

In this PR I propose a way to bring back messages to set and get torque and thrust setpoints. Instead of the ambiguous previous way it's now messages with clear physical meanings.

What we still would need to align on:
- should we add option to specify if setpoints are absolute (in SI units) or normalized?
- Are SET_ACTUATOR_CONTROL_TARGET and ACTUATOR_CONTROL_TARGET used by Ardupilot or could we deprecate them?

I know that removing fields from existing messages is quite impossible, but theoretically these two messages could remove the thrust fields from https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET and https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET. Attitude and thrust should really be decoupled. 