### PR TITLE
Fix ruff rules E711,E712,F841

### DIFF
--- a/mavgenerate.py
+++ b/mavgenerate.py
@@ -23,7 +23,7 @@ Released under GNU GPL version 3 or later
 import os
 import re
 
-from tkinter import *
+from tkinter import *  # noqa: F403
 import tkinter.filedialog
 import tkinter.messagebox
 
@@ -127,7 +127,7 @@ class Application(Frame):
     def browseXMLFile(self):
         # TODO Allow specification of multiple XML definitions
         xml_file = tkinter.filedialog.askopenfilename(parent=self, title='Choose a definition file')
-        if xml_file != None:
+        if xml_file is not None:
             self.xml_value.set(xml_file)
 
     """\
@@ -137,7 +137,7 @@ class Application(Frame):
     def browseOutDirectory(self):
         mavlinkFolder = os.path.dirname(os.path.realpath(__file__))
         out_dir = tkinter.filedialog.askdirectory(parent=self,initialdir=mavlinkFolder,title='Please select an output directory')
-        if out_dir != None:
+        if out_dir is not None:
             self.out_value.set(out_dir)
 
     """\
@@ -145,7 +145,7 @@ class Application(Frame):
     """
     def generateHeaders(self):
         # Verify settings
-        rex = re.compile(".*\\.xml$", re.IGNORECASE)
+        _rex = re.compile(".*\\.xml$", re.IGNORECASE)  # assigned to but never used?
         if not self.xml_value.get():
             tkinter.messagebox.showerror('Error Generating Headers','An XML message definition file must be specified.')
             return

--- a/mavgenerate.py
+++ b/mavgenerate.py
@@ -21,7 +21,6 @@ Released under GNU GPL version 3 or later
 
 """
 import os
-import re
 
 from tkinter import *  # noqa: F403
 import tkinter.filedialog
@@ -145,7 +144,6 @@ class Application(Frame):
     """
     def generateHeaders(self):
         # Verify settings
-        _rex = re.compile(".*\\.xml$", re.IGNORECASE)  # assigned to but never used?
         if not self.xml_value.get():
             tkinter.messagebox.showerror('Error Generating Headers','An XML message definition file must be specified.')
             return

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,8 +1,5 @@
-lint.exclude = [ "pymavlink" ]
-lint.extend-ignore = [
-  "E711",  # none-comparison
-  "E712",  # true-false-comparison
-  "F403",  # undefined-local-with-import-star
-  "F405",  # undefined-local-with-import-star-usage
-  "F841",  # unused-variable
-]
+[lint]
+exclude = [ "pymavlink" ]
+
+[lint.per-file-ignores]
+"mavgenerate.py" = [ "F405" ]  # undefined-local-with-import

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -39,7 +39,7 @@ def check_enum(enum, file_name):
         elif attr == 'bitmask':
             bitmask = True
 
-    if name == None:
+    if name is None:
         raise Exception("%s: No name for Enum: %s" % (file_name, enum))
 
     values = []
@@ -66,7 +66,7 @@ def check_enum(enum, file_name):
         bitmask_values.remove(0)
 
     if len(bitmask_values) > 2:
-        if bitmask == None:
+        if bitmask is None:
             bitmask = False
 
         overlap = False
@@ -95,12 +95,12 @@ def check_field(file_name, msg_name, field, enums):
     units = field.get('units')
 
     # Enum with units doesn't make sense
-    if (enum != None) and (units != None):
+    if enum is not None and units is not None:
         print("%s: Message %s field %s has both units and enum" %
               (file_name, msg_name, name))
         warning_count += 1
 
-    if (enum != None):
+    if enum is not None:
         # Enum should exist
         if enum not in enums:
             print("%s: Message %s field %s enum %s does not exist" %
@@ -110,7 +110,7 @@ def check_field(file_name, msg_name, field, enums):
 
         enums[enum]["used"] = True
         bitmask = enums[enum]["bitmask"]
-        if bitmask != None:
+        if bitmask is not None:
             # Bitmask should match underlying enum
             display_bitmask = field.get("display") == "bitmask"
 
@@ -144,12 +144,12 @@ def check_cmd_param(file_name, cmd_name, entry, enums):
     units = entry.get('units')
 
     # Enum with units doesn't make sense
-    if (enum != None) and (units != None):
+    if enum is not None and units is not None:
         print("%s: Command %s param %s has both units and enum" %
               (file_name, cmd_name, index))
         warning_count += 1
 
-    if (enum != None):
+    if enum is not None:
         # Enum should exist
         if enum not in enums:
             print("%s: Command %s param %s enum %s does not exist" %
@@ -278,7 +278,7 @@ for key in xml:
 
 # Check for unused enums
 for key in all_enums:
-    if all_enums[key]["used"] == False:
+    if all_enums[key]["used"] is False:
         print("%s: Enum: %s is unused" %
               (all_enums[key]['file'], all_enums[key]["name"]))
         warning_count += 1


### PR DESCRIPTION
% `ruff check --select=E711,E712,F841 --statistics`
```
11	E711	none-comparison
 1	E712	true-false-comparison
 1	F841	unused-variable
Found 13 errors.
No fixes available (13 hidden fixes can be enabled with the `--unsafe-fixes` option).
```
% `ruff rule E711`
# [none-comparison (E711)](https://docs.astral.sh/ruff/rules/none-comparison)

[ ... ]

## Why is this bad?
According to [PEP 8], "Comparisons to singletons like None should always be done with
`is` or `is not`, never the equality operators."

[ ... ]