### PR TITLE
common.xml: document invalid values for GPS_INPUT fields

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6959,15 +6959,15 @@
       <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">GNSS fix type</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
-      <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL). Positive for up. If unknown, set to NaN.</field>
-      <field type="float" name="hdop" invalid="NaN">GPS HDOP horizontal dilution of position (unitless). If unknown, set to NaN. UINT16_MAX may be sent by older implementations.</field>
-      <field type="float" name="vdop" invalid="NaN">GPS VDOP vertical dilution of position (unitless). If unknown, set to NaN. UINT16_MAX may be sent by older implementations.</field>
+      <field type="float" name="alt" units="m">Altitude (MSL). Positive for up.</field>
+      <field type="float" name="hdop" invalid="UINT16_MAX">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="float" name="vdop" invalid="UINT16_MAX">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
       <field type="float" name="vn" units="m/s">GPS velocity in north direction in earth-fixed NED frame</field>
       <field type="float" name="ve" units="m/s">GPS velocity in east direction in earth-fixed NED frame</field>
       <field type="float" name="vd" units="m/s">GPS velocity in down direction in earth-fixed NED frame</field>
-      <field type="float" name="speed_accuracy" units="m/s" invalid="NaN">GPS speed accuracy. If unknown, set to NaN.</field>
-      <field type="float" name="horiz_accuracy" units="m" invalid="NaN">GPS horizontal accuracy. If unknown, set to NaN.</field>
-      <field type="float" name="vert_accuracy" units="m" invalid="NaN">GPS vertical accuracy. If unknown, set to NaN.</field>
+      <field type="float" name="speed_accuracy" units="m/s">GPS speed accuracy</field>
+      <field type="float" name="horiz_accuracy" units="m">GPS horizontal accuracy</field>
+      <field type="float" name="vert_accuracy" units="m">GPS vertical accuracy</field>
       <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
       <extensions/>
       <field type="uint16_t" name="yaw" units="cdeg" invalid="0">Yaw of vehicle relative to Earth's North, zero means not available, use 36000 for north</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6956,21 +6956,21 @@
       <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS">Bitmap indicating which GPS input flags fields to ignore.  All other fields must be provided.</field>
       <field type="uint32_t" name="time_week_ms" units="ms">GPS time (from start of GPS week)</field>
       <field type="uint16_t" name="time_week">GPS week number</field>
-      <field type="uint8_t" name="fix_type">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
+      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
-      <field type="float" name="alt" units="m">Altitude (MSL). Positive for up.</field>
-      <field type="float" name="hdop" invalid="UINT16_MAX">GPS HDOP horizontal dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
-      <field type="float" name="vdop" invalid="UINT16_MAX">GPS VDOP vertical dilution of position (unitless). If unknown, set to: UINT16_MAX</field>
+      <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL). Positive for up. If unknown, set to NaN.</field>
+      <field type="float" name="hdop" invalid="NaN">GPS HDOP horizontal dilution of position (unitless). If unknown, set to NaN. UINT16_MAX may be sent by older implementations.</field>
+      <field type="float" name="vdop" invalid="NaN">GPS VDOP vertical dilution of position (unitless). If unknown, set to NaN. UINT16_MAX may be sent by older implementations.</field>
       <field type="float" name="vn" units="m/s">GPS velocity in north direction in earth-fixed NED frame</field>
       <field type="float" name="ve" units="m/s">GPS velocity in east direction in earth-fixed NED frame</field>
       <field type="float" name="vd" units="m/s">GPS velocity in down direction in earth-fixed NED frame</field>
-      <field type="float" name="speed_accuracy" units="m/s">GPS speed accuracy</field>
-      <field type="float" name="horiz_accuracy" units="m">GPS horizontal accuracy</field>
-      <field type="float" name="vert_accuracy" units="m">GPS vertical accuracy</field>
+      <field type="float" name="speed_accuracy" units="m/s" invalid="NaN">GPS speed accuracy. If unknown, set to NaN.</field>
+      <field type="float" name="horiz_accuracy" units="m" invalid="NaN">GPS horizontal accuracy. If unknown, set to NaN.</field>
+      <field type="float" name="vert_accuracy" units="m" invalid="NaN">GPS vertical accuracy. If unknown, set to NaN.</field>
       <field type="uint8_t" name="satellites_visible">Number of satellites visible.</field>
       <extensions/>
-      <field type="uint16_t" name="yaw" units="cdeg">Yaw of vehicle relative to Earth's North, zero means not available, use 36000 for north</field>
+      <field type="uint16_t" name="yaw" units="cdeg" invalid="0">Yaw of vehicle relative to Earth's North, zero means not available, use 36000 for north</field>
     </message>
     <message id="233" name="GPS_RTCM_DATA">
       <description>RTCM message for injecting into the onboard GPS (used for DGPS)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -6956,7 +6956,7 @@
       <field type="uint16_t" name="ignore_flags" enum="GPS_INPUT_IGNORE_FLAGS">Bitmap indicating which GPS input flags fields to ignore.  All other fields must be provided.</field>
       <field type="uint32_t" name="time_week_ms" units="ms">GPS time (from start of GPS week)</field>
       <field type="uint16_t" name="time_week">GPS week number</field>
-      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">0-1: no fix, 2: 2D fix, 3: 3D fix. 4: 3D with DGPS. 5: 3D with RTK</field>
+      <field type="uint8_t" name="fix_type" enum="GPS_FIX_TYPE">GNSS fix type</field>
       <field type="int32_t" name="lat" units="degE7">Latitude (WGS84)</field>
       <field type="int32_t" name="lon" units="degE7">Longitude (WGS84)</field>
       <field type="float" name="alt" units="m" invalid="NaN">Altitude (MSL). Positive for up. If unknown, set to NaN.</field>


### PR DESCRIPTION
Document invalid values for GPS_INPUT fields

- fix_type: add enum="GPS_FIX_TYPE" reference
- yaw: add invalid="0" (already documented in description, just making it explicit)

Fixes #2457
