### PR TITLE
common: SIM_STATE specify attitude units as rad

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6020,9 +6020,9 @@
       <field type="float" name="q2">True attitude quaternion component 2, x (0 in null-rotation)</field>
       <field type="float" name="q3">True attitude quaternion component 3, y (0 in null-rotation)</field>
       <field type="float" name="q4">True attitude quaternion component 4, z (0 in null-rotation)</field>
-      <field type="float" name="roll">Attitude roll expressed as Euler angles, not recommended except for human-readable outputs</field>
-      <field type="float" name="pitch">Attitude pitch expressed as Euler angles, not recommended except for human-readable outputs</field>
-      <field type="float" name="yaw">Attitude yaw expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="roll" units="rad">Attitude roll expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="pitch" units="rad">Attitude pitch expressed as Euler angles, not recommended except for human-readable outputs</field>
+      <field type="float" name="yaw" units="rad">Attitude yaw expressed as Euler angles, not recommended except for human-readable outputs</field>
       <field type="float" name="xacc" units="m/s/s">X acceleration</field>
       <field type="float" name="yacc" units="m/s/s">Y acceleration</field>
       <field type="float" name="zacc" units="m/s/s">Z acceleration</field>


### PR DESCRIPTION
The fields roll, pitch and yaw of [SIM_STATE message](https://mavlink.io/en/messages/common.html#SIM_STATE) do not specify their unit. Even if the recommended use is only for human-readable outputs, I believe it would be beneficial to have the unit specified.

Reasons for choosing radians:
- angular speeds of the same message are in rad/s
- consistency with ATTITUDE, MANUAL_SETPOINT, LOCAL_POSITION_NED_SYSTEM_GLOBAL_OFFSET, HIL_STATE, [GLOBAL_|VICON_]VISION_POSITION_ESTIMATE
- ArduPilot already sends them as rad (I don't have a PX4 setup ready to confirm)

 Other units used for roll and pitch angles in common dialect:
- MAV_CMD_DO_SET_HOME - doesn't refer to attitude, but terrain
- MAV_CMD_DO_MOUNT_CONTROL, MOUNT_ORIENTATION - refers to gimbal and is deprecated, new messages use rad
- HIGH_LATENCY - deprecated
- MAV_CMD_NAV_TAKEOFF - degrees, but MAV_CMD_NAV_TAKEOFF_LOCAL uses rad
- Specifically yaw is often set in degrees in navigation context