### PR TITLE
update GNSS_INTEGRITY messages in development.xml

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -357,11 +357,11 @@
       <entry value="1" name="GPS_SPOOFING_STATE_OK">
         <description>The GPS receiver detected no signal spoofing.</description>
       </entry>
-      <entry value="2" name="GPS_SPOOFING_STATE_MITIGATED">
-        <description>The GPS receiver detected and mitigated signal spoofing.</description>
+      <entry value="2" name="GPS_SPOOFING_STATE_INDICATED">
+        <description>The GPS receiver detected signal spoofing.</description>
       </entry>
-      <entry value="3" name="GPS_SPOOFING_STATE_DETECTED">
-        <description>The GPS receiver detected signal spoofing but still has a fix.</description>
+      <entry value="3" name="GPS_SPOOFING_STATE_MULTIPLE">
+        <description>The GPS receiver detected multiple kind of signal spoofing.</description>
       </entry>
     </enum>
     <enum name="GPS_RAIM_STATE">


### PR DESCRIPTION
I am working on GNSS_INTEGRITY message for septentrio receiver and I would like to rename these messages concerning GPS_SPOOFING_STATE_XXX

- Mitigated -> Indicated : Only one spoofing method is detected
- Detected -> Multiple : More than one spoofing method is detected

Since Spetentrio receiver make difference between inauthentic_gnss_signals and inauthentic_navigation_message.