### PR TITLE
TRAJECTORY_REPRESENTATION_ - deprecated

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7567,7 +7567,7 @@
       <field type="int8_t" name="quality" units="%" invalid="0">Optional odometry quality metric as a percentage. -1 = odometry has failed, 0 = unknown/unset quality, 1 = worst quality, 100 = best quality</field>
     </message>
     <message id="332" name="TRAJECTORY_REPRESENTATION_WAYPOINTS">
-      <deprecated since="2025-03">Implemented PX4 v1.11 to v1.14. Not used in current flight stacks.</deprecated>
+      <deprecated since="2025-03" replaced_by="Nothing">Implemented PX4 v1.11 to v1.14. Not used in current flight stacks.</deprecated>
       <description>Describe a trajectory using an array of up-to 5 waypoints in the local frame (MAV_FRAME_LOCAL_NED).</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="valid_points">Number of valid points (up-to 5 waypoints are possible)</field>
@@ -7585,7 +7585,7 @@
       <field type="uint16_t[5]" name="command" enum="MAV_CMD" invalid="[UINT16_MAX]">MAV_CMD command id of waypoint, set to UINT16_MAX if not being used.</field>
     </message>
     <message id="333" name="TRAJECTORY_REPRESENTATION_BEZIER">
-      <deprecated since="2025-03">Implemented PX4 v1.11 to v1.14. Not used in current flight stacks.</deprecated>
+      <deprecated since="2025-03" replaced_by="Nothing">Implemented PX4 v1.11 to v1.14. Not used in current flight stacks.</deprecated>
       <description>Describe a trajectory using an array of up-to 5 bezier control points in the local frame (MAV_FRAME_LOCAL_NED).</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="valid_points">Number of valid control points (up-to 5 points are possible)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7567,6 +7567,7 @@
       <field type="int8_t" name="quality" units="%" invalid="0">Optional odometry quality metric as a percentage. -1 = odometry has failed, 0 = unknown/unset quality, 1 = worst quality, 100 = best quality</field>
     </message>
     <message id="332" name="TRAJECTORY_REPRESENTATION_WAYPOINTS">
+      <deprecated since="2025-03">Implemented PX4 v1.11 to v1.14. Not used in current flight stacks.</deprecated>
       <description>Describe a trajectory using an array of up-to 5 waypoints in the local frame (MAV_FRAME_LOCAL_NED).</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="valid_points">Number of valid points (up-to 5 waypoints are possible)</field>
@@ -7584,6 +7585,7 @@
       <field type="uint16_t[5]" name="command" enum="MAV_CMD" invalid="[UINT16_MAX]">MAV_CMD command id of waypoint, set to UINT16_MAX if not being used.</field>
     </message>
     <message id="333" name="TRAJECTORY_REPRESENTATION_BEZIER">
+      <deprecated since="2025-03">Implemented PX4 v1.11 to v1.14. Not used in current flight stacks.</deprecated>
       <description>Describe a trajectory using an array of up-to 5 bezier control points in the local frame (MAV_FRAME_LOCAL_NED).</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="valid_points">Number of valid control points (up-to 5 points are possible)</field>


### PR DESCRIPTION
The two trajectory representation messages are no longer supported in PX4, and hence not in any flight stack.

The messages can meet certain use case so they are not "bad" but they don't meet the criteria for being in common.xml any more. This marks the messages as deprecated to make it clear that they are on the path for removal.

Corresponding changes made to docs in https://github.com/mavlink/mavlink-devguide/pull/593 (accidentally already merged). I'll unmerge that if there are any objections to this.

Note discussed/agreed in mav call.