### PR TITLE
common: add GLOBAL_POSITION_SRC_LEO to GLOBAL_POSITION_SRC enum

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5382,6 +5382,9 @@
       <entry value="6" name="GLOBAL_POSITION_SRC_ESTIMATOR">
         <description>Estimated position based on various sensors (eg. a Kalman Filter).</description>
       </entry>
+      <entry value="7" name="GLOBAL_POSITION_SRC_LEO">
+        <description>Low Earth Orbit satellite-based positioning (e.g.: Starlink, Xona PULSAR).</description>
+      </entry>
     </enum>
     <enum name="GLOBAL_POSITION_FLAGS" bitmask="true">
       <description>Status flags for GLOBAL_POSITION</description>


### PR DESCRIPTION
### Summary
Adds `GLOBAL_POSITION_SRC_LEO` (value 7) to the `GLOBAL_POSITION_SRC` enum to identify Low Earth Orbit satellite-based positioning systems (e.g. Starlink, Xona PULSAR).

LEO-satellites don't fit cleanly into existing source values:
- `PSEUDOLITES` are ground-based GNSS-like transmitters by definition.
- `GNSS` hides real differences between MEO GNSS and LEO

Enum is appended, format unchanged (`GLOBAL_POSITION.source` remains `uint8_t`).