### PR TITLE
ESC_EEPROM

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -456,13 +456,13 @@
     <enum name="ESC_FIRMWARE">
       <description>ESC firmware type identifier.</description>
       <entry value="0" name="ESC_FIRMWARE_UNKNOWN">
-        <description>AM32 open source ESC firmware.</description>
+        <description>Unknown firmware.</description>
       </entry>
       <entry value="1" name="ESC_FIRMWARE_AM32">
-        <description>Bluejay open source ESC firmware.</description>
+        <description>AM32 open source ESC firmware.</description>
       </entry>
       <entry value="2" name="ESC_FIRMWARE_BLUEJAY">
-        <description>BLHeli32 ESC firmware.</description>
+        <description>Bluejay open source ESC firmware.</description>
       </entry>
       <entry value="3" name="ESC_FIRMWARE_BLHELI32">
         <description>BLHeli32 ESC firmware.</description>


### PR DESCRIPTION
Discussed in https://github.com/mavlink/rfcs/pull/27

AM32 EEPROM Data layout is here.
https://github.com/am32-firmware/AM32/blob/main/Inc/eeprom.h
The second byte in the structure is the `eeprom_version` which allows us to support changes to the layout. If the version is bumped, the GCS will need to handle the new version correctly. So in some cases an older GCS may not support a newer version of AM32 Settings Programming.