### PR TITLE
doc xml_to_markdown py script, fix for hex enum entries

### DIFF
--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -696,7 +696,7 @@ class MAVEnumEntry(object):
     def __init__(self, soup, basename):
         # name, value, description='', end_marker=False, autovalue=False, origin_file='', origin_line=0, has_location=False
         self.name = soup['name']
-        self.value = int(soup.get('value')) if soup.get('value') else print(
+        self.value = int(soup.get('value'), base = 0) if soup.get('value') else print(
             f"TODO MISSING VALUE in MAVEnumEntry: {self.name}")
         self.basename = basename
         self.description = soup.findChild('description', recursive=False)


### PR DESCRIPTION
The entries in enum field is allowed to be given as dezimals but also as hex-es, like 0x0001, see the mavlink scheme definition. The mavlink_xml_to_markdown.py script however terminates with a ValueError in that case then. 

The issue is related ti using an int() conversion, which per default assumes a base of 10, and for strings like 0x0001 thus raises said error. int() however can be made to auto-determine the base form the given string, by setting the base to 0. This is what this PR does.

The issue apperaed in https://github.com/mavlink/mavlink/pull/2265, where the xml file wants to benefit form using hex calues, but the check fails for the above reason.

I have tested it on my machine that the proposed fix makes mavlink_xml_to_markdown.py to run through fine.

Note: There is another int() which may need that too, but I'm not sure about it so didn't do. 