### PR TITLE
Add MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -245,10 +245,10 @@
         <param index="1" label="Roll" units="deg" minValue="0" maxValue="360">Roll angle. Set to NaN if unknown.</param>
         <param index="2" label="Pitch" units="deg" minValue="0" maxValue="360">Pitch angle. Set to NaN if unknown.</param>
         <param index="3" label="Yaw" units="deg" minValue="0" maxValue="360">Yaw/heading (relative to true north) angle. Set to NaN if unknown.</param>
-        <param index="4" label="Roll accuracy" units="deg">Estimated 1 sigma accuracy of roll angle. Set to NaN if unknown.</param>
-        <param index="5" label="Pitch accuracy" units="deg">Estimated 1 sigma accuracy of pitch angle. Set to NaN if unknown.</param>
-        <param index="6" label="Yaw accuracy" units="deg">Estimated 1 sigma accuracy of yaw angle. Set to NaN if unknown.</param>
-        <param index="7">Empty</param>
+        <param index="4" label="Tilt accuracy" units="deg">Estimated 1 sigma accuracy of roll and pitch angles. Set to NaN if unknown.</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7" label="Yaw accuracy" units="deg">Estimated 1 sigma accuracy of yaw angle. Set to NaN if unknown.</param>
       </entry>
       <entry value="32100" name="MAV_CMD_REQUEST_OPERATOR_CONTROL" hasLocation="false" isDestination="false">
         <description>Request GCS control of a system (or of a specific component in a system).


### PR DESCRIPTION
replaces https://github.com/mavlink/mavlink/pull/2282

The outcome of the discussion linked above was that a new message should be created to manually reset the attitude (or part of it, e.g.: heading) instead of adding it to `MAV_CMD_EXTERNAL_POSITION_ESTIMATE`.

This for example allows the user to manually initialize the heading of the vehicle in case there is no mag, or if the mag cannot be used before takeoff. It could also be used to transfer the alignment from one vehicle to another one; the message could be sent several times to make sure the biases are correctly estimates.

Regarding the uncertainties, I'm not sure if we should define the uncertainty of each angle or the attitude uncertainty (which is defined as a 3D vector in the tangent space. The first solution is more "human friendly" while the 2nd one is better if the full attitude is frequently provided by another estimator working with rotation matrices or quaternions, as this would require less computations.