### PR TITLE
ADSB_VEHICLE.squawk octal code is sent as if decimal

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6808,7 +6808,7 @@
       <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">ADSB emitter type.</field>
       <field type="uint8_t" name="tslc" units="s">Time since last communication in seconds</field>
       <field type="uint16_t" name="flags" enum="ADSB_FLAGS" display="bitmask">Bitmap to indicate various statuses including valid data fields</field>
-      <field type="uint16_t" name="squawk">Squawk code</field>
+      <field type="uint16_t" name="squawk">Squawk code. Note that the code is in decimal: e.g. 7700 (general emergency) is encoded as binary 0b0001_1110_0001_0100, not(!) as 0b0000_111_111_000_000</field>
     </message>
     <message id="247" name="COLLISION">
       <description>Information about a potential collision</description>


### PR DESCRIPTION
Adds documentation that field `squawk` of `ADSB_VEHICLE` message is encoded in decimal, not in octal.

The ADS-B drivers of PX4 and ArduPilot receive the squawk as octal number, but convert it to decimal when creating the MAVLink `ADSB_VEHICLE` message.

This may come as a surprise to aerospace engineers who tend to interpret Squawk as an octal number. In turn, this can lead to a lack of recognition of emergency statuses (safety issue) or mis-identification of emergency statuses (less critical, but still a safety issue).