### PR TITLE
common.xml: revert gripper action renames

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -594,14 +594,14 @@
     <!-- gripper action enum -->
     <enum name="GRIPPER_ACTIONS">
       <description>Gripper actions.</description>
-      <entry value="0" name="GRIPPER_ACTION_OPEN">
-        <description>Gripper commence open. Often used to release cargo.</description>
+      <entry value="0" name="GRIPPER_ACTION_RELEASE">
+        <description>Gripper release cargo.</description>
       </entry>
-      <entry value="1" name="GRIPPER_ACTION_CLOSE">
-        <description>Gripper commence close. Often used to grab onto cargo.</description>
+      <entry value="1" name="GRIPPER_ACTION_GRAB">
+        <description>Gripper grab onto cargo.</description>
       </entry>
-      <entry value="2" name="GRIPPER_ACTION_STOP">
-        <description>Gripper stop (maintain current grip position).</description>
+      <entry value="2" name="GRIPPER_ACTION_HOLD">
+        <description>Gripper hold current grip state/position.</description>
       </entry>
     </enum>
     <!-- winch action enum -->


### PR DESCRIPTION
In response to concerns raised [here](https://github.com/mavlink/mavlink/pull/2342#issuecomment-3625001767):
- Restores open/close actions to release/grab
- Changes "stop" action to "hold", to more clearly define expected behaviour

@peterbarker / @hamishwillee tagging, since I can't request reviews here.