### PR TITLE
MAV_CMD_DO_SET_WIND - Set a custom wind directions

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2466,6 +2466,17 @@
         <param index="6">Empty.</param>
         <param index="7">Empty.</param>
       </entry>
+      <entry value="6000" name="MAV_CMD_DO_SET_WIND" hasLocation="false" isDestination="false">
+        <description>Set a custom wind directions.
+        </description>
+        <param index="1" label="Wind in North (NED) direction">wind_x</param>
+        <param index="2" label="Wind in East (NED) direction">wind_y</param>
+        <param index="3" label="Wind in down (NED) direction">wind_z</param>
+        <param index="4">Reserved</param>
+        <param index="5">Reserved</param>
+        <param index="6">Reserved</param>
+        <param index="7">Reserved</param>
+      </entry>
       <entry value="10001" name="MAV_CMD_DO_ADSB_OUT_IDENT" hasLocation="false" isDestination="false">
         <description>Trigger the start of an ADSB-out IDENT. This should only be used when requested to do so by an Air Traffic Controller in controlled airspace. This starts the IDENT which is then typically held for 18 seconds by the hardware per the Mode A, C, and S transponder spec.</description>
         <param index="1">Reserved (set to 0)</param>


### PR DESCRIPTION
When flying without a GPS receiver, drift correction does not work properly because the autopilot does not have information about the wind speed and direction.
I can get wind information using online services (e.g. windy.com) and with this command set a custom wind speed and direction, which will greatly improve drift correction.