### PR TITLE
Add GLOBAL_POSITION message

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -431,7 +431,8 @@
       <field type="float" name="vx" units="m/s" invalid="[NaN:]">Ground X Speed (Latitude, positive north)</field>
       <field type="float" name="vy" units="m/s" invalid="[NaN:]">Ground Y Speed (Longitude, positive east)</field>
       <field type="float" name="vz" units="m/s" invalid="[NaN:]">Ground Z Speed (Altitude, positive down)</field>
-      <field type="float" name="sacc" units="m/s" invalid="[NaN:]">Standard deviation of speed error</field>
+      <field type="float" name="h_sacc" units="m/s" invalid="[NaN:]">Standard deviation of horizontal velocity error</field>
+      <field type="float" name="v_sacc" units="m/s" invalid="[NaN:]">Standard deviation of vertical velocity error</field>
       <field type="float" name="hdg" units="deg" invalid="[NaN:]">Vehicle heading (yaw angle), 0.0..359.99 degrees</field>
       <field type="float" name="hdg_acc" units="deg" invalid="[NaN:]">Standard deviation of heading error</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -418,8 +418,8 @@
       <field type="float" name="raw_press" units="hPa">Raw differential pressure. NaN for value unknown/not supplied.</field>
       <field type="uint8_t" name="flags" enum="AIRSPEED_SENSOR_FLAGS">Airspeed sensor flags.</field>
     </message>
-    <message id="296" name="EXTERNAL_GLOBAL_POSITION">
-      <description>Global position measurement from an external device.</description>
+    <message id="296" name="GLOBAL_POSITION">
+      <description>Global position measurement or estimate.</description>
       <field type="uint8_t" name="id" instance="true">Sensor ID</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
@@ -428,6 +428,12 @@
       <field type="float" name="alt_ellipsoid" units="m" invalid="[NaN:]">Altitude (WGS84)</field>
       <field type="float" name="eph" units="m" invalid="[NaN:]">Standard deviation of horizontal position error</field>
       <field type="float" name="epv" units="m" invalid="[NaN:]">Standard deviation of vertical position error</field>
+      <field type="float" name="vx" units="m/s" invalid="[NaN:]">Ground X Speed (Latitude, positive north)</field>
+      <field type="float" name="vy" units="m/s" invalid="[NaN:]">Ground Y Speed (Longitude, positive east)</field>
+      <field type="float" name="vz" units="m/s" invalid="[NaN:]">Ground Z Speed (Altitude, positive down)</field>
+      <field type="float" name="sacc" units="m/s" invalid="[NaN:]">Standard deviation of speed error</field>
+      <field type="float" name="hdg" units="deg" invalid="[NaN:]">Vehicle heading (yaw angle), 0.0..359.99 degrees</field>
+      <field type="float" name="hdg_acc" units="deg" invalid="[NaN:]">Standard deviation of heading error</field>
     </message>
     <message id="354" name="SET_VELOCITY_LIMITS">
       <wip/>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -422,19 +422,13 @@
       <description>Global position measurement or estimate.</description>
       <field type="uint8_t" name="id" instance="true">Sensor ID</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source: 0 - unknown, 1 - GNSS, 2 - vision, 3 - pseudolites, 4 - estimator</field>
       <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
       <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>
-      <field type="float" name="alt_ellipsoid" units="m" invalid="NaN">Altitude (WGS84)</field>
+      <field type="float" name="alt_ellipsoid" units="m" invalid="NaN">Altitude (WGS84 elipsoid)</field>
       <field type="float" name="eph" units="m" invalid="NaN">Standard deviation of horizontal position error</field>
       <field type="float" name="epv" units="m" invalid="NaN">Standard deviation of vertical position error</field>
