### PR TITLE
Parameter protocol messages - update to clarify responses

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2820,7 +2820,7 @@
       <entry value="8" name="MAV_PARAM_ERROR_READ_FAIL">
         <description>Parameter exists but reading failed</description>
       </entry>
-      <entry value="8" name="MAV_PARAM_ERROR_NO_PARAMETERS">
+      <entry value="9" name="MAV_PARAM_ERROR_NO_PARAMETERS">
         <description>There are no parameters. This might be sent in response to PARAM_REQUEST_LIST.</description>
       </entry>
     </enum>


### PR DESCRIPTION
Updated descriptions for PARAM_REQUEST_READ, PARAM_REQUEST_LIST, PARAM_VALUE, PARAM_SET, and PARAM_ERROR messages to clarify usage and response requirements.
This makes the descriptions more coherent and consistent so that they are better cross linked.
Also clarifies that the index is not necessarily invariant.

The reason for the change comes out of https://github.com/mavlink/mavlink/pull/2344#issuecomment-3420059955 - clarifying what values must be set for parameter identity in the emitted command. I chose:

> Note that the response must include the parameter identity specified in the request (either `param_id` or `param_index`) and must also include `param_index` if it is available.

So you always return the id (name) if you have it, because that's the invariant thing we really want. However sometimes you can't have it for example in param_error, if you requested an index out of range.
We don't care about the index in the setter case; as long as it is correct.

@peterbarker I think this is good and makes things more clear. 

