### PR TITLE
MAV_CMD_ODID_SET_EMERGENCY - 

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2417,6 +2417,7 @@
         <param index="6">Reserved (set to 0)</param>
         <param index="7">Reserved (set to 0)</param>
       </entry>
+      <!-- Entry 12900 reserved for MAV_CMD_ODID_SET_EMERGENCY in development.xml -->    
       <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
       <!-- BEGIN of payload range (30000 to 30999) -->
       <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY" hasLocation="true" isDestination="true">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2417,7 +2417,7 @@
         <param index="6">Reserved (set to 0)</param>
         <param index="7">Reserved (set to 0)</param>
       </entry>
-      <!-- Entry 12900 reserved for MAV_CMD_ODID_SET_EMERGENCY in development.xml -->    
+      <!-- Entry 12900 reserved for MAV_CMD_ODID_SET_EMERGENCY in development.xml -->
       <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
       <!-- BEGIN of payload range (30000 to 30999) -->
       <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY" hasLocation="true" isDestination="true">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -365,7 +365,6 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      
     </enum>
     <enum name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS" bitmask="true">
       <description>These flags indicate the sensor reporting capabilities for TARGET_ABSOLUTE.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -357,8 +357,8 @@
           See https://mavlink.io/en/services/opendroneid.html for more information.
 	</description>
         <param index="1" label="Number" minValue="0" increment="1">Set/unset emergency 0: unset, 1: set</param>
-        <param index="2" reserved="true" default="NaN" />
-        <param index="3" reserved="true" default="NaN" />
+        <param index="2" reserved="true" default="NaN"/>
+        <param index="3" reserved="true" default="NaN"/>
         <param index="4">Empty</param>
         <param index="5">Empty</param>
         <param index="5">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -350,6 +350,22 @@
         <param index="6" reserved="true"/>
         <param index="7" reserved="true"/>
       </entry>
+      <entry value="12900" name="MAV_CMD_ODID_SET_EMERGENCY" hasLocation="false" isDestination="false">
+        <description>Used to manually set/unset emergency status for remote id.
+          This is for compliance with MOC ASTM docs, specifically F358 section 7.7: "Emergency Status Indicator".
+          The requirement can also be satisfied by automatic setting of the emergency status by flight stack, and that approach is preferred.
+          See https://mavlink.io/en/services/opendroneid.html for more information.
+	</description>
+        <param index="1" label="Number" minValue="0" increment="1">Set/unset emergency 0: unset, 1: set</param>
+        <param index="2" reserved="true" default="NaN" />
+        <param index="3" reserved="true" default="NaN" />
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      
     </enum>
     <enum name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS" bitmask="true">
       <description>These flags indicate the sensor reporting capabilities for TARGET_ABSOLUTE.</description>


### PR DESCRIPTION
This replaces https://github.com/mavlink/mavlink/pull/2027 - moves to develpment.xml and adds some context.

NOte that this is approved in #2086