### PR TITLE
ESC_EEPROM message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -911,6 +911,12 @@
       <entry value="5" name="ACTUATOR_CONFIGURATION_SPIN_DIRECTION2">
         <description>Permanently set the actuator (ESC) to spin direction 2 (opposite of direction 1).</description>
       </entry>
+      <entry value="6" name="ACTUATOR_CONFIGURATION_READ_SETTINGS">
+        <description>Request ESC Settings.</description>
+      </entry>
+      <entry value="7" name="ACTUATOR_CONFIGURATION_WRITE_SETTING">
+        <description>Write a single ESC Setting. The param2 of the command is used for the uin8t address of the setting to write. The param3 of the command is used for the uint8 value to write.</description>
+      </entry>
     </enum>
     <enum name="ACTUATOR_OUTPUT_FUNCTION">
       <description>Actuator output function. Values greater or equal to 1000 are autopilot-specific.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -561,5 +561,11 @@
       <field type="uint8_t" name="sysid_in_control">System ID of GCS MAVLink component in control (0: no GCS in control).</field>
       <field type="uint8_t" name="flags" enum="GCS_CONTROL_STATUS_FLAGS">Control status. For example, whether takeover is allowed, and whether this message instance defines the default controlling GCS for the whole system.</field>
     </message>
+    <message id="292" name="ESC_EEPROM">
+      <description> Contains raw data from the DShot ESC EEPROM </description>
+      <field type="uint8_t" name="index">Index of the ESC</field>
+      <field type="uint8_t" name="length">Length of the data</field>
+      <field type="uint8_t[128]" name="data">EEPROM data (TODO: how long? AM32 EEPROM settings region is 48 Bytes)</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
### Description
This message contains the EEPROM data from an AM32 ESC EEPROM. This allows showing and editing ESC Settings via MAVLink, so that users can configure their ESCs from QGC. 

AM32 EEPROM ESC Settings
https://github.com/am32-firmware/AM32/blob/main/Inc/eeprom.h#L7-L57

The FC can use a dshot command to request ESC Settings (command 6)
https://brushlesswhoop.com/dshot-and-bidirectional-dshot/#special-commands

### DShot Programming Mode
AM32 now supports dshot programming mode https://github.com/am32-firmware/AM32/pull/168. This allows the FC to send a sequence of dshot commands to update a settings value on the ESC EEPROM:

#### Command Sequence
State | Command | Repetitions | Description
-- | -- | -- | --
EnterMode | 36 | 6 | Enter programming mode
SendAddress | `<address>` | 1 | Send EEPROM memory location
SendValue | `<value>` | 1 | Send value to write
ExitMode | 37 | 1 | Exit programming mode
Save | 12 | 6 | Save settings to EEPROM

### Updating an ESC Setting via MAVLink
The programming address and value are sent via the `MAV_CMD_CONFIGURE_ACTUATOR` vehicle command.

For example to set the [beep_volume](https://github.com/am32-firmware/AM32/blob/main/Inc/eeprom.h#L36C17-L36C28) on Motor1 to 0:
```
mavlink_command_long_t cmd;
cmd.command = MAV_CMD_CONFIGURE_ACTUATOR;
cmd.param1 = ACTUATOR_CONFIGURATION_WRITE_SETTING;
cmd.param2 = 30; // address 30
cmd.param3 = 0; // silence the beeping
cmd.param5 = ACTUATOR_OUTPUT_FUNCTION_MOTOR1;
```
