### PR TITLE
common.xml: Add "Power On" action to MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1059,6 +1059,9 @@
       <entry value="3" name="REBOOT_SHUTDOWN_ACTION_REBOOT_TO_BOOTLOADER">
         <description>Reboot component and keep it in the bootloader until upgraded.</description>
       </entry>
+      <entry value="4" name="REBOOT_SHUTDOWN_ACTION_POWER_ON">
+        <description>Power on component. Do nothing if component is already powered (ACK command with MAV_RESULT_ACCEPTED).</description>
+      </entry>
     </enum>
     <enum name="REBOOT_SHUTDOWN_CONDITIONS">
       <description>Specifies the conditions under which the MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command should be accepted.</description>


### PR DESCRIPTION
This PR consists of two commits:
1. Create a `REBOOT_SHUTDOWN_ACTION` enum for the `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN` command. This enum matches the values that were previously defined in the command param descriptions.
2. Add a `POWER_ON` value to the new `REBOOT_SHUTDOWN_ACTION` enum.

Let me know if you'd prefer this as two PRs.