### PR TITLE
development.xml: First prototype for multi-GCS operation.

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2860,6 +2860,9 @@
       <entry value="9" name="MAV_RESULT_COMMAND_UNSUPPORTED_MAV_FRAME">
         <description>Command is invalid because a frame is required and the specified frame is not supported.</description>
       </entry>
+      <entry value="10" name="MAV_RESULT_PERMISSION_DENIED">
+        <description>Command is valid, but the sender is not authorized to control this MAV component. Sender should use MAV_CMD_REQUEST_OPERATOR_CONTROL accordingly to get control, more details in this command's description. (WIP).</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">
       <description>Result of mission operation (in a MISSION_ACK message).</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3245,6 +3245,10 @@
         <description>This component implements/is a gimbal manager. This means the GIMBAL_MANAGER_INFORMATION, and other messages can be requested.
         </description>
       </entry>
+      <entry value="524288" name="MAV_PROTOCOL_CAPABILITY_COMPONENT_ACCEPTS_GCS_CONTROL">
+        <wip/>
+        <description>This component sets its controlling GCS from a CONTROL_STATUS with the flag GCS_CONTROL_STATUS_FLAGS_SYSTEM_GCS set. Note that if a component can also be separately controlled by a GCS it will stream CONTROL_STATUS.</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">
       <description>Type of mission items being requested/sent in mission protocol.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2861,7 +2861,8 @@
         <description>Command is invalid because a frame is required and the specified frame is not supported.</description>
       </entry>
       <entry value="10" name="MAV_RESULT_PERMISSION_DENIED">
-        <description>Command is valid, but the sender is not authorized to control this MAV component. Sender should use MAV_CMD_REQUEST_OPERATOR_CONTROL accordingly to get control, more details in this command's description. (WIP).</description>
+        <wip/>
+        <description>Sender is not authorized to control this MAV component. Control may be requested using MAV_CMD_REQUEST_OPERATOR_CONTROL.</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3248,7 +3248,7 @@
       </entry>
       <entry value="524288" name="MAV_PROTOCOL_CAPABILITY_COMPONENT_ACCEPTS_GCS_CONTROL">
         <wip/>
-        <description>Component supports GCS control (via MAV_CMD_REQUEST_OPERATOR_CONTROL).</description>
+        <description>Component supports locking control to a particular GCS independent of its system (via MAV_CMD_REQUEST_OPERATOR_CONTROL).</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3248,7 +3248,7 @@
       </entry>
       <entry value="524288" name="MAV_PROTOCOL_CAPABILITY_COMPONENT_ACCEPTS_GCS_CONTROL">
         <wip/>
-        <description>This component sets its controlling GCS from a CONTROL_STATUS with the flag GCS_CONTROL_STATUS_FLAGS_SYSTEM_GCS set. Note that if a component can also be separately controlled by a GCS it will stream CONTROL_STATUS.</description>
+        <description>Component supports GCS control (via MAV_CMD_REQUEST_OPERATOR_CONTROL).</description>
       </entry>
     </enum>
     <enum name="MAV_MISSION_TYPE">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -406,7 +406,7 @@
            In this case the command should be sent to the specific component, which should also emit CONTROL_STATUS to indicate its owner (this component would ignore the CONTROL_STATUS set by the autopilot).
            The flow is otherwise the same.
         </description>
