### PR TITLE
docs(tools): doc generator improve text for instance fields

### DIFF
--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -741,7 +741,7 @@ class MAVMessage:
                 else ""
             )
             instanceText = (
-                "<br>Messages with same value are from the same source (instance)."
+                "<br>[Instance field]: Uniquely identifies a device/subcomponent within a single source/target MAVLink component."
                 if field.instance
                 else ""
             )


### PR DESCRIPTION
The text assume instance fields were for emitted messages only. There are some incoming commands. The next works either direction.