### PR TITLE
ftp: add ListDirectoryWithTime with change time

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5166,6 +5166,9 @@
       <entry value="15" name="MAV_FTP_OPCODE_BURSTREADFILE">
         <description>BurstReadFile: Burst download session file</description>
       </entry>
+      <entry value="16" name="MAV_FTP_OPCODE_LISTDIRECTORYWITHTIME">
+        <description>ListDirectoryWithTime: List files and directories in path from offset, as for ListDirectory, but with each entry additionally including its last-modification time. Servers that do not support this opcode respond with a NAK (MAV_FTP_ERR_UNKNOWNCOMMAND).</description>
+      </entry>
       <entry value="128" name="MAV_FTP_OPCODE_ACK">
         <description>ACK: ACK response</description>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5167,7 +5167,7 @@
         <description>BurstReadFile: Burst download session file</description>
       </entry>
       <entry value="16" name="MAV_FTP_OPCODE_LISTDIRECTORYWITHTIME">
-        <description>ListDirectoryWithTime: List files and directories in path from offset, as for ListDirectory, but with each entry additionally including its last-modification time. Servers that do not support this opcode respond with a NAK (MAV_FTP_ERR_UNKNOWNCOMMAND).</description>
+        <description>ListDirectoryWithTime: List files and directories, along with last-modification timestamps, in path from offset. This is the same as ListDirectory except for the addition of timestamps. Servers that do not support this opcode respond with a NAK (MAV_FTP_ERR_UNKNOWNCOMMAND).</description>
       </entry>
       <entry value="128" name="MAV_FTP_OPCODE_ACK">
         <description>ACK: ACK response</description>


### PR DESCRIPTION
The current ListDirectory command doesn't support the last changed time of a file or directory. This is a limitation when it comes to using FTP to download logs.

Therefore, I suggest to add ListDirectoryWithTime here, somewhat similar to how it was done for in the internet FTP protocol which added the machine-readable `MLSD` command alongside the original `LIST`.

See: RFC 3659: https://datatracker.ietf.org/doc/html/rfc3659

FYI @auturgy 

Goes together with https://github.com/mavlink/mavlink-devguide/pull/701.

Related to https://github.com/ArduPilot/ardupilot/pull/32860.