### PR TITLE
development: `AIRSPEED_SENSOR_FLAGS` correct bitmask

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -7,10 +7,10 @@
   <enums>
     <enum name="AIRSPEED_SENSOR_FLAGS" bitmask="true">
       <description>Airspeed sensor flags</description>
-      <entry value="0" name="AIRSPEED_SENSOR_UNHEALTHY">
+      <entry value="1" name="AIRSPEED_SENSOR_UNHEALTHY">
         <description>Airspeed sensor is unhealthy</description>
       </entry>
-      <entry value="1" name="AIRSPEED_SENSOR_USING">
+      <entry value="2" name="AIRSPEED_SENSOR_USING">
         <description>True if the data from this sensor is being actively used by the flight controller for guidance, navigation or control.</description>
       </entry>
     </enum>


### PR DESCRIPTION
Found by https://github.com/mavlink/mavlink/pull/2206. Although embarrassingly this one is my bug in the first place. 

Bitmask should be values, I put in bit numbers. This is implemented in AP, it is doing the bit shift to get the right value, that will have to be removed once this is merged.

https://github.com/ArduPilot/ardupilot/blob/09c8ad81bb1624fb049967ab2987dc0a2aafd0b0/libraries/GCS_MAVLink/GCS_Common.cpp#L2386

https://github.com/ArduPilot/ardupilot/blob/09c8ad81bb1624fb049967ab2987dc0a2aafd0b0/libraries/GCS_MAVLink/GCS_Common.cpp#L2393

