### PR TITLE
fix(development): BATTERY_STATUS_V2 proposed changes

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -107,6 +107,15 @@
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>
       </entry>
+      <entry value="524288" name="MAV_BATTERY_STATUS_FLAGS_CHARGE_STATE_LOW">
+        <description>Battery state is low, warn and monitor close</description>
+      </entry>
+      <entry value="1048576" name="MAV_BATTERY_STATUS_FLAGS_CHARGE_STATE_CRITICAL">
+        <description>Battery state is critical, return / abort immediately</description>
+      </entry>
+      <entry value="2097152" name="MAV_BATTERY_STATUS_FLAGS_CHARGE_STATE_EMERGENCY">
+        <description>Battery state is too low for ordinary abortion, fastest possible emergency stop preventing damage</description>
+      </entry>
       <entry value="2147483648" name="MAV_BATTERY_STATUS_FLAGS_EXTENDED">
         <description>Reserved (not used). If set, this will indicate that an additional status field exists for higher status values.</description>
       </entry>


### PR DESCRIPTION
This proposes updates for discussion in BATTERY_STATUS_V2 following review of first implementation by @MaEtUgR in https://github.com/PX4/PX4-Autopilot/pull/25347#pullrequestreview-4201536836

- Do we need critical/emergency/warning status flags.

See comments inline for discussion start points. There are no live implementations so we can still udpate if we want.

@peterbarker @auturgy Can you suggest who in ArduPilot might like to comment. FWIW I tend to think if SoC is a standard term we should use it. Rest need more discussion. 

> [!NOTE]
> The action "Propose replace percent_remaining with industry standard SoC" was agreed and merged in https://github.com/mavlink/mavlink/pull/2503