### PR TITLE
common(ODOMETRY.time_usec ): Clarify is sample time

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7734,7 +7734,7 @@
     </message>
     <message id="331" name="ODOMETRY">
       <description>Odometry message to communicate odometry information with an external interface. Fits ROS REP 147 standard for aerial vehicles (http://www.ros.org/reps/rep-0147.html).</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint64_t" name="time_usec" units="us">Sample timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="frame_id" enum="MAV_FRAME">Coordinate frame of reference for the pose data.</field>
       <field type="uint8_t" name="child_frame_id" enum="MAV_FRAME">Coordinate frame of reference for the velocity in free space (twist) data.</field>
       <field type="float" name="x" units="m">X Position</field>


### PR DESCRIPTION
This clarifies that the time is sample time for the odometry message. It matters in this case.

@peterbarker @MaEtUgR 
- Are you happy with this text.
- Are there any other messages we know this also to be true for - i.e. that I can specify "Sample timestamp" because it should be sample timestamp.
- Are there any mesages we specifically know are "emitted time" or doesn't matter? Open to suggestions on how to update those.

Related to #2511