### PR TITLE
Docs: Remove the imported headers for everything except common.xml

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -4,10 +4,13 @@ Files:
 
 - **Doxyfile**: Doxygen project configuration file
 - **README**: This file
-- **mavlink.php**: Generates online documentation from MAVLink XML - http://mavlink.org/messages/common
-  - **mavlink_to_html_table.xsl**: XSL transform used by **mavlink.php**
-  - **mavlink.css**: CSS used by online documentation
 - **mavlink_xml_to_markdown.py**: Converts MAVLink XML to markdown
+
+Deprecated files
+
+- **mavlink.php**: Generates online documentation from MAVLink XML - http://mavlink.org/messages/common
+  - **mavlink_to_html_table.xsl**: XSL transform used by **mavlink.php** (Deprecated)
+  - **mavlink.css**: CSS used by online documentation (Deprecated)
 - **mavlink_gitbook.py** (Deprecated): Generates documentation from MAVLink XML that can be imported into gitbook - replaced by mavlink_xml_to_markdown.py
   - **mavlink_to_html_table_gitbook.xsl** (Deprecated): XSL transform used by **mavlink_gitbook.py**
 

--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -582,6 +582,13 @@ class MAVMessage(object):
         """
         Return markdown for a message.
         """
+        # If it is common we include everything.
+        # But for any other dialect don't include the entity
+        if currentDialect == 'common':
+            pass
+        elif self.basename is not currentDialect:
+            return ""
+
         message = f"### {self.name} ({self.id})"
 
         # Add marker after name if there are additions
@@ -599,13 +606,6 @@ class MAVMessage(object):
             message += " [WIP]"
             # message+=f"Included from [{self.basename}](../messages/{self.basename}.md#{self.name})\n\n"  # With basename (dialect name) test
         message += ' {#' + self.name + '}\n\n'
-
-        # If it is common we include everything.
-        # But for any other dialect we don't include the reset of the message
-        if currentDialect == 'common':
-            pass
-        elif self.basename is not currentDialect:
-            return message
 
         if self.deprecated:
             message += self.deprecated.getMarkdown()+"\n\n"
@@ -754,6 +754,13 @@ class MAVEnum(object):
     def getMarkdown(self, currentDialect):
         """Return markdown for a whole enum"""
 
+        # If it is common we include everything.
+        # But for any other dialect don't include the entity
+        if currentDialect == 'common':
+            pass
+        elif self.basename is not currentDialect:
+            return ""
+
         string = f"### {self.name}"
 
         # Add marker after name if there are additions
@@ -770,13 +777,6 @@ class MAVEnum(object):
             string += " [WIP]"
             # message+=f"Included from [{self.basename}](../messages/{self.basename}.md#{self.name})\n\n"  # With basename (dialect name) test
         string += ' {#' + self.name + '}\n\n'
-
-        # If it is common we include everything.
-        # But for any other dialect we don't include the reset of the message
-        if currentDialect == 'common':
-            pass
-        elif self.basename is not currentDialect:
-            return string
 
         if self.deprecated:
             string += self.deprecated.getMarkdown()+"\n\n"
@@ -900,6 +900,13 @@ class MAVCommand(object):
     def getMarkdown(self, currentDialect):
         """Return markdown for a command (entry)"""
 
+        # If it is common we include everything.
+        # But for any other dialect don't include the entity
+        if currentDialect == 'common':
+            pass
+        elif self.basename is not currentDialect:
+            return ""
+
         string = f"### {self.name} ({self.value})"
 
         # Add marker after name if there are additions
@@ -915,14 +922,6 @@ class MAVCommand(object):
         elif self.wip:
             string += " [WIP]"
         string += ' {#' + self.name + '}\n\n'
-
-        # If it is common we include everything.
-        # But for any other dialect we don't include the reset of the message
-        if currentDialect == 'common':
-            pass
-        elif self.basename is not currentDialect:
-            return string
-
 
         if self.deprecated:
             string += self.deprecated.getMarkdown() + "\n\n"


### PR DESCRIPTION
The docs for development.xml (say) were displaying full messages/enums/commands for declarations, but only a heading and a link for included entities. Ditto for everything except common.xml, which had full docs for all entities, whether included or not.

This proved a bit hard to use for working out what was the subset you can use everywhere and what you can use in your dialect. I.e. in development you are only interested really in the entities that are risky to use. Even if you're using ardupilotmega.xml it is easier to be able to look at just what is in the file.

Anyway, common.xml stays the same, but everything else no longer displays a heading for included entities.