### PR TITLE
Rename the jamming and spoofing states within GNSS_INTEGRITY for clarity

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -365,7 +365,7 @@
       <entry value="0" name="GPS_JAMMING_STATE_UNKNOWN">
         <description>The GPS receiver does not provide GPS signal jamming info.</description>
       </entry>
-      <entry value="1" name="GPS_JAMMING_STATE_OK">
+      <entry value="1" name="GPS_JAMMING_STATE_NOT_JAMMED">
         <description>The GPS receiver detected no signal jamming.</description>
       </entry>
       <entry value="2" name="GPS_JAMMING_STATE_MITIGATED">
@@ -380,7 +380,7 @@
       <entry value="0" name="GPS_SPOOFING_STATE_UNKNOWN">
         <description>The GPS receiver does not provide GPS signal spoofing info.</description>
       </entry>
-      <entry value="1" name="GPS_SPOOFING_STATE_OK">
+      <entry value="1" name="GPS_SPOOFING_STATE_NOT_SPOOFED">
         <description>The GPS receiver detected no signal spoofing.</description>
       </entry>
       <entry value="2" name="GPS_SPOOFING_STATE_MITIGATED">


### PR DESCRIPTION
### Summary & Motivation

This PR updates the enum value names in GNSS_INTEGRITY for GPS_SPOOFING_STATE and GPS_JAMMING_STATE, replacing the ambiguous *_OK values with clearer and more explicit names:

→ GPS_SPOOFING_STATE_NOT_SPOOFED
→ GPS_JAMMING_STATE_NOT_JAMMED

The previous “OK” terminology was confusing during implementation, because “jamming OK” or “spoofing OK” could be interpreted in several ways — as “no issue”, “mitigated”, or “not affecting performance”. The updated naming removes this ambiguity and follows the logic already used in the rest of the state definitions (STATE_UNKNOWN, STATE_NOT_*, STATE_MITIGATED, STATE_DETECTED), making the state model more consistent and easier to interpret.

### Background and Related Work

This PR improves on: https://github.com/mavlink/mavlink/pull/2110

The suggestion to refine the naming originated during ArduPilot’s implementation work, with input from @peterbarker.

Implementations using GNSS_INTEGRITY:
→ PX4 (merged): https://github.com/PX4/PX4-Autopilot/pull/25012
→ ArduPilot (in review): https://github.com/ArduPilot/ardupilot/pull/31040
→ QGroundControl (in review): https://github.com/mavlink/qgroundcontrol/pull/13009

Only QGroundControl is directly affected by this naming update. As a substantial logic change was requested in that implementation, a new clean PR will follow where the updated names will be used. For other implementations, follow-up PRs will be opened to align the naming for consistency.