### PR TITLE
Typos: Run codespell on all files

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,9 +37,11 @@ jobs:
       - uses: actions/checkout@v5
       - run: pipx install codespell
       # Discover typos in all non-XML files and the four XML files that this repo controls
-      - run: codespell --ignore-words-list=ned --skip="*.xml"
-      - run: codespell message_definitions/v1.0/all.xml message_definitions/v1.0/common.xml
-                       message_definitions/v1.0/minimal.xml message_definitions/v1.0/standard.xml
+      - run: codespell --skip="*.xml"
+      - run: codespell --ignore-words-list=ned message_definitions/v1.0/all.xml
+                                               message_definitions/v1.0/common.xml
+                                               message_definitions/v1.0/minimal.xml
+                                               message_definitions/v1.0/standard.xml
 
   python-lint:
     name: Lint Python code with ruff

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -34,8 +34,12 @@ jobs:
     name: Find typos with codespell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: pipx run codespell --ignore-words-list=ned
+      - uses: actions/checkout@v5
+      - run: pipx install codespell
+      # Discover typos in all non-XML files and the four XML files that this repo controls
+      - run: codespell --ignore-words-list=ned --skip="*.xml"
+      - run: codespell message_definitions/v1.0/all.xml message_definitions/v1.0/common.xml
+                       message_definitions/v1.0/minimal.xml message_definitions/v1.0/standard.xml
 
   python-lint:
     name: Lint Python code with ruff

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,10 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: pipx run codespell --ignore-words-list=ned
-                          message_definitions/v1.0/all.xml
-                          message_definitions/v1.0/common.xml
-                          message_definitions/v1.0/minimal.xml
-                          message_definitions/v1.0/standard.xml
 
   python-lint:
     name: Lint Python code with ruff


### PR DESCRIPTION
[`codespell`](https://pypi.org/project/codespell/) passes on all files, not just these four.