### PR TITLE
Fix ILLUMINATOR_ERROR_FLAGS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5098,7 +5098,7 @@
       <entry value="2" name="ILLUMINATOR_ERROR_FLAGS_OVER_TEMPERATURE_SHUTDOWN">
         <description>Illuminator over temperature shutdown error.</description>
       </entry>
-      <entry value="3" name="ILLUMINATOR_ERROR_FLAGS_THERMISTOR_FAILURE">
+      <entry value="4" name="ILLUMINATOR_ERROR_FLAGS_THERMISTOR_FAILURE">
         <description>Illuminator thermistor failure.</description>
       </entry>
     </enum>


### PR DESCRIPTION
`ILLUMINATOR_ERROR_FLAGS` is meant to be bit flags so `ILLUMINATOR_ERROR_FLAGS_THERMISTOR_FAILURE` value should be 4 (bit 2) instead of 3