### PR TITLE
minimal.xml(MAV_TYPE): Add MAV_TYPE_RANGING_BEACON wip

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -221,6 +221,11 @@
       <entry value="49" name="MAV_TYPE_RADIO">
         <description>Radio</description>
       </entry>
+      <entry value="50" name="MAV_TYPE_RANGING_BEACON">
+        <wip/>
+        <!-- This value is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Ranging beacon (emits RANGING_BEACON)</description>
+      </entry>
     </enum>
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode, see MAV_MODE enum for useful combinations.</description>


### PR DESCRIPTION
Added work-in-progress entry for MAV_TYPE_RANGING_BEACON.

This depends on https://github.com/mavlink/mavlink/pull/2426 , and specifically https://github.com/mavlink/mavlink/pull/2426/changes/b4ca3cbd8849950b89453f7184bb30fa17b52338..3c3b58d3c7606299a40fbbc312616d3efd9fe5cb#r2957511002

Let's wait for it to move to common, since an independent type isn't needed by the proposed implementation.