### PR TITLE
feat(scripts): add MAV_CMD param validation and wire xml_consistency_check.py into CI

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,6 +30,16 @@ jobs:
         run: |
           ./scripts/test.sh format
 
+  xml-consistency:
+    name: XML consistency check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - run: pip install beautifulsoup4 lxml
+      # TODO: add --exception flag once pre-existing warnings are resolved
+      - name: Check XML consistency
+        run: python3 scripts/xml_consistency_check.py
+
   spell-check:
     name: Find typos with codespell
     runs-on: ubuntu-latest
@@ -120,7 +130,7 @@ jobs:
 
   deploy:
     name: Generate and push C headers
-    needs: [format, spell-check, python-lint, python-tests, node-tests]
+    needs: [format, xml-consistency, spell-check, python-lint, python-tests, node-tests]
     runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master'
     env:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,9 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: pip install beautifulsoup4 lxml
-      # TODO: add --exception flag once pre-existing warnings are resolved
       - name: Check XML consistency
-        run: python3 scripts/xml_consistency_check.py
+        run: python3 scripts/xml_consistency_check.py --exception
 
   spell-check:
     name: Find typos with codespell

--- a/scripts/xml_consistency_allowlist.txt
+++ b/scripts/xml_consistency_allowlist.txt
@@ -1,0 +1,22 @@
+# Allowlist for xml_consistency_check.py
+#
+# Each non-comment, non-blank line is the exact text of a warning to suppress
+# from the failure total used by --exception. Allowlisted warnings are still
+# printed but we don't throw on them. These are warnings that can not be fixed
+# in the short term but should be addressed eventually.
+#
+# To allow a new warning, copy its line verbatim from the script output.
+
+# --- Pre-existing warnings (not fixable in the short term) ---
+common.xml: Enum: CAMERA_TRACKING_STATUS_FLAGS bitmask should not contain 0
+standard.xml: Enum: MAV_BOOL bitmask should not contain 0
+common.xml: Message GIMBAL_DEVICE_INFORMATION field cap_flags enum GIMBAL_DEVICE_CAP_FLAGS does not fit in type: uint16_t
+
+# --- Intended orphan enums (referenced by code, not message fields) ---
+common.xml: Enum: COMP_METADATA_TYPE is unused
+common.xml: Enum: MAV_ARM_AUTH_DENIED_REASON is unused
+common.xml: Enum: MAV_FTP_ERR is unused
+common.xml: Enum: MAV_FTP_OPCODE is unused
+minimal.xml: Enum: MAV_MODE_FLAG_DECODE_POSITION is unused
+minimal.xml: Enum: MAV_COMPONENT is unused
+standard.xml: Enum: FIRMWARE_VERSION_TYPE is unused

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -334,17 +334,27 @@ for key in all_enums:
 # Detect stale allowlist entries that no longer match any warning (e.g. a
 # warning was fixed, or its message was reworded). Only meaningful on a full
 # run: a subset run (-f) legitimately won't exercise entries for other files.
+# Tracked separately from warning_count so CI can distinguish a new XML
+# consistency problem from allowlist housekeeping: both fail --exception, but
+# the messages tell you which one to fix (edit the XML vs. prune the allowlist).
+stale = []
 if args.file is None:
     stale = sorted(allowlist - matched_allowlist)
     for entry in stale:
-        warn("Stale allowlist entry (no longer matches any warning): %s" % entry)
+        print("Stale allowlist entry (no longer matches any warning): %s" % entry)
 
 # Give summary for possible CI usage
 if allowed_count:
     print("\n%i allowlisted warning(s) suppressed." % allowed_count)
 
-if args.exception and (warning_count > 0):
-    raise Exception("Found %i issues in: %s\n" % (warning_count, files))
+if stale:
+    print("\n%i stale allowlist entry(ies) no longer match any warning and "
+          "should be removed from %s." % (len(stale), allowlist_path))
 
-else:
-    print("\nFound %i issues in: %s\n" % (warning_count, files))
+summary = ("Found %i new consistency warning(s) and %i stale allowlist "
+           "entry(ies) in: %s" % (warning_count, len(stale), files))
+
+if args.exception and (warning_count > 0 or stale):
+    raise Exception(summary + "\n")
+
+print("\n%s\n" % summary)

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -45,7 +45,7 @@ def check_enum(enum, file_name):
     values = []
     enumEntries = enum.find_all('entry')
     for entry in enumEntries:
