### PR TITLE
common.xml: mirror GIMBAL_DEVICE and GIMBAL_MANAGER cap flags

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -440,9 +440,15 @@
       <entry value="8192" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RC_INPUTS">
         <description>Gimbal device supports radio control inputs as an alternative input for controlling the gimbal orientation.</description>
       </entry>
+      <entry value="65536" name="GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
+        <description>Gimbal device supports to point to a local position.</description>
+      </entry>
+      <entry value="131072" name="GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
+        <description>Gimbal device supports to point to a global latitude, longitude, altitude position.</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_MANAGER_CAP_FLAGS" bitmask="true">
-      <description>Gimbal manager high level capability flags (bitmap). The first 16 bits are identical to the GIMBAL_DEVICE_CAP_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>
+      <description>Gimbal manager high level capability flags (bitmap). The flags are identical to the GIMBAL_DEVICE_CAP_FLAGS. However, the gimbal manager does not need to copy the flags from the gimbal but can also enhance the capabilities and thus add flags.</description>
       <entry value="1" name="GIMBAL_MANAGER_CAP_FLAGS_HAS_RETRACT">
         <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT.</description>
       </entry>
@@ -486,10 +492,10 @@
         <description>Based on GIMBAL_DEVICE_CAP_FLAGS_HAS_RC_INPUTS.</description>
       </entry>
       <entry value="65536" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL">
-        <description>Gimbal manager supports to point to a local position.</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_LOCAL.</description>
       </entry>
       <entry value="131072" name="GIMBAL_MANAGER_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
-        <description>Gimbal manager supports to point to a global latitude, longitude, altitude position.</description>
+        <description>Based on GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL.</description>
       </entry>
     </enum>
     <enum name="GIMBAL_DEVICE_FLAGS" bitmask="true">
@@ -7336,6 +7342,7 @@
       <field type="float" name="yaw_max" units="rad" invalid="NaN">Maximum hardware yaw angle (positive: to the right, negative: to the left). NAN if unknown.</field>
       <extensions/>
       <field type="uint8_t" name="gimbal_device_id" invalid="0">This field is to be used if the gimbal manager and the gimbal device are the same component and hence have the same component ID. This field is then set to a number between 1-6. If the component ID is separate, this field is not required and must be set to 0.</field>
+      <field type="uint32_t" name="cap_flags2" enum="GIMBAL_DEVICE_CAP_FLAGS" invalid="0">Extended bitmap of gimbal capability flags (32 bit). For backwards compatibility, the lower 16 bits should also be set in cap_flags. Ground stations should prefer this field if non-zero.</field>
     </message>
     <message id="284" name="GIMBAL_DEVICE_SET_ATTITUDE">
       <description>Low level message to control a gimbal device's attitude.


### PR DESCRIPTION
This is an attempt to fix the gimbal device vs. manager flags.

Instead of capping the device flags at 16 bits, we add an extension for 32 bits, and we copy any manager flags across.

For backwards compatibility, a gimbal device needs to set the 16 lower bits as well as the new 32 bits.

A ground station or gimbal manager can tell whether a gimbal device supports the new 32 bit flag if it is non-zero.

Related to https://github.com/mavlink/mavlink/pull/2411.

---

EDIT: HamishW, for context.

The original mechanism defined a 16 bit field for device flags with `GIMBAL_DEVICE_CAP_FLAGS` and a 32 bit field `GIMBAL_MANAGER_CAP_FLAGS`. AFAIK Because a manager has all the abilities of a device the GIMBAL_DEVICE_CAP_FLAGS were duplicated in the lower 16 bits of GIMBAL_MANAGER_CAP_FLAGS. The theory being that you could add more manager flags in the unused upper range.

The update in #2411 was going to add `GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL` , but the feature was already a gimbal manager flag in the gimbal manager bit range -  it was impossible to follow the existing pattern and add a matching gimbal device cap without breaking something.

The solution here is to allow gimbal device to now take a 32 bit enum, which means that GIMBAL_DEVICE_CAP_FLAGS can now be updated to match the existing GIMBAL_MANAGER_CAP_FLAGS layout.

Note, of course at this point we should question why we need two enums for the same values-  and indeed we always should have. 