### PR TITLE
MAV_CMD_NAV_FENCE_POLYGON_VERTEX_ - numbering info

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2406,8 +2406,9 @@
       </entry>
       <entry value="5001" name="MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION" hasLocation="true" isDestination="false">
         <description>Fence vertex for an inclusion polygon (the polygon must not be self-intersecting). The vehicle must stay within this area. Minimum of 3 vertices required.
+          The vertices for a polygon must be sent sequentially, each with param1 set to the total number of vertices in the polygon.
         </description>
-        <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count</param>
+        <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count. This is the number of vertices in the current polygon (all vertices will have the same number).</param>
         <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group, must be the same for all points in each polygon</param>
         <param index="3">Reserved</param>
         <param index="4">Reserved</param>
@@ -2417,8 +2418,9 @@
       </entry>
       <entry value="5002" name="MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION" hasLocation="true" isDestination="false">
         <description>Fence vertex for an exclusion polygon (the polygon must not be self-intersecting). The vehicle must stay outside this area. Minimum of 3 vertices required.
+          The vertices for a polygon must be sent sequentially, each with param1 set to the total number of vertices in the polygon.                
         </description>
-        <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count</param>
+        <param index="1" label="Vertex Count" minValue="3" increment="1">Polygon vertex count. This is the number of vertices in the current polygon (all vertices will have the same number).</param>
         <param index="2">Reserved</param>
         <param index="3">Reserved</param>
         <param index="4">Reserved</param>


### PR DESCRIPTION
There is some confusion about how fence polygons are numbered in param1: https://groups.google.com/g/mavlink/c/S-Z2d9Vyv78/m/W-Lv2CUuAAAJ

Basically my testing (previously) shows that the vertices in a polygon all follow each other in the sequence of a fence, and have the same total vertices count. 

This clarifies the commands.