### PR TITLE
add: gyrocopter/helicopter hybrid vehicle type

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -209,6 +209,9 @@
       <entry value="45" name="MAV_TYPE_SPACECRAFT_ORBITER">
         <description>Orbiter spacecraft. Includes satellites orbiting terrestrial and extra-terrestrial bodies. Follows NASA Spacecraft Classification.</description>
       </entry>
+      <entry value="46" name="MAV_TYPE_GYRO_HELI">
+        <description>Gyrocopter Helicopter Hybrid VTOL</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
Add vehicle type for hybrid gyrocopter/helicopter VTOL. This is able to operate in multi-copter mode much longer than traditional VTOLS.

Making a PR as AMC is currently limited in what can be done in multi-copter mode for standard VTOLS (eg. no standard takeoff option in mission planning, only vtol takeoff). Having a separate MAV_TYPE for VTOLs that are capable of longer hover times will allow different features to be enabled. 

This is quite specific to a particular airframe, and there may be other VTOLS this applies to. So, if there's a better name, let me know :)