### PR TITLE
Add dummy command to all.xml to force merging in commands from lower levels

### DIFF
--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -69,5 +69,17 @@
     messages: 52500 - 52599 (< 60000)
     commands: 52500 - 52599 (< 60000)
   -->
+  <enums>
+    <!-- The MAV_CMD enum entries describe either: -->
+    <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
+    <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
+    <!-- ALL the entries in the MAV_CMD enum have a maximum of 7 parameters -->
+    <enum name="MAV_CMD">
+      <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries</description>
+      <entry value="393" name="MAV_CMD_DUMMY_ALL" hasLocation="false" isDestination="false">
+        <description>A dummy mav cmd to force merging.</description>
+      </entry>
+    </enum>
+  </enums>
   <messages/>
 </mavlink>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -77,6 +77,7 @@
     <enum name="MAV_CMD">
       <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries</description>
       <entry value="393" name="MAV_CMD_DUMMY_ALL" hasLocation="false" isDestination="false">
+        <wip/>
         <description>Dummy/temporary MAV_CMD that causes all.xml to correctly import all commands from both ardupilotmega.xml and development.xml (otherwise only one is imported, for the reasons given in https://github.com/ArduPilot/pymavlink/pull/544#discussion_r2069976980).
           It not be used, and will be removed when the toolchain is fixed.</description>
       </entry>

--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -77,7 +77,8 @@
     <enum name="MAV_CMD">
       <description>Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data. NaN and INT32_MAX may be used in float/integer params (respectively) to indicate optional/default values (e.g. to use the component's current yaw or latitude rather than a specific value). See https://mavlink.io/en/guide/xml_schema.html#MAV_CMD for information about the structure of the MAV_CMD entries</description>
       <entry value="393" name="MAV_CMD_DUMMY_ALL" hasLocation="false" isDestination="false">
-        <description>A dummy mav cmd to force merging.</description>
+        <description>Dummy/temporary MAV_CMD that causes all.xml to correctly import all commands from both ardupilotmega.xml and development.xml (otherwise only one is imported, for the reasons given in https://github.com/ArduPilot/pymavlink/pull/544#discussion_r2069976980).
+          It not be used, and will be removed when the toolchain is fixed.</description>
       </entry>
     </enum>
   </enums>


### PR DESCRIPTION
This adds a dummy command to all.xml. This forces merging of the development/ardupilotmega (and lower) and other peers into the top level all.h file, fixing the problem outlined in https://github.com/ArduPilot/pymavlink/pull/544/files#r2069976980

Note this would still potentially miss other merged enums.

The original and allcom (with commands) is shown below. This does show at least the development.xml and ardupilotmega.xml commands are indeed now present at the top level. 

[mavlink_allcom.zip](https://github.com/user-attachments/files/20033784/mavlink_allcom.zip)

@julianoes @peterbarker This is clearly "more right" than what we had. Peter can you suggest words you'd like for that all.xml command entry?