### PR TITLE
Fix incorrect field name assignment from minValue to maxValue

### DIFF
--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -525,7 +525,7 @@ class MAVField(object):
         if self.minValue:
             parent.fieldnames.add('minValue')
         if self.maxValue:
-            parent.fieldnames.add('minValue')
+            parent.fieldnames.add('maxValue')
         if self.default:
             parent.fieldnames.add('default')
         if self.invalid:


### PR DESCRIPTION
## PR Summary
This PR corrects a logic error where `minValue` was mistakenly added to `parent.fieldnames` instead of `maxValue`. Now, `maxValue` is correctly tracked when set.