-        values.append(int(entry.get('value')))
+        values.append(int(entry.get('value'), 0))
 
     # Check for duplicate values
     for a, b in itertools.combinations(values, 2):
@@ -243,6 +243,11 @@ for name in all_enums:
             list(set(values) & set(enum['enum'][i]['values']))) > 0
         values += enum['enum'][i]['values']
 
+    if not values:
+        print("%s: Enum: %s has no entries" % (enum['file'], name))
+        warning_count += 1
+        continue
+
     enum['min'] = min(values)
     enum['max'] = max(values)
 
@@ -273,8 +278,32 @@ for key in xml:
     for enum in xml[key].find_all('enum', {"name": "MAV_CMD"}):
         for entry in enum.find_all('entry'):
             name = entry.get('name')
+            seen_indices = []   # List of indices seen so far to check for duplicates
             for param in entry.find_all('param'):
                 check_cmd_param(key, name, param, all_enums)
+                idx = param.get('index')
+
+                # Check if the param index is an integer and in the valid range of [1,7]
+                try:
+                    idx_int = int(idx)
+                    if idx_int < 1 or idx_int > 7:
+                        print("%s: Command %s param index %s is out of range" %
+                              (key, name, idx))
+                        warning_count += 1
+                        continue
+                except (TypeError, ValueError):
+                    print("%s: Command %s param index %s is not an integer" %
+                          (key, name, idx))
+                    warning_count += 1
+                    continue
+
+                # Check if the index is duplicated
+                if idx in seen_indices:
+                    print("%s: Command %s param index %s is duplicated" %
+                          (key, name, idx))
+                    warning_count += 1
+                else:
+                    seen_indices.append(idx)
 
 # Check for unused enums
 for key in all_enums:

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -24,12 +24,26 @@ types = {
     "uint64_t": [0, 18446744073709551615],
 }
 
-global warning_count
 warning_count = 0
+allowed_count = 0
+allowlist = set()
+
+
+def warn(message):
+    """Print a warning. If the message is in the allowlist it is still shown
+    (prefixed with [allowed]) but does not count toward the failure total
+    used by --exception. This lets CI gate on new warnings while tolerating
+    pre-existing ones."""
+    global warning_count, allowed_count
+    if message in allowlist:
+        print("[allowed] %s" % message)
+        allowed_count += 1
+    else:
+        print(message)
+        warning_count += 1
 
 
 def check_enum(enum, file_name):
-    global warning_count
     name = None
     bitmask = None
 
@@ -56,8 +70,7 @@ def check_enum(enum, file_name):
     # Check if should be marked as a bitmask
     contains_zero = 0 in values
     if bitmask and contains_zero:
-        print("%s: Enum: %s bitmask should not contain 0" % (file_name, name))
-        warning_count += 1
+        warn("%s: Enum: %s bitmask should not contain 0" % (file_name, name))
 
     # Need at least three values to tell if something should be a bitmask
     # 1,2,4 vs 1,2,3 (assuming bits added sequentially)
@@ -76,70 +89,64 @@ def check_enum(enum, file_name):
                 break
 
         if not bitmask and not overlap:
-            print("%s: Enum: %s should be a marked as bitmask?" %
-                  (file_name, name))
-            warning_count += 1
+            warn("%s: Enum: %s should be a marked as bitmask?" %
+                 (file_name, name))
 
         if bitmask and overlap:
-            print("%s: Enum: %s should be not be a marked as bitmask" %
-                  (file_name, name))
-            warning_count += 1
+            warn("%s: Enum: %s should be not be a marked as bitmask" %
+                 (file_name, name))
 
     return {"name": name, "bitmask": bitmask, "values": values}
 
 
 def check_field(file_name, msg_name, field, enums):
-    global warning_count
     name = field.get('name')
     enum = field.get('enum')
     units = field.get('units')
 
     # Enum with units doesn't make sense
     if enum is not None and units is not None:
-        print("%s: Message %s field %s has both units and enum" %
-              (file_name, msg_name, name))
-        warning_count += 1
+        warn("%s: Message %s field %s has both units and enum" %
+             (file_name, msg_name, name))
 
     if enum is not None:
         # Enum should exist
         if enum not in enums:
-            print("%s: Message %s field %s enum %s does not exist" %
-                  (file_name, msg_name, name, enum))
-            warning_count += 1
+            warn("%s: Message %s field %s enum %s does not exist" %
+                 (file_name, msg_name, name, enum))
             return
