### PR TITLE
common.xml: add MAV_MOUNT_MODE_WPNEXT_OFFSET

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -398,6 +398,9 @@
       <entry value="6" name="MAV_MOUNT_MODE_HOME_LOCATION">
         <description>Gimbal tracks home position</description>
       </entry>
+      <entry value="7" name="MAV_MOUNT_MODE_WPNEXT_OFFSET">
+        <description>Gimbal tracks next waypoint location with offset</description>
+      </entry>
     </enum>
     <enum name="GIMBAL_DEVICE_CAP_FLAGS" bitmask="true">
       <description>Gimbal device (low level) capability flags (bitmap).</description>


### PR DESCRIPTION
Add `MAV_MOUNT_MODE_WPNEXT_OFFSET` to [MAV_MOUNT_MODE](https://mavlink.io/en/messages/common.html#MAV_MOUNT_MODE) to match the command you can give to the gimbal

ArduPilot will be using this internally to keep track of what the gimbal is doing.
It corresponds to [MAV_ROI_WPNEXT](https://mavlink.io/en/messages/common.html#MAV_ROI_WPNEXT) and [MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET)
