### PR TITLE
Document current recommendations for MAV_COMPONENT in its description.

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -297,10 +297,18 @@
       </entry>
     </enum>
     <enum name="MAV_COMPONENT">
-      <description>Default component ids (values) for the different types and instances of onboard hardware/software that might make up a MAVLink system (autopilot, cameras, servos, GPS systems, avoidance systems etc.).
-      Components use ids to determine if they are the intended recipient of an incoming message. The MAV_COMP_ID_ALL value is used to indicate messages that must be processed by all components.
-      Each component must have a unique id within its system, which takes precedence over using values defined here. New code should not depend on MAV_COMPONENT, but use an appropriate MAV_TYPE in the HEARTBEAT message instead.
-      When creating new entries, components that can have multiple instances (e.g. cameras, servos etc.) should be allocated sequential values. An appropriate number of values should be left free after these components to allow the number of instances to be expanded.</description>
+      <description>Legacy component ID values for particular types of hardware/software that might make up a MAVLink system (autopilot, cameras, servos, avoidance systems etc.).
+      
+        Components are not required or expected to use IDs with names that correspond to their type or function, but may choose to do so.
+        Using an ID that matches the type may slightly reduce the chances of component id clashes, as, for historical reasons, it is less likely to be used by some other type of component.
+        System integration will still need to ensure that all components have unique IDs.
+
+        Component IDs are used for addressing messages to a particular component within a system.
+        A component can use any unique ID between 1 and 255 (MAV_COMP_ID_ALL value is the broadcast address, used to send to all components).
+        
+        Historically component ID were also used for identifying the type of component.
+        New code must not use component IDs to infer the component type, but instead check the MAV_TYPE in the HEARTBEAT message!
+      </description>
       <entry value="0" name="MAV_COMP_ID_ALL">
         <description>Target id (target_component) used to broadcast messages to all components of the receiving system. Components should attempt to process messages with this component ID and forward to components on any other interfaces. Note: This is not a valid *source* component id for a message.</description>
       </entry>


### PR DESCRIPTION
Based on discussion in #2272 with @hamishwillee and @peterbarker 

Also consulted [documentation for Heartbeat/Connection Protocol](https://mavlink.io/en/services/heartbeat.html#component-identity), which is very clear and detailed on the topic. It is already linked in HEARTBEAT description, so I thought it's more discoverable now with HEARTBEAT mentioned here as well.