### PR TITLE
development: extend ACTUATOR_TEST_GROUP with thrust actuators

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -419,6 +419,15 @@
       <entry value="3" name="ACTUATOR_TEST_GROUP_COLLECTIVE_TILT">
         <description>Actuators that affect collective tilt.</description>
       </entry>
+      <entry value="4" name="ACTUATOR_TEST_GROUP_X_THRUST">
+        <description>Actuators that contribute to x (longitudinal, positive = forward) thrust.</description>
+      </entry>
+      <entry value="5" name="ACTUATOR_TEST_GROUP_Y_THRUST">
+        <description>Actuators that contribute to y (lateral, positive = right) thrust.</description>
+      </entry>
+      <entry value="6" name="ACTUATOR_TEST_GROUP_Z_THRUST">
+        <description>Actuators that contribute to z (vertical, positive = down) thrust.</description>
+      </entry>
     </enum>
     <enum name="ESC_FIRMWARE">
       <description>ESC firmware type identifier.</description>


### PR DESCRIPTION
The command `MAV_CMD_ACTUATOR_GROUP_TEST` was initially [introduced](https://github.com/mavlink/mavlink/pull/2224) in the context of a pure control surface preflight check (which ended up never being merged...)

We are now planning to generalise that to an actuator group test, as already provisioned for by the naming. For that I propose adding the three thrust axes as actuator test groups, just like the existing ones. 