### PR TITLE
common.xml: remove validity requirement for COMMAND_INT_ONLY

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2774,10 +2774,10 @@
         <description>Command has been cancelled (as a result of receiving a COMMAND_CANCEL message).</description>
       </entry>
       <entry value="7" name="MAV_RESULT_COMMAND_LONG_ONLY">
-        <description>Command is valid, but it is only accepted when sent as a COMMAND_LONG (as it has float values for params 5 and 6).</description>
+        <description>Command is only accepted when sent as a COMMAND_LONG.</description>
       </entry>
       <entry value="8" name="MAV_RESULT_COMMAND_INT_ONLY">
-        <description>Command is valid, but it is only accepted when sent as a COMMAND_INT (as it encodes a location in params 5, 6 and 7, and hence requires a reference MAV_FRAME).</description>
+        <description>Command is only accepted when sent as a COMMAND_INT.</description>
       </entry>
       <entry value="9" name="MAV_RESULT_COMMAND_UNSUPPORTED_MAV_FRAME">
         <description>Command is invalid because a frame is required and the specified frame is not supported.</description>


### PR DESCRIPTION
... and COMMAND_LONG_ONLY

It doesn't really matter why the command is being rejected, just that it is.

Adding constraints about why an autopilot might send the message reduces the usefulness of this.

I hit this problem when writing https://github.com/ArduPilot/ardupilot/pull/25643 .  In this case the new define in ArduPilot simply removes `COMMAND_LONG` support, so if you set the new define to true in ArduPilot *all* commands will be rejected with "INT_ONLY".  We do not want to check the validity of the commands in this case, just say, "INT_ONLY".

@nexton-winjeel 