### PR TITLE
gps: add status and integrity information

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7775,7 +7775,7 @@
     </message>
     <message id="441" name="GNSS_INTEGRITY">
       <description>Information about key components of GNSS receivers, like signal authentication, interference and system errors.</description>
-      <field type="uint8_t" name="instance">Identifier for the GNSS receiver</field>
+      <field type="uint8_t" name="id" instance="true">GNSS receiver id. Must match instance ids of other messages from same receiver.</field>
       <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system</field>
       <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
       <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5081,9 +5081,6 @@
     </enum>
     <enum name="GPS_SYSTEM_ERROR_FLAGS" bitmask="true">
       <description>Flags indicating errors in a GPS receiver.</description>
-      <entry value="0" name="GPS_SYSTEM_ERROR_NONE">
-        <description>There are no errors in the GPS receiver.</description>
-      </entry>
       <entry value="1" name="GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS">
         <description>There are problems with incoming correction streams.</description>
       </entry>
@@ -5144,11 +5141,14 @@
       <entry value="1" name="GPS_SPOOFING_STATE_OK">
         <description>The GPS receiver detected no signal spoofing.</description>
       </entry>
-      <entry value="2" name="GPS_SPOOFING_STATE_DETECTED">
-        <description>The GPS receiver detected signal spoofing.</description>
-      </entry>
-      <entry value="3" name="GPS_SPOOFING_STATE_MITIGATED">
+      <entry value="2" name="GPS_SPOOFING_STATE_MITIGATED">
         <description>The GPS receiver detected and mitigated signal spoofing.</description>
+      </entry>
+      <entry value="3" name="GPS_SPOOFING_STATE_DETECTED">
+        <description>The GPS receiver detected signal spoofing but still has a fix.</description>
+      </entry>
+      <entry value="4" name="GPS_SPOOFING_STATE_CRITICAL">
+        <description>The GPS receiver detected signal spoofing and can't provide a fix.</description>
       </entry>
     </enum>
     <enum name="ILLUMINATOR_MODE">
@@ -5302,10 +5302,6 @@
       <field type="uint32_t" name="vel_acc" units="mm">Speed uncertainty.</field>
       <field type="uint32_t" name="hdg_acc" units="degE5">Heading / track uncertainty</field>
       <field type="uint16_t" name="yaw" units="cdeg" invalid="0">Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use UINT16_MAX if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.</field>
-      <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system</field>
-      <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
-      <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
-      <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
     </message>
     <message id="25" name="GPS_STATUS">
       <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION_INT for the global position estimate. This message can contain information for up to 20 satellites.</description>
@@ -7761,6 +7757,14 @@
       <field type="float" name="temp_c">Temperature in Celsius</field>
       <field type="float" name="min_strobe_period" units="s">Minimum strobing period in seconds</field>
       <field type="float" name="max_strobe_period" units="s">Maximum strobing period in seconds</field>
+    </message>
+    <message id="441" name="GNSS_INTEGRITY">
+      <description>Information about key components of GNSS receivers, like signal authentication, interference and system errors.</description>
+      <field type="uint8_t" name="instance">Identifier for the GNSS receiver</field>
+      <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system</field>
+      <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
+      <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
+      <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
     </message>
     <!-- The message ids 510 and 511 are reserved for ABSOLUTE_TARGET and RELATIVE_TARGET, currently in development.xml. -->
     <message id="387" name="CANFD_FRAME">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5151,6 +5151,21 @@
         <description>The GPS receiver detected signal spoofing and can't provide a fix.</description>
       </entry>
     </enum>
+    <enum name="GPS_RAIM_STATE">
+      <description>State of RAIM processing.</description>
+      <entry value="0" name="GPS_RAIM_STATE_UNKNOWN">
+        <description>RAIM capability is unknown.</description>
+      </entry>
+      <entry value="1" name="GPS_RAIM_STATE_DISABLED">
+        <description>RAIM is disabled.</description>
+      </entry>
+      <entry value="2" name="GPS_RAIM_STATE_OK">
+        <description>RAIM integrity check was successful.</description>
+      </entry>
+      <entry value="3" name="GPS_RAIM_STATE_FAILED">
+        <description>RAIM integrity check failed.</description>
+      </entry>
+    </enum>
     <enum name="ILLUMINATOR_MODE">
       <description>Modes of illuminator</description>
       <entry value="0" name="ILLUMINATOR_MODE_UNKNOWN">
