### PR TITLE
FUEL_STATUS message proposal

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -420,6 +420,9 @@
       <entry value="2" name="MAV_FUEL_TYPE_LIQUID">
         <description>A generic liquid fuel. Fuel levels are in millilitres (ml). Fuel rates are in millilitres/second.</description>
       </entry>
+      <entry value="3" name="MAV_FUEL_TYPE_GAS">
+        <description>A gas tank. Fuel levels are in kilo-Pascal (kPa), and flow rates are in milliliters per second (ml/s).</description>
+      </entry>
     </enum>
   </enums>
   <messages>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -523,7 +523,7 @@
       <field type="float" name="remaining_fuel" invalid="NaN">Remaining fuel until empty (measured). The value should not be inferred: if not measured set to NaN. NaN: field not provided.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Percentage of remaining fuel, relative to full. Values: [0-100], UINT8_MAX: field not provided.</field>
       <field type="float" name="flow_rate" invalid="NaN">Positive value when emptying/using, and negative if filling/replacing. NaN: field not provided.</field>
-      <field type="uint32_t" enum="MAV_FUEL_TYPE">Fuel type. Defines units for fuel capacity and consumption fields above.</field>
+      <field type="uint32_t" name="fuel_type" enum="MAV_FUEL_TYPE">Fuel type. Defines units for fuel capacity and consumption fields above.</field>
     </message>
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -502,7 +502,7 @@
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.</field>
       <field type="uint32_t" name="status_flags" display="bitmask" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
-    <message id="369" name="FUEL_STATUS">
+    <message id="371" name="FUEL_STATUS">
       <description>Fuel status.
         This message provides "generic" fuel level information for display in a GCS and for triggering failsafes in an autopilot.
 	The fuel type and associated units for fields in this message are defined in the enum MAV_FUEL_TYPE.

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -523,6 +523,7 @@
       <field type="float" name="remaining_fuel" invalid="NaN">Remaining fuel until empty (measured). The value should not be inferred: if not measured set to NaN. NaN: field not provided.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Percentage of remaining fuel, relative to full. Values: [0-100], UINT8_MAX: field not provided.</field>
       <field type="float" name="flow_rate" invalid="NaN">Positive value when emptying/using, and negative if filling/replacing. NaN: field not provided.</field>
