### PR TITLE
common: rename/add MAG_CAL_STATUS failure enums to FAILED_* + RESIDUALS_HIGH

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4993,8 +4993,21 @@
       <entry value="3" name="MAG_CAL_RUNNING_STEP_TWO"/>
       <entry value="4" name="MAG_CAL_SUCCESS"/>
       <entry value="5" name="MAG_CAL_FAILED"/>
-      <entry value="6" name="MAG_CAL_BAD_ORIENTATION"/>
-      <entry value="7" name="MAG_CAL_BAD_RADIUS"/>
+      <entry value="6" name="MAG_CAL_FAILED_ORIENTATION">
+        <description>Compass calibration failed: the vehicle orientation is outside the required tolerance.</description>
+      </entry>
+      <entry value="7" name="MAG_CAL_FAILED_RADIUS">
+        <description>Compass calibration failed: the radius of the fitted sphere is unrealistically small or large.</description>
+      </entry>
+      <entry value="8" name="MAG_CAL_FAILED_OFFSETS">
+        <description>Compass calibration failed: offset magnitude too large.</description>
+      </entry>
+      <entry value="9" name="MAG_CAL_FAILED_DIAG_SCALING">
+        <description>Compass calibration failed: diagonal or off-diagonal scaling values out of valid range.</description>
+      </entry>
+      <entry value="10" name="MAG_CAL_FAILED_RESIDUALS_HIGH">
+        <description>Compass calibration failed: fitness (RMS residual) exceeds tolerance.</description>
+      </entry>
     </enum>
     <enum name="MAV_EVENT_ERROR_REASON">
       <description>Reason for an event error response.</description>


### PR DESCRIPTION
## Summary
This PR updates `MAG_CAL_STATUS` failure reason enum names and descriptions for clearer semantics and consistency.

## Final enum names in this PR
- `6`: `MAG_CAL_FAILED_ORIENTATION`
- `7`: `MAG_CAL_FAILED_RADIUS`
- `8`: `MAG_CAL_FAILED_OFFSETS`
- `9`: `MAG_CAL_FAILED_DIAG_SCALING`
- `10`: `MAG_CAL_FAILED_RESIDUALS_HIGH`

## Why
ArduPilot reports these specific failure causes during compass calibration. Without explicit MAVLink enum entries, GCS tools can show raw integers instead of meaningful labels.

## Notes
- Names were revised based on review feedback to use the `FAILED_` pattern and clearer wording.
- This includes renaming existing identifiers (`6` and `7`), which can cause compile-time breakage for consumers using old enum names.

## Verification
```bash
python3 -c "import xml.etree.ElementTree as ET; ET.parse('message_definitions/v1.0/common.xml'); print('OK')"
```

## Related
- ArduPilot/ardupilot#32757