@@ -7765,6 +7780,9 @@
       <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
       <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
       <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
+      <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
+      <field type="uint16_t" name="raim_hfom">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
+      <field type="uint16_t" name="raim_vfom">Vertical expected accuracy using satellites successfully validated using RAIM</field>
     </message>
     <!-- The message ids 510 and 511 are reserved for ABSOLUTE_TARGET and RELATIVE_TARGET, currently in development.xml. -->
     <message id="387" name="CANFD_FRAME">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5079,6 +5079,78 @@
         <description>Safety switch is NOT engaged and motors, propellers and other actuators should be considered active.</description>
       </entry>
     </enum>
+    <enum name="GPS_SYSTEM_ERROR_FLAGS" bitmask="true">
+      <description>Flags indicating errors in a GPS receiver.</description>
+      <entry value="0" name="GPS_SYSTEM_ERROR_NONE">
+        <description>There are no errors in the GPS receiver.</description>
+      </entry>
+      <entry value="1" name="GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS">
+        <description>There are problems with incoming correction streams.</description>
+      </entry>
+      <entry value="2" name="GPS_SYSTEM_ERROR_CONFIGURATION">
+        <description>There are problems with the configuration.</description>
+      </entry>
+      <entry value="4" name="GPS_SYSTEM_ERROR_SOFTWARE">
+        <description>There are problems with the software on the GPS receiver.</description>
+      </entry>
+      <entry value="8" name="GPS_SYSTEM_ERROR_ANTENNA">
+        <description>There are problems with an antenna connected to the GPS receiver.</description>
+      </entry>
+      <entry value="16" name="GPS_SYSTEM_ERROR_EVENT_CONGESTION">
+        <description>There are problems handling all incoming events.</description>
+      </entry>
+      <entry value="32" name="GPS_SYSTEM_ERROR_CPU_OVERLOAD">
+        <description>The GPS receiver CPU is overloaded.</description>
+      </entry>
+      <entry value="64" name="GPS_SYSTEM_ERROR_OUTPUT_CONGESTION">
+        <description>The GPS receiver is experiencing output congestion.</description>
+      </entry>
+    </enum>
+    <enum name="GPS_AUTHENTICATION_STATE">
+      <description>Signal authentication state in a GPS receiver.</description>
+      <entry value="0" name="GPS_AUTHENTICATION_STATE_UNKNOWN">
+        <description>The GPS receiver does not provide GPS signal authentication info.</description>
+      </entry>
+      <entry value="1" name="GPS_AUTHENTICATION_STATE_INITIALIZING">
+        <description>The GPS receiver is initializing signal authentication.</description>
+      </entry>
+      <entry value="2" name="GPS_AUTHENTICATION_STATE_ERROR">
+        <description>The GPS receiver encountered an error while initializing signal authentication.</description>
+      </entry>
+      <entry value="3" name="GPS_AUTHENTICATION_STATE_OK">
+        <description>The GPS receiver has correctly authenticated all signals.</description>
+      </entry>
+      <entry value="4" name="GPS_AUTHENTICATION_STATE_DISABLED">
+        <description>GPS signal authentication is disabled on the receiver.</description>
+      </entry>
+    </enum>
+    <enum name="GPS_JAMMING_STATE">
+      <description>Signal jamming state in a GPS receiver.</description>
+      <entry value="0" name="GPS_JAMMING_STATE_UNKNOWN">
+        <description>The GPS receiver does not provide GPS signal jamming info.</description>
+      </entry>
+      <entry value="1" name="GPS_JAMMING_STATE_OK">
+        <description>The GPS receiver detected no signal jamming.</description>
+      </entry>
+      <entry value="2" name="GPS_JAMMING_STATE_DETECTED">
+        <description>The GPS receiver detected signal jamming.</description>
+      </entry>
+    </enum>
+    <enum name="GPS_SPOOFING_STATE">
+      <description>Signal spoofing state in a GPS receiver.</description>
+      <entry value="0" name="GPS_SPOOFING_STATE_UNKNOWN">
+        <description>The GPS receiver does not provide GPS signal spoofing info.</description>
+      </entry>
+      <entry value="1" name="GPS_SPOOFING_STATE_OK">
+        <description>The GPS receiver detected no signal spoofing.</description>
+      </entry>
+      <entry value="2" name="GPS_SPOOFING_STATE_DETECTED">
+        <description>The GPS receiver detected signal spoofing.</description>
+      </entry>
+      <entry value="3" name="GPS_SPOOFING_STATE_MITIGATED">
+        <description>The GPS receiver detected and mitigated signal spoofing.</description>
+      </entry>
+    </enum>
     <enum name="ILLUMINATOR_MODE">
       <description>Modes of illuminator</description>
       <entry value="0" name="ILLUMINATOR_MODE_UNKNOWN">
