### PR TITLE
Adjust HIGH_LATENCY2 temperature_air field description

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6878,7 +6878,7 @@
       <field type="uint8_t" name="wind_heading" units="deg/2">Wind heading</field>
       <field type="uint8_t" name="eph" units="dm">Maximum error horizontal position since last message</field>
       <field type="uint8_t" name="epv" units="dm">Maximum error vertical position since last message</field>
-      <field type="int8_t" name="temperature_air" units="degC">Air temperature from airspeed sensor</field>
+      <field type="int8_t" name="temperature_air" units="degC">Ambient air temperature</field>
       <field type="int8_t" name="climb_rate" units="dm/s">Maximum climb rate magnitude since last message</field>
       <field type="int8_t" name="battery" units="%" invalid="-1">Battery level (-1 if field not provided).</field>
       <field type="uint16_t" name="wp_num">Current waypoint number</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6878,7 +6878,7 @@
       <field type="uint8_t" name="wind_heading" units="deg/2">Wind heading</field>
       <field type="uint8_t" name="eph" units="dm">Maximum error horizontal position since last message</field>
       <field type="uint8_t" name="epv" units="dm">Maximum error vertical position since last message</field>
-      <field type="int8_t" name="temperature_air" units="degC">Ambient air temperature</field>
+      <field type="int8_t" name="temperature_air" units="degC">Air temperature</field>
       <field type="int8_t" name="climb_rate" units="dm/s">Maximum climb rate magnitude since last message</field>
       <field type="int8_t" name="battery" units="%" invalid="-1">Battery level (-1 if field not provided).</field>
       <field type="uint16_t" name="wp_num">Current waypoint number</field>


### PR DESCRIPTION
temperature_air now corresponds to the ambient temperature which is not necessarily dependent on the airspeed sensor.

According to the new logic in PX4: https://github.com/PX4/PX4-Autopilot/pull/24272

hierarchy is now:
1. Airspeed temperature
2. External baro
3. Default ambient temperature