### PR TITLE
common: add capability flags for camera and gimbal

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3230,6 +3230,14 @@
           Note that either this flag or MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE should be set if the parameter protocol is supported.
         </description>
       </entry>
+      <entry value="262144" name="MAV_PROTOCOL_CAPABILITY_COMPONENT_IMPLEMENTS_CAMERA">
+        <description>This component implements/is a camera. This means the CAMERA_INFORMATION, and other messages can be requested.
+        </description>
+      </entry>
+      <entry value="524288" name="MAV_PROTOCOL_CAPABILITY_COMPONENT_IMPLEMENTS_GIMBAL_MANAGER">
+        <description>This component implements/is a gimbal manager. This means the GIMBAL_MANAGER_INFORMATION, and other messages can be requested.
+        </description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">
       <description>Type of mission items being requested/sent in mission protocol.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3230,11 +3230,7 @@
           Note that either this flag or MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE should be set if the parameter protocol is supported.
         </description>
       </entry>
-      <entry value="262144" name="MAV_PROTOCOL_CAPABILITY_COMPONENT_IMPLEMENTS_CAMERA">
-        <description>This component implements/is a camera. This means the CAMERA_INFORMATION, and other messages can be requested.
-        </description>
-      </entry>
-      <entry value="524288" name="MAV_PROTOCOL_CAPABILITY_COMPONENT_IMPLEMENTS_GIMBAL_MANAGER">
+      <entry value="262144" name="MAV_PROTOCOL_CAPABILITY_COMPONENT_IMPLEMENTS_GIMBAL_MANAGER">
         <description>This component implements/is a gimbal manager. This means the GIMBAL_MANAGER_INFORMATION, and other messages can be requested.
         </description>
       </entry>


### PR DESCRIPTION
Having these two capability flags means that ground stations don't have to ask any discovered components for CAMERA_INFORMATION and GIMBAL_MANAGER_INFORMATION messages and can instead only do so when they see this capability flag set.

This means however, that each ground station now needs to request either AUTOPILOT_VERSION or COMPONENT_INFORMATION_BASIC from any MAVLink component that it discovers, so it's only slightly better.

The alternative would be to make it explicit that cameras and gimbals need to send out CAMERA_CAPTURE_STATUS and GIMBAL_MANAGER_STATUS messages respsectively, to signal implementing a camera/gimbal manager.

FYI @Davidsastresas 