### PR TITLE
Improved docs of 'stream_id' fields in REQUEST_DATA_STREAM and DATA_STREAM messages

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5829,14 +5829,14 @@
       <description>Request a data stream.</description>
       <field type="uint8_t" name="target_system">The target requested to send the message stream.</field>
       <field type="uint8_t" name="target_component">The target requested to send the message stream.</field>
-      <field type="uint8_t" name="req_stream_id">The ID of the requested data stream. See MAV_DATA_STREAM enum</field>
+      <field type="uint8_t" name="req_stream_id" enum="MAV_DATA_STREAM">The ID of the requested data stream.</field>
       <field type="uint16_t" name="req_message_rate" units="Hz">The requested message rate</field>
       <field type="uint8_t" name="start_stop">1 to start sending, 0 to stop sending.</field>
     </message>
     <message id="67" name="DATA_STREAM">
       <superseded since="2015-08" replaced_by="MESSAGE_INTERVAL"/>
       <description>Data stream status information.</description>
-      <field type="uint8_t" name="stream_id">The ID of the requested data stream. See MAV_DATA_STREAM enum</field>
+      <field type="uint8_t" name="stream_id" enum="MAV_DATA_STREAM">The ID of the requested data stream.</field>
       <field type="uint16_t" name="message_rate" units="Hz">The message rate</field>
       <field type="uint8_t" name="on_off">1 stream is enabled, 0 stream is stopped.</field>
     </message>


### PR DESCRIPTION
Updated descriptions for `req_stream_id` and `stream_id` fields to reference [MAV_DATA_STREAM](https://mavlink.io/en/messages/common.html#MAV_DATA_STREAM) enum.