### PR TITLE
ArduPilot dialect changes

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -331,7 +331,16 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <!-- 43003 MAV_CMD_EXTERNAL_POSITION_ESTIMATE moved to common.xml -->
+      <entry value="43003" name="MAV_CMD_EXTERNAL_POSITION_ESTIMATE" hasLocation="true" isDestination="false">
+        <description>Provide an external position estimate for use when dead-reckoning. This is meant to be used for occasional position resets that may be provided by a external system such as a remote pilot using landmarks over a video link.</description>
+        <param index="1" label="transmission_time" units="s">Timestamp that this message was sent as a time in the transmitters time domain. The sender should wrap this time back to zero based on required timing accuracy for the application and the limitations of a 32 bit float. For example, wrapping at 10 hours would give approximately 1ms accuracy. Recipient must handle time wrap in any timing jitter correction applied to this field. Wrap rollover time should not be at not more than 250 seconds, which would give approximately 10 microsecond accuracy.</param>
+        <param index="2" label="processing_time" units="s">The time spent in processing the sensor data that is the basis for this position. The recipient can use this to improve time alignment of the data. Set to zero if not known.</param>
+        <param index="3" label="accuracy">estimated one standard deviation accuracy of the measurement. Set to NaN if not known.</param>
+        <param index="4">Empty</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude, not used. Should be sent as NaN. May be supported in a future version of this message.</param>
+      </entry>
       <entry value="43005" name="MAV_CMD_SET_HAGL" hasLocation="false" isDestination="false">
         <description>Provide a value for height above ground level. This can be used for things like fixed wing and VTOL landing.</description>
         <param index="1" label="hagl" units="m">Height above ground level.</param>
@@ -1062,94 +1071,270 @@
     </enum>
     <enum name="PLANE_MODE">
       <description>A mapping of plane flight modes for custom_mode field of heartbeat.</description>
-      <entry value="0" name="PLANE_MODE_MANUAL"/>
-      <entry value="1" name="PLANE_MODE_CIRCLE"/>
-      <entry value="2" name="PLANE_MODE_STABILIZE"/>
-      <entry value="3" name="PLANE_MODE_TRAINING"/>
-      <entry value="4" name="PLANE_MODE_ACRO"/>
-      <entry value="5" name="PLANE_MODE_FLY_BY_WIRE_A"/>
-      <entry value="6" name="PLANE_MODE_FLY_BY_WIRE_B"/>
-      <entry value="7" name="PLANE_MODE_CRUISE"/>
-      <entry value="8" name="PLANE_MODE_AUTOTUNE"/>
-      <entry value="10" name="PLANE_MODE_AUTO"/>
-      <entry value="11" name="PLANE_MODE_RTL"/>
-      <entry value="12" name="PLANE_MODE_LOITER"/>
-      <entry value="13" name="PLANE_MODE_TAKEOFF"/>
-      <entry value="14" name="PLANE_MODE_AVOID_ADSB"/>
-      <entry value="15" name="PLANE_MODE_GUIDED"/>
-      <entry value="16" name="PLANE_MODE_INITIALIZING"/>
-      <entry value="17" name="PLANE_MODE_QSTABILIZE"/>
-      <entry value="18" name="PLANE_MODE_QHOVER"/>
-      <entry value="19" name="PLANE_MODE_QLOITER"/>
-      <entry value="20" name="PLANE_MODE_QLAND"/>
-      <entry value="21" name="PLANE_MODE_QRTL"/>
-      <entry value="22" name="PLANE_MODE_QAUTOTUNE"/>
-      <entry value="23" name="PLANE_MODE_QACRO"/>
-      <entry value="24" name="PLANE_MODE_THERMAL"/>
+      <entry value="0" name="PLANE_MODE_MANUAL">
+        <description>MANUAL</description>
+      </entry>
+      <entry value="1" name="PLANE_MODE_CIRCLE">
+        <description>CIRCLE</description>
+      </entry>
+      <entry value="2" name="PLANE_MODE_STABILIZE">
+        <description>STABILIZE</description>
+      </entry>
+      <entry value="3" name="PLANE_MODE_TRAINING">
+        <description>TRAINING</description>
+      </entry>
+      <entry value="4" name="PLANE_MODE_ACRO">
+        <description>ACRO</description>
+      </entry>
+      <entry value="5" name="PLANE_MODE_FLY_BY_WIRE_A">
+        <description>FBWA</description>
+      </entry>
+      <entry value="6" name="PLANE_MODE_FLY_BY_WIRE_B">
+        <description>FBWB</description>
+      </entry>
+      <entry value="7" name="PLANE_MODE_CRUISE">
+        <description>CRUISE</description>
+      </entry>
+      <entry value="8" name="PLANE_MODE_AUTOTUNE">
+        <description>AUTOTUNE</description>
+      </entry>
+      <entry value="10" name="PLANE_MODE_AUTO">
+        <description>AUTO</description>
+      </entry>
+      <entry value="11" name="PLANE_MODE_RTL">
+        <description>RTL</description>
+      </entry>
+      <entry value="12" name="PLANE_MODE_LOITER">
+        <description>LOITER</description>
+      </entry>
+      <entry value="13" name="PLANE_MODE_TAKEOFF">
+        <description>TAKEOFF</description>
+      </entry>
+      <entry value="14" name="PLANE_MODE_AVOID_ADSB">
+        <description>AVOID ADSB</description>
+      </entry>
+      <entry value="15" name="PLANE_MODE_GUIDED">
+        <description>GUIDED</description>
+      </entry>
+      <entry value="16" name="PLANE_MODE_INITIALIZING">
+        <description>INITIALISING</description>
+      </entry>
+      <entry value="17" name="PLANE_MODE_QSTABILIZE">
+        <description>QSTABILIZE</description>
+      </entry>
+      <entry value="18" name="PLANE_MODE_QHOVER">
+        <description>QHOVER</description>
+      </entry>
+      <entry value="19" name="PLANE_MODE_QLOITER">
+        <description>QLOITER</description>
+      </entry>
+      <entry value="20" name="PLANE_MODE_QLAND">
+        <description>QLAND</description>
+      </entry>
+      <entry value="21" name="PLANE_MODE_QRTL">
+        <description>QRTL</description>
+      </entry>
+      <entry value="22" name="PLANE_MODE_QAUTOTUNE">
+        <description>QAUTOTUNE</description>
+      </entry>
+      <entry value="23" name="PLANE_MODE_QACRO">
+        <description>QACRO</description>
+      </entry>
+      <entry value="24" name="PLANE_MODE_THERMAL">
+        <description>THERMAL</description>
+      </entry>
+      <entry value="25" name="PLANE_MODE_LOITER_ALT_QLAND">
+        <description>LOITER2QLAND</description>
+      </entry>
+      <entry value="26" name="PLANE_MODE_AUTOLAND">
+        <description>AUTOLAND</description>
+      </entry>
     </enum>
     <enum name="COPTER_MODE">
       <description>A mapping of copter flight modes for custom_mode field of heartbeat.</description>
