### PR TITLE
Allow identifying Illuminators with IDs

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2074,7 +2074,7 @@
       <entry value="405" name="MAV_CMD_ILLUMINATOR_ON_OFF" hasLocation="false" isDestination="false">
         <description>Turns illuminators ON/OFF. An illuminator is a light source that is used for lighting up dark areas external to the system: e.g. a torch or searchlight (as opposed to a light source for illuminating the system itself, e.g. an indicator light).</description>
         <param index="1" label="Enable" enum="MAV_BOOL">Illuminators on/off (MAV_BOOL_TRUE: illuminators on). Values not equal to 0 or 1 are invalid.</param>
-        <param index="2" label="ID" minValue="0" maxValue="255"  increment="1">
+        <param index="2" label="ID" minValue="0" maxValue="255" increment="1">
             Target illuminator ID. 
 
             When the MAV_CMD is used in a mission this param specifies the target illuminator.
@@ -2089,7 +2089,7 @@
         <param index="2" label="Brightness" units="%" minValue="0" maxValue="100">0%: Off, 100%: Max Brightness</param>
         <param index="3" label="Strobe Period" units="s" minValue="0">Strobe period in seconds where 0 means strobing is not used</param>
         <param index="4" label="Strobe Duty" units="%" minValue="0" maxValue="100">Strobe duty cycle where 100% means it is on constantly and 0 means strobing is not used</param>
-        <param index="5" label="ID" minValue="0" maxValue="255"  increment="1">
+        <param index="5" label="ID" minValue="0" maxValue="255" increment="1">
             Target illuminator ID. 
 
             When the MAV_CMD is used in a mission this param specifies the target illuminator.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2074,11 +2074,13 @@
       <entry value="405" name="MAV_CMD_ILLUMINATOR_ON_OFF" hasLocation="false" isDestination="false">
         <description>Turns illuminators ON/OFF. An illuminator is a light source that is used for lighting up dark areas external to the system: e.g. a torch or searchlight (as opposed to a light source for illuminating the system itself, e.g. an indicator light).</description>
         <param index="1" label="Enable" enum="MAV_BOOL">Illuminators on/off (MAV_BOOL_TRUE: illuminators on). Values not equal to 0 or 1 are invalid.</param>
-        <param index="2" label="ID" minValue="0" maxValue="255">
-            Optional ID of the illuminator to configure.
-            Used to handle multiple illuminators within the same System Component.
-            0/NaN/INT32_MAX = all illuminators.
-            Values 1-63 indicate an instance ID to configure
+        <param index="2" label="ID" minValue="0" maxValue="255"  increment="1">
+            Target illuminator ID. 
+
+            When the MAV_CMD is used in a mission this param specifies the target illuminator.
+            This will either be the id of an autopilot-connected illuminator (1-6), the component ID of a MAVLink illuminator (7-255), or 0 to target the autopilot's default illuminator(s).
+            
+            When used in a command sent to the autopilot, this field can specify the id of an autopilot-connected device (1-6). Otherwise it should be set to 0.
         </param>
       </entry>
       <entry value="406" name="MAV_CMD_DO_ILLUMINATOR_CONFIGURE" hasLocation="false" isDestination="false">
@@ -2087,11 +2089,13 @@
         <param index="2" label="Brightness" units="%" minValue="0" maxValue="100">0%: Off, 100%: Max Brightness</param>
         <param index="3" label="Strobe Period" units="s" minValue="0">Strobe period in seconds where 0 means strobing is not used</param>
         <param index="4" label="Strobe Duty" units="%" minValue="0" maxValue="100">Strobe duty cycle where 100% means it is on constantly and 0 means strobing is not used</param>
-        <param index="5" label="ID" minValue="0" maxValue="255">
-            Optional ID of the illuminator to configure.
-            Used to handle multiple illuminators within the same System Component.
-            0/NaN/INT32_MAX = all illuminators.
-            Values 1-63 indicate an instance ID to configure
+        <param index="5" label="ID" minValue="0" maxValue="255"  increment="1">
+            Target illuminator ID. 
+
+            When the MAV_CMD is used in a mission this param specifies the target illuminator.
+            This will either be the id of an autopilot-connected illuminator (1-6), the component ID of a MAVLink illuminator (7-255), or 0 to target the autopilot's default illuminator(s).
+            
+            When used in a command sent to the autopilot, this field can specify the id of an autopilot-connected device (1-6). Otherwise it should be set to 0.
         </param>
       </entry>
       <entry value="410" name="MAV_CMD_GET_HOME_POSITION" hasLocation="false" isDestination="false">
@@ -8154,7 +8158,7 @@
       <field type="float" name="min_strobe_period" units="s">Minimum strobing period in seconds</field>
       <field type="float" name="max_strobe_period" units="s">Maximum strobing period in seconds</field>
       <extensions/>
