### PR TITLE
development.xml - frame for setting the position in MAV_CMD_DO_SET_GLOBAL_ORIGIN

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -189,14 +189,15 @@
           Vehicle should emit GPS_GLOBAL_ORIGIN irrespective of whether the origin is changed.
           This enables transform between the local coordinate frame and the global (GNSS) coordinate frame, which may be necessary when (for example) indoor and outdoor settings are connected and the MAV should move from in- to outdoor.
           This command supersedes SET_GPS_GLOBAL_ORIGIN.
+          Should be sent in a COMMAND_INT (frame is nominally MAV_FRAME_GLOBAL when sent in COMMAND_LONG).
         </description>
         <param index="1">Empty</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
-        <param index="5" label="Latitude">Latitude (WGS84)</param>
-        <param index="6" label="Longitude">Longitude (WGS84)</param>
-        <param index="7" label="Altitude" units="m">Altitude (MSL)</param>
+        <param index="5" label="Latitude">Latitude</param>
+        <param index="6" label="Longitude">Longitude</param>
+        <param index="7" label="Altitude" units="m">Altitude</param>
       </entry>
       <entry value="12900" name="MAV_CMD_ODID_SET_EMERGENCY" hasLocation="false" isDestination="false">
         <description>Used to manually set/unset emergency status for remote id.

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -189,7 +189,7 @@
           Vehicle should emit GPS_GLOBAL_ORIGIN irrespective of whether the origin is changed.
           This enables transform between the local coordinate frame and the global (GNSS) coordinate frame, which may be necessary when (for example) indoor and outdoor settings are connected and the MAV should move from in- to outdoor.
           This command supersedes SET_GPS_GLOBAL_ORIGIN.
-          Should be sent in a COMMAND_INT (frame is nominally MAV_FRAME_GLOBAL when sent in COMMAND_LONG).
+          Should be sent in a COMMAND_INT (Expected frame is MAV_FRAME_GLOBAL, and this should be assumed when sent in COMMAND_LONG).
         </description>
         <param index="1">Empty</param>
         <param index="2">Empty</param>


### PR DESCRIPTION
Tidy MAV_CMD_DO_SET_GLOBAL_ORIGIN to make it clear that should be sent in a COMMAND_INT where frame can be set, but that MAV_FRAME_GLOBAL is "expected" sent in COMMAND_LONG).

This falls out of https://github.com/mavlink/mavlink/pull/2247/files#r2036231744