### PR TITLE
[DISCUSSION] Enhance COMMAND message fields with idempotency key

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5883,7 +5883,7 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="uint8_t" name="frame" enum="MAV_FRAME">The coordinate system of the COMMAND.</field>
       <field type="uint16_t" name="command" enum="MAV_CMD">The scheduled action for the mission item.</field>
-      <field type="uint8_t" name="current">Not used.</field>
+      <field type="uint8_t" name="current" invalid="0">WIP: Idempotency key. A sequence number that uniquely identifies each unique command sent. Must be same number for message resends or same message on multiple channels. Command with number only acted on once and value mirrored COMMAND_ACK.idempotency_key. Keys can wrap. Autopilot should clear old key records based on time and number of records.</field>
       <field type="uint8_t" name="autocontinue">Not used (set 0).</field>
       <field type="float" name="param1" invalid="NaN">PARAM1, see MAV_CMD enum</field>
       <field type="float" name="param2" invalid="NaN">PARAM2, see MAV_CMD enum</field>
@@ -5916,6 +5916,7 @@
       <field type="int32_t" name="result_param2">Additional result information. Can be set with a command-specific enum containing command-specific error reasons for why the command might be denied. If used, the associated enum must be documented in the corresponding MAV_CMD (this enum should have a 0 value to indicate "unused" or "unknown").</field>
       <field type="uint8_t" name="target_system">System ID of the target recipient. This is the ID of the system that sent the command for which this COMMAND_ACK is an acknowledgement.</field>
       <field type="uint8_t" name="target_component">Component ID of the target recipient. This is the ID of the system that sent the command for which this COMMAND_ACK is an acknowledgement.</field>
+      <field type="uint8_t" name="idempotency_key" invalid="0">Key of command to which responding. Mirrors value received in COMMAND_INT.continue.</field>
     </message>
     <message id="80" name="COMMAND_CANCEL">
       <wip/>


### PR DESCRIPTION
The HTTP specifications have a request header `IDEMPOTENCY_KEY` to make HTTP methods such as POST and PATCH idempotent - allowing a particular message to be safely be resent if a response message is not received. The header includes some unique value that is sent if the same message is sent multiple times. A server that gets such a request records the key and will usually also record a hash of the payload. If it gets the same message again (a resend) it responds with success but does not re-execute the operation. If it gets a key but a hash that does not match it may return an error. It may expire the key.

It occurs to me that MAVLink commands have the same problem - they might be sent over different channels and get received multiple times. We hope/try to make them idempotent, but fact is that they aren't always.
Further, we can only have one command of a particular type outstanding because we can't recognize the same command from the same source is different.

This PR is just to discuss whether this feature is of any interest. We could do this using a sequence number replacing the unused `COMMAND_INT.continue` key. Each sender could iterate the key for a unique message. A recipient could then differentiate between commands from the same sequence number and also identify resends - because unlike sequence numbers the values would iterate per command, not per channel. 

As recipient would have to store the id for each command it receives. How many and much though would be tunable. I mean you could choose not to do it for commands that are already idempotent. 

Just a thought and perhaps not worth thinking about. @peterbarker ?
