### PR TITLE
common: remove `FIRMWARE_VERSION_TYPE`

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4,24 +4,6 @@
   <version>3</version>
   <dialect>0</dialect>
   <enums>
-    <enum name="FIRMWARE_VERSION_TYPE">
-      <description>These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65.</description>
-      <entry value="0" name="FIRMWARE_VERSION_TYPE_DEV">
-        <description>development release</description>
-      </entry>
-      <entry value="64" name="FIRMWARE_VERSION_TYPE_ALPHA">
-        <description>alpha release</description>
-      </entry>
-      <entry value="128" name="FIRMWARE_VERSION_TYPE_BETA">
-        <description>beta release</description>
-      </entry>
-      <entry value="192" name="FIRMWARE_VERSION_TYPE_RC">
-        <description>release candidate</description>
-      </entry>
-      <entry value="255" name="FIRMWARE_VERSION_TYPE_OFFICIAL">
-        <description>official stable release</description>
-      </entry>
-    </enum>
     <enum name="HL_FAILURE_FLAG" bitmask="true">
       <description>Flags to report failure cases over the high latency telemetry.</description>
       <entry value="1" name="HL_FAILURE_FLAG_GPS">


### PR DESCRIPTION
Found by https://github.com/mavlink/mavlink/pull/2206.

This was originally added in https://github.com/mavlink/mavlink/commit/a6a2e3d9b94918910263ea680444b7b7aa981cb4 as `FIRMWARE_RELEASE_TYPE` then a few days later renamed to `FIRMWARE_VERSION_TYPE` in https://github.com/mavlink/mavlink/commit/797fc35f1ca3e4b8aee6a0882bdca1d49fdf3e3f. As far as I can tell it has never been used or referenced by any message. 

There are no users in AP.
