### PR TITLE
Merge STANDARD_MODE_SAFE_RECOVERY and MAV_STANDARD_MODE_RETURN_HOME

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -88,33 +88,27 @@
           Other vehicle types must not support this mode (this may be revisited through the PR process).
         </description>
       </entry>
-      <entry value="5" name="MAV_STANDARD_MODE_RETURN_HOME">
-        <description>Return home mode (auto).
-          Automatic mode that returns vehicle to home via a safe flight path.
-          It may also automatically land the vehicle (i.e. RTL).
-          The precise flight path and landing behaviour depend on vehicle configuration and type.
-        </description>
-      </entry>
-      <entry value="6" name="MAV_STANDARD_MODE_SAFE_RECOVERY">
+      <entry value="5" name="MAV_STANDARD_MODE_SAFE_RECOVERY">
         <description>Safe recovery mode (auto).
-          Automatic mode that takes vehicle to a predefined safe location via a safe flight path (rally point or mission defined landing) .
-          It may also automatically land the vehicle.
+          Automatic mode that takes vehicle to a predefined safe location via a safe flight path, and may also automatically land the vehicle.
+          This mode is more commonly referred to as RTL and/or or Smart RTL.
           The precise return location, flight path, and landing behaviour depend on vehicle configuration and type.
+          For example, the vehicle might return to the home/launch location, a rally point, or the start of a mission landing, it might follow a direct path, mission path, or breadcrumb path, and land using a mission landing pattern or some other kind of descent.
         </description>
       </entry>
-      <entry value="7" name="MAV_STANDARD_MODE_MISSION">
+      <entry value="6" name="MAV_STANDARD_MODE_MISSION">
         <description>Mission mode (automatic).
           Automatic mode that executes MAVLink missions.
           Missions are executed from the current waypoint as soon as the mode is enabled.
         </description>
       </entry>
-      <entry value="8" name="MAV_STANDARD_MODE_LAND">
+      <entry value="7" name="MAV_STANDARD_MODE_LAND">
         <description>Land mode (auto).
           Automatic mode that lands the vehicle at the current location.
           The precise landing behaviour depends on vehicle configuration and type.
         </description>
       </entry>
-      <entry value="9" name="MAV_STANDARD_MODE_TAKEOFF">
+      <entry value="8" name="MAV_STANDARD_MODE_TAKEOFF">
         <description>Takeoff mode (auto).
           Automatic takeoff mode.
           The precise takeoff behaviour depends on vehicle configuration and type.


### PR DESCRIPTION
This merges the standard modes MAV_STANDARD_MODE_RETURN_HOME and STANDARD_MODE_SAFE_RECOVERY  into one mode, and renumbers the mode enum.

The original thinking was that it was useful for a user to know whether the vehicle is performing a smart return or a simple/direct RTL. However generally the user is the person who will have done any off-standard configuration, so they will know the expected behaviour. This won't change unless they change it, so telling them they are doing a smart return or an RTL isn't going to be telling them anything they wouldn't know already.

In addition, discussion during prototyping indicates this may be confusing for users. For example, if they set a smart RTL but the vehicle is configured to RTL then it is unclear whether the vehicle should reject a command to set smart recovery mode, or accept it but display the return mode.

The proposal therefore is to have just one return mode that tells the user they are returning to a safe location.

@auturgy @bkueng @julianoes Does this make sense to you? FYI @peterbarker 

