### PR TITLE
Common: mav-cmd-nav-land alt clarification for multicopters

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1186,7 +1186,7 @@
         <param index="4" label="Yaw Angle" units="deg">Desired yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.).</param>
         <param index="5" label="Latitude">Latitude.</param>
         <param index="6" label="Longitude">Longitude.</param>
-        <param index="7" label="Altitude" units="m">Landing altitude (ground level in current frame).</param>
+        <param index="7" label="Altitude" units="m">Landing altitude (ground level in current frame) for forward-only moving vehicles.  Altitude from where to begin vertical descent for multicopters (if zero use current altitude)</param>
       </entry>
       <entry value="22" name="MAV_CMD_NAV_TAKEOFF" hasLocation="true" isDestination="true">
         <description>Takeoff from ground / hand. Vehicles that support multiple takeoff modes (e.g. VTOL quadplane) should take off using the currently configured mode.</description>


### PR DESCRIPTION
This updates the MAV_CMD_NAV_LAND command's Altitude field description so that it (the Altitude field) can be used for multicopters.  At the moment in both ArduPilot (and other multicopter flight stacks), this field is completely unused.

Putting aside the exact wording I've chosen for the moment, the intent is that the altitude be interpreted as the altitude above the lat, lon point from which the vehicle descends vertically.

If the altitude is left as zero then we interpret it as the current altitude.  This is important because it maintains the current behaviour for existing missions.

<img width="528" height="521" alt="image" src="https://github.com/user-attachments/assets/d1aa1e79-dbba-43f3-9cf5-f01618316e8c" />

The benefit of this change is that users could use the Land command's Alt field in the same way that it is used for regular waypoints.  Users could specify the lat, lon **and altitude** and the vehicle would fly to this location and then begin its vertical descent.  I think this is quite a natural intuitive interpretation of the field for multicopters and traditional helicopters.

BTW in ArduPilot (and perhaps other flight stacks) if users specify a lat, lon in the LAND command, the vehicle flies at its current altitude to that point and then begins descending vertically.

To achieve the same thing as what this change allows (e.g. for the vehicle to fly diagonally towards a point at a specified altitude above the landing target) users most often place a WAYPOINT command immediately before the LAND command and then leave the LAND's lat, lon and alt as zero.  This is fine but making the alt field usable would allow them to achieve the same thing without adding another waypoint.

Here's the ArduPilot flight code PR that takes advantage of this change: https://github.com/ArduPilot/ardupilot/pull/32634