-      <entry value="0" name="COPTER_MODE_STABILIZE"/>
-      <entry value="1" name="COPTER_MODE_ACRO"/>
-      <entry value="2" name="COPTER_MODE_ALT_HOLD"/>
-      <entry value="3" name="COPTER_MODE_AUTO"/>
-      <entry value="4" name="COPTER_MODE_GUIDED"/>
-      <entry value="5" name="COPTER_MODE_LOITER"/>
-      <entry value="6" name="COPTER_MODE_RTL"/>
-      <entry value="7" name="COPTER_MODE_CIRCLE"/>
-      <entry value="9" name="COPTER_MODE_LAND"/>
-      <entry value="11" name="COPTER_MODE_DRIFT"/>
-      <entry value="13" name="COPTER_MODE_SPORT"/>
-      <entry value="14" name="COPTER_MODE_FLIP"/>
-      <entry value="15" name="COPTER_MODE_AUTOTUNE"/>
-      <entry value="16" name="COPTER_MODE_POSHOLD"/>
-      <entry value="17" name="COPTER_MODE_BRAKE"/>
-      <entry value="18" name="COPTER_MODE_THROW"/>
-      <entry value="19" name="COPTER_MODE_AVOID_ADSB"/>
-      <entry value="20" name="COPTER_MODE_GUIDED_NOGPS"/>
-      <entry value="21" name="COPTER_MODE_SMART_RTL"/>
-      <entry value="22" name="COPTER_MODE_FLOWHOLD"/>
-      <entry value="23" name="COPTER_MODE_FOLLOW"/>
-      <entry value="24" name="COPTER_MODE_ZIGZAG"/>
-      <entry value="25" name="COPTER_MODE_SYSTEMID"/>
-      <entry value="26" name="COPTER_MODE_AUTOROTATE"/>
-      <entry value="27" name="COPTER_MODE_AUTO_RTL"/>
+      <entry value="0" name="COPTER_MODE_STABILIZE">
+        <description>STABILIZE</description>
+      </entry>
+      <entry value="1" name="COPTER_MODE_ACRO">
+        <description>ACRO</description>
+      </entry>
+      <entry value="2" name="COPTER_MODE_ALT_HOLD">
+        <description>ALT HOLD</description>
+      </entry>
+      <entry value="3" name="COPTER_MODE_AUTO">
+        <description>AUTO</description>
+      </entry>
+      <entry value="4" name="COPTER_MODE_GUIDED">
+        <description>GUIDED</description>
+      </entry>
+      <entry value="5" name="COPTER_MODE_LOITER">
+        <description>LOITER</description>
+      </entry>
+      <entry value="6" name="COPTER_MODE_RTL">
+        <description>RTL</description>
+      </entry>
+      <entry value="7" name="COPTER_MODE_CIRCLE">
+        <description>CIRCLE</description>
+      </entry>
+      <entry value="9" name="COPTER_MODE_LAND">
+        <description>LAND</description>
+      </entry>
+      <entry value="11" name="COPTER_MODE_DRIFT">
+        <description>DRIFT</description>
+      </entry>
+      <entry value="13" name="COPTER_MODE_SPORT">
+        <description>SPORT</description>
+      </entry>
+      <entry value="14" name="COPTER_MODE_FLIP">
+        <description>FLIP</description>
+      </entry>
+      <entry value="15" name="COPTER_MODE_AUTOTUNE">
+        <description>AUTOTUNE</description>
+      </entry>
+      <entry value="16" name="COPTER_MODE_POSHOLD">
+        <description>POSHOLD</description>
+      </entry>
+      <entry value="17" name="COPTER_MODE_BRAKE">
+        <description>BRAKE</description>
+      </entry>
+      <entry value="18" name="COPTER_MODE_THROW">
+        <description>THROW</description>
+      </entry>
+      <entry value="19" name="COPTER_MODE_AVOID_ADSB">
+        <description>AVOID ADSB</description>
+      </entry>
+      <entry value="20" name="COPTER_MODE_GUIDED_NOGPS">
+        <description>GUIDED NOGPS</description>
+      </entry>
+      <entry value="21" name="COPTER_MODE_SMART_RTL">
+        <description>SMARTRTL</description>
+      </entry>
+      <entry value="22" name="COPTER_MODE_FLOWHOLD">
+        <description>FLOWHOLD</description>
+      </entry>
+      <entry value="23" name="COPTER_MODE_FOLLOW">
+        <description>FOLLOW</description>
+      </entry>
+      <entry value="24" name="COPTER_MODE_ZIGZAG">
+        <description>ZIGZAG</description>
+      </entry>
+      <entry value="25" name="COPTER_MODE_SYSTEMID">
+        <description>SYSTEMID</description>
+      </entry>
+      <entry value="26" name="COPTER_MODE_AUTOROTATE">
+        <description>AUTOROTATE</description>
+      </entry>
+      <entry value="27" name="COPTER_MODE_AUTO_RTL">
+        <description>AUTO RTL</description>
+      </entry>
+      <entry value="28" name="COPTER_MODE_TURTLE">
+        <description>TURTLE</description>
+      </entry>
     </enum>
     <enum name="SUB_MODE">
       <description>A mapping of sub flight modes for custom_mode field of heartbeat.</description>
