### PR TITLE
Add codespell to GitHub Actions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,6 +30,17 @@ jobs:
         run: |
           ./scripts/test.sh format
 
+  spell-check:
+    name: Find typos with codespell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pipx run codespell --ignore-words-list=ned
+                          message_definitions/v1.0/all.xml
+                          message_definitions/v1.0/common.xml
+                          message_definitions/v1.0/minimal.xml
+                          message_definitions/v1.0/standard.xml
+
   python-tests:
     name: Python ${{ matrix.python-version }} tests
     runs-on: ubuntu-22.04


### PR DESCRIPTION
* https://github.com/codespell-project/codespell
* https://github.com/codespell-project/actions-codespell
* #2301 

> It would be good to add this to CI for minimal.xml, standard.xml, common.xml, development.xml - even if only a manual workflow.

Experience has taught me that it is best to run fast tools on all pull requests so that typos can be discovered before they are merged.
```
% pipx run codespell --ignore-words-list=ned \
        message_definitions/v1.0/all.xml message_definitions/v1.0/common.xml \
        message_definitions/v1.0/minimal.xml message_definitions/v1.0/standard.xml
```