-      <field type="uint8_t" name="id" label="ID">ID of this illuminator, if not an individual component</field>
+      <field type="uint8_t" name="id" label="ID" invalid="0" minValue="1" maxValue="6">Illuminator id for a non-MAVLink camera attached to an autopilot (1-6). 0 if the component is a MAVLink camera (with its own component id).</field>
     </message>
     <!-- The message ids 510 and 511 are reserved for ABSOLUTE_TARGET and RELATIVE_TARGET, currently in development.xml. -->
     <message id="387" name="CANFD_FRAME">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8158,7 +8158,7 @@
       <field type="float" name="min_strobe_period" units="s">Minimum strobing period in seconds</field>
       <field type="float" name="max_strobe_period" units="s">Maximum strobing period in seconds</field>
       <extensions/>
-      <field type="uint8_t" name="id" label="ID" invalid="0" minValue="1" maxValue="6">Illuminator id for a non-MAVLink camera attached to an autopilot (1-6). 0 if the component is a MAVLink camera (with its own component id).</field>
+      <field type="uint8_t" name="id" invalid="0" minValue="1" maxValue="6">Illuminator id for a non-MAVLink camera attached to an autopilot (1-6). 0 if the component is a MAVLink camera (with its own component id).</field>
     </message>
     <!-- The message ids 510 and 511 are reserved for ABSOLUTE_TARGET and RELATIVE_TARGET, currently in development.xml. -->
     <message id="387" name="CANFD_FRAME">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2074,6 +2074,12 @@
       <entry value="405" name="MAV_CMD_ILLUMINATOR_ON_OFF" hasLocation="false" isDestination="false">
         <description>Turns illuminators ON/OFF. An illuminator is a light source that is used for lighting up dark areas external to the system: e.g. a torch or searchlight (as opposed to a light source for illuminating the system itself, e.g. an indicator light).</description>
         <param index="1" label="Enable" enum="MAV_BOOL">Illuminators on/off (MAV_BOOL_TRUE: illuminators on). Values not equal to 0 or 1 are invalid.</param>
+        <param index="2" label="ID" minValue="0" maxValue="255">
+            Optional ID of the illuminator to configure.
+            Used to handle multiple illuminators within the same System Component.
+            0/NaN/INT32_MAX = all illuminators.
+            Values 1-63 indicate an instance ID to configure
+        </param>
       </entry>
       <entry value="406" name="MAV_CMD_DO_ILLUMINATOR_CONFIGURE" hasLocation="false" isDestination="false">
         <description>Configures illuminator settings. An illuminator is a light source that is used for lighting up dark areas external to the system: e.g. a torch or searchlight (as opposed to a light source for illuminating the system itself, e.g. an indicator light).</description>
@@ -2081,6 +2087,12 @@
         <param index="2" label="Brightness" units="%" minValue="0" maxValue="100">0%: Off, 100%: Max Brightness</param>
         <param index="3" label="Strobe Period" units="s" minValue="0">Strobe period in seconds where 0 means strobing is not used</param>
         <param index="4" label="Strobe Duty" units="%" minValue="0" maxValue="100">Strobe duty cycle where 100% means it is on constantly and 0 means strobing is not used</param>
+        <param index="5" label="ID" minValue="0" maxValue="255">
+            Optional ID of the illuminator to configure.
+            Used to handle multiple illuminators within the same System Component.
+            0/NaN/INT32_MAX = all illuminators.
+            Values 1-63 indicate an instance ID to configure
+        </param>
       </entry>
       <entry value="410" name="MAV_CMD_GET_HOME_POSITION" hasLocation="false" isDestination="false">
         <superseded since="2022-04" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
@@ -8141,6 +8153,8 @@
       <field type="float" name="temp_c">Temperature in Celsius</field>
       <field type="float" name="min_strobe_period" units="s">Minimum strobing period in seconds</field>
       <field type="float" name="max_strobe_period" units="s">Maximum strobing period in seconds</field>
+      <extensions/>
+      <field type="uint8_t" name="id" label="ID">ID of this illuminator, if not an individual component</field>
     </message>
     <!-- The message ids 510 and 511 are reserved for ABSOLUTE_TARGET and RELATIVE_TARGET, currently in development.xml. -->
     <message id="387" name="CANFD_FRAME">


### PR DESCRIPTION
ArduSub has had light support for a long time, but always relied on hard-to-use-programatically MANUAL_CONTROL buttons. As I was attempting to change that, I ran into these messages.
Given that we support two independent sets of lights and don't declare multiple components within the autopilot, a new ID field would allow choosing which set of lights to control, [similarly to what was done to cameras](https://github.com/mavlink/mavlink/pull/2142).

Limiting IDs to 1-63 was @peterbarker 's suggestion, as we could reserve higher IDs to control lights by role rather than IDs