### PR TITLE
feat: added new device_ID reservations

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3096,8 +3096,38 @@
       <entry value="3" name="SERIAL_CONTROL_DEV_GPS2">
         <description>Second GPS port</description>
       </entry>
+      <entry value="4" name="SERIAL_CONTROL_DEV_TELEM3">
+        <description>Third telemetry port</description>
+      </entry>
+      <entry value="5" name="SERIAL_CONTROL_DEV_TELEM4">
+        <description>Fourth telemetry port</description>
+      </entry>
       <entry value="10" name="SERIAL_CONTROL_DEV_SHELL">
         <description>system shell</description>
+      </entry>
+      <entry value="20" name="SERIAL_CONTROL_DEV_ESC0">
+        <description>Electronic Speed Controller 0</description>
+      </entry>
+      <entry value="21" name="SERIAL_CONTROL_DEV_ESC1">
+        <description>Electronic Speed Controller 1</description>
+      </entry>
+      <entry value="22" name="SERIAL_CONTROL_DEV_ESC2">
+        <description>Electronic Speed Controller 2</description>
+      </entry>
+      <entry value="23" name="SERIAL_CONTROL_DEV_ESC3">
+        <description>Electronic Speed Controller 3</description>
+      </entry>
+      <entry value="24" name="SERIAL_CONTROL_DEV_ESC4">
+        <description>Electronic Speed Controller 4</description>
+      </entry>
+      <entry value="25" name="SERIAL_CONTROL_DEV_ESC5">
+        <description>Electronic Speed Controller 5</description>
+      </entry>
+      <entry value="26" name="SERIAL_CONTROL_DEV_ESC6">
+        <description>Electronic Speed Controller 6</description>
+      </entry>
+      <entry value="27" name="SERIAL_CONTROL_DEV_ESC7">
+        <description>Electronic Speed Controller 7</description>
       </entry>
       <entry value="100" name="SERIAL_CONTROL_SERIAL0">
         <description>SERIAL0</description>


### PR DESCRIPTION
## Summary

Reserve device IDs in the `SERIAL_CONTROL_DEV` enum for TELEM3, TELEM4, and ESC passthrough in support of serial passthrough implementations that need stable, interoperable IDs for commonly available hardware ports.

## New entries

| Value | Name | Description |
|-------|------|-------------|
| 4 | `SERIAL_CONTROL_DEV_TELEM3` | Third telemetry port |
| 5 | `SERIAL_CONTROL_DEV_TELEM4` | Fourth telemetry port |
| 20 | `SERIAL_CONTROL_DEV_ESC0` | Electronic Speed Controller 0 |
| 21 | `SERIAL_CONTROL_DEV_ESC1` | Electronic Speed Controller 1 |
| 22 | `SERIAL_CONTROL_DEV_ESC2` | Electronic Speed Controller 2 |
| 23 | `SERIAL_CONTROL_DEV_ESC3` | Electronic Speed Controller 3 |
| 24 | `SERIAL_CONTROL_DEV_ESC4` | Electronic Speed Controller 4 |
| 25 | `SERIAL_CONTROL_DEV_ESC5` | Electronic Speed Controller 5 |
| 26 | `SERIAL_CONTROL_DEV_ESC6` | Electronic Speed Controller 6 |
| 27 | `SERIAL_CONTROL_DEV_ESC7` | Electronic Speed Controller 7 |

## Motivation

TEL3 and TEL4 are among the most widely available serial ports in the PX4 hardware ecosystem:

- **TEL3**: present on 44 supported boards
- **TEL4**: present on 29 supported boards
- **Both TEL3 and TEL4**: 22 boards

Without standardized IDs, GCS and companion implementations cannot reliably target these ports in a hardware-agnostic way.

The ESC range reserves 8 slots (ESC0–ESC7), sufficient for the vast majority of multirotor configurations. Individual ESC addressing is required to perform operations such as firmware flashing and configuration changes on multi-ESC assemblies (e.g. 4-in-1 ESCs), where each ESC is reachable only through its own signal wire. Without dedicated IDs, a GCS cannot unambiguously target a specific ESC in a hardware-agnostic way.



These IDs are required to enable `SERIAL_CONTROL`-based passthrough to these ports in a GCS/autopilot-agnostic way.