### PR TITLE
common: add note regarding LOG_ENTRY id 0/1 base

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6393,7 +6393,7 @@
       <description>Request a list of available logs.
         On some systems calling this may stop on-board logging until LOG_REQUEST_END is called.
         If there are no log files available this request shall be answered with one LOG_ENTRY message with id = 0 and num_logs = 0.
-        LOG_ENTRY messages can start with id 1 (recommended) or 0.
+        LOG_ENTRY messages can start with id 1 or 0.
         The ground station needs to be able to process either.
       </description>
       <field type="uint8_t" name="target_system">System ID</field>


### PR DESCRIPTION
Given PX4 sends LOG_ENTRY with id starting at 0 and ArduPilot starting at id 1, the ground station will have to deal with both, 0 or 1 based indexing.

QGC already does this: https://github.com/mavlink/qgroundcontrol/blob/82ab6e3bd758e3a7c8a127b9e7badd3eb165d580/src/AnalyzeView/LogDownloadController.cc#L157-L158

MAVSDK will support this soon: https://github.com/mavlink/MAVSDK/pull/2756.