### PR TITLE
common.xml: change NAV_VTOL_LAND_OPTIONS enumeration values

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4887,13 +4887,11 @@
       <entry value="0" name="NAV_VTOL_LAND_OPTIONS_DEFAULT">
         <description>Default autopilot landing behaviour.</description>
       </entry>
-      <entry value="1" name="NAV_VTOL_LAND_OPTIONS_FW_DESCENT">
-        <description>Descend in fixed wing mode, transitioning to multicopter mode for vertical landing when close to the ground.
-          The fixed wing descent pattern is at the discretion of the vehicle (e.g. transition altitude, loiter direction, radius, and speed, etc.).
-        </description>
+      <entry value="1" name="NAV_VTOL_LAND_OPTIONS_FW_SPIRAL_APPROACH">
+        <description>Use a fixed wing spiral desent approach before landing.</description>
       </entry>
-      <entry value="2" name="NAV_VTOL_LAND_OPTIONS_HOVER_DESCENT">
-        <description>Land in multicopter mode on reaching the landing coordinates (the whole landing is by "hover descent").</description>
+      <entry value="2" name="NAV_VTOL_LAND_OPTIONS_FW_APPROACH">
+        <description>Use a fixed wing approach before detransitioning and landing vertically.</description>
       </entry>
     </enum>
     <enum name="MAV_WINCH_STATUS_FLAG" bitmask="true">


### PR DESCRIPTION
~Please do not merge until discussed at ArduPilot DevCall.~  We've approved at our DevCall.

I believe we just completely screwed up our synchronisation with mavlink/mavlink/master (patches were merged there, then modified before merging into ardupilot/mavlink/master.

ArduPilot obviously uses the values being merged in here.

I haven't found any other project using values from this enumeration (QGC, PX4-AutoPilot, MissionPlanner, betaflight, Paparazzi)