-      <field type="float" name="vx" units="m/s" invalid="NaN">Ground X Speed (Latitude, positive north)</field>
-      <field type="float" name="vy" units="m/s" invalid="NaN">Ground Y Speed (Longitude, positive east)</field>
-      <field type="float" name="vz" units="m/s" invalid="NaN">Ground Z Speed (Altitude, positive down)</field>
-      <field type="float" name="h_sacc" units="m/s" invalid="NaN">Standard deviation of horizontal velocity error</field>
-      <field type="float" name="v_sacc" units="m/s" invalid="NaN">Standard deviation of vertical velocity error</field>
-      <field type="float" name="hdg" units="deg" minValue="0" maxValue="359.99" invalid="NaN">Vehicle heading (yaw angle). Range is 0.0..359.99 degrees relative to North.</field>
-      <field type="float" name="hdg_acc" units="deg" invalid="NaN">Standard deviation of heading error</field>
     </message>
     <message id="354" name="SET_VELOCITY_LIMITS">
       <wip/>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -418,6 +418,17 @@
       <field type="float" name="raw_press" units="hPa">Raw differential pressure. NaN for value unknown/not supplied.</field>
       <field type="uint8_t" name="flags" enum="AIRSPEED_SENSOR_FLAGS">Airspeed sensor flags.</field>
     </message>
+    <message id="296" name="EXTERNAL_GLOBAL_POSITION">
+      <description>Global position measurement from an external device.</description>
+      <field type="uint8_t" name="id" instance="true">Sensor ID</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
+      <field type="float" name="alt" units="m" invalid="[NaN:]">Altitude (MSL)</field>
+      <field type="float" name="alt_ellipsoid" units="m" invalid="[NaN:]">Altitude (WGS84)</field>
+      <field type="float" name="eph" units="m" invalid="[NaN:]">Standard deviation of horizontal position error</field>
+      <field type="float" name="epv" units="m" invalid="[NaN:]">Standard deviation of vertical position error</field>
+    </message>
     <message id="354" name="SET_VELOCITY_LIMITS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -433,7 +433,7 @@
       <field type="float" name="vz" units="m/s" invalid="NaN">Ground Z Speed (Altitude, positive down)</field>
       <field type="float" name="h_sacc" units="m/s" invalid="NaN">Standard deviation of horizontal velocity error</field>
       <field type="float" name="v_sacc" units="m/s" invalid="NaN">Standard deviation of vertical velocity error</field>
-      <field type="float" name="hdg" units="deg" minValue="0" maxValue="359.00" invalid="NaN">Vehicle heading (yaw angle). Range is 0.0..359.99 degrees relative to North.</field>
+      <field type="float" name="hdg" units="deg" minValue="0" maxValue="359.99" invalid="NaN">Vehicle heading (yaw angle). Range is 0.0..359.99 degrees relative to North.</field>
       <field type="float" name="hdg_acc" units="deg" invalid="NaN">Standard deviation of heading error</field>
     </message>
     <message id="354" name="SET_VELOCITY_LIMITS">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -424,17 +424,17 @@
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
-      <field type="float" name="alt" units="m" invalid="[NaN:]">Altitude (MSL)</field>
-      <field type="float" name="alt_ellipsoid" units="m" invalid="[NaN:]">Altitude (WGS84)</field>
-      <field type="float" name="eph" units="m" invalid="[NaN:]">Standard deviation of horizontal position error</field>
-      <field type="float" name="epv" units="m" invalid="[NaN:]">Standard deviation of vertical position error</field>
-      <field type="float" name="vx" units="m/s" invalid="[NaN:]">Ground X Speed (Latitude, positive north)</field>
-      <field type="float" name="vy" units="m/s" invalid="[NaN:]">Ground Y Speed (Longitude, positive east)</field>
-      <field type="float" name="vz" units="m/s" invalid="[NaN:]">Ground Z Speed (Altitude, positive down)</field>
-      <field type="float" name="h_sacc" units="m/s" invalid="[NaN:]">Standard deviation of horizontal velocity error</field>
-      <field type="float" name="v_sacc" units="m/s" invalid="[NaN:]">Standard deviation of vertical velocity error</field>
-      <field type="float" name="hdg" units="deg" invalid="[NaN:]">Vehicle heading (yaw angle), 0.0..359.99 degrees</field>
-      <field type="float" name="hdg_acc" units="deg" invalid="[NaN:]">Standard deviation of heading error</field>
+      <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>
+      <field type="float" name="alt_ellipsoid" units="m" invalid="NaN">Altitude (WGS84)</field>
+      <field type="float" name="eph" units="m" invalid="NaN">Standard deviation of horizontal position error</field>
+      <field type="float" name="epv" units="m" invalid="NaN">Standard deviation of vertical position error</field>
+      <field type="float" name="vx" units="m/s" invalid="NaN">Ground X Speed (Latitude, positive north)</field>
+      <field type="float" name="vy" units="m/s" invalid="NaN">Ground Y Speed (Longitude, positive east)</field>
+      <field type="float" name="vz" units="m/s" invalid="NaN">Ground Z Speed (Altitude, positive down)</field>
+      <field type="float" name="h_sacc" units="m/s" invalid="NaN">Standard deviation of horizontal velocity error</field>
+      <field type="float" name="v_sacc" units="m/s" invalid="NaN">Standard deviation of vertical velocity error</field>
+      <field type="float" name="hdg" units="deg" minValue="0" maxValue="359.00" invalid="NaN">Vehicle heading (yaw angle). Range is 0.0..359.99 degrees relative to North.</field>
+      <field type="float" name="hdg_acc" units="deg" invalid="NaN">Standard deviation of heading error</field>
     </message>
     <message id="354" name="SET_VELOCITY_LIMITS">
       <wip/>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -408,6 +408,30 @@
         <description>Actuators that affect collective tilt.</description>
       </entry>
     </enum>