-      <entry value="0" name="SUB_MODE_STABILIZE"/>
-      <entry value="1" name="SUB_MODE_ACRO"/>
-      <entry value="2" name="SUB_MODE_ALT_HOLD"/>
-      <entry value="3" name="SUB_MODE_AUTO"/>
-      <entry value="4" name="SUB_MODE_GUIDED"/>
-      <entry value="7" name="SUB_MODE_CIRCLE"/>
-      <entry value="9" name="SUB_MODE_SURFACE"/>
-      <entry value="16" name="SUB_MODE_POSHOLD"/>
-      <entry value="19" name="SUB_MODE_MANUAL"/>
+      <entry value="0" name="SUB_MODE_STABILIZE">
+        <description>STABILIZE</description>
+      </entry>
+      <entry value="1" name="SUB_MODE_ACRO">
+        <description>ACRO</description>
+      </entry>
+      <entry value="2" name="SUB_MODE_ALT_HOLD">
+        <description>ALT HOLD</description>
+      </entry>
+      <entry value="3" name="SUB_MODE_AUTO">
+        <description>AUTO</description>
+      </entry>
+      <entry value="4" name="SUB_MODE_GUIDED">
+        <description>GUIDED</description>
+      </entry>
+      <entry value="7" name="SUB_MODE_CIRCLE">
+        <description>CIRCLE</description>
+      </entry>
+      <entry value="9" name="SUB_MODE_SURFACE">
+        <description>SURFACE</description>
+      </entry>
+      <entry value="16" name="SUB_MODE_POSHOLD">
+        <description>POSHOLD</description>
+      </entry>
+      <entry value="19" name="SUB_MODE_MANUAL">
+        <description>MANUAL</description>
+      </entry>
+      <entry value="20" name="SUB_MODE_MOTORDETECT">
+        <description>MOTORDETECT</description>
+      </entry>
+      <entry value="21" name="SUB_MODE_SURFTRAK">
+        <description>SURFTRAK</description>
+      </entry>
     </enum>
     <enum name="ROVER_MODE">
       <description>A mapping of rover flight modes for custom_mode field of heartbeat.</description>
