### PR TITLE
common.xml: add gripper stop action

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -594,11 +594,14 @@
     <!-- gripper action enum -->
     <enum name="GRIPPER_ACTIONS">
       <description>Gripper actions.</description>
-      <entry value="0" name="GRIPPER_ACTION_RELEASE">
-        <description>Gripper release cargo.</description>
+      <entry value="0" name="GRIPPER_ACTION_OPEN">
+        <description>Gripper commence open. Often used to release cargo.</description>
       </entry>
-      <entry value="1" name="GRIPPER_ACTION_GRAB">
-        <description>Gripper grab onto cargo.</description>
+      <entry value="1" name="GRIPPER_ACTION_CLOSE">
+        <description>Gripper commence close. Often used to grab onto cargo.</description>
+      </entry>
+      <entry value="2" name="GRIPPER_ACTION_STOP">
+        <description>Gripper stop and maintain current opening amount.</description>
       </entry>
     </enum>
     <!-- winch action enum -->


### PR DESCRIPTION
I was chatting with @Williangalvani about things keeping ArduSub in its current bypass of MAVLink's gripper functionality, and we realised that the existing MAVLink Gripper action set doesn't support stop commands, which is a requirement for fully supporting [this gripper](https://bluerobotics.com/store/thrusters/grippers/newton-gripper-asm-r2-rp/) (which is the main gripper used in the ArduSub ecosystem).

Grippers are not always moving, and it can be beneficial to be able to stop the opening or closing process to avoid damaging the cargo and/or the device being controlled.

I've also updated the names and descriptions of the existing actions, to better reflect the actual functionality. It's worth noting that grippers are sometimes "stowed away" in a closed state, so it seems unreasonable to assume closing is always a grab onto some cargo, and that opening is releasing cargo (rather than preparing to grab some, for example).