### PR TITLE
MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN use of param6

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1908,7 +1908,7 @@
         <param index="3" label="Component action" minValue="0" maxValue="3" increment="1">0: Do nothing for component, 1: Reboot component, 2: Shutdown component, 3: Reboot component and keep it in the bootloader until upgraded</param>
         <param index="4" label="Component ID" minValue="0" maxValue="255" increment="1">MAVLink Component ID targeted in param3 (0 for all components).</param>
         <param index="5">Reserved (set to 0)</param>
-        <param index="6">Reserved (set to 0)</param>
+        <param index="6">0: reboot only if allowed by safety checks (e.g. permitted when disarmed and on ground), 20190226: force reboot of the autopilot regardless of system state (e.g. allows reboot in flight or during critical operations)</param>
         <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
       </entry>
       <!-- id "247" reserved for MAV_CMD_DO_UPGRADE in development.xml -->


### PR DESCRIPTION
This PR documents the existing behavior of param6 in MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN. While this parameter is already supported by multiple autopilot implementations, its intended values and behavior are currently not described in the MAVLink specification.

Specifically:
0: reboot only if allowed by safety checks
20190226: force reboot, bypassing all safety checks