### PR TITLE
Added MAV_CMD_EXTERNAL_WIND_ESTIMATE to development

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1809,6 +1809,16 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+      <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
+        <description>Provides an external estimate of wind direction and strength. Can be used to to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
+        <param index="1" label="Wind strength" units="m/s" minValue="0" >Horizontal wind strength.</param>
+        <param index="2" label="Wind strength accuracy" units="m/s" >Estimated 1 sigma accuracy of wind strength. Set to NaN if unknown.</param>
+        <param index="3" label="Wind direction" units="degrees" minValue="0" maxValue="360"> Azimuth (relative to true north) from where the wind is blowing.</param>
+        <param index="4" label="Wind direction accuracy" units="degrees">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT" hasLocation="false" isDestination="false">
         <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW"/>
         <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1811,8 +1811,8 @@
       </entry>
       <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
         <description>Provides an external estimate of wind direction and strength. Can be used to to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
-        <param index="1" label="Wind strength" units="m/s" minValue="0" >Horizontal wind strength.</param>
-        <param index="2" label="Wind strength accuracy" units="m/s" >Estimated 1 sigma accuracy of wind strength. Set to NaN if unknown.</param>
+        <param index="1" label="Wind strength" units="m/s" minValue="0">Horizontal wind strength.</param>
+        <param index="2" label="Wind strength accuracy" units="m/s">Estimated 1 sigma accuracy of wind strength. Set to NaN if unknown.</param>
         <param index="3" label="Wind direction" units="degrees" minValue="0" maxValue="360"> Azimuth (relative to true north) from where the wind is blowing.</param>
         <param index="4" label="Wind direction accuracy" units="degrees">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
         <param index="5">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1810,9 +1810,9 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
-        <description>Provides an external estimate of wind direction and strength. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
-        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind strength.</param>
-        <param index="2" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind strength. Set to NaN if unknown.</param>
+        <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
+        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
+        <param index="2" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
         <param index="3" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
         <param index="4" label="Direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
         <param index="5">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1811,10 +1811,10 @@
       </entry>
       <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
         <description>Provides an external estimate of wind direction and strength. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
-        <param index="1" label="Wind strength" units="m/s" minValue="0">Horizontal wind strength.</param>
-        <param index="2" label="Wind strength accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind strength. Set to NaN if unknown.</param>
-        <param index="3" label="Wind direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
-        <param index="4" label="Wind direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
+        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind strength.</param>
+        <param index="2" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind strength. Set to NaN if unknown.</param>
+        <param index="3" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
+        <param index="4" label="Direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1810,11 +1810,11 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
-        <description>Provides an external estimate of wind direction and strength. Can be used to to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
+        <description>Provides an external estimate of wind direction and strength. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
         <param index="1" label="Wind strength" units="m/s" minValue="0">Horizontal wind strength.</param>
-        <param index="2" label="Wind strength accuracy" units="m/s">Estimated 1 sigma accuracy of wind strength. Set to NaN if unknown.</param>
-        <param index="3" label="Wind direction" units="degrees" minValue="0" maxValue="360"> Azimuth (relative to true north) from where the wind is blowing.</param>
-        <param index="4" label="Wind direction accuracy" units="degrees">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
+        <param index="2" label="Wind strength accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind strength. Set to NaN if unknown.</param>
+        <param index="3" label="Wind direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
+        <param index="4" label="Wind direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1809,16 +1809,6 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
-        <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
-        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
-        <param index="2" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
-        <param index="3" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
-        <param index="4" label="Direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
       <entry value="220" name="MAV_CMD_DO_MOUNT_CONTROL_QUAT" hasLocation="false" isDestination="false">
         <deprecated since="2020-01" replaced_by="MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW"/>
         <description>Mission command to control a camera or antenna mount, using a quaternion as reference.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -294,7 +294,7 @@
       </entry>
       <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
         <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
-        <param index="1" type="float" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
+        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
         <param index="2" type="float" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
         <param index="3" type="float" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
         <param index="4" type="float" label="Direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -292,16 +292,6 @@
         <param index="7" label="Altitude/Z">Center point altitude MSL/Z coordinate according to MAV_FRAME. If no MAV_FRAME specified, MAV_FRAME_GLOBAL is assumed.
         INT32_MAX or NaN: Use current vehicle altitude.</param>
       </entry>
