### PR TITLE
Image/video capture commands do not set mode

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2186,6 +2186,10 @@
           If addressed specifically to an autopilot: param1 should be used in the same way as it is for missions (though command should NACK with MAV_RESULT_DENIED if a specified local camera does not exist).
           If addressed to a MAVLink camera, param 1 can be used to address all cameras (0), or to separately address 1 to 7 individual sensors. Other values should be NACKed with MAV_RESULT_DENIED.
           If the command is broadcast (target_component is 0) then param 1 should be set to 0 (any other value should be NACKED with MAV_RESULT_DENIED). An autopilot would trigger any local cameras and forward the command to all channels.
+
+          Note that this command does not explicitly set the camera mode.
+          If the camera has separate video/image modes (CAMERA_CAP_FLAGS_HAS_MODES) and is in video mode (CAMERA_MODE_VIDEO), and it does not support image capture in video mode (CAMERA_CAP_FLAGS_CAN_CAPTURE_IMAGE_IN_VIDEO_MODE), you will need to first call MAV_CMD_SET_CAMERA_MODE to change the mode to CAMERA_MODE_IMAGE.
+          The command will be rejected with MAV_RESULT_TEMPORARILY_REJECTED if the camera is not able to start image capture.
         </description>
         <param index="1" label="id" minValue="0" maxValue="255" increment="1">Target camera ID. 7 to 255: MAVLink camera component id. 1 to 6 for cameras that don't have a distinct component id (such as autopilot-attached cameras). 0: all cameras. This is used to specifically target autopilot-connected cameras or individual sensors in a multi-sensor MAVLink camera. It is also used to target specific cameras when the MAV_CMD is used in a mission</param>
         <param index="2" label="Interval" units="s" minValue="0">Desired elapsed time between two consecutive pictures (in seconds). Minimum values depend on hardware (typically greater than 2 seconds).</param>
@@ -2252,7 +2256,12 @@
         <description>Stops ongoing tracking.</description>
       </entry>
       <entry value="2500" name="MAV_CMD_VIDEO_START_CAPTURE" hasLocation="false" isDestination="false">
-        <description>Starts video capture (recording).</description>
+        <description>Starts video capture (recording).
+
+          Note that this command does not explicitly set the camera mode.
+          If the camera has separate video/image modes (CAMERA_CAP_FLAGS_HAS_MODES) and is in video mode (CAMERA_MODE_IMAGE), and it does not support image capture in video mode (CAMERA_CAP_FLAGS_CAN_CAPTURE_VIDEO_IN_IMAGE_MODE), you will need to first call MAV_CMD_SET_CAMERA_MODE to change the mode to CAMERA_MODE_VIDEO.
+          The command will be rejected with MAV_RESULT_TEMPORARILY_REJECTED if the camera is not able to start video capture.
+        </description>
         <param index="1" label="Stream ID" minValue="0" increment="1">Video Stream ID (0 for all streams)</param>
         <param index="2" label="Status Frequency" minValue="0" units="Hz">Frequency CAMERA_CAPTURE_STATUS messages should be sent while recording (0 for no messages, otherwise frequency)</param>
         <param index="3" reserved="true" default="NaN"/>


### PR DESCRIPTION
This updates the docs to note that the image and video capture commands do not set the camera mode.
So if you're in video mode and you start video capture the command may fail (depending on whether the camera supports separate image/video modes and whether it allows capture of the opposite type in each mode.)

@julianoes @Davidsastresas @rmackay9 

FYI The camera API allows a GCS to handle cameras for the manual use case because you can query what the camera mode type is, whether separate modes are supported, and whether the camera allows capture in the opposite mode. 

I'm not sure what we can or should do for missions though.
If you're using a camera that allows capture in any mode there is no issue. If you're using a camera that supports separate image/video capture and you're in the wrong mode then the capture will fail, ideally with a status update. That's it.

What a flight stack should do IMO is check the camera mode support as part of mission feasibility checks with associated sensible status/event updates to the GCS as to why the mission is invalid.

1. Should we suggest feasibility check in the docs?
2. Is there a standard behaviour when you get a command while you're already executing a command? 
   - I.e. if I'm executing an image capture, and I get another image capture command, what should the camera do?
   - My thinking is that the command should always be rejected.. If you send another command to capture images on the same camera it should be rejected - you would first need to stop the existing capture. Reason being is that it is more predictable. 
   - This does mean that missions that have a start image capture for a particular target should probably  be preceded by a stop capture.
   - Should we state those things?
   
My concern ^^^ is that a GCS might do a simplistic mission implementation that assumes cameras can all capture images in all modes, and that the camera will always allow image capture commands to be overridden by later commands (the second is not specified)