### PR TITLE
[WIP] common.xml: add new frame MAV_FRAME_GLOBAL_VEHICLERELATIVE_ALT

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -321,6 +321,9 @@
       <entry value="21" name="MAV_FRAME_LOCAL_FLU">
         <description>FLU local tangent frame (x: Forward, y: Left, z: Up) with origin fixed relative to earth. The forward axis is aligned to the front of the vehicle in the horizontal plane.</description>
       </entry>
+      <entry value="22" name="MAV_FRAME_GLOBAL_ALT_VEHICLE_RELATIVE">
+        <description>Global (WGS84) coordinate frame + altitude positive up relative to the vehicle's current altitude. This frame is useful for commands such as "take off 20m above current altitude".</description>
+      </entry>
     </enum>
     <enum name="MAVLINK_DATA_STREAM_TYPE">
       <entry value="0" name="MAVLINK_DATA_STREAM_IMG_JPEG">


### PR DESCRIPTION
this is expected to be used to tell a vehicle to take off to 20m above current altitude.

ArduPlane already actually does this for some commands, but uses an inappropriate altitude frame.

Should also be useful for "go up 20m".

ArduPilot's PR is here: https://github.com/ArduPilot/mavlink/pull/358

For discussion at this point only, please.  Need to make sure this is fit-for-purpose in the ArduPilot codebase :-)
