### PR TITLE
common.xml-SYSTEM_TIME detail

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5288,9 +5288,10 @@
     </message>
     <message id="2" name="SYSTEM_TIME">
       <description>The system time is the time of the master clock.
-        This should be emitted by only one component in the system, and other components should set their time to match.
-        Note that the master clock depends on the system.
-        This is commonly the autopilot, which might get the time from an attached GNSS, or it could be set from computer clock of the main onboard computer, via some internet clock source.</description>
+        This can be emitted by flight controllers, onboard computers, or other components in the MAVLink network.
+        Components can choose to match their system clock to that of a SYSTEM_TYPE that indicates a more recent than their own.
+        The SYSTEM_TIME is intended to provide a near accurate clock o improve date stamping of logs, and so on.
+        If precise time synchronization is needed then use TIMESYNC</description>
       <field type="uint64_t" name="time_unix_usec" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5289,8 +5289,8 @@
     <message id="2" name="SYSTEM_TIME">
       <description>The system time is the time of the master clock.
         This can be emitted by flight controllers, onboard computers, or other components in the MAVLink network.
-        Components can choose to match their system clock to that of a SYSTEM_TYPE that indicates a more recent time.
-        The SYSTEM_TIME is intended to provide a near accurate clock o improve date stamping of logs, and so on.
+        Components that are using a less reliable time source, such as a battery-backed real time clock, can choose to match their system clock to that of a SYSTEM_TYPE that indicates a more recent time.
+        This allows more broadly accurate date stamping of logs, and so on.
         If precise time synchronization is needed then use TIMESYNC</description>
       <field type="uint64_t" name="time_unix_usec" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5289,7 +5289,7 @@
     <message id="2" name="SYSTEM_TIME">
       <description>The system time is the time of the master clock.
         This can be emitted by flight controllers, onboard computers, or other components in the MAVLink network.
-        Components can choose to match their system clock to that of a SYSTEM_TYPE that indicates a more recent than their own.
+        Components can choose to match their system clock to that of a SYSTEM_TYPE that indicates a more recent time.
         The SYSTEM_TIME is intended to provide a near accurate clock o improve date stamping of logs, and so on.
         If precise time synchronization is needed then use TIMESYNC</description>
       <field type="uint64_t" name="time_unix_usec" units="us">Timestamp (UNIX epoch time).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5288,8 +5288,9 @@
     </message>
     <message id="2" name="SYSTEM_TIME">
       <description>The system time is the time of the master clock.
-        This should be emitted by only one component in the system, typically the computer clock of the main onboard computer.
-        Flight controllers and other components should set their time to match.</description>
+        This should be emitted by only one component in the system, and other components should set their time to match.
+        Note that the master clock depends on the system.
+        This is commonly the autopilot, which might get the time from an attached GNSS, or it could be set from computer clock of the main onboard computer, via some internet clock source.</description>
       <field type="uint64_t" name="time_unix_usec" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5291,7 +5291,7 @@
         This can be emitted by flight controllers, onboard computers, or other components in the MAVLink network.
         Components that are using a less reliable time source, such as a battery-backed real time clock, can choose to match their system clock to that of a SYSTEM_TYPE that indicates a more recent time.
         This allows more broadly accurate date stamping of logs, and so on.
-        If precise time synchronization is needed then use TIMESYNC</description>
+        If precise time synchronization is needed then use TIMESYNC instead.</description>
       <field type="uint64_t" name="time_unix_usec" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5287,7 +5287,9 @@
       <field type="uint32_t" name="onboard_control_sensors_health_extended" enum="MAV_SYS_STATUS_SENSOR_EXTENDED" print_format="0x%04x">Bitmap showing which onboard controllers and sensors have an error (or are operational). Value of 0: error. Value of 1: healthy.</field>
     </message>
     <message id="2" name="SYSTEM_TIME">
-      <description>The system time is the time of the master clock, typically the computer clock of the main onboard computer.</description>
+      <description>The system time is the time of the master clock.
+        This should be emitted by only one component in the system, typically the computer clock of the main onboard computer.
+        Flight controllers and other components should set their time to match.</description>
       <field type="uint64_t" name="time_unix_usec" units="us">Timestamp (UNIX epoch time).</field>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>
     </message>


### PR DESCRIPTION
The use of SYSTEM_TIME was inferred but not stated. This updates it following the changes in https://github.com/PX4/PX4-Autopilot/pull/24807

Is there a rate at which this should nominally be streamed, or should it be requested by a flight stack or anything else that wants to know the time?

How does this relate to use of [TIME_SYNC](https://mavlink.io/en/services/timesync.html#time-synchronization-protocol-v2). I mean if everything sets itself to the time in this is TIME_SYNC needed? Should you first do SYSTEM_TIME then time_sync? etc.

@dakejahl @peterbarker Thoughts?