### PR TITLE
common: set COMMAND_ACK.result_param2 for MAV_CMD_REQUEST_MESSAGE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2115,7 +2115,7 @@
       </entry>
       <entry value="512" name="MAV_CMD_REQUEST_MESSAGE" hasLocation="false" isDestination="false">
         <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).
-          The COMMAND_ACK.result_param2 field must be set to the message ID (param1) of the requested message when acknowledging this command.
+          The COMMAND_ACK.result_param2 field should be set to the message ID (param1) of the requested message when acknowledging this command.
         </description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID of the requested message.</param>
         <param index="2" label="Req Param 1">Use for index ID, if required. Otherwise, the use of this parameter (if any) must be defined in the requested message. By default assumed not used (0).</param>
@@ -6032,7 +6032,11 @@
       <field type="uint8_t" name="result" enum="MAV_RESULT">Result of command.</field>
       <extensions/>
       <field type="uint8_t" name="progress" invalid="UINT8_MAX" units="%">The progress percentage when result is MAV_RESULT_IN_PROGRESS. Values: [0-100], or UINT8_MAX if the progress is unknown.</field>
-      <field type="int32_t" name="result_param2">Additional result information. Can be set with a command-specific denial-reason enum or an identifying parameter echoed back on success. If used, semantics must be documented in the corresponding MAV_CMD (enums should have a 0 value for "unused" or "unknown").</field>
+      <field type="int32_t" name="result_param2">Additional result information.
+        This may be set with a command-specific result information on either denial or success, such as an enum of failure reasons or an identifying parameter echoed back on success.
+        If used, semantics must be documented in the corresponding MAV_CMD.
+        0 must be set if the value is unused.
+      </field>
       <field type="uint8_t" name="target_system">System ID of the target recipient. This is the ID of the system that sent the command for which this COMMAND_ACK is an acknowledgement.</field>
       <field type="uint8_t" name="target_component">Component ID of the target recipient. This is the ID of the system that sent the command for which this COMMAND_ACK is an acknowledgement.</field>
     </message>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2114,7 +2114,9 @@
         <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address of message stream (if message has target address fields). 0: Flight-stack default (recommended), 1: address of requester, 2: broadcast.</param>
       </entry>
       <entry value="512" name="MAV_CMD_REQUEST_MESSAGE" hasLocation="false" isDestination="false">
-        <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).</description>
+        <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).
+          The COMMAND_ACK.result_param2 field must be set to the message ID (param1) of the requested message when acknowledging this command.
+        </description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID of the requested message.</param>
         <param index="2" label="Req Param 1">Use for index ID, if required. Otherwise, the use of this parameter (if any) must be defined in the requested message. By default assumed not used (0).</param>
         <param index="3" label="Req Param 2">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
@@ -6030,7 +6032,7 @@
       <field type="uint8_t" name="result" enum="MAV_RESULT">Result of command.</field>
       <extensions/>
       <field type="uint8_t" name="progress" invalid="UINT8_MAX" units="%">The progress percentage when result is MAV_RESULT_IN_PROGRESS. Values: [0-100], or UINT8_MAX if the progress is unknown.</field>
-      <field type="int32_t" name="result_param2">Additional result information. Can be set with a command-specific enum containing command-specific error reasons for why the command might be denied. If used, the associated enum must be documented in the corresponding MAV_CMD (this enum should have a 0 value to indicate "unused" or "unknown").</field>
+      <field type="int32_t" name="result_param2">Additional result information. Can be set with a command-specific denial-reason enum or an identifying parameter echoed back on success. If used, semantics must be documented in the corresponding MAV_CMD (enums should have a 0 value for "unused" or "unknown").</field>
       <field type="uint8_t" name="target_system">System ID of the target recipient. This is the ID of the system that sent the command for which this COMMAND_ACK is an acknowledgement.</field>
       <field type="uint8_t" name="target_component">Component ID of the target recipient. This is the ID of the system that sent the command for which this COMMAND_ACK is an acknowledgement.</field>
     </message>


### PR DESCRIPTION
## The problem
When a GCS sends `MAV_CMD_REQUEST_MESSAGE`, the resulting `COMMAND_ACK` identifies that command 512 was acknowledged, but carries no information about **_which_** message was requested (i.e. `param1` of the original command). 

This forces GCS implementations to work sequentially — always waiting for an ack before issuing the next request — since there is no way to correlate an ack back to a specific in-flight request.

## The proposal
This PR documents that implementations must set `COMMAND_ACK.result_param2` to the requested message ID (`param1`) when acknowledging `MAV_CMD_REQUEST_MESSAGE`. This allows implementations to issue parallel requests and unambiguously correlate each ack to its originating request.

Changes:
- `MAV_CMD_REQUEST_MESSAGE`: document the `result_param2` requirement in the command description
- `COMMAND_ACK.result_param2`: broaden the field description to cover echoing identifying context on success, not just denial reasons


## Backwards compatibility

`result_param2` is currently unused (0) for this command, so existing implementations that ignore it are unaffected.
Only implementations that opt in to reading this field gain the parallelism benefit.

## Prior art

`MAV_CMD_ARM_AUTHORIZATION_REQUEST` is an existing example of `result_param2` being populated in the ack (with `MAV_ARM_AUTH_DENIED_REASON`). Camera messages as well ([link](https://mavlink.io/en/services/camera.html#camera-addressing-in-commands)).