### PR TITLE
AUTOPILOT_VERSION.flight_sw_version - format info

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6668,7 +6668,9 @@
     <message id="148" name="AUTOPILOT_VERSION">
       <description>Version and capability of autopilot software. This should be emitted in response to a request with MAV_CMD_REQUEST_MESSAGE.</description>
       <field type="uint64_t" name="capabilities" enum="MAV_PROTOCOL_CAPABILITY">Bitmap of capabilities</field>
-      <field type="uint32_t" name="flight_sw_version">Firmware version number</field>
+      <field type="uint32_t" name="flight_sw_version">Firmware version number.
+        The field must be encoded as 4 bytes, where each byte (shown from MSB to LSB) is part of a semantic version: (major) (minor) (patch) (FIRMWARE_RELEASE_TYPE).
+      </field>
       <field type="uint32_t" name="middleware_sw_version">Middleware version number</field>
       <field type="uint32_t" name="os_sw_version">Operating system version number</field>
       <field type="uint32_t" name="board_version">HW / board version (last 8 bits should be silicon ID, if any). The first 16 bits of this field specify https://github.com/PX4/PX4-Bootloader/blob/master/board_types.txt</field>


### PR DESCRIPTION
There is a whole bunch of debugging in https://github.com/mavlink/mavlink/pull/2219#issuecomment-2753503265 that demonstrates that both ArduPilot and PX4 format the `AUTOPILOT_VERSION.flight_sw_version` integer in the same way, using the definitions in `FIRMWARE_RELEASE_TYPE` enum to define a string for the LS Byte, and that this is displayed by QGC.

This makes it clear how that version is supposed to be encoded.

@peterbarker @julianoes @auturgy  Are you OK with this? My only concern is that I have written "The field **must** be encoded".
I know we often allow this to be flexible and the field is a recommendation. I prefer that we fix the format as it makes the value parsable by a GCS (if it had been me I would have used the last field as a patch version number rather than the release category such as "dev").

Let me know if you'd prefer "recommends".