-      <entry value="0" name="ROVER_MODE_MANUAL"/>
-      <entry value="1" name="ROVER_MODE_ACRO"/>
-      <entry value="3" name="ROVER_MODE_STEERING"/>
-      <entry value="4" name="ROVER_MODE_HOLD"/>
-      <entry value="5" name="ROVER_MODE_LOITER"/>
-      <entry value="6" name="ROVER_MODE_FOLLOW"/>
-      <entry value="7" name="ROVER_MODE_SIMPLE"/>
-      <entry value="10" name="ROVER_MODE_AUTO"/>
-      <entry value="11" name="ROVER_MODE_RTL"/>
-      <entry value="12" name="ROVER_MODE_SMART_RTL"/>
-      <entry value="15" name="ROVER_MODE_GUIDED"/>
-      <entry value="16" name="ROVER_MODE_INITIALIZING"/>
+      <entry value="0" name="ROVER_MODE_MANUAL">
+        <description>MANUAL</description>
+      </entry>
+      <entry value="1" name="ROVER_MODE_ACRO">
+        <description>ACRO</description>
+      </entry>
+      <entry value="3" name="ROVER_MODE_STEERING">
+        <description>STEERING</description>
+      </entry>
+      <entry value="4" name="ROVER_MODE_HOLD">
+        <description>HOLD</description>
+      </entry>
+      <entry value="5" name="ROVER_MODE_LOITER">
+        <description>LOITER</description>
+      </entry>
+      <entry value="6" name="ROVER_MODE_FOLLOW">
+        <description>FOLLOW</description>
+      </entry>
+      <entry value="7" name="ROVER_MODE_SIMPLE">
+        <description>SIMPLE</description>
+      </entry>
+      <entry value="8" name="ROVER_MODE_DOCK">
+        <description>DOCK</description>
+      </entry>
+      <entry value="9" name="ROVER_MODE_CIRCLE">
+        <description>CIRCLE</description>
+      </entry>
+      <entry value="10" name="ROVER_MODE_AUTO">
+        <description>AUTO</description>
+      </entry>
+      <entry value="11" name="ROVER_MODE_RTL">
+        <description>RTL</description>
+      </entry>
+      <entry value="12" name="ROVER_MODE_SMART_RTL">
+        <description>SMART RTL</description>
+      </entry>
+      <entry value="15" name="ROVER_MODE_GUIDED">
+        <description>GUIDED</description>
+      </entry>
+      <entry value="16" name="ROVER_MODE_INITIALIZING">
+        <description>INITIALISING</description>
+      </entry>
     </enum>
     <enum name="TRACKER_MODE">
       <description>A mapping of antenna tracker flight modes for custom_mode field of heartbeat.</description>
-      <entry value="0" name="TRACKER_MODE_MANUAL"/>
-      <entry value="1" name="TRACKER_MODE_STOP"/>
-      <entry value="2" name="TRACKER_MODE_SCAN"/>
-      <entry value="3" name="TRACKER_MODE_SERVO_TEST"/>
-      <entry value="10" name="TRACKER_MODE_AUTO"/>
-      <entry value="16" name="TRACKER_MODE_INITIALIZING"/>
+      <entry value="0" name="TRACKER_MODE_MANUAL">
+        <description>MANUAL</description>
+      </entry>
+      <entry value="1" name="TRACKER_MODE_STOP">
+        <description>STOP</description>
+      </entry>
+      <entry value="2" name="TRACKER_MODE_SCAN">
+        <description>SCAN</description>
+      </entry>
+      <entry value="3" name="TRACKER_MODE_SERVO_TEST">
+        <description>SERVO TEST</description>
+      </entry>
+      <entry value="4" name="TRACKER_MODE_GUIDED">
+        <description>GUIDED</description>
+      </entry>
+      <entry value="10" name="TRACKER_MODE_AUTO">
+        <description>AUTO</description>
+      </entry>
+      <entry value="16" name="TRACKER_MODE_INITIALIZING">
+        <description>INITIALISING</description>
+      </entry>
     </enum>
     <enum name="OSD_PARAM_CONFIG_TYPE">
       <description>The type of parameter for the OSD parameter editor.</description>
@@ -1334,9 +1519,9 @@
       <field type="uint32_t" name="last_recovery" units="ms">Time (since boot) of last successful recovery.</field>
       <field type="uint32_t" name="last_clear" units="ms">Time (since boot) of last all-clear.</field>
       <field type="uint16_t" name="breach_count">Number of fence breaches.</field>
-      <field type="uint8_t" name="mods_enabled" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of enabled modules.</field>
-      <field type="uint8_t" name="mods_required" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of required modules.</field>
-      <field type="uint8_t" name="mods_triggered" enum="LIMIT_MODULE" display="bitmask">AP_Limit_Module bitfield of triggered modules.</field>
+      <field type="uint8_t" name="mods_enabled" enum="LIMIT_MODULE">AP_Limit_Module bitfield of enabled modules.</field>
+      <field type="uint8_t" name="mods_required" enum="LIMIT_MODULE">AP_Limit_Module bitfield of required modules.</field>
+      <field type="uint8_t" name="mods_triggered" enum="LIMIT_MODULE">AP_Limit_Module bitfield of triggered modules.</field>
     </message>
     <message id="168" name="WIND">
       <description>Wind estimation.</description>
