### PR TITLE
development.xml: GPS:Add granular noise and jamming fields

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -589,6 +589,8 @@
       <field type="uint8_t" name="system_status_summary" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the overall status of the receiver, or 255 if not available.</field>
       <field type="uint8_t" name="gnss_signal_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the quality of incoming GNSS signals, or 255 if not available.</field>
       <field type="uint8_t" name="post_processing_quality" minValue="0" maxValue="10" invalid="UINT8_MAX">An abstract value representing the estimated PPK quality, or 255 if not available.</field>
+      <field type="uint8_t" name="noise_quantity" minValue="0" maxValue="100" invalid="UINT8_MAX">Internal noise floor / RF chain noise level. Higher = worse (more noise), or 255 if not available.</field>
+      <field type="uint8_t" name="jamming_quantity" minValue="0" maxValue="100" invalid="UINT8_MAX">Amount of jamming detected. Higher = worse (more jamming), or 255 if not available.</field>
     </message>
     <!-- Target info from a sensor on the target -->
     <message id="510" name="TARGET_ABSOLUTE">


### PR DESCRIPTION
# Motivation
Allow operators to more granularly monitor how much GPS noise/jamming there is. Currently the `GNSS_INTEGRITY` message reports `jamming_state`, but this is a highly abstracted value reporting `OK`, `MITIGATED`, or `DETECTED`. The new fields `noise_quantity` and `jamming_quantity` will allow operators to get more immediate feedback on how changes in environment affect the noise/jamming of the GPS.

For PX4, the intent is that these fields will be populated using the `noise_per_ms` and `jamming_indicator` properties reported by the GPS driver