### PR TITLE
common.xml: tweak MAV_CMD_GET_HOME_POSITION description

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2028,7 +2028,7 @@
       <entry value="410" name="MAV_CMD_GET_HOME_POSITION" hasLocation="false" isDestination="false">
         <superseded since="2022-04" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
         <description>Request the home position from the vehicle.
-          The vehicle will ACK the command and then emit the HOME_POSITION message.</description>
+          The vehicle will ACK the command and emit the HOME_POSITION message.</description>
         <param index="1">Reserved</param>
         <param index="2">Reserved</param>
         <param index="3">Reserved</param>


### PR DESCRIPTION
order is not important and AP doesn't necessarily follow this.
