### PR TITLE
Set camera ids on messages that might have flight-stack attached cameras

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2108,7 +2108,7 @@
       </entry>
       <entry value="530" name="MAV_CMD_SET_CAMERA_MODE" hasLocation="false" isDestination="false">
         <description>Set camera running mode. Use NaN for reserved values. GCS will send a MAV_CMD_REQUEST_VIDEO_STREAM_STATUS command after a mode change if the camera supports video streaming.</description>
-        <param index="1">Reserved (Set to 0)</param>
+        <param index="1" label="id">Target camera ID. 7 to 255: MAVLink camera component id. 1 to 6 for cameras that don't have a distinct component id (such as autopilot-attached cameras). 0: all cameras. This is used to specifically target autopilot-connected cameras or individual sensors in a multi-sensor MAVLink camera. It is also used to target specific cameras when the MAV_CMD is used in a mission</param>
         <param index="2" label="Camera Mode" enum="CAMERA_MODE">Camera mode</param>
         <param index="3" reserved="true" default="NaN"/>
         <param index="4" reserved="true" default="NaN"/>


### PR DESCRIPTION
This adds id field to allow commands to be sent to a specific camera.
Note, this mirrors the [MAV_CMD_IMAGE_START_CAPTURE](https://mavlink.io/en/messages/common.html#MAV_CMD_IMAGE_START_CAPTURE)/[MAV_CMD_IMAGE_STOP_CAPTURE](https://mavlink.io/en/messages/common.html#MAV_CMD_IMAGE_STOP_CAPTURE) commands by setting param1=id where possible, but otherwise would pick a free id.

- [ ] [MAV_CMD_SET_CAMERA_MODE](https://mavlink.io/en/messages/common.html#MAV_CMD_SET_CAMERA_MODE)

Don't think we need to do anything for video messages, which use a stream id: `MAV_CMD_VIDEO_START_CAPTURE`,  `MAV_CMD_VIDEO_STOP_CAPTURE`, `MAV_CMD_VIDEO_START_STREAMING`, `MAV_CMD_VIDEO_STOP_STREAMING`

Do we need to modify the information messages, such as [CAMERA_INFORMATION](https://mavlink.io/en/messages/common.html#CAMERA_INFORMATION) ? from:

> [[Message] ](https://mavlink.io/en/messages/common.html#messages)(MAVLink 2) Information about a camera. Can be requested with a [MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) command.

TO

> [[Message] ](https://mavlink.io/en/messages/common.html#messages)(MAVLink 2) Information about a camera. Can be requested with a [MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) command. The `MAV_CMD_REQUEST_MESSAGE.param2` value can be used to target cameras attached to the autopilot (values from 1 to 6)

EDITED: Julian doesn't think we need these as they are user facing (and I think if we change our mind we can modify later)

- [MAV_CMD_CAMERA_TRACK_POINT](https://mavlink.io/en/messages/common.html#MAV_CMD_CAMERA_TRACK_POINT)
- [MAV_CMD_CAMERA_TRACK_RECTANGLE](https://mavlink.io/en/messages/common.html#MAV_CMD_CAMERA_TRACK_RECTANGLE)
- [MAV_CMD_CAMERA_STOP_TRACKING](https://mavlink.io/en/messages/common.html#MAV_CMD_CAMERA_STOP_TRACKING)
