### PR TITLE
Try fix build order of generated libraries

### DIFF
--- a/scripts/update_c_library.sh
+++ b/scripts/update_c_library.sh
@@ -68,6 +68,8 @@ generate_headers csAirLink $1
 generate_headers uAvionix $1
 generate_headers cubepilot $1
 generate_headers ualberta $1
+generate_headers icarous $1
+generate_headers loweheiser $1
 generate_headers paparazzi $1
 generate_headers ASLUAV $1
 generate_headers matrixpilot $1


### PR DESCRIPTION
Due to the error described in https://github.com/ArduPilot/pymavlink/pull/544, the generated build libraries are sensitive to build order. 

This appears to have caused the error discussed in https://github.com/mavlink/qgroundcontrol/pull/12410 and https://discord.com/channels/1022170275984457759/1362458777835802766

This attempts to fix the build issues by adding the missing libraries. NOTE, that I don't think this should make any difference. Both before and after this the generated libraries for all.xml appear to include the development messages (i.e. by looking at CRCs) but all.xml does not link them.

I think I have found the reason in https://github.com/ArduPilot/pymavlink/pull/544/files#r2069976980