### PR TITLE
Standard modes - improve cross linking

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7911,8 +7911,9 @@
       <field type="uint8_t" name="reason" enum="MAV_EVENT_ERROR_REASON">Error reason.</field>
     </message>
     <message id="435" name="AVAILABLE_MODES">
-      <description>Get information about a particular flight modes.
-        The message can be enumerated or requested for a particular mode using MAV_CMD_REQUEST_MESSAGE.
+      <description>Information about a flight mode.
+
+        The message can be enumerated for all modes, or requested for a particular mode, using MAV_CMD_REQUEST_MESSAGE.
         Specify 0 in param2 to request that the message is emitted for all available modes or the specific index for just one mode.
         The modes must be available/settable for the current vehicle/frame type.
         Each mode should only be emitted once (even if it is both standard and custom).

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1960,7 +1960,7 @@
       </entry>
       <entry value="262" name="MAV_CMD_DO_SET_STANDARD_MODE" hasLocation="false" isDestination="false">
         <description>Enable the specified standard MAVLink mode.
-          If the mode is not supported the vehicle should ACK with MAV_RESULT_FAILED.
+          If the specified mode is not supported, the vehicle should ACK with MAV_RESULT_FAILED.
         </description>
         <param index="1" label="Standard Mode" enum="MAV_STANDARD_MODE">The mode to set.</param>
         <param index="2" reserved="true" default="0"/>
@@ -5178,7 +5178,8 @@
     <enum name="MAV_STANDARD_MODE">
       <description>Standard modes with a well understood meaning across flight stacks and vehicle types.
         For example, most flight stack have the concept of a "return" or "RTL" mode that takes a vehicle to safety, even though the precise mechanics of this mode may differ.
-        Modes may be set using MAV_CMD_DO_SET_STANDARD_MODE.
+        The modes supported by a flight stack can be queried using AVAILABLE_MODES and set using MAV_CMD_DO_SET_STANDARD_MODE.
+        The current mode is streamed in CURRENT_MODE.
       </description>
       <entry value="0" name="MAV_STANDARD_MODE_NON_STANDARD">
         <description>Non standard mode.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7916,7 +7916,7 @@
     <message id="435" name="AVAILABLE_MODES">
       <description>Information about a flight mode.
 
-        The message can be enumerated for all modes, or requested for a particular mode, using MAV_CMD_REQUEST_MESSAGE.
+        The message can be enumerated to get information for all modes, or requested for a particular mode, using MAV_CMD_REQUEST_MESSAGE.
         Specify 0 in param2 to request that the message is emitted for all available modes or the specific index for just one mode.
         The modes must be available/settable for the current vehicle/frame type.
         Each mode should only be emitted once (even if it is both standard and custom).

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1961,6 +1961,7 @@
       <entry value="262" name="MAV_CMD_DO_SET_STANDARD_MODE" hasLocation="false" isDestination="false">
         <description>Enable the specified standard MAVLink mode.
           If the specified mode is not supported, the vehicle should ACK with MAV_RESULT_FAILED.
+          See https://mavlink.io/en/services/standard_modes.html
         </description>
         <param index="1" label="Standard Mode" enum="MAV_STANDARD_MODE">The mode to set.</param>
         <param index="2" reserved="true" default="0"/>
@@ -5180,6 +5181,7 @@
         For example, most flight stack have the concept of a "return" or "RTL" mode that takes a vehicle to safety, even though the precise mechanics of this mode may differ.
         The modes supported by a flight stack can be queried using AVAILABLE_MODES and set using MAV_CMD_DO_SET_STANDARD_MODE.
         The current mode is streamed in CURRENT_MODE.
+        See https://mavlink.io/en/services/standard_modes.html
       </description>
       <entry value="0" name="MAV_STANDARD_MODE_NON_STANDARD">
         <description>Non standard mode.
@@ -7919,6 +7921,7 @@
         The modes must be available/settable for the current vehicle/frame type.
         Each mode should only be emitted once (even if it is both standard and custom).
         Note that the current mode should be emitted in CURRENT_MODE, and that if the mode list can change then AVAILABLE_MODES_MONITOR must be emitted on first change and subsequently streamed.
+        See https://mavlink.io/en/services/standard_modes.html
       </description>
       <field type="uint8_t" name="number_modes">The total number of available modes for the current vehicle type.</field>
       <field type="uint8_t" name="mode_index">The current mode index within number_modes, indexed from 1. The index is not guaranteed to be persistent, and may change between reboots or if the set of modes change.</field>
@@ -7931,6 +7934,7 @@
       <description>Get the current mode.
         This should be emitted on any mode change, and broadcast at low rate (nominally 0.5 Hz).
         It may be requested using MAV_CMD_REQUEST_MESSAGE.
+        See https://mavlink.io/en/services/standard_modes.html
       </description>
       <field type="uint8_t" name="standard_mode" enum="MAV_STANDARD_MODE">Standard mode.</field>
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
@@ -7940,6 +7944,7 @@
       <description>A change to the sequence number indicates that the set of AVAILABLE_MODES has changed.
         A receiver must re-request all available modes whenever the sequence number changes.
         This is only emitted after the first change and should then be broadcast at low rate (nominally 0.3 Hz) and on change.
+        See https://mavlink.io/en/services/standard_modes.html
       </description>
       <field type="uint8_t" name="seq">Sequence number. The value iterates sequentially whenever AVAILABLE_MODES changes (e.g. support for a new mode is added/removed dynamically).</field>
     </message>


### PR DESCRIPTION
AVAILABLE_modes - first sentence had poor grammar/typo. 
This also adds some better cross linking between modes, including a link to the microservice docs
Self merging.