### PR TITLE
common: added options for hover vs loiter for DO_REPOSITION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3570,6 +3570,12 @@
       <entry value="2" name="MAV_DO_REPOSITION_FLAGS_RELATIVE_YAW">
         <description>Yaw relative to the vehicle current heading (if not set, relative to North).</description>
       </entry>
+      <entry value="4" name="MAV_DO_REPOSITION_FLAGS_VTOL_HOVER">
+        <description>If capable, the aircraft should enter a VTOL hover at the target position</description>
+      </entry>
+      <entry value="8" name="MAV_DO_REPOSITION_FLAGS_FW_LOITER">
+        <description>If capable, the aircraft should enter a fixed wing loiter at the target position</description>
+      </entry>
     </enum>
     <enum name="SPEED_TYPE">
       <description>Speed setpoint types used in MAV_CMD_DO_CHANGE_SPEED</description>


### PR DESCRIPTION
this gives the GCS operator the choice of asking the aircraft to either enter a hover or a fixed wing loiter at the target location.

In ArduPilot this is controlled at the moment using the Q_GUIDED_MODE parameter, but it will be much better to be able to control this using a UI element in the FlyTo dialog.