@@ -5230,6 +5302,10 @@
       <field type="uint32_t" name="vel_acc" units="mm">Speed uncertainty.</field>
       <field type="uint32_t" name="hdg_acc" units="degE5">Heading / track uncertainty</field>
       <field type="uint16_t" name="yaw" units="cdeg" invalid="0">Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use UINT16_MAX if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.</field>
+      <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system</field>
+      <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
+      <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
+      <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
     </message>
     <message id="25" name="GPS_STATUS">
       <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION_INT for the global position estimate. This message can contain information for up to 20 satellites.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5079,93 +5079,6 @@
         <description>Safety switch is NOT engaged and motors, propellers and other actuators should be considered active.</description>
       </entry>
     </enum>
-    <enum name="GPS_SYSTEM_ERROR_FLAGS" bitmask="true">
-      <description>Flags indicating errors in a GPS receiver.</description>
-      <entry value="1" name="GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS">
-        <description>There are problems with incoming correction streams.</description>
-      </entry>
-      <entry value="2" name="GPS_SYSTEM_ERROR_CONFIGURATION">
-        <description>There are problems with the configuration.</description>
-      </entry>
-      <entry value="4" name="GPS_SYSTEM_ERROR_SOFTWARE">
-        <description>There are problems with the software on the GPS receiver.</description>
-      </entry>
-      <entry value="8" name="GPS_SYSTEM_ERROR_ANTENNA">
-        <description>There are problems with an antenna connected to the GPS receiver.</description>
-      </entry>
-      <entry value="16" name="GPS_SYSTEM_ERROR_EVENT_CONGESTION">
-        <description>There are problems handling all incoming events.</description>
-      </entry>
-      <entry value="32" name="GPS_SYSTEM_ERROR_CPU_OVERLOAD">
-        <description>The GPS receiver CPU is overloaded.</description>
-      </entry>
-      <entry value="64" name="GPS_SYSTEM_ERROR_OUTPUT_CONGESTION">
-        <description>The GPS receiver is experiencing output congestion.</description>
-      </entry>
-    </enum>
-    <enum name="GPS_AUTHENTICATION_STATE">
-      <description>Signal authentication state in a GPS receiver.</description>
-      <entry value="0" name="GPS_AUTHENTICATION_STATE_UNKNOWN">
-        <description>The GPS receiver does not provide GPS signal authentication info.</description>
-      </entry>
-      <entry value="1" name="GPS_AUTHENTICATION_STATE_INITIALIZING">
-        <description>The GPS receiver is initializing signal authentication.</description>
-      </entry>
-      <entry value="2" name="GPS_AUTHENTICATION_STATE_ERROR">
-        <description>The GPS receiver encountered an error while initializing signal authentication.</description>
-      </entry>
-      <entry value="3" name="GPS_AUTHENTICATION_STATE_OK">
-        <description>The GPS receiver has correctly authenticated all signals.</description>
-      </entry>
-      <entry value="4" name="GPS_AUTHENTICATION_STATE_DISABLED">
-        <description>GPS signal authentication is disabled on the receiver.</description>
-      </entry>
-    </enum>
-    <enum name="GPS_JAMMING_STATE">
-      <description>Signal jamming state in a GPS receiver.</description>
-      <entry value="0" name="GPS_JAMMING_STATE_UNKNOWN">
-        <description>The GPS receiver does not provide GPS signal jamming info.</description>
-      </entry>
-      <entry value="1" name="GPS_JAMMING_STATE_OK">
-        <description>The GPS receiver detected no signal jamming.</description>
-      </entry>
-      <entry value="2" name="GPS_JAMMING_STATE_DETECTED">
-        <description>The GPS receiver detected signal jamming.</description>
-      </entry>
-    </enum>
-    <enum name="GPS_SPOOFING_STATE">
-      <description>Signal spoofing state in a GPS receiver.</description>
-      <entry value="0" name="GPS_SPOOFING_STATE_UNKNOWN">
-        <description>The GPS receiver does not provide GPS signal spoofing info.</description>
-      </entry>
-      <entry value="1" name="GPS_SPOOFING_STATE_OK">
-        <description>The GPS receiver detected no signal spoofing.</description>
-      </entry>
-      <entry value="2" name="GPS_SPOOFING_STATE_MITIGATED">
-        <description>The GPS receiver detected and mitigated signal spoofing.</description>
-      </entry>
-      <entry value="3" name="GPS_SPOOFING_STATE_DETECTED">
-        <description>The GPS receiver detected signal spoofing but still has a fix.</description>
-      </entry>
-      <entry value="4" name="GPS_SPOOFING_STATE_CRITICAL">
-        <description>The GPS receiver detected signal spoofing and can't provide a fix.</description>
-      </entry>
-    </enum>
-    <enum name="GPS_RAIM_STATE">
-      <description>State of RAIM processing.</description>
-      <entry value="0" name="GPS_RAIM_STATE_UNKNOWN">
-        <description>RAIM capability is unknown.</description>
-      </entry>
-      <entry value="1" name="GPS_RAIM_STATE_DISABLED">
-        <description>RAIM is disabled.</description>
-      </entry>
-      <entry value="2" name="GPS_RAIM_STATE_OK">
-        <description>RAIM integrity check was successful.</description>
-      </entry>
-      <entry value="3" name="GPS_RAIM_STATE_FAILED">
-        <description>RAIM integrity check failed.</description>
-      </entry>
-    </enum>
     <enum name="ILLUMINATOR_MODE">
       <description>Modes of illuminator</description>
       <entry value="0" name="ILLUMINATOR_MODE_UNKNOWN">
