### PR TITLE
common: `HIGHRES_IMU_UPDATED_FLAGS` enum remove `HIGHRES_IMU_UPDATED_ALL` value

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5013,9 +5013,6 @@
       <entry value="4096" name="HIGHRES_IMU_UPDATED_TEMPERATURE">
         <description>The value in the temperature field has been updated</description>
       </entry>
-      <entry value="65535" name="HIGHRES_IMU_UPDATED_ALL">
-        <description>All fields in HIGHRES_IMU have been updated.</description>
-      </entry>
     </enum>
     <enum name="CAN_FILTER_OP">
       <entry value="0" name="CAN_FILTER_REPLACE"/>


### PR DESCRIPTION
PR from https://github.com/mavlink/mavlink/pull/2206, the last value includes all bits, so it is not a true bitmask. If you want all you can check all from the existing definitions. Its posible that removing this is not correct, instead maybe it should be `32,768` for just the last bit rather than all bits?

Added in https://github.com/mavlink/mavlink/pull/1643

We do deal with this in AP, but we don't use the MAVLink enum rather defining our own. There we end up doing some funny messing about to set the all bits rather than just or-ing all the other bits together. 

https://github.com/ArduPilot/ardupilot/blob/e5f719b65a7fc30740b285fd656626b476df8de6/libraries/GCS_MAVLink/GCS_Common.cpp#L2239-L2246
