### PR TITLE
add Yaw/Heading to MAV_CMD_SET_GLOBAL_ORIGIN

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -194,7 +194,7 @@
         <param index="1">Empty</param>
         <param index="2">Empty</param>
         <param index="3">Empty</param>
-        <param index="4">Empty</param>
+        <param index="4" label="Yaw" units="rad">Yaw heading. NaN to indicate Invalid/Unknown.</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude" units="m">Altitude</param>


### PR DESCRIPTION
add Yaw/Heading to MAV_CMD_SET_GLOBAL_ORIGIN to indicate which direction the vehicle is facing on initialization if compass is unavailable.