### PR TITLE
COMPONENT_METADATA - no longer WIP

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7878,8 +7878,6 @@
       <field type="char[32]" name="serial_number">Hardware serial number. The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.</field>
     </message>
     <message id="397" name="COMPONENT_METADATA">
-      <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>
         Component metadata message, which may be requested using MAV_CMD_REQUEST_MESSAGE.
 


### PR DESCRIPTION
This isn't WIP - been in releases and used hard for 5 years, and is also the backbone of other services.

We can reasonably state that at least the parameter use case has been hardened, as QGC supports both parameter import and translation now.
The only case we discussed that isn't supported is dynamic update of component data (other than translation data, which is supported).  Beat proposed a solution that should work for that, it just hasn't been needed by PX4 so isn't tested.

Note, this is not "standard" though, as not implemented by ArduPilot. According to @DonLakeFlyer apparently it being marked as WIP is a blocker for them implementing.