### PR TITLE
minimal.xml - MAV_TYPE for Gripper

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -215,6 +215,9 @@
       <entry value="47" name="MAV_TYPE_VTOL_GYRODYNE">
         <description>VTOL hybrid of helicopter and autogyro. It has a main rotor for lift and separate propellers for forward flight. The rotor must be powered for hover but can autorotate in cruise flight. See: https://en.wikipedia.org/wiki/Gyrodyne</description>
       </entry>
+      <entry value="48" name="MAV_TYPE_GRIPPER">
+        <description>Gripper</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode, see MAV_MODE enum for useful combinations.</description>


### PR DESCRIPTION
This makes updates to gripper types and commands to properly address MAVLink grippers and . It follows the design patterns used for cameras and gimbals.

Specifically 
- [ ] MAV_TYPE_GRIPPER - allows a gripper component to be discovered and addressed.
- [ ] MAV_PROTOCOL_CAPABILITY_GRIPPER - allows an autopilot that has a gripper to advertise support. This is needed because an autopilot doesn't expose itself as a gripper type.
- [ ] The gripper id is changed to a component id, except for numbers 1-6 which are expected to be autopilot connected grippers.
   - This allows addressing of specific grippers in missions.

What this allows is discovery and addressing of MAVLInk and autopilot connected gimbals, and also addressing of any gimbal in a mission.

This falls out of https://github.com/mavlink/MAVSDK/pull/2594#issuecomment-2961051820


