### PR TITLE
[development.xml] delete MAV_CMD_GROUP_START and _GROUP_END  (no implementation)

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -290,22 +290,6 @@
         <param index="6">Reserved</param>
         <param index="7">WIP: upgrade progress report rate (can be used for more granular control).</param>
       </entry>
-      <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
-        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted.
-          The end of a group is marked using MAV_CMD_GROUP_END with the same group id.
-          Group ids are expected, but not required, to iterate sequentially.
-          Groups can be nested.</description>
-        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.
-          Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
-      </entry>
-      <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
-        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted.
-          The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id.
-          Group ids are expected, but not required, to iterate sequentially.
-          Groups can be nested.</description>
-        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.
-          Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
-      </entry>
       <entry value="262" name="MAV_CMD_DO_SET_STANDARD_MODE" hasLocation="false" isDestination="false">
         <description>Enable the specified standard MAVLink mode.
           If the mode is not supported the vehicle should ACK with MAV_RESULT_FAILED.


### PR DESCRIPTION
The `MAV_CMD_GROUP_START` and `_END` commands were added in 2021 (https://github.com/mavlink/mavlink/pull/1687) but do not appear to have implementations.
More specifically, there is this unmerged PR here:
- https://github.com/PX4/PX4-Autopilot/pull/18279

Its been more than two years. Have confirmed with @MatejFranceskin that there is no intent at this time to continue implementation. Removing from development.xml.


```xml
      <entry value="301" name="MAV_CMD_GROUP_START" hasLocation="false" isDestination="false">
        <description>Define start of a group of mission items. When control reaches this command a GROUP_START message is emitted.
          The end of a group is marked using MAV_CMD_GROUP_END with the same group id.
          Group ids are expected, but not required, to iterate sequentially.
          Groups can be nested.</description>
        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.
          Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
      </entry>
      <entry value="302" name="MAV_CMD_GROUP_END" hasLocation="false" isDestination="false">
        <description>Define end of a group of mission items. When control reaches this command a GROUP_END message is emitted.
          The start of the group is marked is marked using MAV_CMD_GROUP_START with the same group id.
          Group ids are expected, but not required, to iterate sequentially.
          Groups can be nested.</description>
        <param index="1" label="Group ID" minValue="0" maxValue="16777216" increment="1">Mission-unique group id.
          Group id is limited because only 24 bit integer can be stored in 32 bit float.</param>
      </entry>
```