### PR TITLE
style: add EditorConfig and format some files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,40 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = tab
+tab_width = 4
+insert_final_newline = true
+
+[*.xml]
+tab_width = 2
+trim_trailing_whitespace = true
+
+[*.php]
+insert_final_newline = false
+
+[*.css]
+insert_final_newline = false
+
+[*.py]
+# Otherwise Python language server complains
+trim_trailing_whitespace = true
+
+[*.xsl]
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = true
+tab_width = 2
+
+[*.json]
+tab_width = 2
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+tab_width = 2
+
+[*.{c,cpp,cc,h,hpp}]
+indent_style = tab
+tab_width = 4
+trim_trailing_whitespace = true

--- a/component_metadata/parameter.schema.json
+++ b/component_metadata/parameter.schema.json
@@ -24,7 +24,7 @@
                         "description":  "Parameter Name.",
                         "type":         "string",
                         "pattern":      "^[\\.\\-a-zA-Z0-9_\\{\\}]{1,16}$",
-                        "comment":      "FOO{n}_BAR for name will match actual name of FOO1_BAR, FOO3_BAR and so forth." 
+                        "comment":      "FOO{n}_BAR for name will match actual name of FOO1_BAR, FOO3_BAR and so forth."
                     },
                     "type": {
                         "description":  "Parameter type.",
@@ -35,13 +35,13 @@
                         "description":  "Short user facing description/name for parameter. Used in UI instead of internal parameter name.",
                         "type":         "string",
                         "default":      "",
-                        "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'." 
+                        "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'."
                     },
                     "longDesc": {
                         "description":  "Long user facing documentation of how the parameters works.",
                         "type":         "string",
                         "default":      "",
-                        "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'." 
+                        "comment":      "{n} index tagging will be replaced by name index. Example: 'FOO3_BAR': 'Description for foo element {n}' will turn into 'Description for foo element 1'."
                     },
                     "units": {
                         "description":  "Units for parameter value.",

--- a/doc/README.md
+++ b/doc/README.md
@@ -13,4 +13,4 @@ Files:
 
 For more information, please visit: https://mavlink.io/en/
 
-(c) 2009-2010 Lorenz Meier / PIXHAWK Team 
+(c) 2009-2010 Lorenz Meier / PIXHAWK Team

--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -1,9 +1,9 @@
 #! /usr/bin/python
 
 """
-This script generates markdown files for all the MAVLink message definition XML at: 
+This script generates markdown files for all the MAVLink message definition XML at:
 https://github.com/mavlink/mavlink/tree/master/message_definitions/v1.0
-  
+
 The files can be imported into a gitbook to display the messages as HTML
 
 The script runs on both Python2 and Python 3. The following libraries must be imported: lxml, requests, bs4.
@@ -36,7 +36,7 @@ with open(xsl_file_name, 'r') as content_file:
     xsl_file = content_file.read()
 xslt = ET.fromstring(xsl_file)
 
-#initialise text for index file. 
+#initialise text for index file.
 index_text="""<!-- THIS FILE IS AUTO-GENERATED (DO NOT UPDATE GITBOOK): https://github.com/mavlink/mavlink/blob/master/doc/mavlink_gitbook.py -->
 # XML Definition Files & Dialects
 
@@ -59,7 +59,7 @@ The following XML definition files are considered standard/core (i.e. not dialec
 
 > **Note** We are still working towards moving the truly standard entities from **common.xml** to **standard.xml**
   Currently you should include [common.xml](../messages/common.md)
-  
+
  In addition:
  - [development.xml](development.md) - XML definitions that are _proposed_ for inclusion in the standard definitions.
    These are work in progress.
@@ -89,7 +89,7 @@ index_text_trailer="""
 """
 
 #Fix up the BeautifulSoup output so to fix build-link errors in the generated gitbook.
-## BS puts each tag/content in its own line. Gitbook generates anchors using the spaces/newlines. 
+## BS puts each tag/content in its own line. Gitbook generates anchors using the spaces/newlines.
 ## This puts displayed text content immediately within tags so that anchors/links generate properly
 def fix_content_in_tags(input_html):
     #print("fix_content_in_tags was called")
@@ -99,7 +99,7 @@ def fix_content_in_tags(input_html):
 
     input_html=re.sub(r'\>(\s+?\w+?.*?)\<', remove_space_between_content_tags, input_html,flags=re.DOTALL)
     return input_html
-    
+
 def fix_external_dialect_link(input_html):
     #print("fix_external_dialect_link was called")
     def fixupexternaldialecturls(matchobj):
@@ -123,9 +123,9 @@ def strip_text_before_string(original_text,strip_text):
     index=original_text.find(strip_text)
     stripped_string=original_text
     if index !=-1 :
-        stripped_string = stripped_string[index:] 
+        stripped_string = stripped_string[index:]
     return stripped_string
-    
+
 def fix_add_implicit_links_items(input_html):
     # Makes screaming snake case into anchors. Special fix for MAV_CMD.
     #print("fix_add_implicit_link was called")
@@ -141,8 +141,8 @@ def fix_add_implicit_links_items(input_html):
 
     input_html=re.sub(r'([\`\(\s,]|^)([A-Z]{2,}(?:_[A-Z0-9]+)+)([\`\)\s\.,:]|$)', make_text_to_link, input_html,flags=re.DOTALL)
     return input_html
-    
-    
+
+
 def inject_top_level_docs(input_html,filename):
     #Inject top level heading and other details.
     print('FILENAME (prefix): %s' % filename)
@@ -204,7 +204,7 @@ This ensure that:
 
 > **Warning** New dialect files in the official repository must be added to **all.xml** and restrict themselves to using ids in their own allocated range.
   A few older dialects are not included because these operate in completely closed networks or because they are only used for tests.
-  
+
 This topic is a human-readable form of the XML definition file: [all.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/all.xml).
 """
     else:
@@ -238,12 +238,12 @@ These are listed below.
 
 {% include "_html/minimal.html" %}"""
 
-    
+
     #print(input_html)
     return input_html
-    
+
 dialect_files = set()
-all_files = set()    
+all_files = set()
 
 for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
     #Generate html for all the XML files
@@ -265,7 +265,7 @@ for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
             #Strip out text before <html> tag in XSLT output
             prettyHTML=strip_text_before_string(prettyHTML,'<html>')
             prettyHTML = fix_content_in_tags(prettyHTML)
-            
+
             #Replace invalid file extensions (workaround for xslt)
             prettyHTML = fix_include_file_extension(prettyHTML)
 
@@ -274,11 +274,11 @@ for subdir, dirs, files in os.walk(xml_message_definitions_dir_name):
 
             #Fix up links to external dialects to not be links
             prettyHTML = fix_external_dialect_link(prettyHTML)
-            
+
             #Fix up plain text mav symbols to be internal links
-            prettyHTML = fix_add_implicit_links_items(prettyHTML)     
-            
-            
+            prettyHTML = fix_add_implicit_links_items(prettyHTML)
+
+
             #Write output html file
             output_file_name_html = file.rsplit('.',1)[0]+".html"
 
@@ -309,12 +309,12 @@ for file_prefix in all_files:
     with open(output_file_name_md_withdir, 'w') as out:
         out.write(markdown_text)
 
-            
+
 for the_file in sorted(dialect_files):
     index_text+='\n* [%s.xml](%s.md)' % (the_file,the_file)
 index_text+='\n\n'
 index_text+=index_text_trailer
-            
+
 #Write the index
 with open(index_file_name, 'w') as content_file:
     content_file.write(index_text)

--- a/doc/mavlink_to_html_table.xsl
+++ b/doc/mavlink_to_html_table.xsl
@@ -59,7 +59,7 @@
    <p>
    The <a href="https://mavlink.io/en/messages/common.html">Official MAVLink message documentation</a> contains additional information, including field units and enum values.
    </p>
-   
+
    <h2>MAVLink Protocol Version</h2>
    <p>The current MAVLink version is 2.<xsl:value-of select="." />. The minor version numbers (after the dot) range from 1-255. </p>
 </xsl:template>

--- a/doc/mavlink_to_html_table_gitbook.xsl
+++ b/doc/mavlink_to_html_table_gitbook.xsl
@@ -47,7 +47,7 @@
      <xsl:if test='*/@units'>
       <th>Units</th>
      </xsl:if>
-     
+
      <xsl:if test='*/@enum'>
       <th>Values</th>
      </xsl:if>
@@ -56,7 +56,7 @@
    </tr>
    </thead>
    <tbody>
-   <xsl:apply-templates select="field" /> 
+   <xsl:apply-templates select="field" />
   </tbody>
   </table>
 </xsl:template>
@@ -72,20 +72,20 @@
        <td><xsl:value-of select="@name" /></td> <!-- mavlink_name -->
      </xsl:otherwise>
    </xsl:choose>
-  
+
    <td><xsl:value-of select="@type" /></td> <!-- mavlink_type -->
-   
+
    <xsl:if test='../*/@units'>
      <td><xsl:value-of select="@units" /></td> <!-- mavlink_units -->
    </xsl:if>
-   
+
    <xsl:if test='../*/@enum'>
    <td><xsl:if test='@enum'>
       <a><xsl:attribute name="href">#<xsl:value-of select="@enum" /></xsl:attribute><xsl:value-of select="@enum" /></a>
       </xsl:if>
    </td> <!-- mavlink_value -->
    </xsl:if>
-     
+
    <td><xsl:value-of select="." /></td> <!-- mavlink_comment -->
    </tr>
 </xsl:template>
@@ -104,7 +104,7 @@
    <h3> <!-- mavlink_enum_name -->
      <xsl:attribute name="id"><xsl:value-of select="@name"/></xsl:attribute>
      <xsl:value-of select="@name" /></h3>
-   <xsl:apply-templates select="deprecated" />  
+   <xsl:apply-templates select="deprecated" />
    <p><a href="#enums">[Enum]</a><xsl:value-of select="description" /></p> <!-- description -->
    <table class="sortable">
    <thead>
@@ -154,7 +154,7 @@
    </tr>
    </thead>
    <tbody>
-    <xsl:apply-templates select="param" mode="params" /> 
+    <xsl:apply-templates select="param" mode="params" />
    </tbody>
   </table>
 
@@ -165,7 +165,7 @@
    <tr id="{@name}"> <!-- mavlink_field -->
    <td><xsl:value-of select="@value" /></td>  <!-- mavlink_type -->
    <td>
-      <a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute><xsl:value-of select="@name" /></a> 
+      <a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute><xsl:value-of select="@name" /></a>
       <xsl:apply-templates select="deprecated" />
       <xsl:apply-templates select="wip" />
    </td> <!-- mavlink_name -->
@@ -188,7 +188,7 @@
 
 <xsl:template match="//param" mode="params">
     <tr>
-        <td><xsl:value-of select="@index" /> 
+        <td><xsl:value-of select="@index" />
         <xsl:if test='@label'>: <xsl:value-of select="@label" /></xsl:if>
         </td> <!-- mission_param -->
 
@@ -214,11 +214,11 @@
       </xsl:choose>
   </td>
    </xsl:if>
-      
+
    <xsl:if test='../*/@units'>
      <td><xsl:value-of select="@units" /></td> <!-- mavlink_units -->
    </xsl:if>
-       
+
    </tr>
 </xsl:template>
 

--- a/examples/c/udp_example.c
+++ b/examples/c/udp_example.c
@@ -85,7 +85,7 @@ void receive_some(int socket_fd, struct sockaddr_in* src_addr, socklen_t* src_ad
     } else if (ret == 0) {
         // peer has done an orderly shutdown
         return;
-    } 
+    }
 
     *src_addr_set = true;
 

--- a/mavgenerate.py
+++ b/mavgenerate.py
@@ -21,7 +21,7 @@ Released under GNU GPL version 3 or later
 
 """
 import os
-import re   
+import re
 import sys
 
 # Python 2.x and 3.x compatibility
@@ -39,7 +39,7 @@ else:
     del tkFileDialog
     tkinter.messagebox = tkMessageBox
     del tkMessageBox
-    
+
 
 from pymavlink.generator import mavgen
 from pymavlink.generator import mavparse

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -13,7 +13,7 @@
   <!-- common.xml range of IDs:
     messages: 300 - 10000
     commands: 0 - 39999
-    Note: entities imported from other dialects may fall outside these ranges.    
+    Note: entities imported from other dialects may fall outside these ranges.
   -->
   <include>common.xml</include>
   <include>development.xml</include>
@@ -42,7 +42,7 @@
   -->
   <include>storm32.xml</include>
   <!-- AVSSUAS.xml range of IDs:
-    messages: 60050 - 60099 
+    messages: 60050 - 60099
     commands: 60050 - 60099
   -->
   <include>AVSSUAS.xml</include>

--- a/message_definitions/v1.0/matrixpilot.xml
+++ b/message_definitions/v1.0/matrixpilot.xml
@@ -3,7 +3,7 @@
   <include>common.xml</include>
   <!-- note that UDB specific messages should use the command id
       range from 150 to 250, to leave plenty of room for growth
-      of common.xml 
+      of common.xml
 
       If you prototype a message here, then you should consider if it
       is general enough to move into common.xml later


### PR DESCRIPTION
Add an EditorConfig to make sure editors know how to correctly edit and save files. Also strip trailing whitespace in some files that don't need it, as configured in the EditorConfig file.