### PR TITLE
common: extend EFI_STATUS with a 'fuel_remaining' field

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6603,6 +6603,7 @@
       <extensions/>
       <field type="float" name="ignition_voltage" units="V">Supply voltage to EFI sparking system.  Zero in this value means "unknown", so if the supply voltage really is zero volts use 0.0001 instead.</field>
       <field type="float" name="fuel_pressure" units="kPa">Fuel pressure. Zero in this value means "unknown", so if the fuel pressure really is zero kPa use 0.0001 instead.</field>
+      <field type="float" name="fuel_remaining" units="cm^3" invalid="0">The calculated amount of fuel remaining in the tank, determined by subtracting the fuel consumed from the initial full tank value. A value of zero indicates an "unknown" quantity; use -1 to represent empty.</field>
     </message>
     <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
     <message id="230" name="ESTIMATOR_STATUS">


### PR DESCRIPTION
Adding a field to the `EFI_STATUS` message so that one is able to monitor how much fuel remains in a fuel tank. This is as, if not more, important than the fuel consumed, although both values are interdependent. The value that represents the tank as being full should be present at the autopilot, either hard-coded, or, preferentially, through a parameter.