### PR TITLE
Update gnss quality info

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -503,8 +503,8 @@
       <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system.</field>
       <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system.</field>
       <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing.</field>
-      <field type="uint16_t" name="raim_hfom" units="cm" invalid="UINT16_MAX">Horizontal expected accuracy using satellites successfully validated using RAIM.</field>
-      <field type="uint16_t" name="raim_vfom" units="cm" invalid="UINT16_MAX">Vertical expected accuracy using satellites successfully validated using RAIM.</field>
+      <field type="uint16_t" name="raim_hfom" units="cm" invalid="0">Horizontal expected accuracy using satellites successfully validated using RAIM.</field>
+      <field type="uint16_t" name="raim_vfom" units="cm" invalid="0">Vertical expected accuracy using satellites successfully validated using RAIM.</field>
       <field type="uint8_t" name="corrections_quality" minValue="1" maxValue="11" invalid="UINT8_MAX">An abstract value representing the estimated quality of incoming corrections from 1 to 11. 0 if unknown.</field>
       <field type="uint8_t" name="system_status_summary" minValue="1" maxValue="11" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver from 1 to 11. 0 if unknown.</field>
       <field type="uint8_t" name="gnss_signal_quality" minValue="1" maxValue="11" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals from 1 to 11. 0 if unknown.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -505,10 +505,10 @@
       <field type="uint8_t" name="raim_state" enum="GPS_RAIM_STATE">The state of the RAIM processing.</field>
       <field type="uint16_t" name="raim_hfom" units="cm" invalid="UINT16_MAX">Horizontal expected accuracy using satellites successfully validated using RAIM.</field>
       <field type="uint16_t" name="raim_vfom" units="cm" invalid="UINT16_MAX">Vertical expected accuracy using satellites successfully validated using RAIM.</field>
-      <field type="uint8_t" name="corrections_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated quality of incoming corrections, or 255 if not available.</field>
-      <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver, or 255 if not available.</field>
-      <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals, or 255 if not available.</field>
-      <field type="uint8_t" name="post_processing_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated PPK quality, or 255 if not available.</field>
+      <field type="uint8_t" name="corrections_quality" minValue="1" maxValue="11" invalid="UINT8_MAX">An abstract value representing the estimated quality of incoming corrections from 1 to 11. 0 if unknown.</field>
+      <field type="uint8_t" name="system_status_summary" minValue="1" maxValue="11" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver from 1 to 11. 0 if unknown.</field>
+      <field type="uint8_t" name="gnss_signal_quality" minValue="1" maxValue="11" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals from 1 to 11. 0 if unknown.</field>
+      <field type="uint8_t" name="post_processing_quality" minValue="1" maxValue="11" invalid="UINT8_MAX">An abstract value representing the estimated PPK quality from 1 to 11. 0 if unknown.</field>
     </message>
     <!-- Target info from a sensor on the target -->
     <message id="510" name="TARGET_ABSOLUTE">


### PR DESCRIPTION
After discussion with the maintainers, it would be wiser to set 0 as the default value (UNKNOW)
I'm drafting this PR for tonight's devcall, so I'll probably have to modify raim fields that are not using default values of 0.

This PR is needed by: https://github.com/PX4/PX4-Autopilot/pull/25012