### PR TITLE
SYSTEM_TIME - description incorrectly highlight SYSTEM_TYPE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5310,9 +5310,9 @@
       <field type="uint32_t" name="onboard_control_sensors_health_extended" enum="MAV_SYS_STATUS_SENSOR_EXTENDED" print_format="0x%04x">Bitmap showing which onboard controllers and sensors have an error (or are operational). Value of 0: error. Value of 1: healthy.</field>
     </message>
     <message id="2" name="SYSTEM_TIME">
-      <description>The system time is the time of the master clock.
+      <description>The system time is the time of the sender's master clock.
         This can be emitted by flight controllers, onboard computers, or other components in the MAVLink network.
-        Components that are using a less reliable time source, such as a battery-backed real time clock, can choose to match their system clock to that of a SYSTEM_TYPE that indicates a more recent time.
+        Components that are using a less reliable time source, such as a battery-backed real time clock, can choose to match their system clock to that of a system that indicates a more recent time.
         This allows more broadly accurate date stamping of logs, and so on.
         If precise time synchronization is needed then use TIMESYNC instead.</description>
       <field type="uint64_t" name="time_unix_usec" units="us">Timestamp (UNIX epoch time).</field>


### PR DESCRIPTION
This fixes a bug highlighted in https://github.com/mavlink/mavlink/pull/2269#issuecomment-3541813199 that seems to be a copy/paste error.

@peterbarker You OK with this?