### PR TITLE
Add TRACKING_MESSAGE (id 11045) — companion-computer visual tracking error

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -2047,6 +2047,12 @@
       <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
       <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
     </message>
+    <message id="11045" name="TRACKING_MESSAGE">
+      <description>Normalised tracking error sent from companion computer to autopilot. errorx and errory are in [-1, 1] where 0 is centred.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (monotonic microseconds)</field>
+      <field type="float" name="errorx">Normalised horizontal tracking error [-1, 1]</field>
+      <field type="float" name="errory">Normalised vertical tracking error [-1, 1]</field>
+    </message>
     <message id="11060" name="NAMED_VALUE_STRING">
       <description>Send a key-value pair as string. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>

--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -2047,12 +2047,6 @@
       <field type="uint16_t[4]" name="rpm" units="rpm">RPM (eRPM).</field>
       <field type="uint16_t[4]" name="count">count of telemetry packets received (wraps at 65535).</field>
     </message>
-    <message id="11045" name="TRACKING_MESSAGE">
-      <description>Normalised tracking error sent from companion computer to autopilot. errorx and errory are in [-1, 1] where 0 is centred.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (monotonic microseconds)</field>
-      <field type="float" name="errorx">Normalised horizontal tracking error [-1, 1]</field>
-      <field type="float" name="errory">Normalised vertical tracking error [-1, 1]</field>
-    </message>
     <message id="11060" name="NAMED_VALUE_STRING">
       <description>Send a key-value pair as string. The use of this message is discouraged for normal packets, but a quite efficient way for testing new messages and getting experimental debug output.</description>
       <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8227,12 +8227,6 @@
       <field type="int16_t" name="temperature" units="degC" invalid="INT16_MAX">Temperature of the motor. INT16_MAX if unknown</field>
       <field type="uint32_t" name="status" enum="MAV_WINCH_STATUS_FLAG">Status flags</field>
     </message>
-    <message id="11045" name="TRACKING_MESSAGE">
-      <description>Normalised tracking error sent from a companion computer to the autopilot. Consumed by the PX4 tracking flight mode. Field order matches the satria-firmware ardupilotmega.xml definition so the CRC_EXTRA agrees and the same drone-seeker payload works on both stacks. Defined in common.xml so the development and ardupilotmega dialects share a single definition (avoids the duplicate-id error when dialects are merged).</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (monotonic microseconds)</field>
-      <field type="float" name="errorx">Normalised horizontal tracking error [-1, 1]. Positive = target right of centre.</field>
-      <field type="float" name="errory">Normalised vertical tracking error [-1, 1]. Positive = target above centre.</field>
-    </message>
     <message id="12900" name="OPEN_DRONE_ID_BASIC_ID">
       <description>Data for filling the OpenDroneID Basic ID message. This and the below messages are primarily meant for feeding data to/from an OpenDroneID implementation. E.g. https://github.com/opendroneid/opendroneid-core-c. These messages are compatible with the ASTM F3411 Remote ID standard and the ASD-STAN prEN 4709-002 Direct Remote ID standard. Additional information and usage of these messages is documented at https://mavlink.io/en/services/opendroneid.html.</description>
       <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8227,6 +8227,12 @@
       <field type="int16_t" name="temperature" units="degC" invalid="INT16_MAX">Temperature of the motor. INT16_MAX if unknown</field>
       <field type="uint32_t" name="status" enum="MAV_WINCH_STATUS_FLAG">Status flags</field>
     </message>
+    <message id="11045" name="TRACKING_MESSAGE">
+      <description>Normalised tracking error sent from a companion computer to the autopilot. Consumed by the PX4 tracking flight mode. Field order matches the satria-firmware ardupilotmega.xml definition so the CRC_EXTRA agrees and the same drone-seeker payload works on both stacks. Defined in common.xml so the development and ardupilotmega dialects share a single definition (avoids the duplicate-id error when dialects are merged).</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (monotonic microseconds)</field>
+      <field type="float" name="errorx">Normalised horizontal tracking error [-1, 1]. Positive = target right of centre.</field>
+      <field type="float" name="errory">Normalised vertical tracking error [-1, 1]. Positive = target above centre.</field>
+    </message>
     <message id="12900" name="OPEN_DRONE_ID_BASIC_ID">
       <description>Data for filling the OpenDroneID Basic ID message. This and the below messages are primarily meant for feeding data to/from an OpenDroneID implementation. E.g. https://github.com/opendroneid/opendroneid-core-c. These messages are compatible with the ASTM F3411 Remote ID standard and the ASD-STAN prEN 4709-002 Direct Remote ID standard. Additional information and usage of these messages is documented at https://mavlink.io/en/services/opendroneid.html.</description>
       <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -675,5 +675,11 @@
       <field type="uint8_t[9]" name="active">Per-source instance bitmask of sensors the estimator is actively fusing.</field>
       <field type="float[9]" name="test_ratio" invalid="[NaN]">Per-source normalized innovation test ratio. NaN if not available.</field>
     </message>
