### PR TITLE
common: `AUTOTUNE_AXIS` remove 0 from bitmask

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1042,7 +1042,7 @@
       </entry>
     </enum>
     <enum name="AUTOTUNE_AXIS" bitmask="true">
-      <description>Axes that will be autotuned by MAV_CMD_DO_AUTOTUNE_ENABLE. If none are set, the flight stack should use its default setting.</description>
+      <description>Axes that will be autotuned by MAV_CMD_DO_AUTOTUNE_ENABLE. For compatibility reasons, if none are set, the flight stack should use its default setting.</description>
       <entry value="1" name="AUTOTUNE_AXIS_ROLL">
         <description>Autotune roll axis.</description>
       </entry>
@@ -1779,7 +1779,7 @@
       <entry value="212" name="MAV_CMD_DO_AUTOTUNE_ENABLE" hasLocation="false" isDestination="false">
         <description>Enable/disable autotune.</description>
         <param index="1" label="Enable" minValue="0" maxValue="1" increment="1">Enable (1: enable, 0:disable).</param>
-        <param index="2" label="Axis" enum="AUTOTUNE_AXIS">Specify which axis are autotuned. 0 indicates autopilot default settings.</param>
+        <param index="2" label="Axis" enum="AUTOTUNE_AXIS">Specify axes for which autotuning is enabled/disabled. 0 indicates the field is unused (for compatiblity reasons). If 0 the autopilot will follow its default behaviour, which is usually to tune all axes.</param>
         <param index="3">Empty.</param>
         <param index="4">Empty.</param>
         <param index="5">Empty.</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1042,7 +1042,7 @@
       </entry>
     </enum>
     <enum name="AUTOTUNE_AXIS" bitmask="true">
-      <description>Enable axes that will be tuned via autotuning. If 0 flight stack should use its default setting.</description>
+      <description>Axes that will be autotuned by MAV_CMD_DO_AUTOTUNE_ENABLE. If none are set, the flight stack should use its default setting.</description>
       <entry value="1" name="AUTOTUNE_AXIS_ROLL">
         <description>Autotune roll axis.</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1043,7 +1043,7 @@
     </enum>
     <enum name="AUTOTUNE_AXIS" bitmask="true">
       <description>Axes that will be autotuned by MAV_CMD_DO_AUTOTUNE_ENABLE.
-        Note that at least one flag must be set in MAV_CMD_DO_AUTOTUNE_ENABLE.param2: if none are set, the flight stack will tune the default set of axes.</description>
+        Note that at least one flag must be set in MAV_CMD_DO_AUTOTUNE_ENABLE.param2: if none are set, the flight stack will tune its default set of axes.</description>
       <entry value="1" name="AUTOTUNE_AXIS_ROLL">
         <description>Autotune roll axis.</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1042,10 +1042,7 @@
       </entry>
     </enum>
     <enum name="AUTOTUNE_AXIS" bitmask="true">
-      <description>Enable axes that will be tuned via autotuning. Used in MAV_CMD_DO_AUTOTUNE_ENABLE.</description>
-      <entry value="0" name="AUTOTUNE_AXIS_DEFAULT">
-        <description>Flight stack tunes axis according to its default settings.</description>
-      </entry>
+      <description>Enable axes that will be tuned via autotuning. If 0 flight stack should use its default setting.</description>
       <entry value="1" name="AUTOTUNE_AXIS_ROLL">
         <description>Autotune roll axis.</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1042,7 +1042,8 @@
       </entry>
     </enum>
     <enum name="AUTOTUNE_AXIS" bitmask="true">
-      <description>Axes that will be autotuned by MAV_CMD_DO_AUTOTUNE_ENABLE. For compatibility reasons, if none are set, the flight stack should use its default setting.</description>
+      <description>Axes that will be autotuned by MAV_CMD_DO_AUTOTUNE_ENABLE.
+        Note that at least one flag must be set in MAV_CMD_DO_AUTOTUNE_ENABLE.param2: if none are set, the flight stack will tune the default set of axes.</description>
       <entry value="1" name="AUTOTUNE_AXIS_ROLL">
         <description>Autotune roll axis.</description>
       </entry>


### PR DESCRIPTION
Found by https://github.com/mavlink/mavlink/pull/2206.

This is used in `MAV_CMD_DO_AUTOTUNE_ENABLE`:

https://github.com/mavlink/mavlink/blob/fe18c424e55e8f5e95e2c933d10db03f79c5b09d/message_definitions/v1.0/common.xml#L1782-L1791

A value of 0 is a special case meaning to do the default. This seems reasonable behavior, but it should not be in the bitmask.

This enum is not used by ArduPilot. 