### PR TITLE
docs: add Ubuntu 24.04 LTS to supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MAVLink is a very lightweight, header-only message library for communication bet
 
 ### Generate C headers
 
-To install the minimal MAVLink environment on Ubuntu LTS 20.04 or 22.04, enter the following on a terminal:
+To install the minimal MAVLink environment on Ubuntu LTS 20.04, 22.04, or 24.04, enter the following on a terminal:
 
 ```bash
 # Dependencies


### PR DESCRIPTION
Ubuntu 24.04 LTS (Noble) was released in April 2024 and is now widely used.
Added it to the supported platforms list in the Quick Start section.