### PR TITLE
MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN use of param6

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1063,15 +1063,15 @@
         <description>Erase all mission data stored on the vehicle (both persistent and volatile storage)</description>
       </entry>
     </enum>
-    <enum name="PREFLIGHT_REBOOT_SHUTDOWN_FORCE">
+    <enum name="REBOOT_SHUTDOWN_OPTIONS">
       <description>
-        Defines how the reboot command should be processed depending on safety conditions or system state.
+        Specifies the conditions under which the MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command should be accepted.
       </description>
-      <entry value="0" name="REBOOT_SHUTDOWN_ALLOWED">
-        <description>Reboot only if allowed by safety checks.</description>
+      <entry value="0" name="REBOOT_SHUTDOWN_CONDITIONS_SAFETY_INERLOCKED">
+        <description>Reboot/Shutdown only if allowed by safety checks, such as being landed.</description>
       </entry>
-      <entry value="20190226" name="REBOOT_SHUTDOWN_FORCE">
-        <description>Force reboot of the autopilot regardless of system state.</description>
+      <entry value="20190226" name="REBOOT_SHUTDOWN_CONDITIONS_FORCE">
+        <description>Force reboot/shutdown of the autopilot/component regardless of system state.</description>
       </entry>
     </enum>
     <!-- The MAV_CMD enum entries describe either: -->
@@ -1919,7 +1919,7 @@
         <param index="3" label="Component action" minValue="0" maxValue="3" increment="1">0: Do nothing for component, 1: Reboot component, 2: Shutdown component, 3: Reboot component and keep it in the bootloader until upgraded</param>
         <param index="4" label="Component ID" minValue="0" maxValue="255" increment="1">MAVLink Component ID targeted in param3 (0 for all components).</param>
         <param index="5">Reserved (set to 0)</param>
-        <param index="6" label="Reboot/Shutdown behavior" enum="PREFLIGHT_REBOOT_SHUTDOWN_FORCE">REBOOT_SHUTDOWN_ALLOWED: reboot only if allowed by safety checks, REBOOT_SHUTDOWN_FORCE: force reboot regardless of system state.</param>
+        <param index="6" label="Conditions" enum="REBOOT_SHUTDOWN_OPTIONS">Conditions under which reboot/shutdown is allowed.</param>
         <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
       </entry>
       <!-- id "247" reserved for MAV_CMD_DO_UPGRADE in development.xml -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1063,6 +1063,17 @@
         <description>Erase all mission data stored on the vehicle (both persistent and volatile storage)</description>
       </entry>
     </enum>
+    <enum name="PREFLIGHT_REBOOT_SHUTDOWN_FORCE">
+      <description>
+        Defines how the reboot command should be processed depending on safety conditions or system state.
+      </description>
+      <entry value="0" name="REBOOT_SHUTDOWN_ALLOWED">
+        <description>Reboot only if allowed by safety checks.</description>
+      </entry>
+      <entry value="20190226" name="REBOOT_SHUTDOWN_FORCE">
+        <description>Force reboot of the autopilot regardless of system state.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -1908,7 +1919,7 @@
         <param index="3" label="Component action" minValue="0" maxValue="3" increment="1">0: Do nothing for component, 1: Reboot component, 2: Shutdown component, 3: Reboot component and keep it in the bootloader until upgraded</param>
         <param index="4" label="Component ID" minValue="0" maxValue="255" increment="1">MAVLink Component ID targeted in param3 (0 for all components).</param>
         <param index="5">Reserved (set to 0)</param>
-        <param index="6">Reserved (set to 0)</param>
+        <param index="6" label="Reboot/Shutdown behavior" enum="PREFLIGHT_REBOOT_SHUTDOWN_FORCE">REBOOT_SHUTDOWN_ALLOWED: reboot only if allowed by safety checks, REBOOT_SHUTDOWN_FORCE: force reboot regardless of system state.</param>
         <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
       </entry>
       <!-- id "247" reserved for MAV_CMD_DO_UPGRADE in development.xml -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1065,7 +1065,7 @@
     </enum>
     <enum name="REBOOT_SHUTDOWN_CONDITIONS">
       <description>Specifies the conditions under which the MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command should be accepted.</description>
-      <entry value="0" name="REBOOT_SHUTDOWN_CONDITIONS_SAFETY_INERLOCKED">
+      <entry value="0" name="REBOOT_SHUTDOWN_CONDITIONS_SAFETY_INTERLOCKED">
         <description>Reboot/Shutdown only if allowed by safety checks, such as being landed.</description>
       </entry>
       <entry value="20190226" name="REBOOT_SHUTDOWN_CONDITIONS_FORCE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1064,9 +1064,7 @@
       </entry>
     </enum>
     <enum name="REBOOT_SHUTDOWN_CONDITIONS">
