### PR TITLE
Add MAV_CMD_NAV_FENCE_HOME_CIRCLE_INCLUSION

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2437,13 +2437,6 @@
         <param index="6" label="Longitude">Longitude</param>
         <param index="7">Reserved</param>
       </entry>
-      <entry value="5005" name="MAV_CMD_NAV_FENCE_HOME_CIRCLE_INCLUSION" hasLocation="false" isDestination="false">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-        <description>Circular fence area centered on home. The vehicle must stay inside this area. If home is moved, the fence moves.</description>
-        <param index="1" label="Radius" units="m">Radius.</param>
-        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group. Ignored when sent as a command.</param>
-      </entry>
       <entry value="5100" name="MAV_CMD_NAV_RALLY_POINT" hasLocation="true" isDestination="false">
         <description>Rally point. You can have multiple rally points defined.
         </description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -90,6 +90,13 @@
       <entry value="4096" name="MAV_BATTERY_STATUS_FLAGS_FAULT_UNDER_TEMPERATURE">
         <description>Under-temperature fault.</description>
       </entry>
+      <entry value="5005" name="MAV_CMD_NAV_FENCE_HOME_CIRCLE_INCLUSION" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Circular fence area centered on home. The vehicle must stay inside this area. If home is moved, the fence moves.</description>
+        <param index="1" label="Radius" units="m">Radius.</param>
+        <param index="2" label="Inclusion Group" minValue="0" increment="1">Vehicle must be inside ALL inclusion zones in a single group, vehicle must be inside at least one group. Ignored when sent as a command.</param>
+      </entry>
       <entry value="8192" name="MAV_BATTERY_STATUS_FLAGS_FAULT_OVER_CURRENT">
         <description>Over-current fault.</description>
       </entry>


### PR DESCRIPTION
* This can replace ArduPilot's home centered circle fence that is set up in parameters
* Instead of the GCS either not displaying AP's "TinCan" [cylindrical](https://ardupilot.org/copter/docs/common-ac2_simple_geofence.html#common-ac2-simple-geofence) fence, or adding AP specific parameter parsing logic for that kind of fence, this is standardized in mavlink messages

See https://discord.com/channels/674039678562861068/781317510392840232/1414337082662584371 for context.

FYI @peterbarker  and @IamPete1 

I assume we want to keep the fence group ability on this? But probably we can avoid duplicating the location fields because the autopilot already knows where home is. 