### PR TITLE
common.xml: adjust description of MAV_CMD_DO_FLIGHTTERMINATION to loosen constraints

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1542,9 +1542,9 @@
       </entry>
       <entry value="185" name="MAV_CMD_DO_FLIGHTTERMINATION" hasLocation="false" isDestination="false">
         <description>Terminate flight immediately.
-          Flight termination immediately and irreversibly terminates the current flight, returning the vehicle to ground.
-          The vehicle will ignore RC or other input until it has been power-cycled.
-          Termination may trigger safety measures, including: disabling motors and deployment of parachute on multicopters, and setting flight surfaces to initiate a landing pattern on fixed-wing).
+          Flight termination immediately terminates the current flight, returning airbound vehicles to the ground.
+          The vehicle will often ignore RC or other input until it has been power-cycled.
+          Termination may trigger safety measures, including: disabling motors and deployment of parachute on multicopters, and setting flight surfaces to initiate a crash landing on fixed-wing).
           On multicopters without a parachute it may trigger a crash landing.
           Support for this command can be tested using the protocol bit: MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION.
           Support for this command can also be tested by sending the command with param1=0 (&lt; 0.5); the ACK should be either MAV_RESULT_FAILED or MAV_RESULT_UNSUPPORTED.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1543,7 +1543,7 @@
       <entry value="185" name="MAV_CMD_DO_FLIGHTTERMINATION" hasLocation="false" isDestination="false">
         <description>Terminate flight immediately.
           Flight termination immediately terminates the current flight, returning airbound vehicles to the ground.
-          The vehicle will often ignore RC or other input until it has been power-cycled.
+          The vehicle should ignore RC or other input until it has been power-cycled.
           Termination may trigger safety measures, including: disabling motors and deployment of parachute on multicopters, and setting flight surfaces to initiate a crash landing on fixed-wing).
           On multicopters without a parachute it may trigger a crash landing.
           Support for this command can be tested using the protocol bit: MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1552,8 +1552,8 @@
       </entry>
       <entry value="185" name="MAV_CMD_DO_FLIGHTTERMINATION" hasLocation="false" isDestination="false">
         <description>Terminate flight immediately.
-          Flight termination immediately and irreversibly terminates the current flight, returning the vehicle to ground.
-          The vehicle will ignore RC or other input until it has been power-cycled.
+          Flight termination immediately and irreversibly terminates the current flight, returning the vehicle to ground.  (n.b. ArduPilot allows several actions to be reversed).
+          The vehicle will ignore RC or other input until it has been power-cycled (n.b. ArduPilot permits RC and other input).
           Termination may trigger safety measures, including: disabling motors and deployment of parachute on multicopters, and setting flight surfaces to initiate a landing pattern on fixed-wing).
           On multicopters without a parachute it may trigger a crash landing.
           Support for this command can be tested using the protocol bit: MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION.


### PR DESCRIPTION

ArduPilot is not compliant with these improved words, and the additional functionality can be useful.


These words were changed in https://github.com/mavlink/mavlink/pull/1774 .

At that time ArduPilot supported terminating a quadplane flight using QLAND rather than aerodynamically terminating the vehicle (since 2019 in fact).

The referenced PR links to ArduPilot's Wiki:
```
We should define what flight termination means:

    ArduPlane https://ardupilot.org/plane/docs/advanced-failsafe-configuration.html#afs-termination
```
since 2019 that Wiki has also mentioned the fact that you can terminate a quadplane via QLAND rather than just smashing the thing into the ground (i.e. the information on our Wiki wasn't accurately parsed to make its way into this command description).
