### PR TITLE
common.xml: add PARAM_ERROR message

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2791,8 +2791,8 @@
     </enum>
     <enum name="MAV_PARAM_ERROR">
       <description>Parameter protocol error types (see PARAM_ERROR).</description>
-      <entry value="0" name="MAV_PARAM_ERROR_NO_ERROR">
-        <description>No error occurred; not expected to appear in a mavlink message but useful in implementations</description>
+      <entry value="0" name="MAV_PARAM_ERROR_UNKNOWN_ERROR">
+        <description>Unknown error</description>
       </entry>
       <entry value="1" name="MAV_PARAM_ERROR_DOES_NOT_EXIST">
         <description>Parameter does not exist</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2789,6 +2789,27 @@
         <description>64-bit floating-point</description>
       </entry>
     </enum>
+    <enum name="MAV_PARAM_ERROR">
+      <description>Parameter protocol error types (see PARAM_ERROR).</description>
+      <entry value="0" name="MAV_PARAM_ERROR_NO_ERROR">
+        <description>No error occurred; not expected to appear in a mavlink message but useful in implementations</description>
+      </entry>
+      <entry value="1" name="MAV_PARAM_ERROR_DOES_NOT_EXIST">
+        <description>Parameter does not exist</description>
+      </entry>
+      <entry value="2" name="MAV_PARAM_ERROR_VALUE_OUT_OF_RANGE">
+        <description>Parameter value does not fit within accepted range</description>
+      </entry>
+      <entry value="3" name="MAV_PARAM_ERROR_PERMISSION_DENIED">
+        <description>Caller is not permitted to set the value of this parameter</description>
+      </entry>
+      <entry value="4" name="MAV_PARAM_ERROR_COMPONENT_NOT_FOUND">
+        <description>Unknown component specified</description>
+      </entry>
+      <entry value="5" name="MAV_PARAM_ERROR_READ_ONLY">
+        <description>Parameter is read-only</description>
+      </entry>
+    </enum>
     <enum name="MAV_PARAM_EXT_TYPE">
       <description>Specifies the datatype of a MAVLink extended parameter.</description>
       <entry value="1" name="MAV_PARAM_EXT_TYPE_UINT8">
@@ -7580,6 +7601,15 @@
       <field type="uint16_t" name="update_rate" units="cs" invalid="0">Time until next update. Set to 0 if unknown or in data driven mode.</field>
       <field type="uint8_t" name="flight_state" enum="UTM_FLIGHT_STATE">Flight state</field>
       <field type="uint8_t" name="flags" enum="UTM_DATA_AVAIL_FLAGS">Bitwise OR combination of the data available flags.</field>
+    </message>
+    <message id="345" name="PARAM_ERROR">
+      <description>Parameter set/get error. Returned from a MAVLink node in response to an error in the parameter protocol, for example failing to set a parameter because it does not exist.
+      </description>
+      <field type="uint8_t" name="target_system">System ID</field>
+      <field type="uint8_t" name="target_component">Component ID</field>
+      <field type="char[16]" name="param_id">Parameter id. Terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="int16_t" name="param_index">Parameter index. Will be -1 if the param ID field should be used as an identifier (else the param id will be ignored)</field>
+      <field type="uint8_t" name="error" enum="MAV_PARAM_ERROR">Error being returned to client.</field>
     </message>
     <message id="350" name="DEBUG_FLOAT_ARRAY">
       <description>Large debug/prototyping array. The message uses the maximum available payload for data. The array_id and name fields are used to discriminate between messages in code and in user interfaces (respectively). Do not use in production code.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2790,6 +2790,8 @@
       </entry>
     </enum>
     <enum name="MAV_PARAM_ERROR">
+      <wip/>
+      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Parameter protocol error types (see PARAM_ERROR).</description>
       <entry value="0" name="MAV_PARAM_ERROR_NO_ERROR">
         <description>No error occurred (not expected in PARAM_ERROR but may be used in future implementations.</description>
@@ -7603,6 +7605,8 @@
       <field type="uint8_t" name="flags" enum="UTM_DATA_AVAIL_FLAGS">Bitwise OR combination of the data available flags.</field>
     </message>
     <message id="345" name="PARAM_ERROR">
+      <wip/>
+      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Parameter set/get error. Returned from a MAVLink node in response to an error in the parameter protocol, for example failing to set a parameter because it does not exist.
       </description>
       <field type="uint8_t" name="target_system">System ID</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2791,8 +2791,8 @@
     </enum>
     <enum name="MAV_PARAM_ERROR">
       <description>Parameter protocol error types (see PARAM_ERROR).</description>
-      <entry value="0" name="MAV_PARAM_ERROR_UNKNOWN_ERROR">
-        <description>Unknown error</description>
+      <entry value="0" name="MAV_PARAM_ERROR_NO_ERROR">
+        <description>No error occurred (not expected in PARAM_ERROR but may be used in future implementations.</description>
       </entry>
       <entry value="1" name="MAV_PARAM_ERROR_DOES_NOT_EXIST">
         <description>Parameter does not exist</description>


### PR DESCRIPTION
allows an error regarding parameter sub-protocol to be passed around

Talking point only, let's not merge it *right now*...
