### PR TITLE
Add new component IDs for multiple radios

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -565,6 +565,15 @@
       <entry value="105" name="MAV_COMP_ID_CAMERA6">
         <description>Camera #6.</description>
       </entry>
+      <entry value="110" name="MAV_COMP_ID_RADIO">
+        <description>Radio #1.</description>
+      </entry>
+      <entry value="111" name="MAV_COMP_ID_RADIO2">
+        <description>Radio #2.</description>
+      </entry>
+      <entry value="112" name="MAV_COMP_ID_RADIO3">
+        <description>Radio #3.</description>
+      </entry>
       <entry value="140" name="MAV_COMP_ID_SERVO1">
         <description>Servo #1.</description>
       </entry>

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -218,6 +218,9 @@
       <entry value="48" name="MAV_TYPE_GRIPPER">
         <description>Gripper</description>
       </entry>
+      <entry value="49" name="MAV_TYPE_RADIO">
+        <description>Radio</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode, see MAV_MODE enum for useful combinations.</description>


### PR DESCRIPTION
Add 3 new component IDs in the `MAV_COMPONENT` enum:

- `MAV_COMP_ID_RADIO=110, /* Radio #1. | */`
- `MAV_COMP_ID_RADIO2=111, /* Radio #2. | */`
- `MAV_COMP_ID_RADIO3=112, /* Radio #3. | */`

Use the space between `MAV_COMP_ID_CAMERA6=105` and `MAV_COMP_ID_SERVO1=140` because it leaves a big gap in between in case we need to add new values in the future.

The primary use of the new IDs is for setups where you connect multiple radios between the airframe and GCS.
Ex: low bandwidth radio + high bandwidth radio
The IDs can be used to identify the different `RADIO_STATUS` messages coming from each individual radio.