### PR TITLE
common.xml: add GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -440,6 +440,9 @@
       <entry value="8192" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RC_INPUTS">
         <description>Gimbal device supports radio control inputs as an alternative input for controlling the gimbal orientation.</description>
       </entry>
+      <entry value="16384" name="GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
+        <description>Gimbal manager supports to point to a global latitude, longitude, absolute altitude position.</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_CAP_FLAGS" bitmask="true">
       <description>Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_DEVICE_CAP_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>


### PR DESCRIPTION
Some gimbals know where they are and can point to absolute coordinates on the planet.  This capability allows a manager to know whether it is reasonable to send them messages pointing to a lat/lng/alt, or whether the manager may need to convert to some other type first (e.g. angle-to-target)


I would imagine that we may need something like `GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL_TERRAIN_ALT` if you want to point to a point on the surface of the planet, where you work that last bit out using a laser rangefinder.  For later....
