### PR TITLE
common.xml: Add "Stream ID" param to MAV_CMD_IMAGE_START_CAPTURE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2135,7 +2135,7 @@
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
         <param index="3" label="Total Images" minValue="0" increment="1">Total number of images to capture. 0 to capture forever/until MAV_CMD_IMAGE_STOP_CAPTURE.</param>
         <param index="4" label="Sequence Number" minValue="1" increment="1">Capture sequence number starting from 1. This is only valid for single-capture (param3 == 1), otherwise set to 0. Increment the capture ID for each capture command to prevent double captures when a command is re-transmitted.</param>
-        <param index="5" reserved="true"/>
+        <param index="5" label="Stream ID" minValue="0" increment="1">Video Stream to capture (0 for current active stream)</param>
         <param index="6" reserved="true"/>
         <param index="7" reserved="true" default="NaN"/>
       </entry>


### PR DESCRIPTION
As noted in [this comment](https://github.com/mavlink/mavlink/pull/2079#issuecomment-1955724877):

> With the current camera protocol, there is no way to specify which stream to take a snapshot from without also enabling output from that stream.

This change will allow a camera to take a snapshot from one stream while another stream is being output.