### PR TITLE
parameter.schema.json: Add readOnly property and make type optional

### DIFF
--- a/component_metadata/parameter.schema.json
+++ b/component_metadata/parameter.schema.json
@@ -8,7 +8,7 @@
         "version": {
             "description":  "Version number for the format of this file.",
             "type":         "integer",
-            "minimum":      2
+            "minimum":      3
         },
         "translation": {
             "type": "object",

--- a/component_metadata/parameter.schema.json
+++ b/component_metadata/parameter.schema.json
@@ -122,9 +122,14 @@
                                 }
                             }
                         }
+                    },
+                    "readOnly": {
+                        "description":  "true: value is read only and should not be changed by user.",
+                        "type":         "boolean",
+                        "default":      false
                     }
                 },
-                "required":             [ "name", "type" ],
+                "required":             [ "name" ],
                 "additionalProperties": false
             }
         }


### PR DESCRIPTION
## Changes

- **Add `readOnly` boolean property** to the parameter metadata schema. When `true`, indicates the parameter value is read only and should not be changed by the user. Defaults to `false`.
- **Make `type` field optional**. The parameter type can be determined at runtime from the `PARAM_VALUE` message, so it no longer needs to be required in the schema.

## Related

- ArduPilot support: https://github.com/ArduPilot/ardupilot/pull/32599