### PR TITLE
Update MAV_TYPE_VTOL_TAILSITTER description to refer to existing types

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -140,7 +140,7 @@
         <description>VTOL with separate fixed rotors for hover and cruise flight. Fuselage and wings stay (nominally) horizontal in all flight phases.</description>
       </entry>
       <entry value="23" name="MAV_TYPE_VTOL_TAILSITTER">
-        <description>Tailsitter VTOL. Fuselage and wings orientation changes depending on flight phase: vertical for hover, horizontal for cruise. Use more specific VTOL MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR if appropriate.</description>
+        <description>Tailsitter VTOL. Fuselage and wings orientation changes depending on flight phase: vertical for hover, horizontal for cruise. Use more specific VTOL MAV_TYPE_VTOL_TAILSITTER_DUOROTOR or MAV_TYPE_VTOL_TAILSITTER_QUADROTOR if appropriate.</description>
       </entry>
       <entry value="24" name="MAV_TYPE_VTOL_TILTWING">
         <description>Tiltwing VTOL. Fuselage stays horizontal in all flight phases. The whole wing, along with any attached engine, can tilt between vertical and horizontal mode.</description>


### PR DESCRIPTION
MAV_TYPE_VTOL_TAILSITTER was referring to old names MAV_TYPE_VTOL_DUOROTOR or MAV_TYPE_VTOL_QUADROTOR for MAV_TYPE_VTOL_TAILSITTER_DUOROTOR or MAV_TYPE_VTOL_TAILSITTER_QUADROTOR.

This falls out of discussion in https://github.com/ArduPilot/pymavlink/pull/889#issuecomment-1870058548

FYI only @peterbarker 