@@ -1401,7 +1586,7 @@
       <!-- Path planned landings are still in the future, but we want these fields ready: -->
       <field type="int16_t" name="break_alt" units="m">Break altitude relative to home.</field>
       <field type="uint16_t" name="land_dir" units="cdeg">Heading to aim for when landing.</field>
-      <field type="uint8_t" name="flags" enum="RALLY_FLAGS" display="bitmask">Configuration flags.</field>
+      <field type="uint8_t" name="flags" enum="RALLY_FLAGS">Configuration flags.</field>
     </message>
     <message id="176" name="RALLY_FETCH_POINT">
       <description>Request a current rally point from MAV. MAV should respond with a RALLY_POINT message. MAV should not respond if the request is invalid.</description>
@@ -1521,7 +1706,7 @@
     <message id="191" name="MAG_CAL_PROGRESS">
       <description>Reports progress of compass calibration.</description>
       <field type="uint8_t" name="compass_id" instance="true">Compass being calibrated.</field>
-      <field type="uint8_t" name="cal_mask" display="bitmask">Bitmask of compasses being calibrated.</field>
+      <field type="uint8_t" name="cal_mask">Bitmask of compasses being calibrated.</field>
       <field type="uint8_t" name="cal_status" enum="MAG_CAL_STATUS">Calibration Status.</field>
       <field type="uint8_t" name="attempt">Attempt number.</field>
       <field type="uint8_t" name="completion_pct" units="%">Completion percentage.</field>
@@ -1534,7 +1719,7 @@
     <!-- EKF status message from autopilot to GCS. -->
     <message id="193" name="EKF_STATUS_REPORT">
       <description>EKF Status message including flags and variances.</description>
-      <field type="uint16_t" name="flags" enum="EKF_STATUS_FLAGS" display="bitmask">Flags.</field>
+      <field type="uint16_t" name="flags" enum="EKF_STATUS_FLAGS">Flags.</field>
       <!-- supported flags see EKF_STATUS_FLAGS enum -->
       <field type="float" name="velocity_variance">Velocity variance.</field>
       <!-- below 0.5 is good, 0.5~0.79 is warning, 0.8 or higher is bad -->
@@ -1608,7 +1793,7 @@
       <description>Heartbeat from a HeroBus attached GoPro.</description>
       <field type="uint8_t" name="status" enum="GOPRO_HEARTBEAT_STATUS">Status.</field>
       <field type="uint8_t" name="capture_mode" enum="GOPRO_CAPTURE_MODE">Current capture mode.</field>
-      <field type="uint8_t" name="flags" enum="GOPRO_HEARTBEAT_FLAGS" display="bitmask">Additional status bits.</field>
+      <field type="uint8_t" name="flags" enum="GOPRO_HEARTBEAT_FLAGS">Additional status bits.</field>
       <!-- see GOPRO_HEARTBEAT_FLAGS -->
     </message>
     <message id="216" name="GOPRO_GET_REQUEST">

--- a/message_definitions/v1.0/csAirLink.xml
+++ b/message_definitions/v1.0/csAirLink.xml
@@ -14,23 +14,6 @@
         <description>Auth successful</description>
       </entry>
     </enum>
-    <enum name="AIRLINK_EYE_GS_HOLE_PUSH_RESP_TYPE">
-      <entry value="0" name="AIRLINK_HPR_PARTNER_NOT_READY"/>
-      <entry value="1" name="AIRLINK_HPR_PARTNER_READY"/>
-    </enum>
-    <enum name="AIRLINK_EYE_IP_VERSION">
-      <entry value="0" name="AIRLINK_IP_V4"/>
-      <entry value="1" name="AIRLINK_IP_V6"/>
-    </enum>
-    <enum name="AIRLINK_EYE_HOLE_PUSH_TYPE">
-      <entry value="0" name="AIRLINK_HP_NOT_PENETRATED"/>
-      <entry value="1" name="AIRLINK_HP_BROKEN"/>
-    </enum>
-    <enum name="AIRLINK_EYE_TURN_INIT_TYPE">
-      <entry value="0" name="AIRLINK_TURN_INIT_START"/>
-      <entry value="1" name="AIRLINK_TURN_INIT_OK"/>
-      <entry value="2" name="AIRLINK_TURN_INIT_BAD"/>
-    </enum>
   </enums>
   <messages>
     <message id="52000" name="AIRLINK_AUTH">
@@ -41,26 +24,6 @@
     <message id="52001" name="AIRLINK_AUTH_RESPONSE">
       <description>Response to the authorization request</description>
       <field type="uint8_t" name="resp_type" enum="AIRLINK_AUTH_RESPONSE_TYPE">Response type</field>
