### PR TITLE
development: add MAV_CMD_DO_CHANGE_COURSE command

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -217,12 +217,6 @@
           The vehicle maintains its current altitude and airspeed while turning to the new ground track bearing.
         </description>
         <param index="1" label="Course" units="deg" minValue="0" maxValue="360" invalid="NaN">Course bearing (0=North, clockwise). NaN = no change.</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
       </entry>
       <entry value="620" name="MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE" hasLocation="false" isDestination="false">
         <description>Set an external estimate of vehicle attitude.

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -216,7 +216,7 @@
         <description>Change the course setpoint.
           The vehicle maintains its current altitude and airspeed while turning to the new ground track bearing.
         </description>
-        <param index="1" label="Course" units="deg" minValue="0" maxValue="360" invalid="NaN">Course bearing (0=North, clockwise). NaN = no change.</param>
+        <param index="1" label="Course" units="deg" minValue="0" maxValue="360">Course bearing (0=North, clockwise). NaN = no change.</param>
       </entry>
       <entry value="620" name="MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE" hasLocation="false" isDestination="false">
         <description>Set an external estimate of vehicle attitude.

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -212,6 +212,18 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
+      <entry value="43007" name="MAV_CMD_DO_CHANGE_COURSE" hasLocation="false" isDestination="false">
+        <description>Change the course setpoint.
+          The vehicle maintains its current altitude and airspeed while turning to the new ground track bearing.
+        </description>
+        <param index="1" label="Course" units="deg" minValue="0" maxValue="360" invalid="NaN">Course bearing (0=North, clockwise). NaN = no change.</param>
+        <param index="2">Empty</param>
+        <param index="3">Empty</param>
+        <param index="4">Empty</param>
+        <param index="5">Empty</param>
+        <param index="6">Empty</param>
+        <param index="7">Empty</param>
+      </entry>
       <entry value="620" name="MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE" hasLocation="false" isDestination="false">
         <description>Set an external estimate of vehicle attitude.
           This might be used to provide an initial attitude (especially heading) estimate to the estimator (EKF). Angles are defined in a 3-2-1 (yaw-pitch-roll) intrinsic Tait-Bryan sequence.


### PR DESCRIPTION
### Summary

Adds `MAV_CMD_DO_CHANGE_COURSE` command to development. To be used similarly to `MAV_CMD_DO_CHANGE_ALTITUDE` and `MAV_CMD_DO_CHANGE_SPEED`. 

### Context 

- PX4 implementation: https://github.com/PX4/PX4-Autopilot/pull/27156