@@ -7772,17 +7685,6 @@
       <field type="float" name="temp_c">Temperature in Celsius</field>
       <field type="float" name="min_strobe_period" units="s">Minimum strobing period in seconds</field>
       <field type="float" name="max_strobe_period" units="s">Maximum strobing period in seconds</field>
-    </message>
-    <message id="441" name="GNSS_INTEGRITY">
-      <description>Information about key components of GNSS receivers, like signal authentication, interference and system errors.</description>
-      <field type="uint8_t" name="id" instance="true">GNSS receiver id. Must match instance ids of other messages from same receiver.</field>
-      <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system</field>
-      <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
-      <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
-      <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
-      <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
-      <field type="uint16_t" name="raim_hfom">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
-      <field type="uint16_t" name="raim_vfom">Vertical expected accuracy using satellites successfully validated using RAIM</field>
     </message>
     <!-- The message ids 510 and 511 are reserved for ABSOLUTE_TARGET and RELATIVE_TARGET, currently in development.xml. -->
     <message id="387" name="CANFD_FRAME">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -684,13 +684,13 @@
     <message id="441" name="GNSS_INTEGRITY">
       <description>Information about key components of GNSS receivers, like signal authentication, interference and system errors.</description>
       <field type="uint8_t" name="id" instance="true">GNSS receiver id. Must match instance ids of other messages from same receiver.</field>
-      <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system</field>
-      <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
-      <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
-      <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
-      <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
-      <field type="uint16_t" name="raim_hfom" units="cm" invalid="UINT16_MAX">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
-      <field type="uint16_t" name="raim_vfom" units="cm" invalid="UINT16_MAX">Vertical expected accuracy using satellites successfully validated using RAIM</field>
+      <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system.</field>
+      <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system.</field>
+      <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system.</field>
+      <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system.</field>
+      <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing.</field>
+      <field type="uint16_t" name="raim_hfom" units="cm" invalid="UINT16_MAX">Horizontal expected accuracy using satellites successfully validated using RAIM.</field>
+      <field type="uint16_t" name="raim_vfom" units="cm" invalid="UINT16_MAX">Vertical expected accuracy using satellites successfully validated using RAIM.</field>
       <field type="uint8_t" name="corrections_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated quality of incoming corrections, or 255 if not available.</field>
       <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver, or 255 if not available.</field>
       <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals, or 255 if not available.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -691,10 +691,10 @@
       <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
       <field type="uint16_t" name="raim_hfom" units="cm">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
       <field type="uint16_t" name="raim_vfom" units="cm">Vertical expected accuracy using satellites successfully validated using RAIM</field>
