### PR TITLE
Remove WIP from MAV_CMD_DO_RETURN_PATH_START (188)

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1588,8 +1588,6 @@
         <param index="7" label="Index" minValue="0" increment="1">Index of actuator set (i.e if set to 1, Actuator 1 becomes Actuator 7)</param>
       </entry>
       <entry value="188" name="MAV_CMD_DO_RETURN_PATH_START" hasLocation="true" isDestination="false">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Mission item to specify the start of a failsafe/landing return-path segment (the end of the segment is the next MAV_CMD_DO_LAND_START item).
           A vehicle that is using missions for landing (e.g. in a return mode) will join the mission on the closest path of the return-path segment (instead of MAV_CMD_DO_LAND_START or the nearest waypoint).
           The main use case is to minimize the failsafe flight path in corridor missions, where the inbound/outbound paths are constrained (by geofences) to the same particular path.


### PR DESCRIPTION
I am **not sure** if this is desired or not. If it should stay WIP, let's just close the PR.

Someone flagged that this is (currently) WIP on mavlink, but [seems supported by ArduPlane](https://ardupilot.org/plane/docs/common-do-return-path-start.html). Should the WIP be removed?