### PR TITLE
[WIP] Deprecate HIL_GPS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6190,6 +6190,7 @@
       <field type="uint32_t" name="seq">Image frame sequence</field>
     </message>
     <message id="113" name="HIL_GPS">
+      <deprecated since="2024-11" replaced_by="GPS_INPUT">Use GPS_INPUT as a near-synonymous replacement.</deprecated>
       <description>The global position, as returned by the Global Positioning System (GPS). This is
                  NOT the global position estimate of the system, but rather a RAW sensor value. See message GLOBAL_POSITION_INT for the global position estimate.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>


### PR DESCRIPTION
HIL_GPS can more or less be replaced by GPS_INPUT, as ArduPilot has done in https://github.com/ArduPilot/ardupilot/pull/28593

If we can get broad agreement from PX4 too, we should deprecate. Discussing in https://github.com/PX4/PX4-Autopilot/issues/23988. I think problematic because PX4 simulators use this.