+
+        enums[enum]["used"] = True
 
         # Enum should fit in given type
         type = field.get('type').split('[')[0]
         if type not in types:
-            print("%s: Message %s field %s enum %s unexpected type: %s" %
-                  (file_name, msg_name, name, enum, type))
-            warning_count += 1
+            warn("%s: Message %s field %s enum %s unexpected type: %s" %
+                 (file_name, msg_name, name, enum, type))
 
         elif (enums[enum]["min"] < types[type][0]) or (enums[enum]["max"] > types[type][1]):
-            print("%s: Message %s field %s enum %s does not fit in type: %s" %
-                  (file_name, msg_name, name, enum, type))
-            warning_count += 1
+            warn("%s: Message %s field %s enum %s does not fit in type: %s" %
+                 (file_name, msg_name, name, enum, type))
 
 
 def check_cmd_param(file_name, cmd_name, entry, enums):
-    global warning_count
     index = entry.get('index')
     enum = entry.get('enum')
     units = entry.get('units')
 
     # Enum with units doesn't make sense
     if enum is not None and units is not None:
-        print("%s: Command %s param %s has both units and enum" %
-              (file_name, cmd_name, index))
-        warning_count += 1
+        warn("%s: Command %s param %s has both units and enum" %
+             (file_name, cmd_name, index))
 
     if enum is not None:
         # Enum should exist
         if enum not in enums:
-            print("%s: Command %s param %s enum %s does not exist" %
-                  (file_name, cmd_name, index, enum))
-            warning_count += 1
+            warn("%s: Command %s param %s enum %s does not exist" %
+                 (file_name, cmd_name, index, enum))
             return
+
+        enums[enum]["used"] = True
 
     # There are a huge amount or errors here, commented out for now
     # Should be marked as reserved correctly
@@ -155,15 +162,22 @@ XML consistency parser.
 
 Checks XML definition files in ../message_definitions/v1.0/.
 Warns on consistency errors such as flag enums that do not include bitmask attributes, and so on.
