### PR TITLE
Added payload types for ModalAI vendor use

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4283,6 +4283,15 @@
       <entry value="209" name="MAV_TUNNEL_PAYLOAD_TYPE_STORM32_RESERVED9">
         <description>Registered for STorM32 gimbal controller.</description>
       </entry>
+      <entry value="210" name="MAV_TUNNEL_PAYLOAD_TYPE_MODALAI_REMOTE_OSD">
+        <description>Registered for ModalAI remote OSD protocol.</description>
+      </entry>
+      <entry value="211" name="MAV_TUNNEL_PAYLOAD_TYPE_MODALAI_ESC_UART_PASSTHRU">
+        <description>Registered for ModalAI ESC UART passthru protocol.</description>
+      </entry>
+      <entry value="212" name="MAV_TUNNEL_PAYLOAD_TYPE_MODALAI_IO_UART_PASSTHRU">
+        <description>Registered for ModalAI vendor use.</description>
+      </entry>
     </enum>
     <enum name="MAV_ODID_ID_TYPE">
       <entry value="0" name="MAV_ODID_ID_TYPE_NONE">


### PR DESCRIPTION
Added payload types for ModalAI vendor use for Mavlink tunnel messages.