### PR TITLE
feat(common): Add WHEP to VIDEO_STREAM_TYPE enum

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3909,6 +3909,9 @@
       <entry value="3" name="VIDEO_STREAM_TYPE_MPEG_TS">
         <description>Stream is MPEG TS (URI gives the port number)</description>
       </entry>
+      <entry value="4" name="VIDEO_STREAM_TYPE_WHEP">
+        <description>Stream is WHEP (WebRTC-HTTP Egress Protocol)</description>
+      </entry>
     </enum>
     <enum name="VIDEO_STREAM_ENCODING">
       <description>Video stream encodings</description>


### PR DESCRIPTION
WHEP is a WebRTC extension that allows to read streams by using a URL, without passing through a web page. This allows to use WebRTC as a general purpose streaming protocol.

Unlike RTSP, WHEP benefits from WebRTC's built-in adaptive bitrate and congestion control, making it significantly more resilient on poor or unstable network connections.