### PR TITLE
mavlink_xml_to_markdown.py - remove unclosed b tag

### DIFF
--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -700,7 +700,7 @@ class MAVEnumEntry(object):
 
     def getMarkdown(self, currentDialect):
         """Return markdown for an enum entry"""
-        deprString = f"<b>{self.deprecated.getMarkdown()}" if self.deprecated else ""
+        deprString = f"{self.deprecated.getMarkdown()}" if self.deprecated else ""
         if self.wip:
             print(f"TODO: WIP in Enum Entry: {self.name}")
         importedNote = ""


### PR DESCRIPTION
This is a typo. The bolding happens in the method.