### PR TITLE
DRAFT: Test ruff's monorepo processing

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,6 +30,30 @@ jobs:
         run: |
           ./scripts/test.sh format
 
+  python-lint:
+    name: Lint Python code with ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+      # Ruff monorepo processing experiment begins here...
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'  # Add the pymavlink submodule which has ruff errors.
+      - run: ruff check --exit-zero  # Show pymavlink's errors but don't fail the job.
+      - name: "Apply ArduPilot/pymavlink#1080"
+        run: |
+          pushd pymavlink
+          echo -e '\n[tool.ruff]\nlint.extend-ignore=["E4","E7","F40","F523","F601","F811","F841"]' >> pyproject.toml
+          pipx run pyproject-fmt pyproject.toml || true
+          pipx run --spec="validate-pyproject[all]" validate-pyproject pyproject.toml
+          popd
+      # Okay, so this is the cool part: We run ruff on the whold (mono)repo.
+      # When ruff is testing inside the pymavlink submodule, it will apply rules
+      # based on pymavlink/pyproject.toml but when testing the rest of the repo,
+      # it will apply rules based on the root ruff.toml file.
+      - name: "Single ruff check with multiple rule sets"
+        run: ruff check  # All checks passed!
   python-tests:
     name: Python ${{ matrix.python-version }} tests
     runs-on: ubuntu-22.04
@@ -100,7 +124,7 @@ jobs:
 
   deploy:
     name: Generate and push C headers
-    needs: [format, python-tests, node-tests]
+    needs: [format, python-lint, python-tests, node-tests]
     runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master'
     env:

--- a/mavgenerate.py
+++ b/mavgenerate.py
@@ -174,14 +174,14 @@ class Application(Frame):
                 return
 
         # Generate headers
-        opts = mavgen.Opts(self.out_value.get(), wire_protocol=self.protocol_value.get(), language=self.language_value.get(), validate=self.validate_value.get(), error_limit=error_limit, strict_units=self.strict_units_value.get());
+        opts = mavgen.Opts(self.out_value.get(), wire_protocol=self.protocol_value.get(), language=self.language_value.get(), validate=self.validate_value.get(), error_limit=error_limit, strict_units=self.strict_units_value.get())
         args = [self.xml_value.get()]
         try:
             mavgen.mavgen(opts,args)
             tkinter.messagebox.showinfo('Successfully Generated Headers', 'Headers generated successfully.')
 
         except Exception as ex:
-            exStr = formatErrorMessage(str(ex));
+            exStr = formatErrorMessage(str(ex))
             tkinter.messagebox.showerror('Error Generating Headers','{0!s}'.format(exStr))
             return
 
@@ -189,10 +189,10 @@ class Application(Frame):
 Format the mavgen exceptions by removing 'ERROR: '.
 """
 def formatErrorMessage(message):
-    reObj = re.compile(r'^(ERROR):\s+',re.M);
-    matches = re.findall(reObj, message);
+    reObj = re.compile(r'^(ERROR):\s+',re.M)
+    matches = re.findall(reObj, message)
     prefix = ("An error occurred in mavgen:" if len(matches) == 1 else "Errors occurred in mavgen:\n")
-    message = re.sub(reObj, '\n', message);
+    message = re.sub(reObj, '\n', message)
 
     return prefix + message
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,11 @@
+lint.extend-ignore = [
+  "E711",  # none-comparison
+  "E712",  # true-false-comparison
+  "E713",  # not-in-test
+  "E714",  # not-is-test
+  "F401",  # unused-import
+  "F403",  # undefined-local-with-import-star
+  "F405",  # undefined-local-with-import-star-usage
+  "F541",  # f-string-missing-placeholders
+  "F841",  # unused-variable
+]


### PR DESCRIPTION
# DRAFT: Do not merge.

This demonstrates the interaction between:
* #2303 
* #2305 
* ArduPilot/pymavlink#1080

As discussed in #2303, this is a monorepo in the sense that it pulls `pymavlink` in as a git submodule.  That submodule has different `ruff` lint violations than the rest of this repo, as documented in ArduPilot/pymavlink#1080.  So let's apply the #2305 `ruff rule E703` fix to `mavgenerate.py` and then run #2303 with the `E703` exclusion removed.  Then let's apply ArduPilot/pymavlink#1080 to the pymavlink git submodule and run ruff again across the whole monorepo...

```
      # Okay, so this is the cool part: We run ruff on the whole (mono)repo.
      # When ruff is testing inside the pymavlink submodule, it will apply rules
      # based on pymavlink/pyproject.toml, but when testing the rest of the repo,
      # it will apply rules based on the root ruff.toml file.
      - name: "Single ruff check with multiple rule sets"
        run: ruff check  # --> All checks passed!
```