### PR TITLE
fix(development): remove duplicate param index=5 in MAV_CMD_ODID_SET_EMERGENCY

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -183,7 +183,6 @@
         <param index="3" reserved="true" default="NaN"/>
         <param index="4">Empty</param>
         <param index="5">Empty</param>
-        <param index="5">Empty</param>
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>


### PR DESCRIPTION
I noticed a small typo:

`MAV_CMD_ODID_SET_EMERGENCY` has `<param index="5">` listed twice. Removed the duplicate.