+    <message id="11045" name="TRACKING_MESSAGE">
+      <description>Normalised tracking error sent from a companion computer to the autopilot. Consumed by the PX4 tracking flight mode. Field order matches the satria-firmware ardupilotmega.xml definition so the CRC_EXTRA agrees and the same drone-seeker payload works on both stacks. Lives in development.xml (not common.xml) to avoid adding dialect-table bytes to flash-constrained NuttX boards that use the "common" dialect.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (monotonic microseconds)</field>
+      <field type="float" name="errorx">Normalised horizontal tracking error [-1, 1]. Positive = target right of centre.</field>
+      <field type="float" name="errory">Normalised vertical tracking error [-1, 1]. Positive = target above centre.</field>
+    </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -696,5 +696,11 @@
       <field type="uint8_t[9]" name="active">Per-source instance bitmask of sensors the estimator is actively fusing.</field>
       <field type="float[9]" name="test_ratio" invalid="[NaN]">Per-source normalized innovation test ratio. NaN if not available.</field>
     </message>
+    <message id="11045" name="TRACKING_MESSAGE">
+      <description>Normalised tracking error sent from a companion computer to the autopilot. Consumed by the PX4 tracking flight mode. Field order matches the satria-firmware ardupilotmega.xml definition so the CRC_EXTRA agrees and the same drone-seeker payload works on both stacks. Lives in development.xml (not common.xml) to avoid adding dialect-table bytes to flash-constrained NuttX boards that use the "common" dialect.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (monotonic microseconds)</field>
+      <field type="float" name="errorx">Normalised horizontal tracking error [-1, 1]. Positive = target right of centre.</field>
+      <field type="float" name="errory">Normalised vertical tracking error [-1, 1]. Positive = target above centre.</field>
+    </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -696,11 +696,5 @@
       <field type="uint8_t[9]" name="active">Per-source instance bitmask of sensors the estimator is actively fusing.</field>
       <field type="float[9]" name="test_ratio" invalid="[NaN]">Per-source normalized innovation test ratio. NaN if not available.</field>
     </message>
-    <message id="11045" name="TRACKING_MESSAGE">
-      <description>Normalised tracking error sent from a companion computer to the autopilot. Consumed by the PX4 tracking flight mode. Field order matches the satria-firmware ardupilotmega.xml definition so the CRC_EXTRA agrees and the same drone-seeker payload works on both stacks. Lives in development.xml (not common.xml) to avoid adding dialect-table bytes to flash-constrained NuttX boards that use the "common" dialect.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (monotonic microseconds)</field>
-      <field type="float" name="errorx">Normalised horizontal tracking error [-1, 1]. Positive = target right of centre.</field>
-      <field type="float" name="errory">Normalised vertical tracking error [-1, 1]. Positive = target above centre.</field>
-    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
# Add TRACKING_MESSAGE (id 11045) — companion-computer visual tracking error

## Summary

Adds a new MAVLink message that lets a companion computer (typically running a vision-based tracker) send a normalised target-position error to the autopilot. The autopilot consumes this signal in a "tracking" flight mode that steers the vehicle to keep the target centred in the camera frame.

The message is added to **both** `ardupilotmega.xml` and `development.xml` with identical field declarations so `CRC_EXTRA` matches across stacks — the same companion-computer payload is wire-compatible with PX4 SITL (which uses the `development` dialect) and ArduPilot (which uses `ardupilotmega`).

## Motivation

Vision-based tracking — drone follows a person, vehicle, or other ground/air target by keeping the camera centred on the object — is a common companion-computer use case. Existing messages don't fit the wire pattern:

- `LANDING_TARGET` is shaped around landing pad geometry (size, type, distance) and assumes a downward-facing camera.
- `OBSTACLE_DISTANCE` / `OBSTACLE_DISTANCE_3D` describe an obstacle, not a tracked target.
- `GLOBAL_VISION_POSITION_ESTIMATE` requires global-frame coordinates from the companion, not a frame-relative pixel offset.

A simple frame-relative `(errorx, errory)` pair in `[-1, 1]` is what every off-the-shelf vision tracker outputs natively (centroid offset divided by half-frame), so this message keeps companion-side code minimal and lets the autopilot map the normalised error to roll/pitch/throttle on its own.

