### PR TITLE
Update storm32.xml, bitmask enums should only have bit values

### DIFF
--- a/message_definitions/v1.0/storm32.xml
+++ b/message_definitions/v1.0/storm32.xml
@@ -10,7 +10,7 @@ Range of IDs:
 Documentation:
   STorM32 and QSHOT additions
   with mLRS additions merged
-  3. Mai. 2025
+  7. Mai. 2025
   All messages are technically WIP, but some are quite stable now.
   Quite stable means that it is in practical use, but may see extension.
   A more detailed description of the concept underlying the STORM32 and QSHOT messages can be found here:
@@ -71,9 +71,6 @@ Documentation:
     <enum name="MAV_STORM32_GIMBAL_MANAGER_FLAGS" bitmask="true">
       <!-- Stable, may grow however -->
       <description>Flags for gimbal manager operation. Used for setting and reporting, unless specified otherwise. If a setting has been accepted by the gimbal manager is reported in the STORM32_GIMBAL_MANAGER_STATUS message.</description>
-      <entry value="0" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_NONE">
-        <description>0 = ignore.</description>
-      </entry>
       <entry value="1" name="MAV_STORM32_GIMBAL_MANAGER_FLAGS_RC_ACTIVE">
         <description>Request to set RC input to active, or report RC input is active. Implies RC mixed. RC exclusive is achieved by setting all clients to inactive.</description>
       </entry>


### PR DESCRIPTION
Removes a bad enum entry, which violates that enums which represent bitmasks should have only bit values.

followup to https://github.com/mavlink/mavlink/pull/2265#pullrequestreview-2820107177

sorry for not having realized this earlier.