-      <field type="uint8_t" name="corrections_quality" minValue="0" maxValue="10">An abstract value representing the estimated quality of incoming corrections.</field>
-      <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10">An abstract value representing the overall status of the receiver.</field>
-      <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10">An abstract value representing the quality of incoming GNSS signals.</field>
-      <field type="uint8_t" name="post_processing_quality" minValue="0" maxValue="10">An abstract value representing the estimated PPK quality.</field>
+      <field type="int8_t" name="corrections_quality" minValue="-1" maxValue="10">An abstract value representing the estimated quality of incoming corrections, or -1 if not available.</field>
+      <field type="int8_t" name="system_status_summary" minValue="-1" maxValue="10">An abstract value representing the overall status of the receiver, or -1 if not available.</field>
+      <field type="int8_t" name="gnss_signal_quality" minValue="-1" maxValue="10">An abstract value representing the quality of incoming GNSS signals, or -1 if not available.</field>
+      <field type="int8_t" name="post_processing_quality" minValue="-1" maxValue="10">An abstract value representing the estimated PPK quality, or -1 if not available.</field>
     </message>
     <!-- Target info from a sensor on the target -->
     <message id="510" name="TARGET_ABSOLUTE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -471,7 +471,10 @@
       <entry value="1" name="GPS_JAMMING_STATE_OK">
         <description>The GPS receiver detected no signal jamming.</description>
       </entry>
-      <entry value="2" name="GPS_JAMMING_STATE_DETECTED">
+      <entry value="2" name="GPS_JAMMING_STATE_MITIGATED">
+        <description>The GPS receiver detected and mitigated signal jamming.</description>
+      </entry>
+      <entry value="3" name="GPS_JAMMING_STATE_DETECTED">
         <description>The GPS receiver detected signal jamming.</description>
       </entry>
     </enum>
@@ -488,9 +491,6 @@
       </entry>
       <entry value="3" name="GPS_SPOOFING_STATE_DETECTED">
         <description>The GPS receiver detected signal spoofing but still has a fix.</description>
-      </entry>
-      <entry value="4" name="GPS_SPOOFING_STATE_CRITICAL">
-        <description>The GPS receiver detected signal spoofing and can't provide a fix.</description>
       </entry>
     </enum>
     <enum name="GPS_RAIM_STATE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -689,12 +689,12 @@
       <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
       <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
       <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
-      <field type="uint16_t" name="raim_hfom" units="cm">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
-      <field type="uint16_t" name="raim_vfom" units="cm">Vertical expected accuracy using satellites successfully validated using RAIM</field>
-      <field type="int8_t" name="corrections_quality" minValue="-1" maxValue="10">An abstract value representing the estimated quality of incoming corrections, or -1 if not available.</field>
-      <field type="int8_t" name="system_status_summary" minValue="-1" maxValue="10">An abstract value representing the overall status of the receiver, or -1 if not available.</field>
-      <field type="int8_t" name="gnss_signal_quality" minValue="-1" maxValue="10">An abstract value representing the quality of incoming GNSS signals, or -1 if not available.</field>
-      <field type="int8_t" name="post_processing_quality" minValue="-1" maxValue="10">An abstract value representing the estimated PPK quality, or -1 if not available.</field>
+      <field type="uint16_t" name="raim_hfom" units="cm" invalid="UINT16_MAX">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
+      <field type="uint16_t" name="raim_vfom" units="cm" invalid="UINT16_MAX">Vertical expected accuracy using satellites successfully validated using RAIM</field>
+      <field type="uint8_t" name="corrections_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated quality of incoming corrections, or -1 if not available.</field>
+      <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver, or -1 if not available.</field>
+      <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals, or -1 if not available.</field>
+      <field type="uint8_t" name="post_processing_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated PPK quality, or -1 if not available.</field>
     </message>
     <!-- Target info from a sensor on the target -->
     <message id="510" name="TARGET_ABSOLUTE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -691,7 +691,7 @@
       <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
       <field type="uint16_t" name="raim_hfom" units="cm" invalid="UINT16_MAX">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
       <field type="uint16_t" name="raim_vfom" units="cm" invalid="UINT16_MAX">Vertical expected accuracy using satellites successfully validated using RAIM</field>