-    </message>
-    <message id="52002" name="AIRLINK_EYE_GS_HOLE_PUSH_REQUEST">
-      <description>Request to hole punching</description>
-      <field type="uint8_t" name="resp_type" enum="AIRLINK_EYE_GS_HOLE_PUSH_RESP_TYPE">Hole push response type</field>
-    </message>
-    <message id="52003" name="AIRLINK_EYE_GS_HOLE_PUSH_RESPONSE">
-      <description>Response information about the connected device</description>
-      <field type="uint8_t" name="resp_type" enum="AIRLINK_EYE_GS_HOLE_PUSH_RESP_TYPE">Hole push response type</field>
-      <field type="uint8_t" name="ip_version" enum="AIRLINK_EYE_IP_VERSION">ip version</field>
-      <field type="uint8_t[4]" name="ip_address_4">ip 4 address</field>
-      <field type="uint8_t[16]" name="ip_address_6">ip 6 address</field>
-      <field type="uint32_t" name="ip_port">port</field>
-    </message>
-    <message id="52004" name="AIRLINK_EYE_HP">
-      <description>A package with information about the hole punching status. It is used for constant sending to avoid NAT closing timeout.</description>
-      <field type="uint8_t" name="resp_type" enum="AIRLINK_EYE_HOLE_PUSH_TYPE">Hole push response type</field>
-    </message>
-    <message id="52005" name="AIRLINK_EYE_TURN_INIT">
-      <description>Initializing the TURN protocol</description>
-      <field type="uint8_t" name="resp_type" enum="AIRLINK_EYE_TURN_INIT_TYPE">Turn init type</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/loweheiser.xml
+++ b/message_definitions/v1.0/loweheiser.xml
@@ -38,7 +38,7 @@
       <!-- EFI fields -->
       <field type="float" name="efi_batt" units="V"> EFI Supply Voltage.</field>
       <field type="float" name="efi_rpm" units="rpm">Motor RPM.</field>
-      <field type="float" name="efi_pw" units="ms">Injector pulse-width in milliseconds.</field>
+      <field type="float" name="efi_pw" units="ms">Injector pulse-width in miliseconds.</field>
       <field type="float" name="efi_fuel_flow">Fuel flow rate in litres/hour.</field>
       <field type="float" name="efi_fuel_consumed" units="l">Fuel consumed.</field>
       <field type="float" name="efi_baro" units="kPa">Atmospheric pressure.</field>

--- a/message_definitions/v1.0/uAvionix.xml
+++ b/message_definitions/v1.0/uAvionix.xml
@@ -82,6 +82,64 @@
       <entry value="6" name="UAVIONIX_ADSB_OUT_DOWNED_AIRCRAFT_EMERGENCY"/>
       <entry value="7" name="UAVIONIX_ADSB_OUT_RESERVED"/>
     </enum>
