### PR TITLE
development: Added RC_CHANNELS_OVERRIDE_V2

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -559,6 +559,8 @@
         Channels with indexes equal or above count should be set to 0, to benefit from MAVLink's trailing-zero trimming.</field>
     </message>
     <message id="421" name="RC_CHANNELS_OVERRIDE_V2">
+      <wip since="2026-03"/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>
         Highly bandwidth-efficient RC override message for professional networked operations (LTE, Zigbee, GCP). 
         Supersedes RC_CHANNELS_OVERRIDE by adding 32-channel support and a bitmask for multi-master conflict avoidance. 


### PR DESCRIPTION
EDITED 
- 202602 - This originally appeared to offer a replacement for RADIO_RC_CHANNELS, but was attended to address different use cases. I have modified this by pulling in relevant discussion https://github.com/mavlink/mavlink/pull/2405#issuecomment-3893367520
- 202603 - Merged. Acceptance in common.xml subject to integration in flight stack (ardupilot) within 3 months and adequate testing. If not, messages may be removed (circa 202607)


### **Updated XML Definition: RC_CHANNELS_OVERRIDE_V2**

```xml
<message id="421" name="RC_CHANNELS_OVERRIDE_V2">
  <description>
    Highly bandwidth-efficient RC override message for professional networked operations (LTE, Zigbee, GCP). 
    Supersedes RC_CHANNELS_OVERRIDE by adding 32-channel support and a bitmask for multi-master conflict avoidance.
  </description>
  <field type="uint8_t" name="target_system">System ID.</field>
  <field type="uint8_t" name="target_component">Component ID.</field>
  <field type="uint64_t" name="time_usec" units="us">Timestamp (microseconds since boot). Critical for reordering packets over jittery LTE/GCP routes.</field>
  <field type="uint32_t" name="active_mask">Bitmap of included channels (bit 0 = CH1). 1: Valid/Override, 0: Ignore (Prevents conflict with other masters).</field>
  <extensions/>
  <field type="int16_t[32]" name="channels" minValue="-4096" maxValue="4096">
    RC channels in centered 13-bit format. Range: -4096 to 4096, Center: 0. 
    Conversion to PWM: $PWM = (x \cdot \frac{5}{32}) + 1500$. 
    Unused channels (Mask=0) must be set to 0 to enable MAVLink 2 trailing-zero trimming.
  </field>
</message>
```

I have chosen to implement a **64-bit `time_usec`** timestamp, which adds 4 bytes back. This is a strategic trade-off: we are replacing low-value telemetry with high-value synchronization data essential for reordering packets over jittery LTE/GCP routes.

### **Why This "V2" is Essential for Safety and Efficiency**

Please refer to the following diagram for the operational context:

<img width="1355" height="801" alt="Screenshot from 2026-02-12 04-27-44" src="https://github.com/user-attachments/assets/eab652f6-daa6-487f-b0fa-b588c0e0389e" />

#### **1. Multi-Master Conflict Avoidance**
* In professional industrial missions, it is common to have a **Remote Actor** (flight) and a **Gimbal Actor** (payload) operating simultaneously. 
* **The Legacy Problem**: Current `RC_CHANNELS_OVERRIDE` messages force all channels to be sent, causing one actor to unintentionally overwrite the other's commands with 0xFFFF.
* **The Masked Solution**: The bitmask allows the Gimbal Actor to send updates *only* for its channels by setting other bits to **0**, effectively declaring "I am not participating in this channel" and preventing interference.

#### **2. Performance on 38.4kbps Zigbee & FC Scheduling**
* **Effective Bandwidth**: While the fixed header size remains neutral, the **effective payload size is drastically reduced**. 
* **Airtime Budget**: On a **38,400bps Zigbee link**, the 20ms frame budget is only ~96 bytes. 
* **Truncation Benefit**: By using centered-zero values, MAVLink 2 trailing-zero truncation reduces a 4-channel update to **~22 bytes total**, compared to ~50 bytes for the legacy message.
* **FC Task Priority**: In ArduPilot's scheduler, `rc_loop` (**Index 3**) is a top-priority task, while MAVLink reception (**Index 102**) is handled much later. 
* **Reliability**: Smaller, truncated packets minimize the parser load at Index 102, ensuring that control injection isn't dropped when the flight controller is under high CPU load.

#### **3. The Safety Significance of "Zero"**
* In this architecture, we cannot use 0 for padding in legacy messages because 0 is a functional command used to **hand over control back to the local Safety Pilot**. 
* **Integrity**: The masked V2 approach is the only way to achieve truncation efficiency while maintaining the integrity of the Safety Pilot's physical authority.

### **Conclusion**
`RC_CHANNELS_OVERRIDE_V2` provides a conflict-free, 32-channel standard optimized for both low-bandwidth industrial links and high-load flight controller environments.