### PR TITLE
common.xml: strip degE7 from MAV_CMD_DO_SET_ROI

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1626,8 +1626,8 @@
         <param index="2">Empty</param>
         <param index="3">Empty</param>
         <param index="4">Empty</param>
-        <param index="5" label="Latitude" units="degE7">Latitude of ROI location</param>
-        <param index="6" label="Longitude" units="degE7">Longitude of ROI location</param>
+        <param index="5" label="Latitude">Latitude of ROI location</param>
+        <param index="6" label="Longitude">Longitude of ROI location</param>
         <param index="7" label="Altitude" units="m">Altitude of ROI location</param>
       </entry>
       <entry value="196" name="MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET" hasLocation="false" isDestination="false">


### PR DESCRIPTION
it's not transported as degE7 when using COMMAND_LONG

I've checked ArduPilot and looked at PX4-AutoPilot - I think https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/mavlink/mavlink_mission.cpp#L1411 shows this is interpeted as any other location-bearing item in a mission.   PX4 doesn't seem to process this command as an immediate-from-GCS command AFAICS?!