-        <param index="1" label="sysid requesting control">System ID MAVLink component requesting control (Usually a GCS).</param>
+        <param index="1" label="Sysid requesting control">System ID of GCS requesting control.</param>
         <param index="2" label="sysid control requested">System ID MAVLink component for which control is being requested (Usually a vehicle).</param>
         <param index="3" label="control action">0: Release control, 1: Request control.</param>
         <param index="4" label="allow_takeover">Allow other systems to take control of the MAV for which we are requesting control automatically, or enforce asking us first (0: don't allow takeover, ask current owner first, 1: allow takeover automatically) </param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -389,23 +389,34 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="43005" name="MAV_CMD_REQUEST_OPERATOR_CONTROL" hasLocation="false" isDestination="false">
-        <description>Request control of a system.
-        
-          A controlled vehicle should only accept MAVLink commands (or command-like messages) that are sent by the controlling GCS, or from other components with the same system id. Commands from other system should be rejected with MAV_RESULT_PERMISSION_DENIED (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
+        <description>Request GCS control of a system (or of a specific component in a system).
 
-          The command is sent by a GCS to the autopilot component to request or release control of a system, specifying whether subsequent takeover requests from another GCS are automatically granted, or require permission.
-          It is important to remember targeting a particular component, and avoiding using 0 targetting (all components). Only components emitting CONTROL_STATUS should be targeted, usually these will be autopilots, but could be other components like onboard computers.
-          The autopilot should grant control to the GCS if the system does not require takeover permission (or is uncontrolled) and ACK the request with MAV_RESULT_ACCEPTED.
-          The autopilot should stream CONTROL_STATUS indicating its controlling system: all other components with the same system id should monitor this message and set their own owner to match that of the autopilot.
+          A controlled system should only accept MAVLink commands and command-like messages that are sent by its controlling GCS, or from other components with the same system id.
+          Commands from other systems should be rejected with MAV_RESULT_PERMISSION_DENIED (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
+          Command-like messages should be ignored (or rejected if that is supported by their associated protocol).
 
-          If the autopilot cannot grant control (because takeover requires permission), the request should be rejected with MAV_RESULT_PERMISSION_DENIED.
-          The autopilot should then send this same command to the current owning GCS in order to notify of the request.
-          The owning GCS would ACK with MAV_RESULT_ACCEPTED, and might choose to release ownership of the vehicle, or re-request ownership with the takeover bit set to allow permission. 
+          GCS control of the whole system is managed via a single component that we will refer to here as the "system manager component".
+          This component streams the CONTROL_STATUS message and sets the GCS_CONTROL_STATUS_FLAGS_SYSTEM_MANAGER flag.
+          Other components in the system should monitor for the CONTROL_STATUS message with this flag, and set their controlling GCS to match its published system id.
+          A GCS that wants to control the system should also monitor for the same message and flag, and address the MAV_CMD_REQUEST_OPERATOR_CONTROL to its component id.
+          Note that integrators are required to ensure that there is only one system manager component in the system (i.e. one component emitting the message with GCS_CONTROL_STATUS_FLAGS_SYSTEM_MANAGER set).
+   
+          The MAV_CMD_REQUEST_OPERATOR_CONTROL command is sent by a GCS to the system manager component to request or release control of a system, specifying whether subsequent takeover requests from another GCS are automatically granted, or require permission.
+
+          The system manager component should grant control to the GCS if the system does not require takeover permission (or is uncontrolled) and ACK the request with MAV_RESULT_ACCEPTED.
+          The system manager component should then stream CONTROL_STATUS indicating its controlling system: all other components with the same system id should monitor this message and set their own controlling GCS to match that of the system manager component.
+
+          If the system manager component cannot grant control (because takeover requires permission), the request should be rejected with MAV_RESULT_PERMISSION_DENIED.
+          The system manager component should then send this same command to the current owning GCS in order to notify of the request.
+          The owning GCS would ACK with MAV_RESULT_ACCEPTED, and might choose to release control of the vehicle, or re-request control with the takeover bit set to allow permission. 
           Note that the pilots of both GCS should co-ordinate safe handover offline.
-
-          It is also possible for a GCS to request control of a specific component rather than the whole system (though this is not recommended).
-          In this case the command should be sent to the specific component, which should also emit CONTROL_STATUS to indicate its owner (this component would ignore the CONTROL_STATUS set by the autopilot).
-          The flow is otherwise the same.
+          
+          Note that in most systems the only controlled component will be the "system manager component", and that will be the autopilot.
+          However separate GCS control of a particular component is also permitted, if supported by the component.
+          In this case the GCS will address MAV_CMD_REQUEST_OPERATOR_CONTROL to the specific component it wants to control.
+          The component will then stream CONTROL_STATUS for its controlling GCS (it must not set GCS_CONTROL_STATUS_FLAGS_SYSTEM_MANAGER).
+          The component should fall back to the system GCS (if any) when it is not directly controlled, and may stop emitting CONTROL_STATUS.
+          The flow is otherwise the same as for requesting control over the whole system.
         </description>
         <param index="1" label="Sysid requesting control">System ID of GCS requesting control. 0 when command sent from GCS to autopilot (autopilot determines requesting GCS sysid from message header). Sysid of GCS requesting control when command sent by autopilot to controlling GCS.</param>
         <param index="2" label="Action">0: Release control, 1: Request control.</param>
@@ -418,8 +429,8 @@
     </enum>
     <enum name="GCS_CONTROL_STATUS_FLAGS" bitmask="true">
       <description>CONTROL_STATUS flags.</description>
-      <entry value="1" name="GCS_CONTROL_STATUS_FLAGS_MASTER_COMPID">
-        <description>When a GCS sends MAV_CMD_REQUEST_OPERATOR_CONTROL to acquire control of a whole system it needs to address the component emitting this flag. Should be set by only one component in the system, normally an autopilot.</description>
+      <entry value="1" name="GCS_CONTROL_STATUS_FLAGS_SYSTEM_MANAGER">
+        <description>If set, this CONTROL_STATUS publishes the controlling GCS for the whole system. If unset, the CONTROL_STATUS indicates the controlling GCS for just the component emitting the message. Note that to request control of the system a GCS should send MAV_CMD_REQUEST_OPERATOR_CONTROL to the component emitting CONTROL_STATUS with this flag set.</description>
       </entry>
       <entry value="2" name="GCS_CONTROL_STATUS_FLAGS_TAKEOVER_ALLOWED">
         <description>Takeover allowed (requests for control will be granted). If not set requests for control will be rejected, but the controlling GCS will be notified (and may release control or allow takeover).</description>
@@ -778,8 +789,8 @@
     </message>
     <message id="512" name="CONTROL_STATUS">
       <description>Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change. Control over MAV is requested using MAV_CMD_REQUEST_OPERATOR_CONTROL.</description>
-      <field type="uint8_t" name="sysid_in_control">System ID of GCS MAVLink component in control (0: no one in control)</field>
-      <field type="uint8_t" name="flags" enum="GCS_CONTROL_STATUS_FLAGS" display="bitmask">Control status. For example, whether takeover is allowed, and whether this component defines the default GCS controller for the whole system</field>
+      <field type="uint8_t" name="sysid_in_control">System ID of GCS MAVLink component in control (0: no GCS in control).</field>
+      <field type="uint8_t" name="flags" enum="GCS_CONTROL_STATUS_FLAGS" display="bitmask">Control status. For example, whether takeover is allowed, and whether this message instance defines the default controlling GCS for the whole system.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -768,7 +768,7 @@
     </message>
     <message id="512" name="CONTROL_STATUS">
       <description>Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change.</description>
-      <field type="uint8_t" name="sysid_in_control">System ID of MAVLink component in control (0: no one in control)</field>
+      <field type="uint8_t" name="sysid_in_control">System ID of GCS MAVLink component in control (0: no one in control)</field>
       <field type="uint8_t" name="takeover_allowed">If current MAVLink component in control requires asking permission before taking control of the MAV emitting this message (0: takeover not allowed, ask current owner first, 1: takeover allowed automatically)</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -406,7 +406,7 @@
           In this case the command should be sent to the specific component, which should also emit CONTROL_STATUS to indicate its owner (this component would ignore the CONTROL_STATUS set by the autopilot).
           The flow is otherwise the same.
         </description>
-        <param index="1" label="Sysid requesting control">System ID of GCS requesting control. It is only needed when an autopilot is forwarding the control request to the current GCS in control. Otherwise, from GCS to autopilot, it should be 0 as it can be deducted from the sender system ID</param>
+        <param index="1" label="Sysid requesting control">System ID of GCS requesting control. 0 when command sent from GCS to autopilot (autopilot determines requesting GCS sysid from message header). Sysid of GCS requesting control when command sent by autopilot to controlling GCS.</param>
         <param index="2" label="Action">0: Release control, 1: Request control.</param>
         <param index="3" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>
         <param index="4">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -409,7 +409,7 @@
         <param index="1" label="Sysid requesting control">System ID of GCS requesting control.</param>
         <param index="2" label="sysid control requested">System ID MAVLink component for which control is being requested (Usually a vehicle).</param>
         <param index="3" label="Action">0: Release control, 1: Request control.</param>
-        <param index="4" label="allow_takeover">Allow other systems to take control of the MAV for which we are requesting control automatically, or enforce asking us first (0: don't allow takeover, ask current owner first, 1: allow takeover automatically) </param>
+        <param index="4" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -770,7 +770,7 @@
     <message id="512" name="CONTROL_STATUS">
       <description>Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change. Control over MAV is requested using MAV_CMD_REQUEST_OPERATOR_CONTROL.</description>
       <field type="uint8_t" name="sysid_in_control">System ID of GCS MAVLink component in control (0: no one in control)</field>
-      <field type="uint8_t" name="takeover_allowed">1: Requests for control will be granted. 0: Requests for control will be rejected, but the controlling GCS will be notified (and may release control or allow takeover).</field>
+      <field type="uint8_t" name="flags" enum="GCS_CONTROL_STATUS_FLAGS" display="bitmask">Control status. For example, whether takeover is allowed, and whether this component defines the default GCS controller for the whole system</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -767,7 +767,7 @@
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
     </message>
     <message id="512" name="CONTROL_STATUS">
-      <description>Current status about the MAVLink component in control of this MAV. It is meant to be broadcasted at a low rate (1 hz or less), and also wehenever the fields on this message changes</description>
+      <description>Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="sysid_in_control">System ID of MAVLink component in control (0: no one in control)</field>
       <field type="uint8_t" name="takeover_allowed">If current MAVLink component in control requires asking permission before taking control of the MAV emitting this message (0: takeover not allowed, ask current owner first, 1: takeover allowed automatically)</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -768,7 +768,6 @@
     </message>
     <message id="512" name="CONTROL_STATUS">
       <description>Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change.</description>
-      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="sysid_in_control">System ID of MAVLink component in control (0: no one in control)</field>
       <field type="uint8_t" name="takeover_allowed">If current MAVLink component in control requires asking permission before taking control of the MAV emitting this message (0: takeover not allowed, ask current owner first, 1: takeover allowed automatically)</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -388,6 +388,16 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+      <entry value="43005" name="MAV_CMD_REQUEST_OPERATOR_CONTROL" hasLocation="false" isDestination="false">
+        <description>Sent by a MAVLink component (usually GCS) to a vehicle to attempt to request control of it, or sent by a vehicle to the MAVLink component in control to ask for permission to grant control to a different MAVLink component.</description>
+        <param index="1" label="sysid requesting control">System ID MAVLink component requesting control (Usually a GCS).</param>
+        <param index="2" label="sysid control requested">System ID MAVLink component for which control is being requested (Usually a vehicle).</param>
+        <param index="3" label="control action">0: Release control, 1: Request control.</param>
+        <param index="4" label="allow_takeover">Allow other systems to take control of the MAV for which we are requesting control automatically, or enforce asking us first (0: don't allow takeover, ask current owner first, 1: allow takeover automatically) </param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
     </enum>
     <enum name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS" bitmask="true">
       <description>These flags indicate the sensor reporting capabilities for TARGET_ABSOLUTE.</description>
@@ -739,6 +749,12 @@
       <field type="float[4]" name="q_target">Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="float[4]" name="q_sensor">Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)</field>
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
+    </message>
+    <message id="512" name="CONTROL_STATUS">
+      <description>Current status about the MAVLink component in control of this MAV. It is meant to be broadcasted at a low rate (1 hz or less), and also wehenever the fields on this message changes</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
+      <field type="uint8_t" name="sysid_in_control">System ID of MAVLink component in control (0: no one in control)</field>
+      <field type="uint8_t" name="takeover_allowed">If current MAVLink component in control requires asking permission before taking control of the MAV emitting this message (0: takeover not allowed, ask current owner first, 1: takeover allowed automatically)</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -407,9 +407,9 @@
            The flow is otherwise the same.
         </description>
         <param index="1" label="Sysid requesting control">System ID of GCS requesting control. It is only needed when an autopilot is forwarding the control request to the current GCS in control. Otherwise, from GCS to autopilot, it should be 0 as it can be deducted from the sender system ID</param>
-        <param index="2" label="sysid control requested">System ID MAVLink component for which control is being requested (Usually a vehicle).</param>
-        <param index="3" label="Action">0: Release control, 1: Request control.</param>
-        <param index="4" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>
+        <param index="2" label="Action">0: Release control, 1: Request control.</param>
+        <param index="3" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>
+        <param index="4">Empty</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -406,7 +406,7 @@
            In this case the command should be sent to the specific component, which should also emit CONTROL_STATUS to indicate its owner (this component would ignore the CONTROL_STATUS set by the autopilot).
            The flow is otherwise the same.
         </description>
-        <param index="1" label="Sysid requesting control">System ID of GCS requesting control.</param>
+        <param index="1" label="Sysid requesting control">System ID of GCS requesting control. It is only needed when an autopilot is forwarding the control request to the current GCS in control. Otherwise, from GCS to autopilot, it should be 0 as it can be deducted from the sender system ID</param>
         <param index="2" label="sysid control requested">System ID MAVLink component for which control is being requested (Usually a vehicle).</param>
         <param index="3" label="Action">0: Release control, 1: Request control.</param>
         <param index="4" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -392,19 +392,19 @@
         <description>Request control of a system.
         
           A controlled vehicle should only accept MAVLink commands (or command-like messages) that are sent by the controlling GCS, or from other components with the same system id. Commands from other system should be rejected with MAV_RESULT_PERMISSION_DENIED (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
-        
-           The command is sent by a GCS to the autopilot component to request or release control of a system, specifying whether subsequent takeover requests from another GCS are automatically granted, or require permission.
-           The autopilot should grant control to the GCS the system does not require takeover permission or is uncontrolled and ACK the request with MAV_RESULT_ACCEPTED.
-           The autopilot should stream CONTROL_STATUS indicating its controlling system: all other components with the same system id should monitor this message and set their own owner to match that of the autopilot.
+
+          The command is sent by a GCS to the autopilot component to request or release control of a system, specifying whether subsequent takeover requests from another GCS are automatically granted, or require permission.
+          The autopilot should grant control to the GCS if the system does not require takeover permission (or is uncontrolled) and ACK the request with MAV_RESULT_ACCEPTED.
+          The autopilot should stream CONTROL_STATUS indicating its controlling system: all other components with the same system id should monitor this message and set their own owner to match that of the autopilot.
 
           If the autopilot cannot grant control (because takeover requires permission), the request should be rejected with MAV_RESULT_PERMISSION_DENIED.
           The autopilot should then send this same command to the current owning GCS in order to notify of the request.
-          The owning GCS would then ACK with MAV_RESULT_ACCEPTED, and might choose to release ownership of the vehicle, or re-request ownership with the takeover bit set to allow permission. 
+          The owning GCS would ACK with MAV_RESULT_ACCEPTED, and might choose to release ownership of the vehicle, or re-request ownership with the takeover bit set to allow permission. 
           Note that the pilots of both GCS should co-ordinate safe handover offline.
-           
-           It is also possible for a GCS to request control of a specific component rather than the whole system (though this is not recommended).
-           In this case the command should be sent to the specific component, which should also emit CONTROL_STATUS to indicate its owner (this component would ignore the CONTROL_STATUS set by the autopilot).
-           The flow is otherwise the same.
+
+          It is also possible for a GCS to request control of a specific component rather than the whole system (though this is not recommended).
+          In this case the command should be sent to the specific component, which should also emit CONTROL_STATUS to indicate its owner (this component would ignore the CONTROL_STATUS set by the autopilot).
+          The flow is otherwise the same.
         </description>
         <param index="1" label="Sysid requesting control">System ID of GCS requesting control. It is only needed when an autopilot is forwarding the control request to the current GCS in control. Otherwise, from GCS to autopilot, it should be 0 as it can be deducted from the sender system ID</param>
         <param index="2" label="Action">0: Release control, 1: Request control.</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -767,7 +767,7 @@
       <field type="uint8_t" name="type" enum="LANDING_TARGET_TYPE">Type of target</field>
     </message>
     <message id="512" name="CONTROL_STATUS">
-      <description>Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change.</description>
+      <description>Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change. Control over MAV is requested using MAV_CMD_REQUEST_OPERATOR_CONTROL.</description>
       <field type="uint8_t" name="sysid_in_control">System ID of GCS MAVLink component in control (0: no one in control)</field>
       <field type="uint8_t" name="takeover_allowed">If current MAVLink component in control requires asking permission before taking control of the MAV emitting this message (0: takeover not allowed, ask current owner first, 1: takeover allowed automatically)</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -394,6 +394,7 @@
           A controlled vehicle should only accept MAVLink commands (or command-like messages) that are sent by the controlling GCS, or from other components with the same system id. Commands from other system should be rejected with MAV_RESULT_PERMISSION_DENIED (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
 
           The command is sent by a GCS to the autopilot component to request or release control of a system, specifying whether subsequent takeover requests from another GCS are automatically granted, or require permission.
+          It is important to remember targeting a particular component, and avoiding using 0 targetting (all components). Only components emitting CONTROL_STATUS should be targeted, usually these will be autopilots, but could be other components like onboard computers.
           The autopilot should grant control to the GCS if the system does not require takeover permission (or is uncontrolled) and ACK the request with MAV_RESULT_ACCEPTED.
           The autopilot should stream CONTROL_STATUS indicating its controlling system: all other components with the same system id should monitor this message and set their own owner to match that of the autopilot.
 

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -408,7 +408,7 @@
         </description>
         <param index="1" label="Sysid requesting control">System ID of GCS requesting control.</param>
         <param index="2" label="sysid control requested">System ID MAVLink component for which control is being requested (Usually a vehicle).</param>
-        <param index="3" label="control action">0: Release control, 1: Request control.</param>
+        <param index="3" label="Action">0: Release control, 1: Request control.</param>
         <param index="4" label="allow_takeover">Allow other systems to take control of the MAV for which we are requesting control automatically, or enforce asking us first (0: don't allow takeover, ask current owner first, 1: allow takeover automatically) </param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -389,7 +389,23 @@
         <param index="7">Empty</param>
       </entry>
       <entry value="43005" name="MAV_CMD_REQUEST_OPERATOR_CONTROL" hasLocation="false" isDestination="false">
-        <description>Sent by a MAVLink component (usually GCS) to a vehicle to attempt to request control of it, or sent by a vehicle to the MAVLink component in control to ask for permission to grant control to a different MAVLink component.</description>
+        <description>Request control of a system.
+        
+          A controlled vehicle should only accept MAVLink commands (or command-like messages) that are sent by the controlling GCS, or from other components with the same system id. Commands from other system should be rejected with MAV_RESULT_PERMISSION_DENIED (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
+        
+           The command is sent by a GCS to the autopilot component to request or release control of a system, specifying whether subsequent takeover requests from another GCS are automatically granted, or require permission.
+           The autopilot should grant control to the GCS the system does not require takeover permission or is uncontrolled and ACK the request with MAV_RESULT_ACCEPTED.
+           The autopilot should stream CONTROL_STATUS indicating its controlling system: all other components with the same system id should monitor this message and set their own owner to match that of the autopilot.
+
+          If the autopilot cannot grant control (because takeover requires permission), the request should be rejected with MAV_RESULT_PERMISSION_DENIED.
+          The autopilot should then send this same command to the current owning GCS in order to notify of the request.
+          The owning GCS would then ACK with MAV_RESULT_ACCEPTED, and might choose to release ownership of the vehicle, or re-request ownership with the takeover bit set to allow permission. 
+          Note that the pilots of both GCS should co-ordinate safe handover offline.
+           
+           It is also possible for a GCS to request control of a specific component rather than the whole system (though this is not recommended).
+           In this case the command should be sent to the specific component, which should also emit CONTROL_STATUS to indicate its owner (this component would ignore the CONTROL_STATUS set by the autopilot).
+           The flow is otherwise the same.
+        </description>
         <param index="1" label="sysid requesting control">System ID MAVLink component requesting control (Usually a GCS).</param>
         <param index="2" label="sysid control requested">System ID MAVLink component for which control is being requested (Usually a vehicle).</param>
         <param index="3" label="control action">0: Release control, 1: Request control.</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -769,7 +769,7 @@
     <message id="512" name="CONTROL_STATUS">
       <description>Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change. Control over MAV is requested using MAV_CMD_REQUEST_OPERATOR_CONTROL.</description>
       <field type="uint8_t" name="sysid_in_control">System ID of GCS MAVLink component in control (0: no one in control)</field>
-      <field type="uint8_t" name="takeover_allowed">If current MAVLink component in control requires asking permission before taking control of the MAV emitting this message (0: takeover not allowed, ask current owner first, 1: takeover allowed automatically)</field>
+      <field type="uint8_t" name="takeover_allowed">1: Requests for control will be granted. 0: Requests for control will be rejected, but the controlling GCS will be notified (and may release control or allow takeover).</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -416,6 +416,15 @@
         <param index="7">Empty</param>
       </entry>
     </enum>
+    <enum name="GCS_CONTROL_STATUS_FLAGS" bitmask="true">
+      <description>CONTROL_STATUS flags.</description>
+      <entry value="1" name="GCS_CONTROL_STATUS_FLAGS_MASTER_COMPID">
+        <description>When a GCS sends MAV_CMD_REQUEST_OPERATOR_CONTROL to acquire control of a whole system it needs to address the component emitting this flag. Should be set by only one component in the system, normally an autopilot.</description>
+      </entry>
+      <entry value="2" name="GCS_CONTROL_STATUS_FLAGS_TAKEOVER_ALLOWED">
+        <description>Takeover allowed (requests for control will be granted). If not set requests for control will be rejected, but the controlling GCS will be notified (and may release control or allow takeover).</description>
+      </entry>
+    </enum>
     <enum name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_FLAGS" bitmask="true">
       <description>These flags indicate the sensor reporting capabilities for TARGET_ABSOLUTE.</description>
       <entry value="1" name="TARGET_ABSOLUTE_SENSOR_CAPABILITY_POSITION"/>


### PR DESCRIPTION
Implement basic functionality for a MAV to broadcast information about the current MAVLink component (usually a GCS) in control of it and a new command to request this control. This follows the discussion in https://github.com/mavlink/mavlink/issues/2098, specifically the latest comments @hamishwillee suggested in https://github.com/mavlink/mavlink/issues/2098#issuecomment-2360036137 about the "cannot be taken over bit", as it makes more sense than the previous approach suggested.

### Description       
A controlled vehicle should only accept MAVLink commands (or command-like messages) that are sent by the controlling GCS, or from other components with the same system id. Commands from other system should be rejected with MAV_RESULT_PERMISSION_DENIED (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
        
The command is sent by a GCS to the autopilot component to request or release control of a system, specifying whether subsequent takeover requests from another GCS are automatically granted, or require permission. The autopilot should grant control to the GCS if the system does not require takeover permission or is uncontrolled and ACK the request with MAV_RESULT_ACCEPTED. The autopilot should stream CONTROL_STATUS indicating its controlling system: all other components with the same system id should monitor this message and set their own owner to match that of the autopilot.

If the autopilot cannot grant control (because takeover requires permission), the request should be rejected with MAV_RESULT_PERMISSION_DENIED. The autopilot should then send this same command to the current owning GCS in order to notify of the request.

The owning GCS would then ACK with MAV_RESULT_ACCEPTED, and might choose to release ownership of the vehicle, or re-request ownership with the takeover bit set to allow permission. 
Note that the pilots of both GCS should co-ordinate safe handover offline.
           
It is also possible for a GCS to request control of a specific component rather than the whole system (though this is not recommended). In this case the command should be sent to the specific component, which should also emit CONTROL_STATUS to indicate its owner (this component would ignore the CONTROL_STATUS set by the autopilot). The flow is otherwise the same.

### New messages and commands:
#### New messages:
- CONTROL_STATUS: Information about GCS in control of this MAV. This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change. Control over MAV is requested using MAV_CMD_REQUEST_OPERATOR_CONTROL:

    - sysid_in_control: System ID of GCS MAVLink component in control (0: no one in control)
    - takeover_allowed: 1: Requests for control will be granted. 0: Requests for control will be rejected, but the controlling GCS will be notified (and may release control or allow takeover).
   
#### New commands:
- MAV_CMD_REQUEST_OPERATOR_CONTROL: Request control of a system.

    - param 1: Sysid requesting control - System ID of GCS requesting control. 0 when command sent from GCS to autopilot (autopilot determines requesting GCS sysid from message header). Sysid of GCS requesting control when command sent by autopilot to controlling GCS.
    - param 2: Action - 0: Release control, 1: Request control.
    - param 3: Allow takeover - Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.

### Some workflow diagrams
##### Diagram 1 - 2 GCS, one of them asks for control without enforcing being asked before other GCS takes over (MAV_CMD_REQUEST_OPERATOR_CONTROL param 3 = 1):
```mermaid
sequenceDiagram;
    participant GCS - 253
    participant Vehicle - 1
    participant GCS - 250
    note over Vehicle - 1: Broadcast CONTROL_STATUS: Nobody in control <br> - Sysid In control: 0
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 0
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 0 
    Note over GCS - 253: GCS 253 wants to request control <br> not enforcing asking for takeover
    GCS - 253->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 1 (allow automatic takeover)
    Vehicle - 1->>GCS - 253: COMMAND_ACK
    Note over Vehicle - 1: Control is transfered to GCS 253
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 253 <br> - takeover_allowed: 1 (takeover allowed automatically)
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 253 <br> - takeover_allowed: 1 (takeover allowed automatically)
    Note over GCS - 253: It is now in control of vehicle 1
    Note over GCS - 250: Now GCS 250 wants to request control. <br> As GCS 253 didn't enforce being asked, <br> it will be granted automatically.
    GCS - 250->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 1 (allow automatic takeover, although irrelevant right now)
    Vehicle - 1->>GCS - 250: COMMAND_ACK
    Note over Vehicle - 1: As asking for takeover wasn't enforced by GCS 253, <br> control is granted automatically.
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 250 <br> - takeover_allowed: 1 (takeover allowed automatically)
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 250 <br> - takeover_allowed: 1 (takeover allowed automatically)
```

##### Diagram 2 - Now one of them asks for control enforcing being asked before other GCS takes over. When the other GCS takes over, the original GCS in control just requests again control without enforcing being asked before. This situation is interesting so the vehicle is never with no GCS in control. An alternative approach is in diagram 3.
```mermaid
sequenceDiagram;
    participant GCS - 253
    participant Vehicle - 1
    participant GCS - 250
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 0
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 0 
    Note over GCS - 253: GCS 253 wants to request control <br> ENFORCING asking for takeover first
    GCS - 253->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 0 (Do not allow automatic takeover, ask first)
    Vehicle - 1->>GCS - 253: COMMAND_ACK
    Note over Vehicle - 1: Control is transfered to GCS 253
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 253 <br> - takeover_allowed: 0 (automatic takeover not allowed, ask first)
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 253 <br> - takeover_allowed: 0 (automatic takeover not allowed, ask first)
    Note over GCS - 253: It is now in control of vehicle 1
    Note over GCS - 250: Now GCS 250 wants to request control
    GCS - 250->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 1 (allow automatic takeover, although irrelevant at this point)
    Vehicle - 1->>GCS - 250: COMMAND_ACK
    Vehicle - 1->>GCS - 253: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 250 (Sysid requesting control) <br> - param 2: 1 (request control) <br> - param 3: 1 (allow automatic takeover, although irrelevant at this point)
    Note over GCS - 253: Popup appears in GCS comunicating the request from GCS 250. <br>User accepts. Requesting control again without enforcint being asked for takeover
    GCS - 253->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 1 (allow automatic takeover)
    Vehicle - 1->>GCS - 253: COMMAND_ACK
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 253 <br> - takeover_allowed: 1 (automatic takeover allowed)
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 253 <br> - takeover_allowed: 1 (automatic takeover allowed)
    Note over GCS - 250: As vehicle is reporting now automatic takeover <br> is allowed, we are free to request control  
    GCS - 250->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 0 (do not allow automatic takeover, although irrelevant at this point)
    Vehicle - 1->>GCS - 250: COMMAND_ACK
    Note over Vehicle - 1: Control will be granted automatically now
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 250 <br> - takeover_allowed: 1 (allow automatic takeover)
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 250 <br> - takeover_allowed: 1 (allow automatic takeover)
```
##### Diagram 3 - Now one of them asks for control enforcing being asked before other GCS takes over. When the other GCS takes over, the original GCS in control just releases control. This might be desirable in some situations, but leaves the vehicle with no owner until the second GCS requests control:
```mermaid
sequenceDiagram;
    participant GCS - 253
    participant Vehicle - 1
    participant GCS - 250
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 0
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 0 
    Note over GCS - 253: GCS 253 wants to request control <br> ENFORCING asking for takeover first
    GCS - 253->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 0 (Do not allow automatic takeover, ask first)
    Vehicle - 1->>GCS - 253: COMMAND_ACK
    Note over Vehicle - 1: Control is transfered to GCS 253
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 253 <br> - takeover_allowed: 0 (automatic takeover not allowed, ask first)
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 253 <br> - takeover_allowed: 0 (automatic takeover not allowed, ask first)
    Note over GCS - 253: It is now in control of vehicle 1
    Note over GCS - 250: Now GCS 250 wants to request control
    GCS - 250->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 1 (allow automatic takeover, although irrelevant at this point)
    Vehicle - 1->>GCS - 250: COMMAND_ACK
    Vehicle - 1->>GCS - 253: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 250 (Sysid requesting control) <br> - param 2: 1 (request control) <br> - param 3: 1 (allow automatic takeover, although irrelevant at this point)
    Note over GCS - 253: Popup appears in GCS comunicating the request from GCS 250. <br>User accepts. Releasing control
    GCS - 253->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 0 (release control) <br> - param 3: 1 (allow automatic takeover, although it doesn't apply as we drop control)
    Vehicle - 1->>GCS - 253: COMMAND_ACK
    Note over Vehicle - 1: Nobody in control now
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 0 <br> - takeover_allowed: 1 (automatic takeover allowed)
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 0 <br> - takeover_allowed: 1 (automatic takeover allowed)
    Note over GCS - 250: As vehicle is reporting now nobody in control <br> We are free to request control  
    GCS - 250->>Vehicle - 1: MAV_CMD_REQUEST_OPERATOR_CONTROL: <br> - param 1: 0 (Sysid requesting control not needed, can be deducted from sender) <br> - param 2: 1 (request control) <br> - param 3: 0 (do not allow automatic takeover, although irrelevant at this point)
    Vehicle - 1->>GCS - 250: COMMAND_ACK
    Note over Vehicle - 1: Control will be granted automatically now, as <br> nobody is in control
    Vehicle - 1->>GCS - 253: CONTROL_STATUS <br> - sysid_in_control: 250 <br> - takeover_allowed: 1 (allow automatic takeover)
    Vehicle - 1->>GCS - 250: CONTROL_STATUS <br> - sysid_in_control: 250 <br> - takeover_allowed: 1 (allow automatic takeover)
```


We could expand and add more diagrams for the documentation, but I wanted to double check this looks good first.

For awareness @rmackay9 @julianoes.

Thanks!
