### PR TITLE
Add Messages For Controlling LED Strips Over MAVLink

### DIFF
--- a/message_definitions/v1.0/all.xml
+++ b/message_definitions/v1.0/all.xml
@@ -71,13 +71,13 @@
   -->
   <include>marsh.xml</include>
   <!-- stemstudios.xml range of IDs:
-    messages: 52600 - 52649
-    commands: 52600 - 52649
+    messages: 52600 - 52609
+    commands: 52600 - 52609
   -->
   <include>stemstudios.xml</include>
   <!--Next range to allocate range of IDs:
-    messages: 52650 - 52699 (< 60000)
-    commands: 52650 - 52699 (< 60000)
+    messages: 52610 - 52619 (< 60000)
+    commands: 52610 - 52619 (< 60000)
   -->
   <enums>
     <!-- The MAV_CMD enum entries describe either: -->

--- a/message_definitions/v1.0/stemstudios.xml
+++ b/message_definitions/v1.0/stemstudios.xml
@@ -4,8 +4,8 @@ Contact:
   - github user name: @danieladelodun
   - email: daniel_adelodun@hotmail.co.uk
 Range of IDs:
-  messages: 52600 - 52649
-  commands: 52600 - 52649
+  messages: 52600 - 52609
+  commands: 52600 - 52609
 Documentation:
   WIP messages for controlling LED strips attached to MAVLink enabled vehicles.
 -->


### PR DESCRIPTION
### This is a new **set of messages for controlling LED strips**.

It supports up to **255 LED strips per system and any number of LEDs per strip**.

**Each message can set up to 8 RGB LEDs** on a single strip. Which strip, and which 8 LEDs along the strip are to be set by that particular message are configured using the appropriate fields.

RGB colour values are given as a 24bit hex value 0xRRGGBB (right-aligned in a uint32_t). Each colour channel ranges from 00 -> 255 (0xFF). 8 can be set at a time using the `colors` array of the `LED_STRIP_CONFIG` message.

You can set up to 8 consecutive LEDs along a strip at a time. `length` is used to specify how many (up to 8). Use `index` to indicate where along the strip to start.
**You can also set all LEDs on a strip to the same color, turn all the LEDs off, or have all LEDs on the strip change colours according to the current flightmode by setting the `fill_mode` field appropriately.** 

The `strip_id` field is used to set which LED strip to target. How these indices map to hardware would be user defined. setting `strip_id = 255` targets all strips at once.

I've tested adding support for these messages into [MAVSDK](https://github.com/DanielAdelodun/MAVSDK/tree/lights-plugin), [MAVSDK-Proto](https://github.com/DanielAdelodun/MAVSDK-Proto/tree/lights-plugin), and [MAVSDK-Python](https://github.com/DanielAdelodun/MAVSDK-Python/tree/lights-plugin). 
And an RP2xxx  (Raspberry Pi Pico) based [LED controller]() that reads the messages and configures the attached LEDs.

My intention is to keep maintaining this and to potentially sell [opensource hardware](https://github.com/DanielAdelodun/MAVLink-Lights-Hardware) that can easily plug into a MAVLink flight controller and work as an LED controller.

**Demos:
[Red Heart Using MAVSDK-Python Offboard Example](https://youtu.be/aNKbazAUzbI)
[Waypoints](https://youtu.be/iBu-zbaUTHk?si=AqnKdKJmvez6inXw)**