### PR TITLE
Add Generic 4 Legged Quadruped Rover

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -210,7 +210,7 @@
         <description>Orbiter spacecraft. Includes satellites orbiting terrestrial and extra-terrestrial bodies. Follows NASA Spacecraft Classification.</description>
       </entry>
       <entry value="46" name="MAV_TYPE_GROUND_QUADRUPED">
-        <description>A generic 4 legged rover.</description>
+        <description>A generic four-legged ground vehicle (e.g., a robot dog).</description>
       </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -209,7 +209,7 @@
       <entry value="45" name="MAV_TYPE_SPACECRAFT_ORBITER">
         <description>Orbiter spacecraft. Includes satellites orbiting terrestrial and extra-terrestrial bodies. Follows NASA Spacecraft Classification.</description>
       </entry>
-      <entry value="46" name="MAV_TYPE_QUADRUPED">
+      <entry value="46" name="MAV_TYPE_GROUND_QUADRUPED">
         <description>A generic 4 legged rover.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -209,6 +209,9 @@
       <entry value="45" name="MAV_TYPE_SPACECRAFT_ORBITER">
         <description>Orbiter spacecraft. Includes satellites orbiting terrestrial and extra-terrestrial bodies. Follows NASA Spacecraft Classification.</description>
       </entry>
+      <entry value="46" name="MAV_TYPE_QUADRUPED">
+        <description>A generic 4 legged rover.</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode.</description>


### PR DESCRIPTION
Add a generic quadruped ground rover type to describe robots that are not well described by existing types. This type is meant to describe robots such as the Boston Dynamics Spot or Unitree Go2.