### PR TITLE
MAV_MODE_PROPERTY for auto/manual distinquishing

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5267,6 +5267,11 @@
           The mode might still be selected by the FC directly (for example as part of a failsafe).
         </description>
       </entry>
+      <entry value="4" name="MAV_MODE_PROPERTY_AUTO_MODE">
+        <description>If set, this mode is automatically controlled (it may use but does not require a manual controller).
+          If unset the mode is a assumed to require user input (be a manual mode).
+        </description>
+      </entry>
     </enum>
   </enums>
   <messages>


### PR DESCRIPTION
This adds a mode property to allow a GCS to distinguish between custom auto and manual modes. 

@sfuhrer proposed that this is a flaw for being able to configure the UI, which I think is reasonable.

@sfuhrer @bkueng @julianoes @auturgy @IamPete1 What do you think? We don't make additions unless they are going to be implemented/have a stakeholder. Anyone interested in this in a more than abstract way?