-      <field type="uint8_t" name="corrections_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated quality of incoming corrections, or -1 if not available.</field>
+      <field type="uint8_t" name="corrections_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated quality of incoming corrections, or 255 if not available.</field>
       <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver, or 255 if not available.</field>
       <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals, or 255 if not available.</field>
       <field type="uint8_t" name="post_processing_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated PPK quality, or 255 if not available.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -421,6 +421,93 @@
         <description>A gas tank. Fuel levels are in kilo-Pascal (kPa), and flow rates are in milliliters per second (ml/s).</description>
       </entry>
     </enum>
+    <enum name="GPS_SYSTEM_ERROR_FLAGS" bitmask="true">
+      <description>Flags indicating errors in a GPS receiver.</description>
+      <entry value="1" name="GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS">
+        <description>There are problems with incoming correction streams.</description>
+      </entry>
+      <entry value="2" name="GPS_SYSTEM_ERROR_CONFIGURATION">
+        <description>There are problems with the configuration.</description>
+      </entry>
+      <entry value="4" name="GPS_SYSTEM_ERROR_SOFTWARE">
+        <description>There are problems with the software on the GPS receiver.</description>
+      </entry>
+      <entry value="8" name="GPS_SYSTEM_ERROR_ANTENNA">
+        <description>There are problems with an antenna connected to the GPS receiver.</description>
+      </entry>
+      <entry value="16" name="GPS_SYSTEM_ERROR_EVENT_CONGESTION">
+        <description>There are problems handling all incoming events.</description>
+      </entry>
+      <entry value="32" name="GPS_SYSTEM_ERROR_CPU_OVERLOAD">
+        <description>The GPS receiver CPU is overloaded.</description>
+      </entry>
+      <entry value="64" name="GPS_SYSTEM_ERROR_OUTPUT_CONGESTION">
+        <description>The GPS receiver is experiencing output congestion.</description>
+      </entry>
+    </enum>
+    <enum name="GPS_AUTHENTICATION_STATE">
+      <description>Signal authentication state in a GPS receiver.</description>
+      <entry value="0" name="GPS_AUTHENTICATION_STATE_UNKNOWN">
+        <description>The GPS receiver does not provide GPS signal authentication info.</description>
+      </entry>
+      <entry value="1" name="GPS_AUTHENTICATION_STATE_INITIALIZING">
+        <description>The GPS receiver is initializing signal authentication.</description>
+      </entry>
+      <entry value="2" name="GPS_AUTHENTICATION_STATE_ERROR">
+        <description>The GPS receiver encountered an error while initializing signal authentication.</description>
+      </entry>
+      <entry value="3" name="GPS_AUTHENTICATION_STATE_OK">
+        <description>The GPS receiver has correctly authenticated all signals.</description>
+      </entry>
+      <entry value="4" name="GPS_AUTHENTICATION_STATE_DISABLED">
+        <description>GPS signal authentication is disabled on the receiver.</description>
+      </entry>
+    </enum>
+    <enum name="GPS_JAMMING_STATE">
+      <description>Signal jamming state in a GPS receiver.</description>
+      <entry value="0" name="GPS_JAMMING_STATE_UNKNOWN">
+        <description>The GPS receiver does not provide GPS signal jamming info.</description>
+      </entry>
+      <entry value="1" name="GPS_JAMMING_STATE_OK">
+        <description>The GPS receiver detected no signal jamming.</description>
+      </entry>
+      <entry value="2" name="GPS_JAMMING_STATE_DETECTED">
+        <description>The GPS receiver detected signal jamming.</description>
+      </entry>
+    </enum>
+    <enum name="GPS_SPOOFING_STATE">
+      <description>Signal spoofing state in a GPS receiver.</description>
+      <entry value="0" name="GPS_SPOOFING_STATE_UNKNOWN">
+        <description>The GPS receiver does not provide GPS signal spoofing info.</description>
+      </entry>
+      <entry value="1" name="GPS_SPOOFING_STATE_OK">
+        <description>The GPS receiver detected no signal spoofing.</description>
+      </entry>
+      <entry value="2" name="GPS_SPOOFING_STATE_MITIGATED">
+        <description>The GPS receiver detected and mitigated signal spoofing.</description>
+      </entry>
+      <entry value="3" name="GPS_SPOOFING_STATE_DETECTED">
+        <description>The GPS receiver detected signal spoofing but still has a fix.</description>
+      </entry>
+      <entry value="4" name="GPS_SPOOFING_STATE_CRITICAL">
+        <description>The GPS receiver detected signal spoofing and can't provide a fix.</description>
+      </entry>
+    </enum>
+    <enum name="GPS_RAIM_STATE">
+      <description>State of RAIM processing.</description>
+      <entry value="0" name="GPS_RAIM_STATE_UNKNOWN">
+        <description>RAIM capability is unknown.</description>
+      </entry>
+      <entry value="1" name="GPS_RAIM_STATE_DISABLED">
+        <description>RAIM is disabled.</description>
+      </entry>
+      <entry value="2" name="GPS_RAIM_STATE_OK">
+        <description>RAIM integrity check was successful.</description>
+      </entry>
+      <entry value="3" name="GPS_RAIM_STATE_FAILED">
+        <description>RAIM integrity check failed.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- Transactions for parameter protocol -->
@@ -593,6 +680,17 @@
         This is only emitted after the first change and should then be broadcast at low rate (nominally 0.3 Hz) and on change.
       </description>
       <field type="uint8_t" name="seq">Sequence number. The value iterates sequentially whenever AVAILABLE_MODES changes (e.g. support for a new mode is added/removed dynamically).</field>