+      <field type="float" name="temperature" units="K" invalid="NaN">Fuel temperature. NaN: field not provided.</field>
       <field type="uint32_t" name="fuel_type" enum="MAV_FUEL_TYPE">Fuel type. Defines units for fuel capacity and consumption fields above.</field>
     </message>
     <message id="414" name="GROUP_START">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -414,13 +414,10 @@
       <entry value="0" name="MAV_FUEL_TYPE_UNKNOWN">
         <description>Not specified. Fuel levels are normalized (i.e. maximum is 1, and other levels are relative to 1.</description>
       </entry>
-      <entry value="1" name="MAV_FUEL_TYPE_BATTERY">
-        <description>A battery. Fuel levels are in Ampere-hours (Ah), and flow rates are in Amps (A)</description>
-      </entry>
-      <entry value="2" name="MAV_FUEL_TYPE_LIQUID">
+      <entry value="1" name="MAV_FUEL_TYPE_LIQUID">
         <description>A generic liquid fuel. Fuel levels are in millilitres (ml). Fuel rates are in millilitres/second.</description>
       </entry>
-      <entry value="3" name="MAV_FUEL_TYPE_GAS">
+      <entry value="2" name="MAV_FUEL_TYPE_GAS">
         <description>A gas tank. Fuel levels are in kilo-Pascal (kPa), and flow rates are in milliliters per second (ml/s).</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -409,6 +409,18 @@
         <description>Channel data may be out of date. This is set when the receiver is unable to validate incoming data from the transmitter and has therefore resent the last valid data it received.</description>
       </entry>
     </enum>
+    <enum name="MAV_FUEL_TYPE">
+      <description>Fuel types for use in FUEL_TYPE. Fuel types specify the units for the maximum, available and consumed fuel, and for the flow rates.</description>
+      <entry value="0" name="MAV_FUEL_TYPE_UNKNOWN">
+        <description>Not specified. Fuel levels are normalized (i.e. maximum is 1, and other levels are relative to 1.</description>
+      </entry>
+      <entry value="1" name="MAV_FUEL_TYPE_BATTERY">
+        <description>A battery. Fuel levels are in Ampere-hours (Ah), and flow rates are in Amps (A)</description>
+      </entry>
+      <entry value="2" name="MAV_FUEL_TYPE_LIQUID">
+        <description>A generic liquid fuel. Fuel levels are in millilitres (ml). Fuel rates are in millilitres/second.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -489,6 +501,29 @@
       <field type="float" name="capacity_remaining" units="Ah" invalid="NaN">Remaining charge (until empty). NaN: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.</field>
       <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.</field>
       <field type="uint32_t" name="status_flags" display="bitmask" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
+    </message>
+    <message id="369" name="FUEL_STATUS">
+      <description>Fuel status.
+        This message provides "generic" fuel level information for display in a GCS and for triggering failsafes in an autopilot.
+	The fuel type and associated units for fields in this message are defined in the enum MAV_FUEL_TYPE.
+
+	The reported `consumed_fuel` and `remaining_fuel` must only be supplied if measured: they must not be inferred from the `maximum_fuel` and the other value.
+        A recipient can assume that if these fields are supplied they are accurate.
+        If not provided, the recipient can infer `remaining_fuel` from `maximum_fuel` and `consumed_fuel` on the assumption that the fuel was initially at its maximum (this is what battery monitors assume).
+	Note however that this is an assumption, and the UI should prompt the user appropriately (i.e. notify user that they should fill the tank before boot).
+
+	This kind of information may also be sent in fuel-specific messages such as BATTERY_STATUS_V2.
+	If both messages are sent for the same fuel system, the ids and corresponding information must match.
+
+	This should be streamed (nominally at 0.1 Hz).
+      </description>
+      <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as BATTERY_STATUS_V2.</field>
+      <field type="float" name="maximum_fuel">Capacity when full. Must be provided.</field>
+      <field type="float" name="consumed_fuel" invalid="NaN">Consumed fuel (measured). This value should not be inferred: if not measured set to NaN. NaN: field not provided.</field>
+      <field type="float" name="remaining_fuel" invalid="NaN">Remaining fuel until empty (measured). The value should not be inferred: if not measured set to NaN. NaN: field not provided.</field>
+      <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Percentage of remaining fuel, relative to full. Values: [0-100], UINT8_MAX: field not provided.</field>
+      <field type="float" name="flow_rate" invalid="NaN">Positive value when emptying/using, and negative if filling/replacing. NaN: field not provided.</field>
+      <field type="uint32_t" enum="MAV_FUEL_TYPE">Fuel type. Defines units for fuel capacity and consumption fields above.</field>
     </message>
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>


### PR DESCRIPTION
This is a proposal for a message to report fuel levels in a generic way that can be displayed by a GCS, and used for autopilot fuel-level failsafes. Note that ArduPilot simply uses the battery messages fields for this, with the consequence that the values displayed are inaccurate. This message can be used for all sorts of fuels.

The design is similar to the battery messages but has some differences. 

1.  Consumed/remaining levels are _measured_ values or NaN.

    Battery messages are designed around power monitors that can only measure consumed charge, and that hence report consumed charge and make an assumption that the battery is full for estimating/providing remaining charge. A smart battery tracks the amounts effectively, so they have a flag there to indicate when the values can be trusted.

   By contrast a fuel system might measure consumed fuel, or remaining fuel, or both. Rather than make assumptions, the fuel message reports what is measured and allows the consumer to make appropriate assumptions and provide feedback to the user.
 
2. Fuel types have different units - an enum provides the units that should be displayed by the GCS.

   The current enum suggests normalized units for "unknown" - but maybe this should be an invalid value or a default value for a liquid? Or perhaps suggest that flow isn't supplied in this case?

   Other enums are for battery (matching battery_status_v2 values) and liquid (in ml, and ml/s).

   What other types do we need? Gas? What units?

3. This doesn't include temperature. I'm open to the idea of extra fields as long as they are "broadly useful". Someone would have to decide what that use is, and commit to implementing.
4. This has no flags for status. I like the simplicity. Arguably we might have some basic flags like fatal fault, warning fault or whatever to allow an autopilot to react to fault behaviours without knowing what they are.

Comments welcome.   
   
   