### PR TITLE
scripts: xml consistency check: updates 

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: pip install beautifulsoup4 lxml
+      - name: Run xml consistency check unit tests
+        run: python -m unittest scripts/test_xml_consistency_check.py -v
       - name: Check XML consistency
         run: python3 scripts/xml_consistency_check.py --exception
 

--- a/scripts/test_xml_consistency_check.py
+++ b/scripts/test_xml_consistency_check.py
@@ -1,0 +1,186 @@
+#! /usr/bin/env python3
+"""
+Unit tests for xml_consistency_check.py.
+
+Exercises check_enum/check_field/check_cmd_param against small in-memory XML
+fixtures, so regressions in the consistency checks are caught in CI instead
+of relying on manual testing against real message definitions.
+"""
+import importlib.util
+import os
+import unittest
+
+from bs4 import BeautifulSoup as bs
+
+_MODULE_PATH = os.path.join(os.path.dirname(__file__), "xml_consistency_check.py")
+_spec = importlib.util.spec_from_file_location("xml_consistency_check", _MODULE_PATH)
+xml_consistency_check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(xml_consistency_check)
+
+check_enum = xml_consistency_check.check_enum
+check_field = xml_consistency_check.check_field
+check_cmd_param = xml_consistency_check.check_cmd_param
+
+
+def parse_enum(xml):
+    return bs(xml, 'xml').find('enum')
+
+
+def parse_field(xml):
+    return bs(xml, 'xml').find('field')
+
+
+def parse_param(xml):
+    return bs(xml, 'xml').find('param')
+
+
+class ConsistencyCheckTestCase(unittest.TestCase):
+    """Resets the module's global warning-tracking state before each test,
+    since warn() accumulates into module-level globals."""
+
+    def setUp(self):
+        xml_consistency_check.warning_count = 0
+        xml_consistency_check.allowed_count = 0
+        xml_consistency_check.allowlist = set()
+        xml_consistency_check.matched_allowlist = set()
+
+    def warnings(self, fn, *args):
+        messages = []
+        original_warn = xml_consistency_check.warn
+
+        def capture(message):
+            messages.append(message)
+            original_warn(message)
+
+        xml_consistency_check.warn = capture
+        try:
+            fn(*args)
+        finally:
+            xml_consistency_check.warn = original_warn
+        return messages
+
+
+def make_enum_entry(name, bitmask):
+    enum = parse_enum(
+        '<enum name="%s"%s><entry name="%s_A" value="1"/>'
+        '<entry name="%s_B" value="2"/></enum>'
+        % (name, ' bitmask="true"' if bitmask else "", name, name)
+    )
+    decoded = check_enum(enum, "test.xml")
+    return {
+        "name": decoded["name"],
+        "bitmask": decoded["bitmask"],
+        "min": min(decoded["values"]),
+        "max": max(decoded["values"]),
+        "used": False,
+    }
+
+
+class DisplayBitmaskDeprecationTests(ConsistencyCheckTestCase):
+    """display="bitmask" is only deprecated when the field's enum= is itself
+    marked bitmask="true" - the enum already conveys the same information in
+    that case. A field with no enum= has no other way to signal it's a raw
+    bitmask, so it must not be flagged."""
+
+    def test_raw_bitmask_field_without_enum_is_not_deprecated(self):
+        field = parse_field('<field type="uint32_t" name="mask" display="bitmask">desc</field>')
+        messages = self.warnings(check_field, "test.xml", "MY_MSG", field, {})
+        self.assertEqual(messages, [])
+
+    def test_display_bitmask_with_bitmask_enum_is_deprecated(self):
+        enums = {"MY_FLAGS": make_enum_entry("MY_FLAGS", bitmask=True)}
+        field = parse_field(
+            '<field type="uint32_t" name="flags" enum="MY_FLAGS" display="bitmask">desc</field>'
+        )
+        messages = self.warnings(check_field, "test.xml", "MY_MSG", field, enums)
+        self.assertEqual(
+            messages,
+            ['test.xml: Message MY_MSG field flags display="bitmask" is deprecated'],
+        )
+
+    def test_display_bitmask_with_non_bitmask_enum_is_not_deprecated(self):
+        enums = {"MY_ENUM": make_enum_entry("MY_ENUM", bitmask=False)}
+        field = parse_field(
+            '<field type="uint32_t" name="flags" enum="MY_ENUM" display="bitmask">desc</field>'
+        )
+        messages = self.warnings(check_field, "test.xml", "MY_MSG", field, enums)
+        self.assertEqual(messages, [])
+
+    def test_field_without_display_is_never_flagged(self):
+        enums = {"MY_FLAGS": make_enum_entry("MY_FLAGS", bitmask=True)}
+        field = parse_field('<field type="uint32_t" name="flags" enum="MY_FLAGS">desc</field>')
+        messages = self.warnings(check_field, "test.xml", "MY_MSG", field, enums)
+        self.assertEqual(messages, [])
+
+
+class DeprecatedElementSkippedTests(ConsistencyCheckTestCase):
+    """Enums/messages/MAV_CMD entries wrapped in <deprecated/> are skipped
+    entirely by the top-level scan loops (not exercised via check_enum/
+    check_field/check_cmd_param directly, since the skip happens one level
+    up in main()'s find_all() loops)."""
+
+    def test_deprecated_message_has_no_deprecated_marker_in_soup(self):
+        soup = bs(
+            '<mavlink><messages><message name="OLD_MSG" id="1">'
+            '<deprecated since="2020-01" replaced_by="NEW_MSG"/>'
+            '<field type="uint8_t" name="foo" display="bitmask">desc</field>'
+            '</message></messages></mavlink>',
+            'xml',
+        )
+        message = soup.find('message')
+        self.assertIsNotNone(message.find('deprecated', recursive=False))
+
+    def test_non_deprecated_message_has_no_deprecated_marker(self):
+        soup = bs(
+            '<mavlink><messages><message name="MSG" id="1">'
+            '<field type="uint8_t" name="foo" display="bitmask">desc</field>'
+            '</message></messages></mavlink>',
+            'xml',
+        )
+        message = soup.find('message')
+        self.assertIsNone(message.find('deprecated', recursive=False))
+
+
+class CmdParamRangeTests(ConsistencyCheckTestCase):
+    def test_small_range_with_increment_one_suggests_enum(self):
+        param = parse_param(
+            '<param index="1" minValue="0" maxValue="5" increment="1">desc</param>'
+        )
+        messages = self.warnings(check_cmd_param, "test.xml", "MY_CMD", param, {})
+        self.assertEqual(
+            messages,
+            ["test.xml: Command MY_CMD param 1 min, max close and increment of 1, "
+             "should there be a enum?"],
+        )
+
+    def test_range_incompatible_with_increment_warns(self):
+        param = parse_param(
+            '<param index="1" minValue="0" maxValue="10" increment="3">desc</param>'
+        )
+        messages = self.warnings(check_cmd_param, "test.xml", "MY_CMD", param, {})
+        self.assertEqual(
+            messages,
+            ["test.xml: Command MY_CMD param 1 range 0.000000 => 10.000000 "
+             "incompatible with increment 3.000000"],
+        )
+
+    def test_invalid_range_warns(self):
+        param = parse_param(
+            '<param index="1" minValue="10" maxValue="5">desc</param>'
+        )
+        messages = self.warnings(check_cmd_param, "test.xml", "MY_CMD", param, {})
+        self.assertEqual(
+            messages,
+            ["test.xml: Command MY_CMD param 1 min and max invalid got 10.000000 => 5.000000"],
+        )
+
+    def test_large_range_does_not_warn(self):
+        param = parse_param(
+            '<param index="1" minValue="0" maxValue="100" increment="1">desc</param>'
+        )
+        messages = self.warnings(check_cmd_param, "test.xml", "MY_CMD", param, {})
+        self.assertEqual(messages, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/xml_consistency_allowlist.txt
+++ b/scripts/xml_consistency_allowlist.txt
@@ -12,6 +12,45 @@ common.xml: Enum: CAMERA_TRACKING_STATUS_FLAGS bitmask should not contain 0
 standard.xml: Enum: MAV_BOOL bitmask should not contain 0
 common.xml: Message GIMBAL_DEVICE_INFORMATION field cap_flags enum GIMBAL_DEVICE_CAP_FLAGS does not fit in type: uint16_t
 
+# --- Messages referencing removed/missing enums ---
+common.xml: Message HIL_CONTROLS field mode enum MAV_MODE does not exist
+
+# --- Fields still using deprecated display attribute ---
+common.xml: Message TERRAIN_REQUEST field mask display="bitmask" is deprecated
+common.xml: Message MAG_CAL_REPORT field cal_mask display="bitmask" is deprecated
+common.xml: Message HIGH_LATENCY field custom_mode display="bitmask" is deprecated
+common.xml: Message HIGH_LATENCY2 field custom_mode display="bitmask" is deprecated
+common.xml: Message BUTTON_CHANGE field state display="bitmask" is deprecated
+common.xml: Message ACTUATOR_OUTPUT_STATUS field active display="bitmask" is deprecated
+common.xml: Message RELAY_STATUS field on display="bitmask" is deprecated
+common.xml: Message RELAY_STATUS field present display="bitmask" is deprecated
+
+# --- Commands referencing removed/missing enums ---
+common.xml: Command MAV_CMD_DO_MOUNT_CONFIGURE param 1 enum MAV_MOUNT_MODE does not exist
+common.xml: Command MAV_CMD_DO_MOUNT_CONTROL param 7 enum MAV_MOUNT_MODE does not exist
+
+# --- Command params with small integer ranges (no enum defined yet) ---
+common.xml: Command MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT param 1 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_NAV_LOITER_TO_ALT param 4 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_DO_FOLLOW param 4 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_NAV_PATHPLANNING param 1 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_NAV_PATHPLANNING param 2 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_CONDITION_YAW param 3 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_DO_FLIGHTTERMINATION param 1 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_DO_CONTROL_VIDEO param 2 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_DO_CONTROL_VIDEO param 4 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_DO_FENCE_ENABLE param 1 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 1 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 4 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 6 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 7 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS param 1 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_SET_MESSAGE_INTERVAL param 7 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_REQUEST_MESSAGE param 7 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_DO_TRIGGER_CONTROL param 1 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_DO_TRIGGER_CONTROL param 2 min, max close and increment of 1, should there be a enum?
+common.xml: Command MAV_CMD_PAYLOAD_PREPARE_DEPLOY param 1 min, max close and increment of 1, should there be a enum?
+
 # --- Intended orphan enums (referenced by code, not message fields) ---
 common.xml: Enum: COMP_METADATA_TYPE is unused
 common.xml: Enum: MAV_ARM_AUTH_DENIED_REASON is unused

--- a/scripts/xml_consistency_allowlist.txt
+++ b/scripts/xml_consistency_allowlist.txt
@@ -15,16 +15,6 @@ common.xml: Message GIMBAL_DEVICE_INFORMATION field cap_flags enum GIMBAL_DEVICE
 # --- Messages referencing removed/missing enums ---
 common.xml: Message HIL_CONTROLS field mode enum MAV_MODE does not exist
 
-# --- Fields still using deprecated display attribute ---
-common.xml: Message TERRAIN_REQUEST field mask display="bitmask" is deprecated
-common.xml: Message MAG_CAL_REPORT field cal_mask display="bitmask" is deprecated
-common.xml: Message HIGH_LATENCY field custom_mode display="bitmask" is deprecated
-common.xml: Message HIGH_LATENCY2 field custom_mode display="bitmask" is deprecated
-common.xml: Message BUTTON_CHANGE field state display="bitmask" is deprecated
-common.xml: Message ACTUATOR_OUTPUT_STATUS field active display="bitmask" is deprecated
-common.xml: Message RELAY_STATUS field on display="bitmask" is deprecated
-common.xml: Message RELAY_STATUS field present display="bitmask" is deprecated
-
 # --- Commands referencing removed/missing enums ---
 common.xml: Command MAV_CMD_DO_MOUNT_CONFIGURE param 1 enum MAV_MOUNT_MODE does not exist
 common.xml: Command MAV_CMD_DO_MOUNT_CONTROL param 7 enum MAV_MOUNT_MODE does not exist

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -106,6 +106,12 @@ def check_field(file_name, msg_name, field, enums):
     enum = field.get('enum')
     units = field.get('units')
 
+    # Display property has been removed
+    display = field.get('display')
+    if display is not None:
+        warn("%s: Message %s field %s display=\"%s\" is deprecated" %
+             (file_name, msg_name, name, display))
+
     # Enum with units doesn't make sense
     if enum is not None and units is not None:
         warn("%s: Message %s field %s has both units and enum" %
@@ -140,6 +146,9 @@ def check_cmd_param(file_name, cmd_name, entry, enums):
     index = entry.get('index')
     enum = entry.get('enum')
     units = entry.get('units')
+    minValue = entry.get('minValue')
+    maxValue = entry.get('maxValue')
+    increment = entry.get('increment')
 
     # Enum with units doesn't make sense
     if enum is not None and units is not None:
@@ -154,6 +163,27 @@ def check_cmd_param(file_name, cmd_name, entry, enums):
             return
 
         enums[enum]["used"] = True
+
+    if minValue is not None and maxValue is not None :
+        min = float(minValue)
+        max = float(maxValue)
+        range = max - min
+        if range <= 0:
+            warn("%s: Command %s param %s min and max invalid got %f => %f" %
+                 (file_name, cmd_name, index, min, max))
+            return
+
+        if increment is not None:
+            step = float(increment)
+            if range % step != 0:
+                warn("%s: Command %s param %s range %f => %f incompatible with increment %f" %
+                     (file_name, cmd_name, index, min, max, step))
+                return
+
+            if (step == 1) and range <= 20:
+                warn("%s: Command %s param %s min, max close and increment of 1, should there be a enum?" %
+                     (file_name, cmd_name, index))
+                return
 
     # There are a huge amount or errors here, commented out for now
     # Should be marked as reserved correctly
@@ -237,6 +267,9 @@ for file in files:
 all_enums = {}
 for key in xml:
     for enum in xml[key].find_all('enum'):
+        if enum.find('deprecated', recursive=False) is not None:
+            # Skip and deprecated items
+            continue
         decoded = check_enum(enum, key)
         name = decoded["name"]
         if name in all_enums:
@@ -288,6 +321,9 @@ for name in all_enums:
 # Check all fields against enums
 for key in xml:
     for message in xml[key].find_all('message'):
+        if message.find('deprecated', recursive=False) is not None:
+            # Skip and deprecated items
+            continue
         name = message.get('name')
         fields = message.find_all('field')
         for field in fields:
@@ -297,6 +333,9 @@ for key in xml:
 for key in xml:
     for enum in xml[key].find_all('enum', {"name": "MAV_CMD"}):
         for entry in enum.find_all('entry'):
+            if entry.find('deprecated', recursive=False) is not None:
+                # Skip and deprecated items
+                continue
             name = entry.get('name')
             seen_indices = set()   # Indices seen so far, to check for duplicates
             for param in entry.find_all('param'):

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -53,7 +53,7 @@ def check_enum(enum, file_name):
         if attr == 'name':
             name = value
         elif attr == 'bitmask':
-            bitmask = True
+            bitmask = value == 'true'
 
     if name is None:
         raise Exception("%s: No name for Enum: %s" % (file_name, enum))
@@ -66,8 +66,8 @@ def check_enum(enum, file_name):
     # Check for duplicate values
     for a, b in itertools.combinations(values, 2):
         if a == b:
-            raise Exception("%s: Enum: %s duplicate value %i" %
-                            (file_name, name, a))
+            warn("%s: Enum: %s duplicate value %i" %
+                 (file_name, name, a))
 
     # Check if should be marked as a bitmask
     contains_zero = 0 in values

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -105,12 +105,7 @@ def check_field(file_name, msg_name, field, enums):
     name = field.get('name')
     enum = field.get('enum')
     units = field.get('units')
-
-    # Display property has been removed
     display = field.get('display')
-    if display is not None:
-        warn("%s: Message %s field %s display=\"%s\" is deprecated" %
-             (file_name, msg_name, name, display))
 
     # Enum with units doesn't make sense
     if enum is not None and units is not None:
@@ -125,6 +120,14 @@ def check_field(file_name, msg_name, field, enums):
             return
 
         enums[enum]["used"] = True
+
+        # display="bitmask" is redundant once the referenced enum is itself
+        # marked bitmask="true" - the enum already says so. A raw (non-enum)
+        # bitmask field still needs display="bitmask" as its only way to
+        # signal that, so that case is not deprecated.
+        if display is not None and enums[enum].get("bitmask"):
+            warn("%s: Message %s field %s display=\"%s\" is deprecated" %
+                 (file_name, msg_name, name, display))
 
         # An enum with no entries has min/max set to None during aggregation
         # and was already warned about there, so there's nothing to range-check.
@@ -194,7 +197,8 @@ def check_cmd_param(file_name, cmd_name, entry, enums):
     #        print("%s: Command %s param %s should be marked reserved=\"true\"" % (file_name, cmd_name, index))
 
 
-description = """
+def main():
+    description = """
 XML consistency parser.
 
 Checks XML definition files in ../message_definitions/v1.0/.
@@ -204,196 +208,200 @@ Known, pre-existing warnings can be listed in an allowlist file (see --allowlist
 so that CI can gate on new warnings while tolerating ones we can't fix yet.
 """
 
-parser = ArgumentParser(description=description,
-                        formatter_class=RawDescriptionHelpFormatter)
+    parser = ArgumentParser(description=description,
+                            formatter_class=RawDescriptionHelpFormatter)
 
-parser.add_argument('-f', '--file', default=None, nargs='+',
-                    help="XML file name(s) to check (defaults to the managed dialects)")
-parser.add_argument('-e', '--exception', action='store_true',
-                    help="Throw error if any non-allowlisted warnings are found")
-parser.add_argument('-a', '--allowlist', default=None,
-                    help="Path to allowlist file of known-acceptable warnings "
-                         "(defaults to xml_consistency_allowlist.txt next to this script)")
+    parser.add_argument('-f', '--file', default=None, nargs='+',
+                        help="XML file name(s) to check (defaults to the managed dialects)")
+    parser.add_argument('-e', '--exception', action='store_true',
+                        help="Throw error if any non-allowlisted warnings are found")
+    parser.add_argument('-a', '--allowlist', default=None,
+                        help="Path to allowlist file of known-acceptable warnings "
+                             "(defaults to xml_consistency_allowlist.txt next to this script)")
 
-args = parser.parse_args()
+    args = parser.parse_args()
 
-# Resolve paths relative to this script, not the working directory, so the
-# defaults work regardless of where the script is invoked from.
-script_dir = os.path.dirname(os.path.abspath(__file__))
-source_dir = os.path.join(script_dir, "../message_definitions/v1.0/")
+    # Resolve paths relative to this script, not the working directory, so the
+    # defaults work regardless of where the script is invoked from.
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    source_dir = os.path.join(script_dir, "../message_definitions/v1.0/")
 
-# Dialects this repository controls. Other dialects (e.g. ardupilotmega.xml)
-# are vendored/synced from downstream projects, so we don't gate CI on their
-# content. They are free to run this script on their side if they wish (pass
-# their files via -f/--file).
-managed_dialects = ["common.xml", "minimal.xml", "standard.xml", "development.xml"]
+    # Dialects this repository controls. Other dialects (e.g. ardupilotmega.xml)
+    # are vendored/synced from downstream projects, so we don't gate CI on their
+    # content. They are free to run this script on their side if they wish (pass
+    # their files via -f/--file).
+    managed_dialects = ["common.xml", "minimal.xml", "standard.xml", "development.xml"]
 
-if args.file is None:
-    files = managed_dialects
-else:
-    files = [f if f.endswith('.xml') else f + '.xml' for f in args.file]
+    if args.file is None:
+        files = managed_dialects
+    else:
+        files = [f if f.endswith('.xml') else f + '.xml' for f in args.file]
 
-# Load the allowlist of known-acceptable warnings. An explicitly-passed path
-# that doesn't exist is a hard error; a missing default is reported (not
-# silently ignored) so that unexpectedly-failing CI is easy to diagnose.
-default_allowlist = os.path.join(script_dir, "xml_consistency_allowlist.txt")
-allowlist_path = args.allowlist if args.allowlist is not None else default_allowlist
+    # Load the allowlist of known-acceptable warnings. An explicitly-passed path
+    # that doesn't exist is a hard error; a missing default is reported (not
+    # silently ignored) so that unexpectedly-failing CI is easy to diagnose.
+    default_allowlist = os.path.join(script_dir, "xml_consistency_allowlist.txt")
+    allowlist_path = args.allowlist if args.allowlist is not None else default_allowlist
 
-if os.path.exists(allowlist_path):
-    with open(allowlist_path, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith('#'):
-                allowlist.add(line)
-elif args.allowlist is not None:
-    raise SystemExit("Allowlist file not found: %s" % allowlist_path)
-else:
-    print("Note: no allowlist found at %s; all warnings will count toward the total." %
-          allowlist_path)
+    if os.path.exists(allowlist_path):
+        with open(allowlist_path, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    allowlist.add(line)
+    elif args.allowlist is not None:
+        raise SystemExit("Allowlist file not found: %s" % allowlist_path)
+    else:
+        print("Note: no allowlist found at %s; all warnings will count toward the total." %
+              allowlist_path)
 
-print(f"Files: {files}")
+    print(f"Files: {files}")
 
-xml = {}
-for file in files:
-    # Read the XML file
-    path = source_dir + file
-    with open(path, 'r') as f:
-        xml_content = f.read()
+    xml = {}
+    for file in files:
+        # Read the XML file
+        path = source_dir + file
+        with open(path, 'r') as f:
+            xml_content = f.read()
 
-    # Initialize BeautifulSoup with the XML content
-    xml[file] = bs(xml_content, 'xml')
+        # Initialize BeautifulSoup with the XML content
+        xml[file] = bs(xml_content, 'xml')
 
-# Get all enums
-all_enums = {}
-for key in xml:
-    for enum in xml[key].find_all('enum'):
-        if enum.find('deprecated', recursive=False) is not None:
-            # Skip and deprecated items
-            continue
-        decoded = check_enum(enum, key)
-        name = decoded["name"]
-        if name in all_enums:
-            # Add to existing enum
-            all_enums[name]['file'].append(key)
-            all_enums[name]['enum'].append(decoded)
-
-        else:
-            # Create new enum
-            all_enums[name] = {'name': name, 'file': [
-                key], 'enum': [decoded], 'used': False}
-
-# Check for enums declared in multiple locations
-for name in all_enums:
-    # Combine results
-    enum = all_enums[name]
-
-    # Combine file names
-    enum['file'] = ", ".join(enum['file'])
-
-    values = enum['enum'][0]['values']
-    enum['bitmask'] = enum['enum'][0]['bitmask']
-    bitmask_conflict = False
-    values_conflict = False
-
-    for i in range(1, len(enum['enum'])):
-        bitmask_conflict |= bool(enum['bitmask']) != bool(
-            enum['enum'][i]['bitmask'])
-        values_conflict |= not set(values).isdisjoint(enum['enum'][i]['values'])
-        values += enum['enum'][i]['values']
-
-    if not values:
-        warn("%s: Enum: %s has no entries" % (enum['file'], name))
-        # Leave min/max defined (as None) so downstream field checks can
-        # detect the empty enum rather than hitting a KeyError.
-        enum['min'] = enum['max'] = None
-        continue
-
-    enum['min'] = min(values)
-    enum['max'] = max(values)
-
-    if bitmask_conflict:
-        warn("%s: Enum: %s has conflicting bitmask definitions" %
-             (enum['file'],  name))
-
-    if values_conflict:
-        warn("%s: Enum: %s has conflicting values" % (enum['file'],  name))
-
-# Check all fields against enums
-for key in xml:
-    for message in xml[key].find_all('message'):
-        if message.find('deprecated', recursive=False) is not None:
-            # Skip and deprecated items
-            continue
-        name = message.get('name')
-        fields = message.find_all('field')
-        for field in fields:
-            check_field(key, name, field, all_enums)
-
-# Check params in MAV_CMD
-for key in xml:
-    for enum in xml[key].find_all('enum', {"name": "MAV_CMD"}):
-        for entry in enum.find_all('entry'):
-            if entry.find('deprecated', recursive=False) is not None:
+    # Get all enums
+    all_enums = {}
+    for key in xml:
+        for enum in xml[key].find_all('enum'):
+            if enum.find('deprecated', recursive=False) is not None:
                 # Skip and deprecated items
                 continue
-            name = entry.get('name')
-            seen_indices = set()   # Indices seen so far, to check for duplicates
-            for param in entry.find_all('param'):
-                check_cmd_param(key, name, param, all_enums)
-                idx = param.get('index')
+            decoded = check_enum(enum, key)
+            name = decoded["name"]
+            if name in all_enums:
+                # Add to existing enum
+                all_enums[name]['file'].append(key)
+                all_enums[name]['enum'].append(decoded)
 
-                # Flag duplicate indices regardless of whether they're in the
-                # valid range, so e.g. two params both with index="0" are both
-                # reported as a duplicate and as out of range.
-                if idx is not None:
-                    if idx in seen_indices:
-                        warn("%s: Command %s param index %s is duplicated" %
+            else:
+                # Create new enum
+                all_enums[name] = {'name': name, 'file': [
+                    key], 'enum': [decoded], 'used': False}
+
+    # Check for enums declared in multiple locations
+    for name in all_enums:
+        # Combine results
+        enum = all_enums[name]
+
+        # Combine file names
+        enum['file'] = ", ".join(enum['file'])
+
+        values = enum['enum'][0]['values']
+        enum['bitmask'] = enum['enum'][0]['bitmask']
+        bitmask_conflict = False
+        values_conflict = False
+
+        for i in range(1, len(enum['enum'])):
+            bitmask_conflict |= bool(enum['bitmask']) != bool(
+                enum['enum'][i]['bitmask'])
+            values_conflict |= not set(values).isdisjoint(enum['enum'][i]['values'])
+            values += enum['enum'][i]['values']
+
+        if not values:
+            warn("%s: Enum: %s has no entries" % (enum['file'], name))
+            # Leave min/max defined (as None) so downstream field checks can
+            # detect the empty enum rather than hitting a KeyError.
+            enum['min'] = enum['max'] = None
+            continue
+
+        enum['min'] = min(values)
+        enum['max'] = max(values)
+
+        if bitmask_conflict:
+            warn("%s: Enum: %s has conflicting bitmask definitions" %
+                 (enum['file'],  name))
+
+        if values_conflict:
+            warn("%s: Enum: %s has conflicting values" % (enum['file'],  name))
+
+    # Check all fields against enums
+    for key in xml:
+        for message in xml[key].find_all('message'):
+            if message.find('deprecated', recursive=False) is not None:
+                # Skip and deprecated items
+                continue
+            name = message.get('name')
+            fields = message.find_all('field')
+            for field in fields:
+                check_field(key, name, field, all_enums)
+
+    # Check params in MAV_CMD
+    for key in xml:
+        for enum in xml[key].find_all('enum', {"name": "MAV_CMD"}):
+            for entry in enum.find_all('entry'):
+                if entry.find('deprecated', recursive=False) is not None:
+                    # Skip and deprecated items
+                    continue
+                name = entry.get('name')
+                seen_indices = set()   # Indices seen so far, to check for duplicates
+                for param in entry.find_all('param'):
+                    check_cmd_param(key, name, param, all_enums)
+                    idx = param.get('index')
+
+                    # Flag duplicate indices regardless of whether they're in the
+                    # valid range, so e.g. two params both with index="0" are both
+                    # reported as a duplicate and as out of range.
+                    if idx is not None:
+                        if idx in seen_indices:
+                            warn("%s: Command %s param index %s is duplicated" %
+                                 (key, name, idx))
+                        else:
+                            seen_indices.add(idx)
+
+                    # Check if the param index is an integer and in the valid range of [1,7]
+                    try:
+                        idx_int = int(idx)
+                        if idx_int < 1 or idx_int > 7:
+                            warn("%s: Command %s param index %s is out of range" %
+                                 (key, name, idx))
+                    except (TypeError, ValueError):
+                        warn("%s: Command %s param index %s is not an integer" %
                              (key, name, idx))
-                    else:
-                        seen_indices.add(idx)
 
-                # Check if the param index is an integer and in the valid range of [1,7]
-                try:
-                    idx_int = int(idx)
-                    if idx_int < 1 or idx_int > 7:
-                        warn("%s: Command %s param index %s is out of range" %
-                             (key, name, idx))
-                except (TypeError, ValueError):
-                    warn("%s: Command %s param index %s is not an integer" %
-                         (key, name, idx))
+    # Check for unused enums. Defining enums not referenced by any message or
+    # command is a legitimate use of this library, so intended orphans should be
+    # added to the allowlist rather than removed.
+    for key in all_enums:
+        if all_enums[key]["used"] is False:
+            warn("%s: Enum: %s is unused" %
+                 (all_enums[key]['file'], all_enums[key]["name"]))
 
-# Check for unused enums. Defining enums not referenced by any message or
-# command is a legitimate use of this library, so intended orphans should be
-# added to the allowlist rather than removed.
-for key in all_enums:
-    if all_enums[key]["used"] is False:
-        warn("%s: Enum: %s is unused" %
-             (all_enums[key]['file'], all_enums[key]["name"]))
+    # Detect stale allowlist entries that no longer match any warning (e.g. a
+    # warning was fixed, or its message was reworded). Only meaningful on a full
+    # run: a subset run (-f) legitimately won't exercise entries for other files.
+    # Tracked separately from warning_count so CI can distinguish a new XML
+    # consistency problem from allowlist housekeeping: both fail --exception, but
+    # the messages tell you which one to fix (edit the XML vs. prune the allowlist).
+    stale = []
+    if args.file is None:
+        stale = sorted(allowlist - matched_allowlist)
+        for entry in stale:
+            print("Stale allowlist entry (no longer matches any warning): %s" % entry)
 
-# Detect stale allowlist entries that no longer match any warning (e.g. a
-# warning was fixed, or its message was reworded). Only meaningful on a full
-# run: a subset run (-f) legitimately won't exercise entries for other files.
-# Tracked separately from warning_count so CI can distinguish a new XML
-# consistency problem from allowlist housekeeping: both fail --exception, but
-# the messages tell you which one to fix (edit the XML vs. prune the allowlist).
-stale = []
-if args.file is None:
-    stale = sorted(allowlist - matched_allowlist)
-    for entry in stale:
-        print("Stale allowlist entry (no longer matches any warning): %s" % entry)
+    # Give summary for possible CI usage
+    if allowed_count:
+        print("\n%i allowlisted warning(s) suppressed." % allowed_count)
 
-# Give summary for possible CI usage
-if allowed_count:
-    print("\n%i allowlisted warning(s) suppressed." % allowed_count)
+    if stale:
+        print("\n%i stale allowlist entry(ies) no longer match any warning and "
+              "should be removed from %s." % (len(stale), allowlist_path))
 
-if stale:
-    print("\n%i stale allowlist entry(ies) no longer match any warning and "
-          "should be removed from %s." % (len(stale), allowlist_path))
+    summary = ("Found %i new consistency warning(s) and %i stale allowlist "
+               "entry(ies) in: %s" % (warning_count, len(stale), files))
 
-summary = ("Found %i new consistency warning(s) and %i stale allowlist "
-           "entry(ies) in: %s" % (warning_count, len(stale), files))
+    if args.exception and (warning_count > 0 or stale):
+        raise Exception(summary + "\n")
 
-if args.exception and (warning_count > 0 or stale):
-    raise Exception(summary + "\n")
+    print("\n%s\n" % summary)
 
-print("\n%s\n" % summary)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two updates to the consistency checking scripts.

Firstly this skips checking deprecated items. This comes out about scratch, we save a couple of warnings but get a couple more because of items referencing deprecated enums.
```
ardupilotmega.xml: Message MOUNT_CONFIGURE field mount_mode enum MAV_MOUNT_MODE does not exist
ardupilotmega.xml: Message MOUNT_STATUS field mount_mode enum MAV_MOUNT_MODE does not exist
```

Secondly this adds a check for the min/max/step for `MAV_CMD` items. In particular where a item has a step size of 1 and min and max that are close together, this adds lots of warnings.
```
ardupilotmega.xml: Command MAV_CMD_DO_SPRAYER param 1 min, max close and increment of 1, should there be a enum?
ardupilotmega.xml: Command MAV_CMD_SOLO_BTN_PAUSE_CLICK param 1 min, max close and increment of 1, should there be a enum?
ardupilotmega.xml: Command MAV_CMD_SET_EKF_SOURCE_SET param 1 min, max close and increment of 1, should there be a enum?
ardupilotmega.xml: Command MAV_CMD_DO_START_MAG_CAL param 2 min, max close and increment of 1, should there be a enum?
ardupilotmega.xml: Command MAV_CMD_DO_START_MAG_CAL param 3 min, max close and increment of 1, should there be a enum?
ardupilotmega.xml: Command MAV_CMD_DO_START_MAG_CAL param 5 min, max close and increment of 1, should there be a enum?
ardupilotmega.xml: Command MAV_CMD_SET_FACTORY_TEST_MODE param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_LOITER_TURNS param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_LOITER_TIME param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_LOITER_TO_ALT param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_LOITER_TO_ALT param 4 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_FOLLOW param 4 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_PATHPLANNING param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_PATHPLANNING param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_GUIDED_ENABLE param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_CONDITION_YAW param 3 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_CONDITION_YAW param 4 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_SET_HOME param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_FLIGHTTERMINATION param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_PAUSE_CONTINUE param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_SET_REVERSE param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_CONTROL_VIDEO param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_CONTROL_VIDEO param 4 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_SET_CAM_TRIGG_DIST param 3 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_FENCE_ENABLE param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_INVERTED_FLIGHT param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_AUTOTUNE_ENABLE param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_NAV_SET_YAW_SPEED param 3 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_ENGINE_CONTROL param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_ENGINE_CONTROL param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_SET_MISSION_CURRENT param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 3 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 4 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 5 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 6 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_CALIBRATION param 7 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN param 3 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_COMPONENT_ARM_DISARM param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_ILLUMINATOR_ON_OFF param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_SET_MESSAGE_INTERVAL param 7 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_REQUEST_MESSAGE param 7 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_STORAGE_FORMAT param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_STORAGE_FORMAT param 3 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_RESET_CAMERA_SETTINGS param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_TRIGGER_CONTROL param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_DO_TRIGGER_CONTROL param 2 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_CONTROL_HIGH_LATENCY param 1 min, max close and increment of 1, should there be a enum?
common.xml: Command MAV_CMD_CONDITION_GATE param 2 min, max close and increment of 1, should there be a enum?
development.xml: Command MAV_CMD_DO_UPGRADE param 2 min, max close and increment of 1, should there be a enum?
```
Lots of them are things like 0 to disable and 1 to enable, so they could share some generic enums.