+    <enum name="UAVIONIX_ADSB_OUT_CONTROL_STATE" bitmask="true">
+      <description>State flags for ADS-B transponder dynamic report</description>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_EXTERNAL_BARO_CROSSCHECKED"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_ON_GROUND"/>
+      <entry value="8" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_IDENT_BUTTON_ACTIVE"/>
+      <entry value="16" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_MODE_A_ENABLED"/>
+      <entry value="32" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_MODE_C_ENABLED"/>
+      <entry value="64" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_MODE_S_ENABLED"/>
+      <entry value="128" name="UAVIONIX_ADSB_OUT_CONTROL_STATE_1090ES_TX_ENABLED"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_XBIT" bitmask="true">
+      <description>State flags for X-Bit and reserved fields.</description>
+      <entry value="128" name="UAVIONIX_ADSB_XBIT_ENABLED"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_STATUS_STATE" bitmask="true">
+      <description>State flags for ADS-B transponder status report</description>
+      <entry value="1" name="UAVIONIX_ADSB_OUT_STATUS_STATE_ON_GROUND"/>
+      <entry value="2" name="UAVIONIX_ADSB_OUT_STATUS_STATE_INTERROGATED_SINCE_LAST"/>
+      <entry value="4" name="UAVIONIX_ADSB_OUT_STATUS_STATE_XBIT_ENABLED"/>
+      <entry value="8" name="UAVIONIX_ADSB_OUT_STATUS_STATE_IDENT_ACTIVE"/>
+      <entry value="16" name="UAVIONIX_ADSB_OUT_STATUS_STATE_MODE_A_ENABLED"/>
+      <entry value="32" name="UAVIONIX_ADSB_OUT_STATUS_STATE_MODE_C_ENABLED"/>
+      <entry value="64" name="UAVIONIX_ADSB_OUT_STATUS_STATE_MODE_S_ENABLED"/>
+      <entry value="128" name="UAVIONIX_ADSB_OUT_STATUS_STATE_1090ES_TX_ENABLED"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_STATUS_NIC_NACP">
+      <description>State flags for ADS-B transponder status report</description>
+      <entry value="1" name="UAVIONIX_ADSB_NIC_CR_20_NM"/>
+      <entry value="2" name="UAVIONIX_ADSB_NIC_CR_8_NM"/>
+      <entry value="3" name="UAVIONIX_ADSB_NIC_CR_4_NM"/>
+      <entry value="4" name="UAVIONIX_ADSB_NIC_CR_2_NM"/>
+      <entry value="5" name="UAVIONIX_ADSB_NIC_CR_1_NM"/>
+      <entry value="6" name="UAVIONIX_ADSB_NIC_CR_0_3_NM"/>
+      <entry value="7" name="UAVIONIX_ADSB_NIC_CR_0_2_NM"/>
+      <entry value="8" name="UAVIONIX_ADSB_NIC_CR_0_1_NM"/>
+      <entry value="9" name="UAVIONIX_ADSB_NIC_CR_75_M"/>
+      <entry value="10" name="UAVIONIX_ADSB_NIC_CR_25_M"/>
+      <entry value="11" name="UAVIONIX_ADSB_NIC_CR_7_5_M"/>
+      <entry value="16" name="UAVIONIX_ADSB_NACP_EPU_10_NM"/>
+      <entry value="32" name="UAVIONIX_ADSB_NACP_EPU_4_NM"/>
+      <entry value="48" name="UAVIONIX_ADSB_NACP_EPU_2_NM"/>
+      <entry value="64" name="UAVIONIX_ADSB_NACP_EPU_1_NM"/>
+      <entry value="80" name="UAVIONIX_ADSB_NACP_EPU_0_5_NM"/>
+      <entry value="96" name="UAVIONIX_ADSB_NACP_EPU_0_3_NM"/>
+      <entry value="112" name="UAVIONIX_ADSB_NACP_EPU_0_1_NM"/>
+      <entry value="128" name="UAVIONIX_ADSB_NACP_EPU_0_05_NM"/>
+      <entry value="144" name="UAVIONIX_ADSB_NACP_EPU_30_M"/>
+      <entry value="160" name="UAVIONIX_ADSB_NACP_EPU_10_M"/>
+      <entry value="176" name="UAVIONIX_ADSB_NACP_EPU_3_M"/>
+    </enum>
+    <enum name="UAVIONIX_ADSB_OUT_STATUS_FAULT" bitmask="true">
+      <description>State flags for ADS-B transponder fault report</description>
+      <entry value="8" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_STATUS_MESSAGE_UNAVAIL"/>
+      <entry value="16" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_GPS_NO_POS"/>
+      <entry value="32" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_GPS_UNAVAIL"/>
+      <entry value="64" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_TX_SYSTEM_FAIL"/>
+      <entry value="128" name="UAVIONIX_ADSB_OUT_STATUS_FAULT_MAINT_REQ"/>
+    </enum>
   </enums>
   <messages>
     <message id="10001" name="UAVIONIX_ADSB_OUT_CFG">
@@ -93,7 +151,7 @@
       <field type="uint8_t" name="gpsOffsetLat" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LAT">GPS antenna lateral offset (table 2-36 of DO-282B)</field>
       <field type="uint8_t" name="gpsOffsetLon" enum="UAVIONIX_ADSB_OUT_CFG_GPS_OFFSET_LON">GPS antenna longitudinal offset from nose [if non-zero, take position (in meters) divide by 2 and add one] (table 2-37 DO-282B)</field>
       <field type="uint16_t" name="stallSpeed" units="cm/s">Aircraft stall speed in cm/s</field>
-      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT" display="bitmask">ADS-B transponder receiver and transmit enable flags</field>
+      <field type="uint8_t" name="rfSelect" enum="UAVIONIX_ADSB_OUT_RF_SELECT">ADS-B transponder reciever and transmit enable flags</field>
     </message>
     <message id="10002" name="UAVIONIX_ADSB_OUT_DYNAMIC">
       <description>Dynamic data used to generate ADS-B out transponder data (send at 5Hz)</description>
@@ -111,12 +169,42 @@
       <field type="int16_t" name="velNS" units="cm/s">North-South velocity over ground in cm/s North +ve. If unknown set to INT16_MAX</field>
       <field type="int16_t" name="VelEW" units="cm/s">East-West velocity over ground in cm/s East +ve. If unknown set to INT16_MAX</field>
       <field type="uint8_t" name="emergencyStatus" enum="UAVIONIX_ADSB_EMERGENCY_STATUS">Emergency status</field>
-      <field type="uint16_t" name="state" enum="UAVIONIX_ADSB_OUT_DYNAMIC_STATE" display="bitmask">ADS-B transponder dynamic input state flags</field>
+      <field type="uint16_t" name="state" enum="UAVIONIX_ADSB_OUT_DYNAMIC_STATE">ADS-B transponder dynamic input state flags</field>
       <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
     </message>
     <message id="10003" name="UAVIONIX_ADSB_TRANSCEIVER_HEALTH_REPORT">
       <description>Transceiver heartbeat with health report (updated every 10s)</description>
