### PR TITLE
common.xml - typo MISSION_SET_CURRENT not SET_MISSION_CURRENT

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   format:
     name: Formatting check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -32,7 +32,7 @@ jobs:
 
   python-tests:
     name: Python ${{ matrix.python-version }} tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +75,7 @@ jobs:
 
   node-tests:
     name: Node ${{ matrix.node-version }} test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -101,7 +101,7 @@ jobs:
   deploy:
     name: Generate and push C headers
     needs: [format, python-tests, node-tests]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master'
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5602,7 +5602,7 @@
       <description>
         Message that announces the sequence number of the current target mission item (that the system will fly towards/execute when the mission is running).
         This message should be streamed all the time (nominally at 1Hz).
-        This message should be emitted following a call to MAV_CMD_DO_SET_MISSION_CURRENT or SET_MISSION_CURRENT.
+        This message should be emitted following a call to MAV_CMD_DO_SET_MISSION_CURRENT or MISSION_SET_CURRENT.
       </description>
       <field type="uint16_t" name="seq">Sequence</field>
       <extensions/>


### PR DESCRIPTION
Fix a typo. Is in description so no compat issue. Self merging.

Also updating the workflow so that tests run.