### PR TITLE
update(CELLULAR_STATUS): Remove spurious space

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -834,7 +834,7 @@
         <description>Invalid Password.</description>
       </entry>
     </enum>
-    <enum name="CELLULAR_CONFIG_RESPONSE">
+    <enum name="_CONFIG_RESPONSE">
       <description>Possible responses from a CELLULAR_CONFIG message.</description>
       <entry value="0" name="CELLULAR_CONFIG_RESPONSE_ACCEPTED">
         <description>Changes accepted.</description>
@@ -7786,9 +7786,9 @@
     <!-- cellular status information -->
     <message id="334" name="CELLULAR_STATUS">
       <description>Cellular network status as reported by a particular modem.
-      
+
         This is primarily intended for logging, but a GCS may choose to display link_tx_rate and link_rx_rate.
-        
+
         Note that a value of 0 in the id field indicates that the sender does not support reporting of multiple modems.
         Message data should be from a single modem, but that is not guaranteed.
       </description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -834,7 +834,7 @@
         <description>Invalid Password.</description>
       </entry>
     </enum>
-    <enum name="_CONFIG_RESPONSE">
+    <enum name="CELLULAR_CONFIG_RESPONSE">
       <description>Possible responses from a CELLULAR_CONFIG message.</description>
       <entry value="0" name="CELLULAR_CONFIG_RESPONSE_ACCEPTED">
         <description>Changes accepted.</description>


### PR DESCRIPTION
Gets rid of some space that keeps appearing in unrelated PRs, because tooling tends to remove it.