### PR TITLE
Fix missing increment and max value typo

### DIFF
--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -885,7 +885,7 @@ class MAVCommand(object):
                     if param.minValue:
                         valString += f"min: {param.minValue}"
                     if param.maxValue:
-                        valString += f" min: {param.maxValue}"
+                        valString += f" max: {param.maxValue}"
                     if param.maxValue:
                         valString += f" inc: {param.increment}"
                     valString = valString.strip()

--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -886,7 +886,7 @@ class MAVCommand(object):
                         valString += f"min: {param.minValue}"
                     if param.maxValue:
                         valString += f" max: {param.maxValue}"
-                    if param.maxValue:
+                    if param.increment:
                         valString += f" inc: {param.increment}"
                     valString = valString.strip()
                 row.append(valString)


### PR DESCRIPTION
This PR changes the label for maxValue to be `max` rather than `min`, and also fixes the bug which causes increment to be shown when maxValue is set, even if there's no increment

## Screenshot
![image](https://github.com/mavlink/mavlink/assets/53450844/a7f501fb-b7d0-48db-bac4-dc1daabca8dd)
