### PR TITLE
common: `FENCE_TYPE` bitmask clarifications

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -399,7 +399,10 @@
     </enum>
     <!-- enum of fence types to enable or disable as a bitmask -->
     <enum name="FENCE_TYPE" bitmask="true">
-      <description>Fence types to enable or disable as a bitmask. A value of 0 indicates that all fences should be enabled or disabled.</description>
+      <description>Fence types to enable or disable when using MAV_CMD_DO_FENCE_ENABLE.
+        Note that at least one of these flags must be set in MAV_CMD_DO_FENCE_ENABLE.param2.
+        If none are set, the flight stack will ignore the field and enable/disable its default set of fences (usually all of them).
+      </description>
       <entry value="1" name="FENCE_TYPE_ALT_MAX">
         <description>Maximum altitude fence</description>
       </entry>
@@ -1730,7 +1733,7 @@
           Flight stacks typically reset the setting to system defaults on reboot.
 	</description>
         <param index="1" label="Enable" minValue="0" maxValue="2" increment="1">enable? (0=disable, 1=enable, 2=disable_floor_only)</param>
-        <param index="2" label="Types" enum="FENCE_TYPE">Fence types to enable or disable as a bitmask. A value of 0 indicates that all fences should be enabled or disabled. This parameter is ignored if param 1 has the value 2</param>
+        <param index="2" label="Types" enum="FENCE_TYPE">Fence types to enable or disable as a bitmask. 0 indicates the field is unused (for compatiblity reasons, if 0 the autopilot will follow its default behaviour, which is usually that all fences should be enabled or disabled). This parameter is ignored if param1=2.</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
         <param index="5">Empty</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -399,9 +399,7 @@
     </enum>
     <!-- enum of fence types to enable or disable as a bitmask -->
     <enum name="FENCE_TYPE" bitmask="true">
-      <entry value="0" name="FENCE_TYPE_ALL">
-        <description>All fence types</description>
-      </entry>
+      <description>Fence types to enable or disable as a bitmask. A value of 0 indicates that all fences should be enabled or disabled.</description>
       <entry value="1" name="FENCE_TYPE_ALT_MAX">
         <description>Maximum altitude fence</description>
       </entry>


### PR DESCRIPTION
Found by https://github.com/mavlink/mavlink/pull/2206. 

This is used in `MAV_CMD_DO_FENCE_ENABLE`:

https://github.com/mavlink/mavlink/blob/fe18c424e55e8f5e95e2c933d10db03f79c5b09d/message_definitions/v1.0/common.xml#L1726-L1741

This one is a little odd. Is a bit-mask but if no bits are set the description says to treat it the same as all bits being set. So 0x00 should be the same behavior as 0xFF. It has to be this way so that 0 works for unset.

But then the first param has a value that results in ignoring the second param (The first param is also a example of a param that should have a enum but is instead enumerated in the description).

Maybe it would be better to invert the bit mask so each bit is a fence to ignore the command for

In conclusion the enum is odd, but I think removing the zero case at least makes it a true bitmask, I have added the oddness to the enum description and its also described in the command description.

