### PR TITLE
ruff check --select=E713,E714,F401,F541 —fix

### DIFF
--- a/doc/mavlink_gitbook.py
+++ b/doc/mavlink_gitbook.py
@@ -12,7 +12,6 @@ The file is run in mavlink/doc/ with no arguments. It writes the files to /messa
 """
 
 import lxml.etree as ET
-import requests
 from bs4 import BeautifulSoup as bs
 import re
 import os # for walk

--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -1106,7 +1106,7 @@ def tidyDescription(desc_string, type="markdown"):
 
 
 def fix_add_implicit_links_items(input_text):
-    if not type(input_text) is str:
+    if type(input_text) is not str:
         # Its not something we can handle
         return input_text
 

--- a/mavgenerate.py
+++ b/mavgenerate.py
@@ -22,7 +22,6 @@ Released under GNU GPL version 3 or later
 """
 import os
 import re
-import sys
 
 from tkinter import *
 import tkinter.filedialog

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,11 +2,7 @@ lint.exclude = [ "pymavlink" ]
 lint.extend-ignore = [
   "E711",  # none-comparison
   "E712",  # true-false-comparison
-  "E713",  # not-in-test
-  "E714",  # not-is-test
-  "F401",  # unused-import
   "F403",  # undefined-local-with-import-star
   "F405",  # undefined-local-with-import-star-usage
-  "F541",  # f-string-missing-placeholders
   "F841",  # unused-variable
 ]

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -102,7 +102,7 @@ def check_field(file_name, msg_name, field, enums):
 
     if (enum != None):
         # Enum should exist
-        if not (enum in enums):
+        if enum not in enums:
             print("%s: Message %s field %s enum %s does not exist" %
                   (file_name, msg_name, name, enum))
             warning_count += 1
@@ -126,7 +126,7 @@ def check_field(file_name, msg_name, field, enums):
 
         # Enum should fit in given type
         type = field.get('type').split('[')[0]
-        if not (type in types):
+        if type not in types:
             print("%s: Message %s field %s enum %s unexpected type: %s" %
                   (file_name, msg_name, name, enum, type))
             warning_count += 1
@@ -151,7 +151,7 @@ def check_cmd_param(file_name, cmd_name, entry, enums):
 
     if (enum != None):
         # Enum should exist
-        if not (enum in enums):
+        if enum not in enums:
             print("%s: Command %s param %s enum %s does not exist" %
                   (file_name, cmd_name, index, enum))
             warning_count += 1
@@ -168,7 +168,7 @@ def check_cmd_param(file_name, cmd_name, entry, enums):
     #        print("%s: Command %s param %s should be marked reserved=\"true\"" % (file_name, cmd_name, index))
 
 
-description = f"""
+description = """
 XML consistency parser.
 
 Checks XML definition files in ../message_definitions/v1.0/.


### PR DESCRIPTION
Apply fixes for four ruff rules.

% `ruff check --select=E713,E714,F401,F541 —statistics`
```
 3      E713    not-in-test
 2      F401    unused-import
 1      E714    not-is-test
 1      F541    f-string-missing-placeholders
```
% `ruff check --select=E713,E714,F401,F541 —fix`
```
Found 7 errors (7 fixed, 0 remaining).
```
% `ruff rule E713`