## Message definition

```xml
<message id="11045" name="TRACKING_MESSAGE">
  <description>Normalised tracking error sent from companion computer to autopilot.
               errorx and errory are in [-1, 1] where 0 is centred.</description>
  <field type="uint64_t" name="time_usec" units="us">Timestamp (monotonic microseconds)</field>
  <field type="float" name="errorx">Normalised horizontal tracking error [-1, 1]</field>
  <field type="float" name="errory">Normalised vertical tracking error [-1, 1]</field>
</message>
```

- **`time_usec`** — companion's monotonic timestamp so the autopilot can timeout stale data and reset PID state on signal loss.
- **`errorx`** — `> 0` means the target is to the right of frame centre → vehicle should bank right.
- **`errory`** — `> 0` means the target is above frame centre → vehicle should pitch up (or, on a multicopter, reduce throttle for a target *below*).

Total wire payload: 16 bytes (uint64 reordered first per MAVLink size-descending convention, then two floats).

## Why id 11045

Sits inside the ArduPilot-allocated block (11000–11099) so it doesn't collide with the common-dialect range. Same id is used by every consuming implementation listed below.

## Implementations

This message is already consumed by:

- **ArduPilot (satria-firmware fork)** — `ArduPlane/mode_tracking.cpp` and `ArduCopter/mode_tracking.cpp`. The autopilot enters a `TRACKING` flight mode, runs roll / pitch / throttle PIDs on the incoming error, and reverts to a hold mode if no message arrives within a configurable timeout.
- **PX4 SITL** — `src/modules/tracking/Tracking.cpp`. Registers an external flight mode (`NAVIGATION_STATE_EXTERNAL1`) that publishes `vehicle_attitude_setpoint` based on the same PID treatment.
- **drone-seeker** companion app (Python + pymavlink) — sends the message at the camera frame rate (~30 Hz) with the centroid offset from a CamShift/Kalman pink-target tracker.

## Why both dialects

| Dialect | Used by | Reason |
|---|---|---|
| `ardupilotmega.xml` | ArduPilot, ArduPlane variants | Original satria-firmware location. ArduPilot stacks always load this dialect. |
| `development.xml` | PX4 SITL (prototyping dialect) | PX4's NuttX boards default to the `common` dialect; putting TRACKING_MESSAGE in `common.xml` would add dialect-table bytes to every constrained-flash board (kakutef7 at 928 KB overflows by ~330 bytes). Putting it in `development.xml` keeps the signal available for SITL/experimentation while leaving stable PX4 NuttX builds untouched. If/when this graduates to a stable PX4 feature it can be promoted to `common.xml`. |

The two definitions are byte-identical in field order and types, so the generated `CRC_EXTRA` is the same value in both dialects — packets from a sender that only knows the `ardupilotmega` definition are still accepted by a receiver that only knows the `development` definition (and vice versa).

## Backward compatibility

- New message id; no existing message changed, no field reordered, no enum touched.
- Receivers that haven't loaded a dialect containing id 11045 will see it as `MAVLINK_MSG_ID_UNKNOWN` and drop the packet — same behaviour as any unknown message.

## Test plan

- [x] `mavgen` generates `mavlink_msg_tracking_message.h` from both dialects without warnings (`pymavlink/tools/mavgen.py --lang C --wire-protocol 2.0`).
- [x] Round-trip encode/decode against a Python sender (`pymavlink`) verified — payload `(time_usec=1234567, errorx=-0.5, errory=+0.3)` decoded byte-for-byte identical.
- [x] CRC_EXTRA computed from `ardupilotmega.xml` matches the value computed from `development.xml` (both `127`).
- [x] PX4 SITL build with `CONFIG_MAVLINK_DIALECT="development"` compiles `mavlink_receiver.cpp` with the TRACKING_MESSAGE case enabled.
- [x] PX4 NuttX board (`holybro_kakutef7_default`) — which keeps the default `common` dialect — builds with the receiver code compiled out via `#ifdef MAVLINK_MSG_ID_TRACKING_MESSAGE`; no flash size regression on constrained boards.
- [x] satria-firmware ArduPlane built against this branch decodes packets from the same drone-seeker that was talking to the old ardupilotmega definition.

## Related PRs / references

- PX4 fork using this message: `tatataufik/PX4-Autopilot` branch `xplane-sitl` (tracking module + SITL X-Plane integration).
- ArduPilot fork using this message: `tatataufik/satria-firmware` `ModeTracking` mode on Copter/Plane.
- Companion app: `tatataufik/drone-seeker` (pink-target tracker + PID gains tuning UI).
