### PR TITLE
development: `MAV_BATTERY_STATUS_FLAGS_EXTENDED` correct final bit `MAV_BATTERY_STATUS_FLAGS_EXTENDED`

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -116,7 +116,7 @@
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>
       </entry>
-      <entry value="4294967295" name="MAV_BATTERY_STATUS_FLAGS_EXTENDED">
+      <entry value="2147483648" name="MAV_BATTERY_STATUS_FLAGS_EXTENDED">
         <description>Reserved (not used). If set, this will indicate that an additional status field exists for higher status values.</description>
       </entry>
     </enum>


### PR DESCRIPTION
PR from https://github.com/mavlink/mavlink/pull/2206, should be last bit not all bits.

Added in https://github.com/mavlink/mavlink/pull/1846.

We could also remove it. Its not used and refers to a possible extension that may or may not be added in the future. If we did want to reserve it I think a comment in the xml would serve just as well without having to have unused things in the generated output since we don't support `reserved="true"` for enums entrys.