-      <entry value="215" name="MAV_CMD_EXTERNAL_WIND_ESTIMATE" hasLocation="false" isDestination="false">
-        <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
-        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
-        <param index="2" type="float" label="Wind speed accuracy" units="m/s">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
-        <param index="3" type="float" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
-        <param index="4" type="float" label="Direction accuracy" units="degrees">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
-      </entry>
       <entry value="900" name="MAV_CMD_PARAM_TRANSACTION" hasLocation="false" isDestination="false">
         <description>Request to start or end a parameter transaction. Multiple kinds of transport layers can be used to exchange parameters in the transaction (param, param_ext and mavftp). The command response can either be a success/failure or an in progress in case the receiving side takes some time to apply the parameters.</description>
         <param index="1" label="Action" enum="PARAM_TRANSACTION_ACTION">Action to be performed (start, commit, cancel, etc.)</param>
@@ -382,6 +372,16 @@
         <param index="3" reserved="true" default="NaN"/>
         <param index="4">Empty</param>
         <param index="5">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
+      <entry value="43004" name="MAV_CMD_EXTERNAL_WIND_ESTIMATE" hasLocation="false" isDestination="false">
+        <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
+        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
+        <param index="2" label="Wind speed accuracy" units="m/s">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
+        <param index="3" label="Direction" units="deg" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
+        <param index="4" label="Direction accuracy" units="deg">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -297,7 +297,7 @@
         <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
         <param index="2" type="float" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
         <param index="3" type="float" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
-        <param index="4" type="float" label="Direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
+        <param index="4" type="float" label="Direction accuracy" units="degrees">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -292,6 +292,16 @@
         <param index="7" label="Altitude/Z">Center point altitude MSL/Z coordinate according to MAV_FRAME. If no MAV_FRAME specified, MAV_FRAME_GLOBAL is assumed.
         INT32_MAX or NaN: Use current vehicle altitude.</param>
       </entry>
+      <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
+        <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
+        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
+        <param index="2" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
+        <param index="3" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
+        <param index="4" label="Direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <entry value="900" name="MAV_CMD_PARAM_TRANSACTION" hasLocation="false" isDestination="false">
         <description>Request to start or end a parameter transaction. Multiple kinds of transport layers can be used to exchange parameters in the transaction (param, param_ext and mavftp). The command response can either be a success/failure or an in progress in case the receiving side takes some time to apply the parameters.</description>
         <param index="1" label="Action" enum="PARAM_TRANSACTION_ACTION">Action to be performed (start, commit, cancel, etc.)</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -295,7 +295,7 @@
       <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
         <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
         <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
-        <param index="2" type="float" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
+        <param index="2" type="float" label="Wind speed accuracy" units="m/s">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
         <param index="3" type="float" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
         <param index="4" type="float" label="Direction accuracy" units="degrees">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
         <param index="5">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -294,10 +294,10 @@
       </entry>
       <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
         <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
-        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
-        <param index="2" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
-        <param index="3" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
-        <param index="4" label="Direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
+        <param index="1" type="float" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
+        <param index="2" type="float" label="Wind speed accuracy" units="m/s" invalid="NaN">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
+        <param index="3" type="float" label="Direction" units="degrees" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
+        <param index="4" type="float" label="Direction accuracy" units="degrees" invalid="NaN">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -292,7 +292,7 @@
         <param index="7" label="Altitude/Z">Center point altitude MSL/Z coordinate according to MAV_FRAME. If no MAV_FRAME specified, MAV_FRAME_GLOBAL is assumed.
         INT32_MAX or NaN: Use current vehicle altitude.</param>
       </entry>
-      <entry value="215" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
+      <entry value="215" name="MAV_CMD_EXTERNAL_WIND_ESTIMATE" hasLocation="false" isDestination="false">
         <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
         <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
         <param index="2" type="float" label="Wind speed accuracy" units="m/s">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -377,7 +377,9 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="43004" name="MAV_CMD_EXTERNAL_WIND_ESTIMATE" hasLocation="false" isDestination="false">
-        <description>Provides an external estimate of wind direction and speed. Can be used to provide a more accurate wind estimate in the case where the vehicle is wind dead-reckoning.</description>
+        <description>Set an external estimate of wind direction and speed.
+          This might be used to provide an initial wind estimate to the estimator (EKF) in the case where the vehicle is wind dead-reckoning, extending the time when operating without GPS before before position drift builds to an unsafe level. For this use case the command might reasonably be sent every few minutes when operating at altitude, and the value is cleared if the estimator resets itself.
+        </description>
         <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
         <param index="2" label="Wind speed accuracy" units="m/s">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
         <param index="3" label="Direction" units="deg" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>


### PR DESCRIPTION
When taking off in GNSS denied environments with a fixed wing or a VTOL airplane, wind dead-reckoning performance strongly relies on an accurate wind estimate. Since the wind states are not really observable without any velocity / position aiding, it makes sense to allow the operator to externally set the wind states in order to improve dead-reckoning performance.