+    <enum name="GLOBAL_POSITION_SRC">
+      <description>Source for GLOBAL_POSITION measurement or estimate.</description>
+      <entry value="0" name="GLOBAL_POSITION_UNKNOWN">
+        <description>Source is unknown or not one of the listed types.</description>
+      </entry>
+      <entry value="1" name="GLOBAL_POSITION_GNSS">
+        <description>Global Navigation Satellite System (e.g.: GPS, Galileo, Glonass, BeiDou).</description>
+      </entry>
+      <entry value="2" name="GLOBAL_POSITION_VISION">
+        <description>Vision system (e.g.: map matching).</description>
+      </entry>
+      <entry value="3" name="GLOBAL_POSITION_PSEUDOLITES">
+        <description>Pseudo-satellite system (performs GNSS-like function, but usually with transceiver beacons).</description>
+      </entry>
+      <entry value="4" name="GLOBAL_POSITION_TRN">
+        <description>Terrain referenced navigation.</description>
+      </entry>
+      <entry value="5" name="GLOBAL_POSITION_MAGNETIC">
+        <description>Magnetic positioning.</description>
+      </entry>
+      <entry value="6" name="GLOBAL_POSITION_ESTIMATOR">
+        <description>Estimated position based on various sensors (eg. a Kalman Filter).</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="295" name="AIRSPEED">
@@ -422,7 +446,7 @@
       <description>Global position measurement or estimate.</description>
       <field type="uint8_t" name="id" instance="true">Sensor ID</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source: 0 - unknown, 1 - GNSS, 2 - vision, 3 - pseudolites, 4 - estimator</field>
+      <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source of position/estimate (such as GNSS, estimator, etc.)</field>
       <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
       <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -432,6 +432,15 @@
         <description>Estimated position based on various sensors (eg. a Kalman Filter).</description>
       </entry>
     </enum>
+    <enum name="GLOBAL_POSITION_FLAGS" bitmask="true">
+      <description>Status flags for GLOBAL_POSITION</description>
+      <entry value="1" name="GLOBAL_POSITION_UNHEALTHY">
+        <description>Unhealthy sensor/estimator.</description>
+      </entry>
+      <entry value="2" name="GLOBAL_POSITION_PRIMARY">
+        <description>True if the data originates from or is consumed by the primary estimator.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="295" name="AIRSPEED">
@@ -447,6 +456,7 @@
       <field type="uint8_t" name="id" instance="true">Sensor ID</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source of position/estimate (such as GNSS, estimator, etc.)</field>
+      <field type="uint8_t" name="flags" enum="GLOBAL_POSITION_FLAGS">Status flags</field>
       <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
       <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>


### PR DESCRIPTION
Used for an auxiliary global position sensor such as a map matching sensor.