+    </message>
+    <message id="441" name="GNSS_INTEGRITY">
+      <description>Information about key components of GNSS receivers, like signal authentication, interference and system errors.</description>
+      <field type="uint8_t" name="id" instance="true">GNSS receiver id. Must match instance ids of other messages from same receiver.</field>
+      <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system</field>
+      <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
+      <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
+      <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
+      <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
+      <field type="uint16_t" name="raim_hfom">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
+      <field type="uint16_t" name="raim_vfom">Vertical expected accuracy using satellites successfully validated using RAIM</field>
     </message>
     <!-- Target info from a sensor on the target -->
     <message id="510" name="TARGET_ABSOLUTE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -691,6 +691,10 @@
       <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
       <field type="uint16_t" name="raim_hfom" units="cm">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
       <field type="uint16_t" name="raim_vfom" units="cm">Vertical expected accuracy using satellites successfully validated using RAIM</field>
+      <field type="uint8_t" name="corrections_quality" minValue="0" maxValue="10">An abstract value representing the estimated quality of incoming corrections.</field>
+      <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10">An abstract value representing the overall status of the receiver.</field>
+      <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10">An abstract value representing the quality of incoming GNSS signals.</field>
+      <field type="uint8_t" name="post_processing_quality" minValue="0" maxValue="10">An abstract value representing the estimated PPK quality.</field>
     </message>
     <!-- Target info from a sensor on the target -->
     <message id="510" name="TARGET_ABSOLUTE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -692,9 +692,9 @@
       <field type="uint16_t" name="raim_hfom" units="cm" invalid="UINT16_MAX">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
       <field type="uint16_t" name="raim_vfom" units="cm" invalid="UINT16_MAX">Vertical expected accuracy using satellites successfully validated using RAIM</field>
       <field type="uint8_t" name="corrections_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated quality of incoming corrections, or -1 if not available.</field>
-      <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver, or -1 if not available.</field>
-      <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals, or -1 if not available.</field>
-      <field type="uint8_t" name="post_processing_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated PPK quality, or -1 if not available.</field>
+      <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver, or 255 if not available.</field>
+      <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals, or 255 if not available.</field>
+      <field type="uint8_t" name="post_processing_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated PPK quality, or 255 if not available.</field>
     </message>
     <!-- Target info from a sensor on the target -->
     <message id="510" name="TARGET_ABSOLUTE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -689,8 +689,8 @@
       <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
       <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
       <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing</field>
-      <field type="uint16_t" name="raim_hfom">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
-      <field type="uint16_t" name="raim_vfom">Vertical expected accuracy using satellites successfully validated using RAIM</field>
+      <field type="uint16_t" name="raim_hfom" units="cm">Horizontal expected accuracy using satellites successfully validated using RAIM</field>
+      <field type="uint16_t" name="raim_vfom" units="cm">Vertical expected accuracy using satellites successfully validated using RAIM</field>
     </message>
     <!-- Target info from a sensor on the target -->
     <message id="510" name="TARGET_ABSOLUTE">


### PR DESCRIPTION
Add fields to report resilience and status information from GNSS receivers back to ground control stations for representation in the user interface.