### PR TITLE
common: change unit of DO_REPOSITION yaw

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1564,7 +1564,7 @@
         <param index="1" label="Speed" units="m/s" minValue="-1">Ground speed, less than 0 (-1) for default</param>
         <param index="2" label="Bitmask" enum="MAV_DO_REPOSITION_FLAGS">Bitmask of option flags.</param>
         <param index="3" label="Radius" units="m">Loiter radius for planes. Positive values only, direction is controlled by Yaw value. A value of zero or NaN is ignored. </param>
-        <param index="4" label="Yaw" units="deg">Yaw heading. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.). For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
+        <param index="4" label="Yaw" units="rad">Yaw heading. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.). For planes indicates loiter direction (0: clockwise, 1: counter clockwise)</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude" units="m">Altitude</param>


### PR DESCRIPTION
I'm proposing to change the unit of DO_REPOSITION param4, which is used for the yaw setpoint for multirotors.

Currently, the spec specifies degrees, however, PX4 implements it as radians:
- https://github.com/PX4/PX4-Autopilot/blob/fee575f944191546c0d8ab1845db7cfc676f60f4/src/modules/navigator/navigator_main.cpp#L318
- https://github.com/PX4/PX4-Autopilot/blob/fee575f944191546c0d8ab1845db7cfc676f60f4/msg/PositionSetpoint.msg#L25

And so did MAVSDK until I fixed it by accident:
- https://github.com/mavlink/MAVSDK/pull/2562/files
But I have to revert:
- https://github.com/mavlink/MAVSDK/pull/2567

ArduPilot seems to ignore param4, so we should not be breaking anything, if I read this right:
- https://github.com/ArduPilot/ardupilot/blob/384f0ffa6a2230bcb2d3beca7468a3a147958a6a/ArduCopter/GCS_MAVLink_Copter.cpp#L468-L510

The unit was added here, presumably without checking PX4:
- https://github.com/mavlink/mavlink/pull/1284/files#diff-9ef151b30f09d6d4f130434d941db479c3411ec15eca23580c5587b2c3b59ecdR1697