### PR TITLE
update(development): Remove all empty and reserved params

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -135,7 +135,6 @@
         <param index="1" label="System ID" minValue="1" maxValue="255" increment="1">New system ID for target component(s). 0: ignore and reject command (broadcast system ID not allowed).</param>
         <param index="2" label="Component ID" minValue="0" maxValue="255" increment="1">New component ID for target component(s). 0: ignore (component IDs don't change).</param>
         <param index="3" label="Reboot">Reboot components after ID change. Any non-zero value triggers the reboot.</param>
-        <param index="4" reserved="true" default="NaN"/>
       </entry>
       <entry value="611" name="MAV_CMD_DO_SET_GLOBAL_ORIGIN" hasLocation="true" isDestination="false">
         <description>Sets the GNSS coordinates of the vehicle local origin (0,0,0) position.
@@ -144,10 +143,6 @@
           This command supersedes SET_GPS_GLOBAL_ORIGIN.
           Should be sent in a COMMAND_INT (Expected frame is MAV_FRAME_GLOBAL, and this should be assumed when sent in COMMAND_LONG).
         </description>
-        <param index="1">Empty</param>
-        <param index="2">Empty</param>
-        <param index="3">Empty</param>
-        <param index="4">Empty</param>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude" units="m">Altitude</param>
@@ -179,12 +174,6 @@
           See https://mavlink.io/en/services/opendroneid.html for more information.
         </description>
         <param index="1" label="Number" minValue="0" increment="1">Set/unset emergency 0: unset, 1: set</param>
-        <param index="2" reserved="true" default="NaN"/>
-        <param index="3" reserved="true" default="NaN"/>
-        <param index="4">Empty</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
       </entry>
       <entry value="43004" name="MAV_CMD_EXTERNAL_WIND_ESTIMATE" hasLocation="false" isDestination="false">
         <description>Set an external estimate of wind direction and speed.
@@ -194,9 +183,6 @@
         <param index="2" label="Wind speed accuracy" units="m/s">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
         <param index="3" label="Direction" units="deg" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
         <param index="4" label="Direction accuracy" units="deg">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
       </entry>
       <entry value="43006" name="MAV_CMD_ESTIMATOR_SENSOR_ENABLE" hasLocation="false" isDestination="false">
         <description>Enable or disable a specific estimator sensor fusion source at runtime.
@@ -206,9 +192,6 @@
         <param index="2" label="Instance" minValue="0" increment="1">Sensor instance (0-based, for multi-instance).</param>
         <param index="3" label="Enable" enum="MAV_BOOL">Enable (1) or Disable (0) the source.</param>
         <param index="4" label="Estimator Instance" default="NaN" minValue="0" increment="1">Estimator instance (0-based, for systems with multiple estimators).</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
       </entry>
       <entry value="620" name="MAV_CMD_EXTERNAL_ATTITUDE_ESTIMATE" hasLocation="false" isDestination="false">
         <description>Set an external estimate of vehicle attitude.
@@ -218,8 +201,6 @@
         <param index="2" label="Pitch" units="deg" minValue="0" maxValue="360">Pitch angle. Set to NaN if unknown.</param>
         <param index="3" label="Yaw" units="deg" minValue="0" maxValue="360">Yaw/heading (relative to true north) angle. Set to NaN if unknown.</param>
         <param index="4" label="Tilt accuracy" units="deg">Estimated 1 sigma accuracy of roll and pitch angles. Set to NaN if unknown.</param>
-        <param index="5">Empty</param>
-        <param index="6">Empty</param>
         <param index="7" label="Yaw accuracy" units="deg">Estimated 1 sigma accuracy of yaw angle. Set to NaN if unknown.</param>
       </entry>
       <entry value="32100" name="MAV_CMD_REQUEST_OPERATOR_CONTROL" hasLocation="false" isDestination="false">
@@ -268,8 +249,6 @@
         <param index="3" label="Request timeout" units="s" minValue="3" maxValue="60">Timeout in seconds before a request to a GCS to allow takeover is assumed to be rejected. This is used to display the timeout graphically on requester and GCS in control.</param>
         <param index="4" label="GCS Sysid">System ID of GCS requesting control. For a range of GCS in control, this the minimum id (and the sender system ID may be anywhere in the range).</param>
         <param index="5" label="GCS Sysid (upper range)">Upper range of controlling GCS system IDs. 0 for single-GCS control. If non-zero the sender system ID may be anywhere in the range).</param>
-        <param index="6">Empty</param>
-        <param index="7">Empty</param>
       </entry>
     </enum>
     <enum name="GCS_CONTROL_STATUS_FLAGS" bitmask="true">


### PR DESCRIPTION
This removes all empty and reserved parameters. As previously discussed, a parameter that is empty doesn't need to be defined, and has a default reserved value of `NaN` for param 1,2,3,4,7, and INT32MAX for params5,6. 

Not specifying them is more clear than having potential for typos etc.

Note that in theory the previous defaults should have been respected, but they weren't: `<param index="4" reserved="true" default="NaN"/>`. 

I am making the assumption here that these aren't implemented, so we can change at will.