### PR TITLE
common.xml: Add NOT_IN_CONTROL entry to MAV_RESULT enum

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2854,6 +2854,10 @@
       <entry value="9" name="MAV_RESULT_COMMAND_UNSUPPORTED_MAV_FRAME">
         <description>Command is invalid because a frame is required and the specified frame is not supported.</description>
       </entry>
+      <entry value="10" name="MAV_RESULT_NOT_IN_CONTROL">
+        <wip/>
+        <description>Command has been rejected because source system is not in control of the target system/component.</description>
+      </entry>
     </enum>
     <enum name="MAV_MISSION_RESULT">
       <description>Result of mission operation (in a MISSION_ACK message).</description>


### PR DESCRIPTION
Adds a new `NOT_IN_CONTROL` entry to the `MAV_RESULT` enum. Currently marked as WIP.

There are various messages that can be used to set who is in control of a system (e.g. [`CHANGE_OPERATOR_CONTROL`](https://mavlink.io/en/messages/common.html#CHANGE_OPERATOR_CONTROL), [`MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE`](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE)). When a command is rejected because the requesting system is not in control, we should report this via an explicit NACK rather than using e.g. `MAV_RESULT_DENIED`.