### PR TITLE
DO_FENCE_ENABLE when sent as a command

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1707,7 +1707,8 @@
           Enable the geofence.
           This can be used in a mission or via the command protocol.
           The persistence/lifetime of the setting is undefined.
-          Depending on flight stack implementation it may persist until superseded (even across reboots), or it may revert to a system default at the end of a mission or on reboot.
+          Depending on flight stack implementation it may persist until superseded, or it may revert to a system default at the end of a mission.
+          Flight stacks typically reset the setting to system defaults on reboot.
 	</description>
         <param index="1" label="Enable" minValue="0" maxValue="2" increment="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
         <param index="2" label="Types" enum="FENCE_TYPE">Fence types to enable or disable as a bitmask. A value of 0 indicates that all fences should be enabled or disabled. This parameter is ignored if param 1 has the value 2</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1703,7 +1703,13 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="207" name="MAV_CMD_DO_FENCE_ENABLE" hasLocation="false" isDestination="false">
-        <description>Mission command to enable the geofence</description>
+        <description>
+          Enable the geofence.
+          This can be used in a mission or via the command protocol.
+          The effects persist while the mission is being executed, until superseded by another mission item or the mission completes.
+          When used as a command (outside of mission) the value persists until superseded by another command, a mode change (which reverts system back to system defaults), or reboot.
+          When used as a command while a mission is running the value is treated as though it were a mission item, and will change the current mission value.
+	</description>      
         <param index="1" label="Enable" minValue="0" maxValue="2" increment="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
         <param index="2" label="Types" enum="FENCE_TYPE">Fence types to enable or disable as a bitmask. A value of 0 indicates that all fences should be enabled or disabled. This parameter is ignored if param 1 has the value 2</param>
         <param index="3">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1708,7 +1708,7 @@
           This can be used in a mission or via the command protocol.
           The effects persist while the mission is being executed, until superseded by another mission item or the mission completes.
           When used as a command (outside of mission) the value persists until superseded by another command, a mode change (which reverts system back to system defaults), or reboot.
-          When used as a command while a mission is running the value is treated as though it were a mission item, and will change the current mission value.
+          When used as a command the fence will change to the set value (even while a mission is running).
 	</description>      
         <param index="1" label="Enable" minValue="0" maxValue="2" increment="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
         <param index="2" label="Types" enum="FENCE_TYPE">Fence types to enable or disable as a bitmask. A value of 0 indicates that all fences should be enabled or disabled. This parameter is ignored if param 1 has the value 2</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1706,10 +1706,9 @@
         <description>
           Enable the geofence.
           This can be used in a mission or via the command protocol.
-          The effects persist while the mission is being executed, until superseded by another mission item or the mission completes.
-          When used as a command (outside of mission) the value persists until superseded by another command, a mode change (which reverts system back to system defaults), or reboot.
-          When used as a command the fence will change to the set value (even while a mission is running).
-	</description>      
+          The persistence/lifetime of the setting is undefined.
+          Depending on flight stack implementation it may persist until superseded (even across reboots), or it may revert to a system default at the end of a mission or on reboot.
+	</description>
         <param index="1" label="Enable" minValue="0" maxValue="2" increment="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
         <param index="2" label="Types" enum="FENCE_TYPE">Fence types to enable or disable as a bitmask. A value of 0 indicates that all fences should be enabled or disabled. This parameter is ignored if param 1 has the value 2</param>
         <param index="3">Empty</param>


### PR DESCRIPTION
The MAV_CMD_DO_FENCE_ENABLE states that it is a mission item, but it can, and is sent as a command. This attempts to clarify the expected behaviour in this case. 

The points of interest being that:
- mission settings persist in the mission context, even on flight stacks that pause by switching mode to "Hold": on return to the mission the mission setting would be used.
- As a command the value only persists until mode change or reboot.
- A command can affect a mission

Originates from discussion with @andyp1per in https://github.com/ArduPilot/mavlink/pull/349#discussion_r1482155395

@sfuhrer @peterbarker Does this makes sense? Is it what is done? That's my assumption on what you'd want to happen but I haven't tested.