### PR TITLE
development.xml: change OPERATOR_CONTROL id to 43006:

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -388,7 +388,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="43005" name="MAV_CMD_REQUEST_OPERATOR_CONTROL" hasLocation="false" isDestination="false">
+      <entry value="32100" name="MAV_CMD_REQUEST_OPERATOR_CONTROL" hasLocation="false" isDestination="false">
         <description>Request GCS control of a system (or of a specific component in a system).
 
           A controlled system should only accept MAVLink commands and command-like messages that are sent by its controlling GCS, or from other components with the same system id.


### PR DESCRIPTION
It collides with a new command in Ardupilotmega.xml, in Ardupilot repo. See:
https://github.com/ArduPilot/mavlink/blob/4c64b9522f9bb9815b089ab98cf2f33f11bded52/message_definitions/v1.0/ardupilotmega.xml#L344

Is it alright to do this being in development.xml @hamishwillee? Thanks!