### PR TITLE
Some modifications to multi-GCS protocol

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2860,10 +2860,6 @@
       <entry value="9" name="MAV_RESULT_COMMAND_UNSUPPORTED_MAV_FRAME">
         <description>Command is invalid because a frame is required and the specified frame is not supported.</description>
       </entry>
-      <entry value="10" name="MAV_RESULT_PERMISSION_DENIED">
-        <wip/>
-        <description>Sender is not authorized to control this MAV component. Control may be requested using MAV_CMD_REQUEST_OPERATOR_CONTROL.</description>
-      </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">
       <description>Result of mission operation (in a MISSION_ACK message).</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -355,7 +355,7 @@
         <description>Request GCS control of a system (or of a specific component in a system).
 
           A controlled system should only accept MAVLink commands and command-like messages that are sent by its controlling GCS, or from other components with the same system id.
-          Commands from other systems should be rejected with MAV_RESULT_PERMISSION_DENIED (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
+          Commands from other systems should be rejected with MAV_RESULT_FAILED (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
           Command-like messages should be ignored (or rejected if that is supported by their associated protocol).
 
           GCS control of the whole system is managed via a single component that we will refer to here as the "system manager component".
@@ -369,7 +369,7 @@
           The system manager component should grant control to the GCS if the system does not require takeover permission (or is uncontrolled) and ACK the request with MAV_RESULT_ACCEPTED.
           The system manager component should then stream CONTROL_STATUS indicating its controlling system: all other components with the same system id should monitor this message and set their own controlling GCS to match that of the system manager component.
 
-          If the system manager component cannot grant control (because takeover requires permission), the request should be rejected with MAV_RESULT_PERMISSION_DENIED.
+          If the system manager component cannot grant control (because takeover requires permission), the request should be rejected with MAV_RESULT_FAILED.
           The system manager component should then send this same command to the current owning GCS in order to notify of the request.
           The owning GCS would ACK with MAV_RESULT_ACCEPTED, and might choose to release control of the vehicle, or re-request control with the takeover bit set to allow permission. 
           Note that the pilots of both GCS should co-ordinate safe handover offline.

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -385,7 +385,7 @@
         <param index="1" label="Sysid requesting control">System ID of GCS requesting control. 0 when command sent from GCS to autopilot (autopilot determines requesting GCS sysid from message header). Sysid of GCS requesting control when command sent by autopilot to controlling GCS.</param>
         <param index="2" label="Action">0: Release control, 1: Request control.</param>
         <param index="3" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>
-        <param index="4" label="Request timeout">In case the current system is not allowing takeover, this is the timeout in seconds before the request should be automatically rejected by GCS in control. This is used to display the timeout graphically on requestor and GCS in control. Should not be larger than 60 seconds or smaller than 2 seconds</param>
+        <param index="4" label="Request timeout" units="s" minValue="3" maxValue="60">Timeout in seconds before a request to a GCS to allow takeover is assumed to be rejected. This is used to display the timeout graphically on requestor and GCS in control.</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -372,6 +372,7 @@
           If the system manager component cannot grant control (because takeover requires permission), the request should be rejected with MAV_RESULT_FAILED.
           The system manager component should then send this same command to the current owning GCS in order to notify of the request.
           The owning GCS would ACK with MAV_RESULT_ACCEPTED, and might choose to release control of the vehicle, or re-request control with the takeover bit set to allow permission. 
+          In case it choses to re-request control with takeover bit set to allow permission, requestor GCS will only have 10 seconds to get control, otherwise owning GCS will re-request control with takeover bit set to disallow permission, and requestor GCS will need repeat the request if still interested in getting control.
           Note that the pilots of both GCS should co-ordinate safe handover offline.
           
           Note that in most systems the only controlled component will be the "system manager component", and that will be the autopilot.

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -384,7 +384,7 @@
         <param index="1" label="Sysid requesting control">System ID of GCS requesting control. 0 when command sent from GCS to autopilot (autopilot determines requesting GCS sysid from message header). Sysid of GCS requesting control when command sent by autopilot to controlling GCS.</param>
         <param index="2" label="Action">0: Release control, 1: Request control.</param>
         <param index="3" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>
-        <param index="4">Empty</param>
+        <param index="4" label="Request timeout">In case the current system is not allowing takeover, this is the timeout in seconds before the request should be automatically rejected by GCS in control. This is used to display the timeout graphically on requestor and GCS in control. Should not be larger than 60 seconds or smaller than 2 seconds</param>
         <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>


### PR DESCRIPTION
After some discussions with @hamishwillee and @julianoes, apply folowing fixes:

- Include in one of the request parameters the timeout time: so we can show a "synchronized" indicator both on the requestor GCS, and on the GCS in control. This will control how long a control request is visible before being automatically rejected. See screenshot of current QGC approach under development.
![Screenshot from 2024-11-13 23-57-01](https://github.com/user-attachments/assets/5bbfee89-1c61-4dbb-9c1b-94e4498201a7)

- If the GCS in control ( with takeover not allowed ) accepts allow takeover after a request, have a fixed timeout to re-request control with takeover not allowed, in case the requestor GCS doesn't take control, fixed to 10 seconds. This is used to prevent operators forgetting they allowed takeover for a possible failed ownership change. If requestor GCS doesn't take control before those 10 seconds, GCS in control will disallow takeover again and the request should be repeated if still wanting to get control.

- Remove MAV_CMD_RESULT_PERMISSION_DENIED, and use MAV_RESULT_FAILED instead ( should we use RESULT_TEMPORARILY_REJECTED instead? ) as discussed here https://github.com/mavlink/mavlink/pull/2158#discussion_r1849761526