### PR TITLE
GIMBAL_DEVICE_FLAGS_YAW* replace the lock

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -553,6 +553,7 @@
         <description>Lock pitch angle to absolute angle relative to horizon (not relative to vehicle). This is generally the default with a stabilizing gimbal.</description>
       </entry>
       <entry value="16" name="GIMBAL_DEVICE_FLAGS_YAW_LOCK">
+        <deprecated since="2024-03" replaced_by="GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME">Devices should set either GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME or GIMBAL_DEVICE_FLAGS_YAW_IN_EARTH_FRAME instead. Recipients should still handle this flag if the new flags are not set.</deprecated>
         <description>Lock yaw angle to absolute angle relative to North (not relative to vehicle). If this flag is set, the yaw angle and z component of angular velocity are relative to North (earth frame, x-axis pointing North), else they are relative to the vehicle heading (vehicle frame, earth frame rotated so that the x-axis is pointing forward).</description>
       </entry>
       <entry value="32" name="GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME">


### PR DESCRIPTION
The `GIMBAL_DEVICE_FLAGS_YAW_LOCK` is retained for backwards compatibility. This is captured in https://github.com/mavlink/mavlink-devguide/pull/531 but perhaps here as well @Davidsastresas @julianoes ?