### PR TITLE
MAV_RESULT_DENIED - clarify invalid

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2866,7 +2866,7 @@
         <description>Command is valid, but cannot be executed at this time. This is used to indicate a problem that should be fixed just by waiting (e.g. a state machine is busy, can't arm because have not got GPS lock, etc.). Retrying later should work.</description>
       </entry>
       <entry value="2" name="MAV_RESULT_DENIED">
-        <description>Command is invalid; it is supported but one or more parameter values are invalid (i.e. parameter reserved, value allowed by spec but not supported by flight stack, and so on). Retrying same command and parameters will not work.</description>
+        <description>Command is invalid; it is supported but one or more parameter values are invalid (i.e. parameter reserved, value allowed by spec but not supported by flight stack, and so on). Retrying the same command and parameters will not work.</description>
       </entry>
       <entry value="3" name="MAV_RESULT_UNSUPPORTED">
         <description>Command is not supported (unknown).</description>


### PR DESCRIPTION
Seems odd to be clarifying something so fundamental. I wanted to capture that a parameter value might be value in the spec but not supported by the flight stack, or it might just be not allowed.

@julianoes @peterbarker Thoughts? I was wondering if we might provide the specific problem bits in the result field, but I think this would be a pain to code, and not worth doing unless people could rely on it.