### PR TITLE
GLOBAL_POSITION: move message from dev to standard

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -420,39 +420,6 @@
         <description>Actuators that affect collective tilt.</description>
       </entry>
     </enum>
-    <enum name="GLOBAL_POSITION_SRC">
-      <description>Source for GLOBAL_POSITION measurement or estimate.</description>
-      <entry value="0" name="GLOBAL_POSITION_UNKNOWN">
-        <description>Source is unknown or not one of the listed types.</description>
-      </entry>
-      <entry value="1" name="GLOBAL_POSITION_GNSS">
-        <description>Global Navigation Satellite System (e.g.: GPS, Galileo, Glonass, BeiDou).</description>
-      </entry>
-      <entry value="2" name="GLOBAL_POSITION_VISION">
-        <description>Vision system (e.g.: map matching).</description>
-      </entry>
-      <entry value="3" name="GLOBAL_POSITION_PSEUDOLITES">
-        <description>Pseudo-satellite system (performs GNSS-like function, but usually with transceiver beacons).</description>
-      </entry>
-      <entry value="4" name="GLOBAL_POSITION_TRN">
-        <description>Terrain referenced navigation.</description>
-      </entry>
-      <entry value="5" name="GLOBAL_POSITION_MAGNETIC">
-        <description>Magnetic positioning.</description>
-      </entry>
-      <entry value="6" name="GLOBAL_POSITION_ESTIMATOR">
-        <description>Estimated position based on various sensors (eg. a Kalman Filter).</description>
-      </entry>
-    </enum>
-    <enum name="GLOBAL_POSITION_FLAGS" bitmask="true">
-      <description>Status flags for GLOBAL_POSITION</description>
-      <entry value="1" name="GLOBAL_POSITION_UNHEALTHY">
-        <description>Unhealthy sensor/estimator.</description>
-      </entry>
-      <entry value="2" name="GLOBAL_POSITION_PRIMARY">
-        <description>True if the data originates from or is consumed by the primary estimator.</description>
-      </entry>
-    </enum>
     <enum name="ESC_FIRMWARE">
       <description>ESC firmware type identifier.</description>
       <entry value="0" name="ESC_FIRMWARE_UNKNOWN">
@@ -470,19 +437,6 @@
     </enum>
   </enums>
   <messages>
-    <message id="296" name="GLOBAL_POSITION">
-      <description>Global position measurement or estimate.</description>
-      <field type="uint8_t" name="id" instance="true">Sensor ID</field>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source of position/estimate (such as GNSS, estimator, etc.)</field>
-      <field type="uint8_t" name="flags" enum="GLOBAL_POSITION_FLAGS">Status flags</field>
-      <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
-      <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
-      <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>
-      <field type="float" name="alt_ellipsoid" units="m" invalid="NaN">Altitude (WGS84 elipsoid)</field>
-      <field type="float" name="eph" units="m" invalid="NaN">Standard deviation of horizontal position error</field>
-      <field type="float" name="epv" units="m" invalid="NaN">Standard deviation of vertical position error</field>
-    </message>
     <message id="354" name="SET_VELOCITY_LIMITS">
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->

--- a/message_definitions/v1.0/standard.xml
+++ b/message_definitions/v1.0/standard.xml
@@ -109,6 +109,39 @@
         <description>official stable release</description>
       </entry>
     </enum>
+    <enum name="GLOBAL_POSITION_SRC">
+      <description>Source for GLOBAL_POSITION measurement or estimate.</description>
+      <entry value="0" name="GLOBAL_POSITION_UNKNOWN">
+        <description>Source is unknown or not one of the listed types.</description>
+      </entry>
+      <entry value="1" name="GLOBAL_POSITION_GNSS">
+        <description>Global Navigation Satellite System (e.g.: GPS, Galileo, Glonass, BeiDou).</description>
+      </entry>
+      <entry value="2" name="GLOBAL_POSITION_VISION">
+        <description>Vision system (e.g.: map matching).</description>
+      </entry>
+      <entry value="3" name="GLOBAL_POSITION_PSEUDOLITES">
+        <description>Pseudo-satellite system (performs GNSS-like function, but usually with transceiver beacons).</description>
+      </entry>
+      <entry value="4" name="GLOBAL_POSITION_TRN">
+        <description>Terrain referenced navigation.</description>
+      </entry>
+      <entry value="5" name="GLOBAL_POSITION_MAGNETIC">
+        <description>Magnetic positioning.</description>
+      </entry>
+      <entry value="6" name="GLOBAL_POSITION_ESTIMATOR">
+        <description>Estimated position based on various sensors (eg. a Kalman Filter).</description>
+      </entry>
+    </enum>
+    <enum name="GLOBAL_POSITION_FLAGS" bitmask="true">
+      <description>Status flags for GLOBAL_POSITION</description>
+      <entry value="1" name="GLOBAL_POSITION_UNHEALTHY">
+        <description>Unhealthy sensor/estimator.</description>
+      </entry>
+      <entry value="2" name="GLOBAL_POSITION_PRIMARY">
+        <description>True if the data originates from or is consumed by the primary estimator.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <!-- also includes minimal.xml messages -->
@@ -141,6 +174,19 @@
       <field type="uint64_t" name="uid">UID if provided by hardware (see uid2)</field>
       <extensions/>
       <field type="uint8_t[18]" name="uid2">UID if provided by hardware (supersedes the uid field. If this is non-zero, use this field, otherwise use uid)</field>
+    </message>
+    <message id="296" name="GLOBAL_POSITION">
+      <description>Global position measurement or estimate.</description>
+      <field type="uint8_t" name="id" instance="true">Sensor ID</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="source" enum="GLOBAL_POSITION_SRC">Source of position/estimate (such as GNSS, estimator, etc.)</field>
+      <field type="uint8_t" name="flags" enum="GLOBAL_POSITION_FLAGS">Status flags</field>
+      <field type="int32_t" name="lat" units="degE7" invalid="INT32_MAX">Latitude (WGS84)</field>
+      <field type="int32_t" name="lon" units="degE7" invalid="INT32_MAX">Longitude (WGS84)</field>
+      <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL - position-system specific value)</field>
+      <field type="float" name="alt_ellipsoid" units="m" invalid="NaN">Altitude (WGS84 elipsoid)</field>
+      <field type="float" name="eph" units="m" invalid="NaN">Standard deviation of horizontal position error</field>
+      <field type="float" name="epv" units="m" invalid="NaN">Standard deviation of vertical position error</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
## Description:

Move the GLOBAL_POSITION message (ID 296) and its associated enums (GLOBAL_POSITION_SRC, GLOBAL_POSITION_FLAGS) from development.xml to standard.xml. 

GLOBAL_POSITION provides a generic way to report position measurements or estimates from various sources (GNSS, vision, pseudolites, terrain-referenced navigation, etc.) with explicit source identification. This complements the existing GLOBAL_POSITION_INT by:

  - Supporting multiple concurrent position sources via the id field
  - Explicitly identifying the position source type with GLOBAL_POSITION_SRC enum                               

The message has been implemented and tested in PX4 for auxiliary global position fusion in the EKF2, enabling use cases like pseudolite-based navigation and multi-source position fusion. Related PR: https://github.com/PX4/PX4-Autopilot/pull/26307