### PR TITLE
ESC_INFO_V2 and ESC_STATUS_V2

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -670,7 +670,7 @@
 
         The message `index` field is incremented to indicate which set of ESCs are described.
         The data for each ESC is in the same index for each of the array fields.
-        The ESC number `(message index * 4) + array index` is mapped to the a particular motor using an autopilot specific mechanism.
+        The ESC number `(message index * 4) + array index` is mapped to a particular motor using an autopilot specific mechanism.
 
         ESC_STATUS_V2 with the same message index contains contains corresponding higher-rate ESC data.</description>
       <field type="uint8_t" name="index" instance="true" minValue="0" increment="1" maxValue="25">Message index. ESC data corresponds to ESC_STATUS_V2 message with same index.</field>


### PR DESCRIPTION
As discussed in [20251203-Dev-Meeting](https://github.com/mavlink/mavlink/wiki/20251203-Dev-Meeting) there _are_ implementations of the ESC_INFO and ESC_STATUS messages, which means that we should not just update the messages how we like - even though they are WIP and those are closed source.

We could just accept the current messages and/or extend them as these have previously been agreed subject to testing. However we know that they are not great, and in particular that ArduPilot would hesitate before migrating from their existing messages. 
Therefore the proposal is to create replacement messages and immediately accept and deprecate the older messages. This creates a clean path forward.

This PR replaces #2386 which has a complicated history.
The messages are as discussed in that PR. I have added notes for where there are open questions.

FYI @dakejahl @peterbarker @IamPete1 @julianoes @auturgy 