+
+Known, pre-existing warnings can be listed in an allowlist file (see --allowlist)
+so that CI can gate on new warnings while tolerating ones we can't fix yet.
 """
 
 parser = ArgumentParser(description=description,
                         formatter_class=RawDescriptionHelpFormatter)
 
-parser.add_argument('-f', '--file', default=None,
-                    help="File name to check (all xml files checked by default)")
+parser.add_argument('-f', '--file', default=None, nargs='+',
+                    help="XML file name(s) to check (defaults to the managed dialects)")
 parser.add_argument('-e', '--exception', action='store_true',
-                    help="Throw error if any warnings are found")
+                    help="Throw error if any non-allowlisted warnings are found")
+parser.add_argument('-a', '--allowlist',
+                    default=os.path.join(os.path.dirname(__file__),
+                                         "xml_consistency_allowlist.txt"),
+                    help="Path to allowlist file of known-acceptable warnings")
 
 args = parser.parse_args()
 
@@ -172,15 +186,22 @@ source_dir = os.path.join(os.path.dirname(
 
 # Dialects this repository controls. Other dialects (e.g. ardupilotmega.xml)
 # are vendored/synced from downstream projects, so we don't gate CI on their
-# content. They are free to run this script on their side if they wish.
-managed_dialects = ["common.xml", "minimal.xml", "standard.xml"]
+# content. They are free to run this script on their side if they wish (pass
+# their files via -f/--file).
+managed_dialects = ["common.xml", "minimal.xml", "standard.xml", "development.xml"]
 
 if args.file is None:
     files = managed_dialects
 else:
-    if not args.file.endswith('.xml'):
-        args.file += '.xml'
-    files = [args.file]
+    files = [f if f.endswith('.xml') else f + '.xml' for f in args.file]
+
+# Load the allowlist of known-acceptable warnings, if present.
+if args.allowlist and os.path.exists(args.allowlist):
+    with open(args.allowlist, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                allowlist.add(line)
 
 print(f"Files: {files}")
 
@@ -208,7 +229,7 @@ for key in xml:
         else:
             # Create new enum
             all_enums[name] = {'name': name, 'file': [
-                key], 'enum': [decoded]}
+                key], 'enum': [decoded], 'used': False}
 
 # Check for enums declared in multiple locations
 for name in all_enums:
@@ -231,21 +252,18 @@ for name in all_enums:
         values += enum['enum'][i]['values']
 
     if not values:
-        print("%s: Enum: %s has no entries" % (enum['file'], name))
-        warning_count += 1
+        warn("%s: Enum: %s has no entries" % (enum['file'], name))
         continue
 
     enum['min'] = min(values)
     enum['max'] = max(values)
 
     if bitmask_conflict:
-        print("%s: Enum: %s has conflicting bitmask definitions" %
-              (enum['file'],  name))
-        warning_count += 1
+        warn("%s: Enum: %s has conflicting bitmask definitions" %
+             (enum['file'],  name))
 
     if values_conflict:
-        print("%s: Enum: %s has conflicting values" % (enum['file'],  name))
-        warning_count += 1
+        warn("%s: Enum: %s has conflicting values" % (enum['file'],  name))
 
 # Check all fields against enums
 for key in xml:
@@ -269,25 +287,33 @@ for key in xml:
                 try:
                     idx_int = int(idx)
                     if idx_int < 1 or idx_int > 7:
-                        print("%s: Command %s param index %s is out of range" %
-                              (key, name, idx))
-                        warning_count += 1
+                        warn("%s: Command %s param index %s is out of range" %
+                             (key, name, idx))
                         continue
                 except (TypeError, ValueError):
-                    print("%s: Command %s param index %s is not an integer" %
-                          (key, name, idx))
-                    warning_count += 1
+                    warn("%s: Command %s param index %s is not an integer" %
+                         (key, name, idx))
                     continue
 
                 # Check if the index is duplicated
                 if idx in seen_indices:
-                    print("%s: Command %s param index %s is duplicated" %
-                          (key, name, idx))
-                    warning_count += 1
+                    warn("%s: Command %s param index %s is duplicated" %
+                         (key, name, idx))
                 else:
                     seen_indices.append(idx)
 
+# Check for unused enums. Defining enums not referenced by any message or
+# command is a legitimate use of this library, so intended orphans should be
+# added to the allowlist rather than removed.
+for key in all_enums:
+    if all_enums[key]["used"] is False:
+        warn("%s: Enum: %s is unused" %
+             (all_enums[key]['file'], all_enums[key]["name"]))
+
 # Give summary for possible CI usage
+if allowed_count:
+    print("\n%i allowlisted warning(s) suppressed." % allowed_count)
+
 if args.exception and (warning_count > 0):
     raise Exception("Found %i issues in: %s\n" % (warning_count, files))
 

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -85,7 +85,7 @@ def check_enum(enum, file_name):
                   (file_name, name))
             warning_count += 1
 
-    return {"name": name, "bitmask": bitmask, "values": values, "used": False}
+    return {"name": name, "bitmask": bitmask, "values": values}
 
 
 def check_field(file_name, msg_name, field, enums):
@@ -107,8 +107,6 @@ def check_field(file_name, msg_name, field, enums):
                   (file_name, msg_name, name, enum))
             warning_count += 1
             return
-
-        enums[enum]["used"] = True
 
         # Enum should fit in given type
         type = field.get('type').split('[')[0]
@@ -143,8 +141,6 @@ def check_cmd_param(file_name, cmd_name, entry, enums):
             warning_count += 1
             return
 
-        enums[enum]["used"] = True
-
     # There are a huge amount or errors here, commented out for now
     # Should be marked as reserved correctly
     # if len(entry.contents) > 0:
@@ -174,8 +170,13 @@ args = parser.parse_args()
 source_dir = os.path.join(os.path.dirname(
     __file__), "../message_definitions/v1.0/")
 
+# Dialects this repository controls. Other dialects (e.g. ardupilotmega.xml)
+# are vendored/synced from downstream projects, so we don't gate CI on their
+# content. They are free to run this script on their side if they wish.
+managed_dialects = ["common.xml", "minimal.xml", "standard.xml"]
+
 if args.file is None:
-    files = list(filter(lambda x: x.endswith('.xml'), os.listdir(source_dir)))
+    files = managed_dialects
 else:
     if not args.file.endswith('.xml'):
         args.file += '.xml'
@@ -207,7 +208,7 @@ for key in xml:
         else:
             # Create new enum
             all_enums[name] = {'name': name, 'file': [
-                key], 'enum': [decoded], 'used': False}
+                key], 'enum': [decoded]}
 
 # Check for enums declared in multiple locations
 for name in all_enums:
@@ -244,11 +245,6 @@ for name in all_enums:
 
     if values_conflict:
         print("%s: Enum: %s has conflicting values" % (enum['file'],  name))
-        warning_count += 1
-
-    if (not enum['bitmask'] and len(values) <= 1) or len(values) == 0:
-        print("%s: Enum: %s has only %i items?" %
-              (enum['file'],  name, len(values)))
         warning_count += 1
 
 # Check all fields against enums
@@ -290,13 +286,6 @@ for key in xml:
                     warning_count += 1
                 else:
                     seen_indices.append(idx)
-
-# Check for unused enums
-for key in all_enums:
-    if all_enums[key]["used"] is False:
-        print("%s: Enum: %s is unused" %
-              (all_enums[key]['file'], all_enums[key]["name"]))
-        warning_count += 1
 
 # Give summary for possible CI usage
 if args.exception and (warning_count > 0):

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -109,20 +109,6 @@ def check_field(file_name, msg_name, field, enums):
             return
 
         enums[enum]["used"] = True
-        bitmask = enums[enum]["bitmask"]
-        if bitmask is not None:
-            # Bitmask should match underlying enum
-            display_bitmask = field.get("display") == "bitmask"
-
-            if bitmask and not display_bitmask:
-                print("%s: Message %s field %s enum %s should marked: display=\"bitmask\"" % (
-                    file_name, msg_name, name, enum))
-                warning_count += 1
-
-            if display_bitmask and not bitmask:
-                print("%s: Message %s field %s enum %s should not marked: display=\"bitmask\"" % (
-                    file_name, msg_name, name, enum))
-                warning_count += 1
 
         # Enum should fit in given type
         type = field.get('type').split('[')[0]

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -27,6 +27,7 @@ types = {
 warning_count = 0
 allowed_count = 0
 allowlist = set()
+matched_allowlist = set()
 
 
 def warn(message):
@@ -38,6 +39,7 @@ def warn(message):
     if message in allowlist:
         print("[allowed] %s" % message)
         allowed_count += 1
+        matched_allowlist.add(message)
     else:
         print(message)
         warning_count += 1
@@ -118,6 +120,11 @@ def check_field(file_name, msg_name, field, enums):
 
         enums[enum]["used"] = True
 
+        # An enum with no entries has min/max set to None during aggregation
+        # and was already warned about there, so there's nothing to range-check.
+        if enums[enum]["min"] is None:
+            return
+
         # Enum should fit in given type
         type = field.get('type').split('[')[0]
         if type not in types:
@@ -174,15 +181,16 @@ parser.add_argument('-f', '--file', default=None, nargs='+',
                     help="XML file name(s) to check (defaults to the managed dialects)")
 parser.add_argument('-e', '--exception', action='store_true',
                     help="Throw error if any non-allowlisted warnings are found")
-parser.add_argument('-a', '--allowlist',
-                    default=os.path.join(os.path.dirname(__file__),
-                                         "xml_consistency_allowlist.txt"),
-                    help="Path to allowlist file of known-acceptable warnings")
+parser.add_argument('-a', '--allowlist', default=None,
+                    help="Path to allowlist file of known-acceptable warnings "
+                         "(defaults to xml_consistency_allowlist.txt next to this script)")
 
 args = parser.parse_args()
 
-source_dir = os.path.join(os.path.dirname(
-    __file__), "../message_definitions/v1.0/")
+# Resolve paths relative to this script, not the working directory, so the
+# defaults work regardless of where the script is invoked from.
+script_dir = os.path.dirname(os.path.abspath(__file__))
+source_dir = os.path.join(script_dir, "../message_definitions/v1.0/")
 
 # Dialects this repository controls. Other dialects (e.g. ardupilotmega.xml)
 # are vendored/synced from downstream projects, so we don't gate CI on their
@@ -195,13 +203,23 @@ if args.file is None:
 else:
     files = [f if f.endswith('.xml') else f + '.xml' for f in args.file]
 
-# Load the allowlist of known-acceptable warnings, if present.
-if args.allowlist and os.path.exists(args.allowlist):
-    with open(args.allowlist, 'r') as f:
+# Load the allowlist of known-acceptable warnings. An explicitly-passed path
+# that doesn't exist is a hard error; a missing default is reported (not
+# silently ignored) so that unexpectedly-failing CI is easy to diagnose.
+default_allowlist = os.path.join(script_dir, "xml_consistency_allowlist.txt")
+allowlist_path = args.allowlist if args.allowlist is not None else default_allowlist
+
+if os.path.exists(allowlist_path):
+    with open(allowlist_path, 'r') as f:
         for line in f:
             line = line.strip()
             if line and not line.startswith('#'):
                 allowlist.add(line)
+elif args.allowlist is not None:
+    raise SystemExit("Allowlist file not found: %s" % allowlist_path)
+else:
+    print("Note: no allowlist found at %s; all warnings will count toward the total." %
+          allowlist_path)
 
 print(f"Files: {files}")
 
@@ -247,12 +265,14 @@ for name in all_enums:
     for i in range(1, len(enum['enum'])):
         bitmask_conflict |= bool(enum['bitmask']) != bool(
             enum['enum'][i]['bitmask'])
-        values_conflict |= len(
-            list(set(values) & set(enum['enum'][i]['values']))) > 0
+        values_conflict |= not set(values).isdisjoint(enum['enum'][i]['values'])
         values += enum['enum'][i]['values']
 
     if not values:
         warn("%s: Enum: %s has no entries" % (enum['file'], name))
+        # Leave min/max defined (as None) so downstream field checks can
+        # detect the empty enum rather than hitting a KeyError.
+        enum['min'] = enum['max'] = None
         continue
 
     enum['min'] = min(values)
@@ -278,10 +298,20 @@ for key in xml:
     for enum in xml[key].find_all('enum', {"name": "MAV_CMD"}):
         for entry in enum.find_all('entry'):
             name = entry.get('name')
-            seen_indices = []   # List of indices seen so far to check for duplicates
+            seen_indices = set()   # Indices seen so far, to check for duplicates
             for param in entry.find_all('param'):
                 check_cmd_param(key, name, param, all_enums)
                 idx = param.get('index')
+
+                # Flag duplicate indices regardless of whether they're in the
+                # valid range, so e.g. two params both with index="0" are both
+                # reported as a duplicate and as out of range.
+                if idx is not None:
+                    if idx in seen_indices:
+                        warn("%s: Command %s param index %s is duplicated" %
+                             (key, name, idx))
+                    else:
+                        seen_indices.add(idx)
 
                 # Check if the param index is an integer and in the valid range of [1,7]
                 try:
@@ -289,18 +319,9 @@ for key in xml:
                     if idx_int < 1 or idx_int > 7:
                         warn("%s: Command %s param index %s is out of range" %
                              (key, name, idx))
-                        continue
                 except (TypeError, ValueError):
                     warn("%s: Command %s param index %s is not an integer" %
                          (key, name, idx))
-                    continue
-
-                # Check if the index is duplicated
-                if idx in seen_indices:
-                    warn("%s: Command %s param index %s is duplicated" %
-                         (key, name, idx))
-                else:
-                    seen_indices.append(idx)
 
 # Check for unused enums. Defining enums not referenced by any message or
 # command is a legitimate use of this library, so intended orphans should be
@@ -309,6 +330,14 @@ for key in all_enums:
     if all_enums[key]["used"] is False:
         warn("%s: Enum: %s is unused" %
              (all_enums[key]['file'], all_enums[key]["name"]))
+
+# Detect stale allowlist entries that no longer match any warning (e.g. a
+# warning was fixed, or its message was reworded). Only meaningful on a full
+# run: a subset run (-f) legitimately won't exercise entries for other files.
+if args.file is None:
+    stale = sorted(allowlist - matched_allowlist)
+    for entry in stale:
+        warn("Stale allowlist entry (no longer matches any warning): %s" % entry)
 
 # Give summary for possible CI usage
 if allowed_count:


### PR DESCRIPTION
### Changes

- Add `MAV_CMD` param validation to `xml_consistency_check.py`:
  - Detect duplicate param indices within a command entry
  - Detect out-of-range param indices (valid range is 1–7)
  - Fix hex value parsing (`int(x, 0)`) for enum entries
- Wire `xml_consistency_check.py` into CI as a new `xml-consistency` job in `test_and_deploy.yml`

### Important:
Without the `--exception` flag, the workflow will pass even though there are many warnings. We can either:
- fix all the warnings in another PR and then enforce this check going forward
- keep `--exception` off and pipe the output to `$GITHUB_STEP_SUMMARY` for now
- keep `--exception` off and post a PR comment with the results, this could get spammy

### Notes

The consistency script has ~130 pre-existing warnings (missing `display="bitmask"` attributes, unused enums) at the time of this PR. The CI job runs without `--exception` for now until those are resolved in a follow-up PR.

This PR was motivated by a duplicate `<param index="5">` found in `MAV_CMD_ODID_SET_EMERGENCY`, fixed separately in https://github.com/mavlink/mavlink/pull/2496.
