### PR TITLE
common: remove unneeded 0 values in bitmasks

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -740,9 +740,6 @@
     <enum name="ESC_FAILURE_FLAGS" bitmask="true">
       <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Flags to report ESC failures.</description>
-      <entry value="0" name="ESC_FAILURE_NONE">
-        <description>No ESC failure.</description>
-      </entry>
       <entry value="1" name="ESC_FAILURE_OVER_CURRENT">
         <description>Over current failure.</description>
       </entry>
@@ -3915,9 +3912,6 @@
     </enum>
     <enum name="CAMERA_TRACKING_TARGET_DATA" bitmask="true">
       <description>Camera tracking target data (shows where tracked target is within image)</description>
-      <entry value="0" name="CAMERA_TRACKING_TARGET_DATA_NONE">
-        <description>No target data</description>
-      </entry>
       <entry value="1" name="CAMERA_TRACKING_TARGET_DATA_EMBEDDED">
         <description>Target data embedded in image data (proprietary)</description>
       </entry>
@@ -4923,9 +4917,6 @@
     </enum>
     <enum name="HIL_SENSOR_UPDATED_FLAGS" bitmask="true">
       <description>Flags in the HIL_SENSOR message indicate which fields have updated since the last message</description>
-      <entry value="0" name="HIL_SENSOR_UPDATED_NONE">
-        <description>None of the fields in HIL_SENSOR have been updated</description>
-      </entry>
       <entry value="1" name="HIL_SENSOR_UPDATED_XACC">
         <description>The value in the xacc field has been updated</description>
       </entry>
@@ -4971,9 +4962,6 @@
     </enum>
     <enum name="HIGHRES_IMU_UPDATED_FLAGS" bitmask="true">
       <description>Flags in the HIGHRES_IMU message indicate which fields have updated since the last message</description>
-      <entry value="0" name="HIGHRES_IMU_UPDATED_NONE">
-        <description>None of the fields in HIGHRES_IMU have been updated</description>
-      </entry>
       <entry value="1" name="HIGHRES_IMU_UPDATED_XACC">
         <description>The value in the xacc field has been updated</description>
       </entry>


### PR DESCRIPTION
Found by https://github.com/mavlink/mavlink/pull/2206. These values are all unnecessary, none of them are referenced by AP.

There are a couple of other 0's in bitmasks in this file, but there not so clear cut, I will PR those individually in the future.  