### PR TITLE
Fix typos in field descriptions: development.xml and storm32.xml

### DIFF
--- a/message_definitions/v1.0/storm32.xml
+++ b/message_definitions/v1.0/storm32.xml
@@ -381,7 +381,7 @@ Documentation:
       <field type="uint8_t" name="target_system">System ID.</field>
       <field type="uint8_t" name="target_component">Component ID.</field>
       <field type="uint64_t" name="time_boot_us" units="us">Timestamp (time since system boot).</field>
-      <field type="float" name="wind_x" units="m/s" invalid="NaN">Wind X speed in NED (North,Est, Down). NAN if unknown.</field>
+      <field type="float" name="wind_x" units="m/s" invalid="NaN">Wind X speed in NED (North, East, Down). NAN if unknown.</field>
       <field type="float" name="wind_y" units="m/s" invalid="NaN">Wind Y speed in NED (North, East, Down). NAN if unknown.</field>
       <field type="float" name="wind_correction_angle" units="rad" invalid="NaN">Correction angle due to wind. NaN if unknown.</field>
     </message>


### PR DESCRIPTION
Fix typo found in message field description text:

- storm32.xml line 384: `North,Est` → `North, East` (also matches the format used in the adjacent wind_y field on line 385)

No protocol or code changes — description text only.