### PR TITLE
[Discussion] MAV_STANDARD_MODE_SAFE_RECOVERY - allow return mode

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5211,11 +5211,11 @@
         </description>
       </entry>
       <entry value="5" name="MAV_STANDARD_MODE_SAFE_RECOVERY">
-        <description>Safe recovery mode (auto).
+        <description>Safe recovery mode (auto) / Return mode.
           Automatic mode that takes vehicle to a predefined safe location via a safe flight path, and may also automatically land the vehicle.
-          This mode is more commonly referred to as RTL and/or or Smart RTL.
           The precise return location, flight path, and landing behaviour depend on vehicle configuration and type.
           For example, the vehicle might return to the home/launch location, a rally point, or the start of a mission landing, it might follow a direct path, mission path, or breadcrumb path, and land using a mission landing pattern or some other kind of descent.
+          This mode can map to custom flight modes such as RTL, RTH, smart RTL, Return mode, and so on.
         </description>
       </entry>
       <entry value="6" name="MAV_STANDARD_MODE_MISSION">


### PR DESCRIPTION
The name  "Safe recovery mode" was chosen deliberately to create a clear break from custom modes such as Return mode, RTL, RTH, smart RTL, and smart RTH.

Thats because:
- It can represent any and all of these modes.
- None of these modes necessarily return.
- None of these modes necessarily land.

However GCS have the real world problem that flight-stack specific setup such as Failsafe triggers refer to the custom mode - such as Return mode. So you get the situation where a GCS that knows about return mode offers that as a failsafe trigger, and then what the user sees being triggered is Safe Recovery.

There are a few options: 
- We ignore that RTL/Return are all poor and  change the standard mode, or perhaps just the allowed name of the mode in the UI (this PR does that - it essentially allows you to all the mode either Return mode or Safe recovery mode
- Flight stack updates its modes to match the names of the standard modes.

I would like the second option, and I'm happy to do the work, since it is mostly changing strings in parameters and docs.
@dakejahl @mrpollo Would that be palatable to you? It would make things consistent.

The problem would not go away for ArduPilot - if they implement standard modes then they would have similar inconsistencies unless they also renamed their modes. HOwever that is true if we change it to return mode too - since we all have difffent mode names. NOTE, we chose the names to match as close to flight stack existing modes as possible, choosing the most logical based on flight behaviour in the case of conflict.

Fyi @peterbarker @auturgy @DonLakeFlyer @julianoes 