-      <description>
-        Specifies the conditions under which the MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command should be accepted.
-      </description>
+      <description>Specifies the conditions under which the MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command should be accepted.</description>
       <entry value="0" name="REBOOT_SHUTDOWN_CONDITIONS_SAFETY_INERLOCKED">
         <description>Reboot/Shutdown only if allowed by safety checks, such as being landed.</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1063,14 +1063,14 @@
         <description>Erase all mission data stored on the vehicle (both persistent and volatile storage)</description>
       </entry>
     </enum>
-    <enum name="PREFLIGHT_REBOOT_SHUTDOWN_CONDITIONS">
+    <enum name="REBOOT_SHUTDOWN_CONDITIONS">
       <description>
         Specifies the conditions under which the MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command should be accepted.
       </description>
-      <entry value="0" name="PREFLIGHT_REBOOT_SHUTDOWN_CONDITIONS_SAFETY_INERLOCKED">
+      <entry value="0" name="REBOOT_SHUTDOWN_CONDITIONS_SAFETY_INERLOCKED">
         <description>Reboot/Shutdown only if allowed by safety checks, such as being landed.</description>
       </entry>
-      <entry value="20190226" name="PREFLIGHT_REBOOT_SHUTDOWN_CONDITIONS_FORCE">
+      <entry value="20190226" name="REBOOT_SHUTDOWN_CONDITIONS_FORCE">
         <description>Force reboot/shutdown of the autopilot/component regardless of system state.</description>
       </entry>
     </enum>
@@ -1919,7 +1919,7 @@
         <param index="3" label="Component action" minValue="0" maxValue="3" increment="1">0: Do nothing for component, 1: Reboot component, 2: Shutdown component, 3: Reboot component and keep it in the bootloader until upgraded</param>
         <param index="4" label="Component ID" minValue="0" maxValue="255" increment="1">MAVLink Component ID targeted in param3 (0 for all components).</param>
         <param index="5">Reserved (set to 0)</param>
-        <param index="6" label="Conditions" enum="PREFLIGHT_REBOOT_SHUTDOWN_CONDITIONS">Conditions under which reboot/shutdown is allowed.</param>
+        <param index="6" label="Conditions" enum="REBOOT_SHUTDOWN_CONDITIONS">Conditions under which reboot/shutdown is allowed.</param>
         <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
       </entry>
       <!-- id "247" reserved for MAV_CMD_DO_UPGRADE in development.xml -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1063,14 +1063,14 @@
         <description>Erase all mission data stored on the vehicle (both persistent and volatile storage)</description>
       </entry>
     </enum>
-    <enum name="REBOOT_SHUTDOWN_OPTIONS">
+    <enum name="PREFLIGHT_REBOOT_SHUTDOWN_CONDITIONS">
       <description>
         Specifies the conditions under which the MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command should be accepted.
       </description>
-      <entry value="0" name="REBOOT_SHUTDOWN_CONDITIONS_SAFETY_INERLOCKED">
+      <entry value="0" name="PREFLIGHT_REBOOT_SHUTDOWN_CONDITIONS_SAFETY_INERLOCKED">
         <description>Reboot/Shutdown only if allowed by safety checks, such as being landed.</description>
       </entry>
-      <entry value="20190226" name="REBOOT_SHUTDOWN_CONDITIONS_FORCE">
+      <entry value="20190226" name="PREFLIGHT_REBOOT_SHUTDOWN_CONDITIONS_FORCE">
         <description>Force reboot/shutdown of the autopilot/component regardless of system state.</description>
       </entry>
     </enum>
@@ -1919,7 +1919,7 @@
         <param index="3" label="Component action" minValue="0" maxValue="3" increment="1">0: Do nothing for component, 1: Reboot component, 2: Shutdown component, 3: Reboot component and keep it in the bootloader until upgraded</param>
         <param index="4" label="Component ID" minValue="0" maxValue="255" increment="1">MAVLink Component ID targeted in param3 (0 for all components).</param>
         <param index="5">Reserved (set to 0)</param>
-        <param index="6" label="Conditions" enum="REBOOT_SHUTDOWN_OPTIONS">Conditions under which reboot/shutdown is allowed.</param>
+        <param index="6" label="Conditions" enum="PREFLIGHT_REBOOT_SHUTDOWN_CONDITIONS">Conditions under which reboot/shutdown is allowed.</param>
         <param index="7">WIP: ID (e.g. camera ID -1 for all IDs)</param>
       </entry>
       <!-- id "247" reserved for MAV_CMD_DO_UPGRADE in development.xml -->


### PR DESCRIPTION
This PR documents the existing behavior of param6 in MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN. While this parameter is already supported by multiple autopilot implementations, its intended values and behavior are currently not described in the MAVLink specification.

Specifically:
REBOOT_SHUTDOWN_ALLOWED: reboot only if allowed by safety checks REBOOT_SHUTDOWN_FORCE: force reboot, bypassing all safety checks