### PR TITLE
Fix mavgenerate.py

### DIFF
--- a/mavgenerate.py
+++ b/mavgenerate.py
@@ -21,6 +21,7 @@ Released under GNU GPL version 3 or later
 
 """
 import os
+import re
 
 from tkinter import *  # noqa: F403
 import tkinter.filedialog


### PR DESCRIPTION
`error_limit` got deleted in mavgen: https://github.com/ArduPilot/pymavlink/pull/1093