-      <field type="uint8_t" name="rfHealth" enum="UAVIONIX_ADSB_RF_HEALTH" display="bitmask">ADS-B transponder messages</field>
+      <field type="uint8_t" name="rfHealth" enum="UAVIONIX_ADSB_RF_HEALTH">ADS-B transponder messages</field>
+    </message>
+    <message id="10004" name="UAVIONIX_ADSB_OUT_CFG_REGISTRATION">
+      <description>Aircraft Registration.</description>
+      <field type="char[9]" name="registration">Aircraft Registration (ASCII string A-Z, 0-9 only), e.g. "N8644B ". Trailing spaces (0x20) only. This is null-terminated.</field>
+    </message>
+    <message id="10005" name="UAVIONIX_ADSB_OUT_CFG_FLIGHTID">
+      <description>Flight Identification for ADSB-Out vehicles.</description>
+      <field type="char[9]" name="flight_id">Flight Identification: 8 ASCII characters, '0' through '9', 'A' through 'Z' or space. Spaces (0x20) used as a trailing pad character, or when call sign is unavailable. Reflects Control message setting. This is null-terminated.</field>
+    </message>
+    <message id="10006" name="UAVIONIX_ADSB_GET">
+      <description>Request messages.</description>
+      <field type="uint32_t" name="ReqMessageId">Message ID to request. Supports any message in this 10000-10099 range</field>
+    </message>
+    <message id="10007" name="UAVIONIX_ADSB_OUT_CONTROL">
+      <description>Control message with all data sent in UCP control message.</description>
+      <field type="uint8_t" name="state" enum="UAVIONIX_ADSB_OUT_CONTROL_STATE">ADS-B transponder control state flags</field>
+      <field type="int32_t" name="baroAltMSL" units="mbar">Barometric pressure altitude (MSL) relative to a standard atmosphere of 1013.2 mBar and NOT bar corrected altitude (m * 1E-3). (up +ve). If unknown set to INT32_MAX</field>
+      <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
+      <field type="uint8_t" name="emergencyStatus" enum="UAVIONIX_ADSB_EMERGENCY_STATUS">Emergency status</field>
+      <field type="char[8]" name="flight_id">Flight Identification: 8 ASCII characters, '0' through '9', 'A' through 'Z' or space. Spaces (0x20) used as a trailing pad character, or when call sign is unavailable.</field>
+      <field type="uint8_t" name="x_bit" enum="UAVIONIX_ADSB_XBIT">X-Bit enable (military transponders only)</field>
+    </message>
+    <message id="10008" name="UAVIONIX_ADSB_OUT_STATUS">
+      <description>Status message with information from UCP Heartbeat and Status messages.</description>
+      <field type="uint8_t" name="state" enum="UAVIONIX_ADSB_OUT_STATUS_STATE">ADS-B transponder status state flags</field>
+      <field type="uint16_t" name="squawk">Mode A code (typically 1200 [0x04B0] for VFR)</field>
+      <field type="uint8_t" name="NIC_NACp" enum="UAVIONIX_ADSB_OUT_STATUS_NIC_NACP">Integrity and Accuracy of traffic reported as a 4-bit value for each field (NACp 7:4, NIC 3:0) and encoded by Containment Radius (HPL) and Estimated Position Uncertainty (HFOM), respectively</field>
+      <field type="uint8_t" name="boardTemp">Board temperature in C</field>
+      <field type="uint8_t" name="fault" enum="UAVIONIX_ADSB_OUT_STATUS_FAULT">ADS-B transponder fault flags</field>
+      <field type="char[8]" name="flight_id">Flight Identification: 8 ASCII characters, '0' through '9', 'A' through 'Z' or space. Spaces (0x20) used as a trailing pad character, or when call sign is unavailable.</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
This pushes changes to ardupilot dialects - in part to get changes for removal of `display="bitmask"` submitted in https://github.com/ArduPilot/mavlink/pull/383
This is the ArduPilot part of the work in https://github.com/mavlink/mavlink/pull/2215

More generally, this is a better way to merge the ArduPilot changes.

Process was

```
git clone https://github.com/mavlink/mavlink.git --recursive
git remote add ardupilot https://github.com/ArduPilot/mavlink.git
git fetch ardupilot master
git sparse-checkout init
git sparse-checkout set message_definitions/v1.0/
git checkout ardupilot/master -- message_definitions/v1.0/ardupilotmega.xml
git checkout ardupilot/master -- message_definitions/v1.0/icarous.xml
git checkout ardupilot/master -- message_definitions/v1.0/csAirLink.xml
git checkout ardupilot/master -- message_definitions/v1.0/loweheiser.xml
git checkout ardupilot/master -- message_definitions/v1.0/uAvionix.xml
git checkout ardupilot/master -- message_definitions/v1.0/cubepilot.xml
git add .
git checkout -b pr_ardupilot_dialect_changes
git commit -m "ArduPilot changes [Date]"
```
