### PR TITLE
MAV_CMD_SET_MESSAGE_INTERVAL - additional params for requestor

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2042,6 +2042,10 @@
         <description>Set the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM.</description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID</param>
         <param index="2" label="Interval" units="us" minValue="-1" increment="1">The interval between two messages. -1: disable. 0: request default rate (which may be zero).</param>
+        <param index="3" label="Req Param 3">Use for index ID, if required. Otherwise, the use of this parameter (if any) must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="4" label="Req Param 4">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="5" label="Req Param 5">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
+        <param index="6" label="Req Param 6">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
         <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address of message stream (if message has target address fields). 0: Flight-stack default (recommended), 1: address of requestor, 2: broadcast.</param>
       </entry>
       <entry value="512" name="MAV_CMD_REQUEST_MESSAGE" hasLocation="false" isDestination="false">


### PR DESCRIPTION
This adds parameter details to [MAV_CMD_SET_MESSAGE_INTERVAL](https://mavlink.io/en/messages/common.html#MAV_CMD_SET_MESSAGE_INTERVAL ) to mirror [MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE) .

Specifically, request message allows you to get a particular instance of a message. So if you're only interested in the message for Battery_status instance 2 say, then that's the one you'll get. This allows you to do the same thing for intervals, if you're only interested in setting the interval for one thing. Note, I'm not sure you'll ever need this, and it would be a pain to implement, but the facility is there.

Further, you might want to configure other information that decides what values you get back, and this updates the remaining params to be used in this way.

This is needed for https://github.com/mavlink/mavlink/pull/2145, which wants to be able to specify that a streamed message belongs to a specific camera and video stream.

@peterbarker @julianoes Does this make sense to you?