### PR TITLE
development: remove disarmed requirement in MAV_CMD_ACTUATOR_GROUP_TEST

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -122,7 +122,6 @@
           This might include groups such as the actuators that contribute to roll, pitch, or yaw torque, actuators that contribute to thrust in x, y, z axis, tilt mechanisms, flaps and spoilers, and so on.
           This is similar to MAV_CMD_ACTUATOR_TEST, except that multiple actuators may be affected.
           Different groups may also affect the same actuators (as in the case of controls that affect torque in different axes).
-          Autopilots must NACK this command with MAV_RESULT_TEMPORARILY_REJECTED while armed.
         </description>
         <param index="1" label="Group" enum="ACTUATOR_TEST_GROUP">Actuator group to check, such as actuators related to roll torque.</param>
         <param index="2" label="Value" minValue="-1" maxValue="1">Value to set. This is a normalized value across the full range of the tested group [-1,1].</param>


### PR DESCRIPTION
Precise definition of armed states and proper safety considerations are the responsibility of autopilots, not the mavlink specification. 