### PR TITLE
remove display="bitmask"

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6115,8 +6115,8 @@
       <description>Sent from autopilot to simulation. Hardware in the loop control outputs. Alternative to HIL_CONTROLS.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="float[16]" name="controls">Control outputs -1 .. 1. Channel assignment depends on the simulated hardware.</field>
-      <field type="uint8_t" name="mode" enum="MAV_MODE_FLAG" display="bitmask">System mode. Includes arming state.</field>
-      <field type="uint64_t" name="flags" enum="HIL_ACTUATOR_CONTROLS_FLAGS" display="bitmask">Flags bitmask.</field>
+      <field type="uint8_t" name="mode" enum="MAV_MODE_FLAG">System mode. Includes arming state.</field>
+      <field type="uint64_t" name="flags" enum="HIL_ACTUATOR_CONTROLS_FLAGS">Flags bitmask.</field>
     </message>
     <message id="100" name="OPTICAL_FLOW">
       <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>

--- a/message_definitions/v1.0/storm32.xml
+++ b/message_definitions/v1.0/storm32.xml
@@ -414,7 +414,7 @@ Documentation:
       </description>
       <field type="uint8_t" name="target_system">System ID (ID of target system, normally flight controller).</field>
       <field type="uint8_t" name="target_component">Component ID (normally 0 for broadcast).</field>
-      <field type="uint16_t" name="flags" enum="MLRS_RADIO_LINK_STATS_FLAGS" display="bitmask">Radio link statistics flags.</field>
+      <field type="uint16_t" name="flags" enum="MLRS_RADIO_LINK_STATS_FLAGS">Radio link statistics flags.</field>
       <field type="uint8_t" name="rx_LQ_rc" units="c%" invalid="UINT8_MAX">Link quality of RC data stream from Tx to Rx. Values: 1..100, 0: no link connection, UINT8_MAX: unknown.</field>
       <field type="uint8_t" name="rx_LQ_ser" units="c%" invalid="UINT8_MAX">Link quality of serial MAVLink data stream from Tx to Rx. Values: 1..100, 0: no link connection, UINT8_MAX: unknown.</field>
       <field type="uint8_t" name="rx_rssi1" invalid="UINT8_MAX">Rssi of antenna 1. 0: no reception, UINT8_MAX: unknown.</field>


### PR DESCRIPTION
Follow up to https://github.com/mavlink/mavlink/pull/2241 a few regressions have crept in, found by https://github.com/mavlink/mavlink/pull/2220

All enums are marked as bitmasks:

https://github.com/mavlink/mavlink/blob/81c0901153695d7db5077330a47408fae585e794/message_definitions/v1.0/minimal.xml#L219

https://github.com/mavlink/mavlink/blob/81c0901153695d7db5077330a47408fae585e794/message_definitions/v1.0/common.xml#L5261

https://github.com/mavlink/mavlink/blob/81c0901153695d7db5077330a47408fae585e794/message_definitions/v1.0/storm32.xml#L232

