### PR TITLE
ardupilotmega.xml: Include active srcset and core ids in EKF_STATUS_REPORT

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1720,6 +1720,8 @@
       <field type="float" name="terrain_alt_variance">Terrain Altitude variance.</field>
       <extensions/>
       <field type="float" name="airspeed_variance">Airspeed variance.</field>
+      <field type="uint8_t" name="active_srcset_id">Currently active source set.</field>
+      <field type="uint8_t" name="active_lane_id">Currently estimator lane (core).</field>
     </message>
     <!-- realtime PID tuning message -->
     <message id="194" name="PID_TUNING">


### PR DESCRIPTION
As per conversation with ArduPilot devs.

AP has a concept of source sets which can be used to transition between GPS/non-GPS navigation, e.g. going indoors. There is a command to switch the active set, but there is no way to know which set is active (aside from maybe parsing text messages). This PR adds the currently active source set information to the ArduPilot specific EKF_STATUS_REPORT message.

As a bonus I'm also adding the id of the currently active estimator lane (core).


@peterbarker asking for your review/blessing here while I do the AP part

