### PR TITLE
Add MAV_PARAM_ERROR_TYPE_MISMATCH entry

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2811,6 +2811,9 @@
       <entry value="5" name="MAV_PARAM_ERROR_READ_ONLY">
         <description>Parameter is read-only</description>
       </entry>
+      <entry value="6" name="MAV_PARAM_ERROR_TYPE_MISMATCH">
+        <description>Parameter type does not match expected type</description>
+      </entry>
     </enum>
     <enum name="MAV_PARAM_EXT_TYPE">
       <description>Specifies the datatype of a MAVLink extended parameter.</description>


### PR DESCRIPTION
This reflects an error path in PX4 - attempting to set a real param using an int type or visa versa.

@peterbarker @julianoes Make sense to you?