### PR TITLE
Docs generate fix

### DIFF
--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -710,9 +710,8 @@ class MAVEnumEntry(object):
 
     def getMarkdown(self, currentDialect):
         """Return markdown for an enum entry"""
-        deprString = f"{self.deprecated.getMarkdown()}" if self.deprecated else ""
-        if self.wip:
-            print(f"TODO: WIP in Enum Entry: {self.name}")
+        deprString = f"<br>{self.deprecated.getMarkdown()}" if self.deprecated else ""
+        wipString = f"<br>{self.wip.getMarkdown()}" if self.wip else ""
         importedNote = ""
         if self.basename is not currentDialect:
             importedNote = " — \[from: [{self.basename}](../messages/{self.basename}.md#{self.name})\]"
@@ -721,7 +720,7 @@ class MAVEnumEntry(object):
                 f"TODO/Debug: Check rendering - imported merged enum value {self.name}")
         desc = fix_add_implicit_links_items(tidyDescription(
             self.description, 'table')) if self.description else ""
-        string = f"<a id='{self.name}'></a>{self.value} | [{self.name}](#{self.name}) | {desc}{importedNote}{deprString} \n"
+        string = f"<a id='{self.name}'></a>{self.value} | [{self.name}](#{self.name}) | {desc}{importedNote}{wipString}{deprString} \n"
         return string
 
 

--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -1139,47 +1139,33 @@ class XMLFiles(object):
 
 # MAVLink-Standard Definitions
 
-MAVLink definitions for messages, commands, and enums are defined in XML files.
-The **standard definitions** discussed here are those that are managed by the project.
-They are expected to be used in multiple flight stacks and ground stations (see [Dialects](dialects.md) for flight-stack specific XML definitions).
+The following XML definition files are part of the standard set that are managed by this project.
+They contain messages, commands, and enums that are expected to be used in multiple flight stacks and ground stations:
 
-## Standard Definitions
-
-The following XML definition files are managed as part of the standard set:
-
-- [common.xml](common.md) - the set of entities that have been implemented in at least one core flight stack.
+- [common.xml](common.md) - the set of entities that have been implemented in at least one core flight stack (and including those in `standard.xml` and `common.xml`).
 
   ::: tip
   Most developers should use this set of definitions.
-  It `includes` [standard.xml](minimal.md), which in turn `includes` [minimal.xml](minimal.md).
   :::
 
-- [standard.xml](standard.md) - the standard set of entities that are implemented by almost all flight stacks (at least 2, in a compatible way).
-- [minimal.xml](minimal.md) - the minimum set of entities (messages, enums, MAV_CMD) required to set up a MAVLink network.
+- [standard.xml](standard.md) — the standard set of entities that are implemented by at least two core flight stacks, in a compatible way.
+- [minimal.xml](minimal.md) — the minimum set of entities (messages, enums, MAV_CMD) required to set up a MAVLink network.
 
 ::: info
-We are still working towards moving the truly standard entities from **common.xml** to **standard.xml**
+See [Dialects & Test Definitions](dialects.md) for flight-stack specific XML definitions.
 :::
 
 ## Development Definitions
 
-The following definitions are being considered for inclusion.
+The following definitions are being considered for inclusion in the standard definitions.
 They are a "work in progress" and should not be used in released software.
 
-- [development.xml](development.md) - XML definitions that are _proposed_ for inclusion in the standard definitions.
+- [development.xml](development.md) — XML definitions that are _proposed_ for inclusion in the standard definitions.
 - Any standard definitions that have `<wip />` tags.
-
-## Test Definitions
-
-The following definitions are used for testing and dialect validation:
-
-- [all.xml](all.md) - This includes all other XML files, and is used to verify that there are no ID clashes (and can potentially be used by GCS to communicate with any core dialect).
-- [test.xml](test.md) - Test XML definition file.
-- [python_array_test.xml](python_array_test.md) - Test XML definition file for arrays.
 
 ## See Also
 
-- [Dialects](dialects.md)
+- [Dialects & Test Definitions](dialects.md)
 - [XSD schema](../guide/xml_schema.md)
 - [mavlink/message_definitions](https://github.com/mavlink/mavlink/blob/master/message_definitions/) - Source of all XML definition files
 
@@ -1201,7 +1187,9 @@ The following definitions are used for testing and dialect validation:
         #initialise text for index file.
         dialect_text="""<!-- THIS FILE IS AUTO-GENERATED FROM XML: https://github.com/mavlink/mavlink/blob/master/doc/mavlink_xml_to_markdown.py (Do not update mavlink-devguide) -->
 
-# Dialects
+# Dialects & Test Definitions
+
+## Dialects
 
 MAVLink _dialects_ are XML definition files that define _protocol-_ and _vendor-specific_ messages, enums and commands.
 
@@ -1227,6 +1215,14 @@ The dialect definitions are:
 Note that dialects may `include` [MAVLink-Standard Definitions](index.md) or other dialects.
 Up to 5 levels of XML file nesting are allowed - see `MAXIMUM_INCLUDE_FILE_NESTING` in [mavgen.py](https://github.com/ArduPilot/pymavlink/blob/master/generator/mavgen.py#L44).
 A typical pattern is for a dialect to include [common.xml](../messages/common.md) (containing the _MAVLink standard definitions_), extending it with vendor or protocol specific messages.
+
+## Test Definitions
+
+The following definitions are used for testing and dialect validation:
+
+- [all.xml](all.md) — This includes all other XML files, and is used to verify that there are no ID clashes (and can potentially be used by GCS to communicate with any core dialect).
+- [test.xml](test.md) — Test XML definition file.
+- [python_array_test.xml](python_array_test.md) — Test XML definition file for arrays.
 
 ## See Also
 


### PR DESCRIPTION
This improves the docs output for dialects/message definition header pages, and also adds wip output for enum values.