### PR TITLE
RC_TYPE for binding

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4005,7 +4005,7 @@
       </entry>
     </enum>
     <enum name="RC_TYPE">
-      <description>RC type</description>
+      <description>RC type. Used in MAV_CMD_START_RX_PAIR.</description>
       <entry value="0" name="RC_TYPE_SPEKTRUM_DSM2">
         <description>Spektrum DSM2</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4012,6 +4012,9 @@
       <entry value="1" name="RC_TYPE_SPEKTRUM_DSMX">
         <description>Spektrum DSMX</description>
       </entry>
+      <entry value="2" name="RC_TYPE_CRSF">
+        <description>CRSF radio</description>
+      </entry>
     </enum>
     <enum name="POSITION_TARGET_TYPEMASK" bitmask="true">
       <description>Bitmap to indicate which dimensions should be ignored by the vehicle: a value of 0b0000000000000000 or 0b0000001000000000 indicates that none of the setpoint dimensions should be ignored. If bit 9 is set the floats afx afy afz should be interpreted as force instead of acceleration.</description>


### PR DESCRIPTION
This adds a type for binding CRSF RC radios, which is being supported in https://github.com/PX4/PX4-Autopilot/pull/23294

There is an alternative proposal https://github.com/mavlink/mavlink/pull/2162 this is probably better - but I created this before I saw that. Lets discuss in mav call.

@benjinne I've described this as "CRSF radio". The way I saw this message is that is was poorly designed originally with just spectrum and then the other options were added later with RC_TYPE when someone wanted to implement those. In other words it wasn't a design to go type/and subtype. I could be wrong though.

FWIW I'm not even sure having an RC type is actually useful. You could just say "I get this command, then I check what types of RC radios I have, and if they support binding, I attempt to bind them. Too late to change now I guess - we just need to work out how to take this forward.
Note, the RC type isn't even useful for the two RC on vehicle case, since they might be the same kind.

@auturgy @julianoes 

FMI  Is it ever useful to specify the RC "kind" here?
