### PR TITLE
common.xml: Add COASTING flag to CAMERA_TRACKING_STATUS_FLAGS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3801,6 +3801,10 @@
         <wip/>
         <description>Camera Moving Target Indicators (MTI) are active</description>
       </entry>
+      <entry value="8" name="CAMERA_TRACKING_STATUS_FLAGS_COASTING">
+        <wip/>
+        <description>Camera tracking target is obscured and is being predicted</description>
+      </entry>
     </enum>
     <enum name="CAMERA_TRACKING_MODE">
       <description>Camera tracking modes</description>


### PR DESCRIPTION
Tracking algorithms can track a target through obscuration (e.g. a vehicle going under a bridge or a drone going behind a tree) by predicting the position of the target and re-acquiring the track when it is visible again. The common term for this is coasting. This PR adds a `COASTING` flag to `CAMERA_TRACKING_STATUS_FLAGS` to report when this occurs.

Extends #2323.