### PR TITLE
fix(failure injection): enable instance bitmask for multi-instance failures

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2103,8 +2103,8 @@
         <description>Inject artificial failure for testing purposes. Note that autopilots should implement an additional protection before accepting this command such as a specific param setting.</description>
         <param index="1" label="Failure unit" enum="FAILURE_UNIT">The unit which is affected by the failure.</param>
         <param index="2" label="Failure type" enum="FAILURE_TYPE">The type how the failure manifests itself.</param>
-        <param index="3" label="Instance" minValue="0" increment="1">Instance affected by failure (0 to signal all). Set to NaN if using the Instance bitmask (param4) instead.</param>
-        <param index="4" label="Instance bitmask" minValue="0">Bitmask of instances affected by the failure (bit 0 = first instance, bit 1 = second instance, etc.). Takes precedence over the Instance param3. Set to NaN if using the Instance param3 instead.</param>
+        <param index="3" label="Instance" minValue="0" increment="1">Instance affected by failure (0 to signal all). Takes precedence over Instance bitmask (param4) when not NaN. Set to NaN to use Instance bitmask instead.</param>
+        <param index="4" label="Instance bitmask" minValue="0">Bitmask of instances affected by the failure (bit 0 = first instance, bit 1 = second instance, etc.). Used only when Instance (param3) is NaN.</param>
       </entry>
       <entry value="500" name="MAV_CMD_START_RX_PAIR" hasLocation="false" isDestination="false">
         <description>Starts receiver pairing.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2103,7 +2103,8 @@
         <description>Inject artificial failure for testing purposes. Note that autopilots should implement an additional protection before accepting this command such as a specific param setting.</description>
         <param index="1" label="Failure unit" enum="FAILURE_UNIT">The unit which is affected by the failure.</param>
         <param index="2" label="Failure type" enum="FAILURE_TYPE">The type how the failure manifests itself.</param>
-        <param index="3" label="Instance">Instance affected by failure (0 to signal all).</param>
+        <param index="3" label="Instance" minValue="0" increment="1">Instance affected by failure (0 to signal all). Set to NaN if using the Instance bitmask (param4) instead.</param>
+        <param index="4" label="Instance bitmask" minValue="0">Bitmask of instances affected by the failure (bit 0 = first instance, bit 1 = second instance, etc.). Takes precedence over the Instance param3. Set to NaN if using the Instance param3 instead.</param>
       </entry>
       <entry value="500" name="MAV_CMD_START_RX_PAIR" hasLocation="false" isDestination="false">
         <description>Starts receiver pairing.</description>
@@ -4926,11 +4927,16 @@
       <entry value="7" name="FAILURE_UNIT_SENSOR_DISTANCE_SENSOR"/>
       <entry value="8" name="FAILURE_UNIT_SENSOR_AIRSPEED"/>
       <entry value="100" name="FAILURE_UNIT_SYSTEM_BATTERY"/>
-      <entry value="101" name="FAILURE_UNIT_SYSTEM_MOTOR"/>
+      <entry value="101" name="FAILURE_UNIT_SYSTEM_MOTOR">
+        <description>Interrupts the commanded output to the motor.</description>
+      </entry>
       <entry value="102" name="FAILURE_UNIT_SYSTEM_SERVO"/>
       <entry value="103" name="FAILURE_UNIT_SYSTEM_AVOIDANCE"/>
       <entry value="104" name="FAILURE_UNIT_SYSTEM_RC_SIGNAL"/>
       <entry value="105" name="FAILURE_UNIT_SYSTEM_MAVLINK_SIGNAL"/>
+      <entry value="106" name="FAILURE_UNIT_SYSTEM_ESC">
+        <description>Interrupts the telemetry reported by the ESC.</description>
+      </entry>
     </enum>
     <enum name="FAILURE_TYPE">
       <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->


### PR DESCRIPTION
## Summary

Backward-compatible redo of the initial approach. Adds an optional instance bitmask (param 4) to `MAV_CMD_INJECT_FAILURE` so several instances can be failed at once, without touching the deployed meaning of the existing Instance param 3. Also adds `FAILURE_UNIT_SYSTEM_ESC` comment which clarifies the MOTOR vs ESC units.

The actual need behind that PR still stands: a way to target a specific instance, or multiple instances, unambiguously; and a way to distinguish an ESC-telemetry failure from a motor-output failure.

## Problem

No way to inject a failure into multiple instances simultaneously, and no way to distinguish an ESC-telemetry failure from a motor-output failure.

## Solution

- Add param 4 "Instance bitmask". This is purely additive — param 4 was unused for command 420, so no deployed sender or receiver is affected. Bit `i` targets instance `i`.
- param 3 and param 4 are mutually exclusive via NaN = "not provided" convention: param 3 takes precedence when not NaN; bitmask senders set param 3 to NaN and param 4 to the desired bitmask. Legacy senders always set param 3 to a non-NaN integer (and never touched param 4), so they keep working unchanged with no receiver-side adaptation needed.
- Added `minValue` and `increment` attributes to param 3.
- Add `FAILURE_UNIT_SYSTEM_ESC` and descriptions clarifying that MOTOR interrupts the commanded motor output while ESC interrupts the telemetry reported by the ESC.