### PR TITLE
update(development): ENERGY_SYSTEM BATTERY and FUEL v2 proposal

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8042,7 +8042,7 @@
         BATTERY_STATUS_V2 is used for higher-rate battery status information.
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery.</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_ENERGY_SYSTEM">Function of the battery.</field>
       <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery.</field>
       <field type="uint8_t" name="state_of_health" units="%" invalid="UINT8_MAX">State of Health (SOH) estimate. Typically 100% at the time of manufacture and will decrease over time and use. -1: field not provided.</field>
       <field type="uint8_t" name="cells_in_series" invalid="0">Number of battery cells in series. 0: field not provided.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8042,7 +8042,7 @@
         BATTERY_STATUS_V2 is used for higher-rate battery status information.
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery. (MAV_ENERGY_SYSTEM)</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery. See also the energy_system field.</field>
       <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery.</field>
       <field type="uint8_t" name="state_of_health" units="%" invalid="UINT8_MAX">State of Health (SOH) estimate. Typically 100% at the time of manufacture and will decrease over time and use. -1: field not provided.</field>
       <field type="uint8_t" name="cells_in_series" invalid="0">Number of battery cells in series. 0: field not provided.</field>
@@ -8061,6 +8061,8 @@
       <field type="char[9]" name="manufacture_date" invalid="[0]">Manufacture date (DDMMYYYY) in ASCII characters, 0 terminated. All 0: field not provided.</field>
       <field type="char[32]" name="serial_number" invalid="[0]">Serial number in ASCII characters, 0 terminated. All 0: field not provided.</field>
       <field type="char[50]" name="name" invalid="[0]">Battery device name. Formatted as manufacturer name then product name, separated with an underscore (in ASCII characters), 0 terminated. All 0: field not provided.</field>
+      <extensions/>
+      <field type="uint16_t" name="energy_system" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system(s) this battery is associated with. A source is associated with an ENERGY_SYSTEM_INFO/ENERGY_SYSTEM_STATUS stream if any bit is set in both energy_system values (bitwise AND is non-zero) - see MAV_ENERGY_SYSTEM_FLAGS. 0: field not provided; a consumer may instead make a best guess at the energy system from battery_function.</field>
     </message>
     <message id="373" name="GENERATOR_STATUS">
       <description>Telemetry of power generation system. Alternator or mechanical generator.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8042,7 +8042,7 @@
         BATTERY_STATUS_V2 is used for higher-rate battery status information.
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="uint8_t" name="battery_function" enum="MAV_ENERGY_SYSTEM">Function of the battery.</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery. (MAV_ENERGY_SYSTEM)</field>
       <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery.</field>
       <field type="uint8_t" name="state_of_health" units="%" invalid="UINT8_MAX">State of Health (SOH) estimate. Typically 100% at the time of manufacture and will decrease over time and use. -1: field not provided.</field>
       <field type="uint8_t" name="cells_in_series" invalid="0">Number of battery cells in series. 0: field not provided.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3472,6 +3472,12 @@
       <entry value="64" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED2">
         <description>User-defined energy system (2). Name is provided in ENERGY_SYSTEM_INFO.</description>
       </entry>
+      <entry value="128" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED3">
+        <description>User-defined energy system (3). Name is provided in ENERGY_SYSTEM_INFO.</description>
+      </entry>
+      <entry value="256" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED4">
+        <description>User-defined energy system (4). Name is provided in ENERGY_SYSTEM_INFO.</description>
+      </entry>
     </enum>
     <enum name="MAV_BATTERY_CHARGE_STATE">
       <description>Enumeration for battery charge states.</description>
@@ -8099,7 +8105,7 @@
       <field type="char[32]" name="serial_number" invalid="[0]">Serial number in ASCII characters, 0 terminated. All 0: field not provided.</field>
       <field type="char[50]" name="name" invalid="[0]">Battery device name. Formatted as manufacturer name then product name, separated with an underscore (in ASCII characters), 0 terminated. All 0: field not provided.</field>
       <extensions/>
-      <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system(s) this battery is associated with. A source is associated with an ENERGY_SYSTEM_INFO/ENERGY_SYSTEM_STATUS stream if any bit is set in both energy_systems values (bitwise AND is non-zero) - see MAV_ENERGY_SYSTEM_FLAGS. 0: field not provided; a consumer may instead make a best guess at the energy systems from battery_function.</field>
+      <field type="uint16_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system(s) this battery is associated with. A source is associated with an ENERGY_SYSTEM_INFO/ENERGY_SYSTEM_STATUS stream if any bit is set in both energy_systems values (bitwise AND is non-zero) - see MAV_ENERGY_SYSTEM_FLAGS. 0: field not provided; a consumer may instead make a best guess at the energy systems from battery_function.</field>
     </message>
     <message id="373" name="GENERATOR_STATUS">
       <description>Telemetry of power generation system. Alternator or mechanical generator.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3436,6 +3436,43 @@
         <description>Payload battery</description>
       </entry>
     </enum>
+    <enum name="MAV_ENERGY_SYSTEM_FLAGS" bitmask="true">
+      <wip/>
+      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Energy system function flags.
+        In an ENERGY_SYSTEM_STATUS it indicates the function domains the energy system supplies.
+        In source messages (BATTERY_INFO.energy_systems, FUEL_INFORMATION_V2.energy_systems) it indicates the functional domains the source contributes to;
+        if any bits in a source message match corresponding bits in an energy system, the source should appear in a drop down for the energy system.
+
+        ENERGY_SYSTEM_STATUS should never be emitted with a zero value.
+        A source that has zero may be grouped with other sources that set 0, but this is not encouraged.
+      </description>
+      <entry value="1" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION">
+        <description>Propulsion energy system.</description>
+      </entry>
+      <entry value="2" name="MAV_ENERGY_SYSTEM_FLAGS_AVIONICS">
+        <description>Avionics energy system.</description>
+      </entry>
+      <entry value="4" name="MAV_ENERGY_SYSTEM_FLAGS_PAYLOAD">
+        <description>Payload energy system.</description>
+      </entry>
+      <entry value="8" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION_VTOL_MC">
+        <description>Propulsion energy system for a VTOL in MC mode.
+          Used when reporting modes usage separately (for either different or the same underlying sources).
+          MAV_ENERGY_SYSTEM_FLAGS_PROPULSION can be used if there is a single physical source and you want to report the consumption in the current mode.</description>
+      </entry>
+      <entry value="16" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION_VTOL_FW">
+        <description>Propulsion energy system for a VTOL in FW mode.
+          Used when reporting modes usage separately (for either different or the same underlying sources).
+          MAV_ENERGY_SYSTEM_FLAGS_PROPULSION can be used if there is a single physical source and you want to report the consumption in the current mode.</description>
+      </entry>
+      <entry value="32" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED1">
+        <description>User-defined energy system (1). Name is provided in ENERGY_SYSTEM_INFO.</description>
+      </entry>
+      <entry value="64" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED2">
+        <description>User-defined energy system (2). Name is provided in ENERGY_SYSTEM_INFO.</description>
+      </entry>
+    </enum>
     <enum name="MAV_BATTERY_CHARGE_STATE">
       <description>Enumeration for battery charge states.</description>
       <entry value="0" name="MAV_BATTERY_CHARGE_STATE_UNDEFINED">
@@ -8042,7 +8079,7 @@
         BATTERY_STATUS_V2 is used for higher-rate battery status information.
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
-      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery. See also the energy_system field.</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery. See also the energy_systems field.</field>
       <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery.</field>
       <field type="uint8_t" name="state_of_health" units="%" invalid="UINT8_MAX">State of Health (SOH) estimate. Typically 100% at the time of manufacture and will decrease over time and use. -1: field not provided.</field>
       <field type="uint8_t" name="cells_in_series" invalid="0">Number of battery cells in series. 0: field not provided.</field>
@@ -8062,7 +8099,7 @@
       <field type="char[32]" name="serial_number" invalid="[0]">Serial number in ASCII characters, 0 terminated. All 0: field not provided.</field>
       <field type="char[50]" name="name" invalid="[0]">Battery device name. Formatted as manufacturer name then product name, separated with an underscore (in ASCII characters), 0 terminated. All 0: field not provided.</field>
       <extensions/>
-      <field type="uint16_t" name="energy_system" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system(s) this battery is associated with. A source is associated with an ENERGY_SYSTEM_INFO/ENERGY_SYSTEM_STATUS stream if any bit is set in both energy_system values (bitwise AND is non-zero) - see MAV_ENERGY_SYSTEM_FLAGS. 0: field not provided; a consumer may instead make a best guess at the energy system from battery_function.</field>
+      <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system(s) this battery is associated with. A source is associated with an ENERGY_SYSTEM_INFO/ENERGY_SYSTEM_STATUS stream if any bit is set in both energy_systems values (bitwise AND is non-zero) - see MAV_ENERGY_SYSTEM_FLAGS. 0: field not provided; a consumer may instead make a best guess at the energy systems from battery_function.</field>
     </message>
     <message id="373" name="GENERATOR_STATUS">
       <description>Telemetry of power generation system. Alternator or mechanical generator.</description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -99,11 +99,10 @@
       <entry value="131072" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_CELLS_CONFIGURATION">
         <description>Battery is not compatible due to cell configuration (e.g. 5s1p when vehicle requires 6s).</description>
       </entry>
-      <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL">
+      <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE">
         <description>
-          Battery capacity_consumed and capacity_remaining values are relative to a full battery (they sum to the total capacity of the battery).
-          This flag would be set for a smart battery that can accurately determine its remaining charge across vehicle reboots and discharge/recharge cycles.
-          If unset the capacity_consumed indicates the consumption since vehicle power-on, as measured using a power monitor. The capacity_remaining, if provided, indicates the estimated remaining capacity on the assumption that the battery was full on vehicle boot.
+          Battery system tracks its own charge and accurately reports state of charge through vehiclepower cycles.
+          This should be unset for power monitors, which track consumption since vehicle power-on and only provide a reliable estimate of state of charge if the battery is full on boot.
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>
       </entry>
@@ -490,19 +489,18 @@
       <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: No limit applied</field>
     </message>
     <message id="369" name="BATTERY_STATUS_V2">
+      <wip/>
       <description>Battery dynamic information.
         This should be streamed (nominally at 1Hz).
         Static/invariant battery information is sent in BATTERY_INFO.
-        Note that smart batteries should set the MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL bit to indicate that supplied capacity values are relative to a battery that is known to be full.
-        Power monitors would not set this bit, indicating that capacity_consumed is relative to drone power-on, and that other values are estimated based on the assumption that the battery was full on power-on.
+        Batteries that can accurately estimate their own charge level should set the MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE flag (power monitors must not set this bit).
+        NOTE: This message should not be used for providing synthesized total system power status.
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
-      <field type="float" name="capacity_consumed" units="Ah" invalid="NaN">Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.</field>
-      <field type="float" name="capacity_remaining" units="Ah" invalid="NaN">Remaining charge (until empty). NaN: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.</field>
-      <field type="float" name="state_of_charge" units="%" invalid="NaN">State of Charge (SoC). Remaining capacity relative to current fully-charged capacity as a percentage. Values: [0-100], NaN: field not provided. Note that the value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
+      <field type="uint16_t" name="state_of_charge" units="%" scale="0.01" minValue="0" maxValue="10000" invalid="UINT16_MAX">State of Charge (SoC) in 0.01% increments. Values: [0-10000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage. The value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
     <message id="414" name="GROUP_START">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -500,7 +500,7 @@
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
-      <field type="float" name="state_of_charge" units="%" invalid="NaN">State of Charge (SoC). Values: [0-100], NaN: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage. The value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
+      <field type="float" name="state_of_charge" units="%" invalid="NaN">State of Charge (SoC). Values: [0-100], NaN: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage.</field>
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
     <message id="414" name="GROUP_START">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -500,7 +500,7 @@
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
-      <field type="uint16_t" name="state_of_charge" units="%" multiplier="1E-2" minValue="0" maxValue="10000" invalid="UINT16_MAX">State of Charge (SoC) in 0.01% increments. Values: [0-10000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage. The value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
+      <field type="float" name="state_of_charge" units="%" invalid="NaN">State of Charge (SoC). Values: [0-100], NaN: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage. The value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
     <message id="414" name="GROUP_START">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -500,7 +500,7 @@
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
-      <field type="uint16_t" name="state_of_charge" units="%" scale="0.01" minValue="0" maxValue="10000" invalid="UINT16_MAX">State of Charge (SoC) in 0.01% increments. Values: [0-10000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage. The value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
+      <field type="uint16_t" name="state_of_charge" units="%" factor="1E-2" minValue="0" maxValue="10000" invalid="UINT16_MAX">State of Charge (SoC) in 0.01% increments. Values: [0-10000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage. The value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
     <message id="414" name="GROUP_START">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -500,7 +500,7 @@
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
-      <field type="uint16_t" name="state_of_charge" units="%" factor="1E-2" minValue="0" maxValue="10000" invalid="UINT16_MAX">State of Charge (SoC) in 0.01% increments. Values: [0-10000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage. The value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
+      <field type="uint16_t" name="state_of_charge" units="%" multiplier="1E-2" minValue="0" maxValue="10000" invalid="UINT16_MAX">State of Charge (SoC) in 0.01% increments. Values: [0-10000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage. The value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
     <message id="414" name="GROUP_START">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -101,7 +101,7 @@
       </entry>
       <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE">
         <description>
-          Battery system tracks its own charge and accurately reports state of charge through vehiclepower cycles.
+          Battery system tracks its own charge and accurately reports state of charge through vehicle power cycles.
           This should be unset for power monitors, which track consumption since vehicle power-on and only provide a reliable estimate of state of charge if the battery is full on boot.
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -102,7 +102,7 @@
       <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE">
         <description>
           Battery system tracks its own charge and accurately reports state of charge through vehicle power cycles.
-          This should be unset for power monitors, which track consumption since vehicle power-on and only provide a reliable estimate of state of charge if the battery is full on boot.
+          This should be unset for simple current monitors which track consumption, since vehicle power-on and only provide a reliable estimate of state of charge if the battery is full on boot.
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>
       </entry>
@@ -493,7 +493,7 @@
       <description>Battery dynamic information.
         This should be streamed (nominally at 1Hz).
         Static/invariant battery information is sent in BATTERY_INFO.
-        Batteries that can accurately estimate their own charge level should set the MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE flag (power monitors must not set this bit).
+        Batteries that can accurately estimate their own charge level should set the MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE flag (basic current monitors must not set this bit).
         NOTE: This message should not be used for providing synthesized total system power status.
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -500,7 +500,7 @@
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
-      <field type="float" name="state_of_charge" units="%" invalid="NaN">State of Charge (SoC). Values: [0-100], NaN: field not provided. Note that SoC is remaining capacity relative to current fully-charged capacity as a percentage.</field>
+      <field type="uint16_t" name="state_of_charge" units="%" multiplier="2E-3" minValue="0" maxValue="50000" invalid="UINT16_MAX">State of Charge (SoC). Values: [0-50000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to fully-charged capacity as a percentage.</field>      
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
     <message id="414" name="GROUP_START">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -110,6 +110,24 @@
         <description>Reserved (not used). If set, this will indicate that an additional status field exists for higher status values.</description>
       </entry>
     </enum>
+    <enum name="MAV_FUEL_STATUS_FLAGS" bitmask="true">
+      <description>Fuel status flags for fault, health and state indication of a single fuel source. These indicate conditions of the fuel source itself; they do not indicate the status of the aggregated energy system as a whole (see MAV_ENERGY_STATUS in ENERGY_SYSTEM_STATUS for that).</description>
+      <entry value="1" name="MAV_FUEL_STATUS_FLAGS_NOT_READY_TO_USE">
+        <description>
+          The fuel source is not ready to use (fly).
+          Set if the fuel source has faults or other conditions that make it unsafe to fly with.
+        </description>
+      </entry>
+      <entry value="2" name="MAV_FUEL_STATUS_FLAGS_TANK_EMPTY">
+        <description>The fuel tank is empty.</description>
+      </entry>
+      <entry value="4" name="MAV_FUEL_STATUS_FLAGS_LEAK_DETECTED">
+        <description>A fuel leak has been detected.</description>
+      </entry>
+      <entry value="8" name="MAV_FUEL_STATUS_FLAGS_SENSOR_FAULT">
+        <description>A fuel level or flow sensor fault has been detected; reported values may be inaccurate.</description>
+      </entry>
+    </enum>
     <!-- The MAV_CMD enum entries describe either: -->
     <!--  * the data payload of mission items (as used in the MISSION_ITEM_INT message) -->
     <!--  * the data payload of mavlink commands (as used in the COMMAND_INT and COMMAND_LONG messages) -->
@@ -639,6 +657,27 @@
         <description></description>
       </entry>
     </enum>
+    <enum name="MAV_ENERGY_STATUS">
+      <description>Status of an aggregated energy system, as reported in ENERGY_SYSTEM_STATUS.
+        Applies to the energy system as a whole (not necessarily a specific battery or fuel tank contributing to it).
+        Note that the associated action/reaction of a vehicle depends on the energy system: an emergency status in a propulsion system should trigger an emergency landing, while a similar status in a payload might trigger a return to home.
+      </description>
+      <entry value="0" name="MAV_ENERGY_STATUS_UNDEFINED">
+        <description>Energy system status not provided.</description>
+      </entry>
+      <entry value="1" name="MAV_ENERGY_STATUS_LOW">
+        <description>Energy state is low, warn and monitor close.</description>
+      </entry>
+      <entry value="2" name="MAV_ENERGY_STATUS_CRITICAL">
+        <description>Energy state is critical. For flight-critical energy systems (i.e. propulsion), return or abort immediately.</description>
+      </entry>
+      <entry value="3" name="MAV_ENERGY_STATUS_EMERGENCY">
+        <description>Energy state is at emergency/failure level. For flight-critical energy systems (i.e. propulsion) land immediately.</description>
+      </entry>
+      <entry value="4" name="MAV_ENERGY_STATUS_UNAVAILABLE">
+        <description>Energy system unavailable. Arming might be blocked for a propulsion energy system.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="354" name="SET_VELOCITY_LIMITS">
@@ -676,6 +715,18 @@
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
       <field type="uint16_t" name="state_of_charge" units="%" multiplier="2E-3" minValue="0" maxValue="50000" invalid="UINT16_MAX">State of Charge (SoC). Values: [0-50000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to fully-charged capacity as a percentage.</field>
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
+    </message>
+    <message id="364" name="BATTERY_CELL_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Battery cell voltages.
+        The id field matches the id field of the corresponding BATTERY_STATUS_V2 and BATTERY_INFO messages.
+        A battery with more than 6 cells in series (see BATTERY_INFO.cells_in_series) sends multiple instances of this message, indexed by cells_instance, to cover all cells.
+        Note that the aggregate battery voltage is provided in BATTERY_STATUS_V2.voltage.
+      </description>
+      <field type="uint8_t" name="id" instance="true">Battery ID. Matches the id field of BATTERY_STATUS_V2.</field>
+      <field type="uint8_t" name="cells_instance">Instance of this message for the given energy system.  </field>
+      <field type="uint16_t[6]" name="voltages" units="mV" invalid="[UINT16_MAX]">Battery voltage of cells 6*cells_instance+1 to 6*cells_instance+7.</field>
     </message>
     <message id="414" name="GROUP_START">
       <description>Emitted during mission execution when control reaches MAV_CMD_GROUP_START.</description>
@@ -919,7 +970,7 @@
 
         ENERGY_SYSTEM_STATUS provides corresponding status information.
 
-        An energy system represents the energy supply for a single function domain (which might be "all" if all functions are supplied by a single system).
+        An energy system represents the energy supply for a single functional domain (which might be "all" if all functions are supplied by a single system).
         Each energy system aggregates one or more batteries and/or fuel systems and represents them as a single time or percentage remaining (it is up to the emitting system to determine the aggregation strategy).
         The intent is that a GCS can display a high level energy system as a simple indicator, and users can drill down to see the individual sources that contribute to it.
 
@@ -929,6 +980,7 @@
         For many cases the default functional domains are sufficient.
         If more granular functions are needed then user defined energy_systems can be used (such as MAV_ENERGY_SYSTEM_USER_DEFINED1).
         These can be given a human-readable name in the energy_system_name field.
+        Systems that support component metadata can use this as a key to provide translation information.
       </description>
       <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system. Vehicle unique.</field>
       <field type="char[25]" name="energy_system_name">User-defined energy system name (allows a GCS to provide a human readable string for an energy_system such as MAV_ENERGY_SYSTEM_USER_DEFINED1). Empty for predefined energy_system types. This is UTF-8 encoded and without null termination character.</field>
@@ -942,6 +994,10 @@
         This provides corresponding low rate/invariant information, including a human readable name if user-defined energy_system values are used.
       </description>
       <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system.</field>
+      <field type="float" name="remaining_capacity" units="%" invalid="NaN">Remaining capacity relative to full capacity as a percentage. Values: [0-100], NaN: field not provided.</field>
+      <field type="float" name="remaining_time" units="s">Estimated time remaining at current consumption rate.
+        When landed, estimated time at nominal in-use consumption rate (such as during hover/cruise mode for normal propulsion) hover/cruise mode.</field>
+      <field type="uint16_t" name="status_flags" enum="MAV_ENERGY_STATUS">Health and readiness state of overall power system.</field>
     </message>
     <message id="367" name="FUEL_INFORMATION_V2">
       <wip/>
@@ -952,6 +1008,8 @@
       </description>
       <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as FUEL_STATUS_V2.</field>
       <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system.</field>
+      <field type="uint32_t" name="fuel_type" enum="MAV_FUEL_TYPE">Fuel type. Defines units for fuel capacity and consumption fields in FUEL_STATUS_V2.</field>
+      <field type="float" name="maximum_fuel">Capacity when full. Must be provided.</field>
     </message>
     <message id="368" name="FUEL_STATUS_V2">
       <wip/>
@@ -961,6 +1019,12 @@
         Static/invariant fuel information is sent in FUEL_INFORMATION_V2.
       </description>
       <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as FUEL_INFORMATION_V2.</field>
+      <field type="float" name="consumed_fuel" invalid="NaN">Consumed fuel (measured). Units defined by MAV_FUEL_TYPE. This value should not be inferred: if not measured set to NaN. NaN: field not provided.</field>
+      <field type="float" name="remaining_fuel" invalid="NaN">Remaining fuel until empty (measured). Units defined by MAV_FUEL_TYPE. The value should not be inferred: if not measured set to NaN. NaN: field not provided.</field>
+      <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Percentage of remaining fuel, relative to full. Values: [0-100], UINT8_MAX: field not provided.</field>
+      <field type="float" name="flow_rate" invalid="NaN">Positive value when emptying/using, and negative if filling/replacing. NaN: field not provided.</field>
+      <field type="float" name="temperature" units="K" invalid="NaN">Fuel temperature. NaN: field not provided.</field>
+      <field type="uint32_t" name="status_flags" enum="MAV_FUEL_STATUS_FLAGS">Fault, health, readiness, and other status indications for this fuel source.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -603,6 +603,42 @@
         <description>Exhaust-gas-recirculation (EGR) system fault.</description>
       </entry>
     </enum>
+    <enum name="MAV_ENERGY_SYSTEM">
+      <description>Energy system identifier.
+        Batteries and and other fuel systems are grouped by energy systems that support particular functions.
+        Referenced by ENERGY_SYSTEM_INFO, BATTERY_INFO, and FUEL_INFORMATION_V2.
+        BATTERY_STATUS_V2 and FUEL_STATUS_V2 are associated with an energy system via their instance association with the INFO messages.</description>
+      <entry value="0" name="MAV_ENERGY_SYSTEM_UNKNOWN">
+        <description>Energy system is unknown</description>
+      </entry>
+      <entry value="1" name="MAV_ENERGY_SYSTEM_ALL">
+        <description>Energy system supports all flight systems</description>
+      </entry>
+      <entry value="2" name="MAV_ENERGY_SYSTEM_PROPULSION">
+        <description>Propulsion energy system</description>
+      </entry>
+      <entry value="3" name="MAV_ENERGY_SYSTEM_AVIONICS">
+        <description>Avionics energy system</description>
+      </entry>
+      <entry value="4" name="MAV_ENERGY_SYSTEM_PAYLOAD">
+        <description>Payload energy system</description>
+      </entry>
+      <entry value="5" name="MAV_ENERGY_SYSTEM_USER_DEFINED1">
+        <description>User-defined energy system (1). Name is provided in ENERGY_SYSTEM_INFO. </description>
+      </entry>
+      <entry value="6" name="MAV_ENERGY_SYSTEM_USER_DEFINED2">
+        <description></description>
+      </entry>
+      <entry value="7" name="MAV_ENERGY_SYSTEM_USER_DEFINED3">
+        <description></description>
+      </entry>
+      <entry value="8" name="MAV_ENERGY_SYSTEM_USER_DEFINED4">
+        <description></description>
+      </entry>
+      <entry value="9" name="MAV_ENERGY_SYSTEM_USER_DEFINED5">
+        <description></description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="354" name="SET_VELOCITY_LIMITS">
@@ -638,7 +674,7 @@
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
-      <field type="uint16_t" name="state_of_charge" units="%" multiplier="2E-3" minValue="0" maxValue="50000" invalid="UINT16_MAX">State of Charge (SoC). Values: [0-50000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to fully-charged capacity as a percentage.</field>      
+      <field type="uint16_t" name="state_of_charge" units="%" multiplier="2E-3" minValue="0" maxValue="50000" invalid="UINT16_MAX">State of Charge (SoC). Values: [0-50000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to fully-charged capacity as a percentage.</field>
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
     <message id="414" name="GROUP_START">
@@ -875,6 +911,56 @@
       <field type="uint8_t" name="id" instance="true">Sensor ID. Matches the id field of DISTANCE_SENSOR_INFO.</field>
       <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if not provided.</field>
       <field type="int8_t" name="signal_quality" units="%" invalid="INT8_MAX">Signal quality (sensor-type specific). Represents the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. Values: [0-100], 0 = unusable signal, 100 = perfect signal. INT8_MAX = unknown/not provided.</field>
+    </message>
+    <message id="365" name="ENERGY_SYSTEM_INFO">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Energy system (propulsion, avionics, payload, all, or user-defined) low rate/static information.
+
+        ENERGY_SYSTEM_STATUS provides corresponding status information.
+
+        An energy system represents the energy supply for a single function domain (which might be "all" if all functions are supplied by a single system).
+        Each energy system aggregates one or more batteries and/or fuel systems and represents them as a single time or percentage remaining (it is up to the emitting system to determine the aggregation strategy).
+        The intent is that a GCS can display a high level energy system as a simple indicator, and users can drill down to see the individual sources that contribute to it.
+
+        The ENERGY_SYSTEM_INFO, ENERGY_SYSTEM_STATUS, FUEL_INFORMATION_V2, are grouped having the same value in energy_system field (BATTERY_INFO.battery_function is used for batteries).
+        The BATTERY_STATUS_V2 and FUEL_STATUS_V2 are mapped via their corresponding INFO messages.
+
+        For many cases the default functional domains are sufficient.
+        If more granular functions are needed then user defined energy_systems can be used (such as MAV_ENERGY_SYSTEM_USER_DEFINED1).
+        These can be given a human-readable name in the energy_system_name field.
+      </description>
+      <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system. Vehicle unique.</field>
+      <field type="char[25]" name="energy_system_name">User-defined energy system name (allows a GCS to provide a human readable string for an energy_system such as MAV_ENERGY_SYSTEM_USER_DEFINED1). Empty for predefined energy_system types. This is UTF-8 encoded and without null termination character.</field>
+    </message>
+    <message id="366" name="ENERGY_SYSTEM_STATUS">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Energy system (propulsion, avionics, payload, all, or user-defined) status information.
+
+        See ENERGY_SYSTEM_INFO for an overview of energy systems.
+        This provides corresponding low rate/invariant information, including a human readable name if user-defined energy_system values are used.
+      </description>
+      <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system.</field>
+    </message>
+    <message id="367" name="FUEL_INFORMATION_V2">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Fuel information that is static, or requires infrequent update.
+        This message should be requested using MAV_CMD_REQUEST_MESSAGE and/or streamed at very low rate.
+        FUEL_STATUS_V2 is used for higher-rate fuel status information.
+      </description>
+      <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as FUEL_STATUS_V2.</field>
+      <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system.</field>
+    </message>
+    <message id="368" name="FUEL_STATUS_V2">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Fuel dynamic information.
+        This should be streamed (nominally at 1Hz).
+        Static/invariant fuel information is sent in FUEL_INFORMATION_V2.
+      </description>
+      <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as FUEL_INFORMATION_V2.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -955,7 +955,8 @@
         These can be given a human-readable name in the energy_system_name field.
         Systems that support component metadata can use this as a key to provide translation information.
       </description>
-      <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system. Vehicle unique.</field>
+      <field type="uint8_t" name="index" instance="true">Index of this energy system. Matches the index field of the corresponding ENERGY_SYSTEM_STATUS message.</field>
+      <field type="uint16_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system.</field>
       <field type="char[25]" name="energy_system_name">User-defined energy system name (allows a GCS to provide a human readable string for an energy_system such as MAV_ENERGY_SYSTEM_USER_DEFINED1). Empty for predefined energy_system types. This is UTF-8 encoded and without null termination character.</field>
     </message>
     <message id="366" name="ENERGY_SYSTEM_STATUS">
@@ -964,9 +965,8 @@
       <description>Energy system (propulsion, avionics, payload, all, or user-defined) status information.
 
         See ENERGY_SYSTEM_INFO for an overview of energy systems.
-        This provides corresponding low rate/invariant information, including a human readable name if user-defined energy_systems values are used.
       </description>
-      <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system.</field>
+      <field type="uint8_t" name="index" instance="true">Index of this energy system. Matches the index field of the corresponding ENERGY_SYSTEM_INFO message.</field>
       <field type="float" name="remaining_capacity" units="%" invalid="NaN">Remaining capacity relative to full capacity as a percentage. Values: [0-100], NaN: field not provided.</field>
       <field type="float" name="remaining_time" units="s" invalid="NaN">Estimated time remaining at current consumption rate.
         When landed, estimated time at nominal in-use consumption rate (such as during hover/cruise mode for normal propulsion) hover/cruise mode.</field>
@@ -980,7 +980,7 @@
         FUEL_STATUS_V2 is used for higher-rate fuel status information.
       </description>
       <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as FUEL_STATUS_V2.</field>
-      <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy systems this source contributes to. Will be associated with any ENERGY_SYSTEM_STATUS that sets any matching flags.</field>
+      <field type="uint16_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy systems this source contributes to. Will be associated with any ENERGY_SYSTEM_INFO that sets any matching flags.</field>
       <field type="uint32_t" name="fuel_type" enum="MAV_FUEL_TYPE">Fuel type. Defines units for fuel capacity and consumption fields in FUEL_STATUS_V2.</field>
       <field type="float" name="maximum_fuel">Capacity when full. Must be provided.</field>
     </message>
@@ -992,9 +992,7 @@
         Static/invariant fuel information is sent in FUEL_INFORMATION_V2.
       </description>
       <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as FUEL_INFORMATION_V2.</field>
-      <field type="float" name="consumed_fuel" invalid="NaN">Consumed fuel (measured). Units defined by MAV_FUEL_TYPE. This value should not be inferred: if not measured set to NaN. NaN: field not provided.</field>
-      <field type="float" name="remaining_fuel" invalid="NaN">Remaining fuel until empty (measured). Units defined by MAV_FUEL_TYPE. The value should not be inferred: if not measured set to NaN. NaN: field not provided.</field>
-      <field type="uint8_t" name="percent_remaining" units="%" invalid="UINT8_MAX">Percentage of remaining fuel, relative to full. Values: [0-100], UINT8_MAX: field not provided.</field>
+      <field type="uint16_t" name="percent_remaining" units="%" invalid="UINT16_MAX">Percentage of remaining fuel, relative to full. Values: [0-100], UINT16_MAX: field not provided.</field>
       <field type="float" name="flow_rate" invalid="NaN">Positive value when emptying/using, and negative if filling/replacing. NaN: field not provided.</field>
       <field type="float" name="temperature" units="K" invalid="NaN">Fuel temperature. NaN: field not provided.</field>
       <field type="uint32_t" name="status_flags" enum="MAV_FUEL_STATUS_FLAGS">Fault, health, readiness, and other status indications for this fuel source.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -111,7 +111,7 @@
       </entry>
     </enum>
     <enum name="MAV_FUEL_STATUS_FLAGS" bitmask="true">
-      <description>Fuel status flags for fault, health and state indication of a single fuel source. These indicate conditions of the fuel source itself; they do not indicate the status of the aggregated energy system as a whole (see MAV_ENERGY_STATUS in ENERGY_SYSTEM_STATUS for that).</description>
+      <description>Fuel status flags for fault, health and state indication of a single fuel source. These indicate conditions of the fuel source itself; they do not indicate the status of the aggregated energy system as a whole (see MAV_ENERGY_STATUS_FLAGS in ENERGY_SYSTEM_STATUS for that).</description>
       <entry value="1" name="MAV_FUEL_STATUS_FLAGS_NOT_READY_TO_USE">
         <description>
           The fuel source is not ready to use (fly).
@@ -621,61 +621,77 @@
         <description>Exhaust-gas-recirculation (EGR) system fault.</description>
       </entry>
     </enum>
-    <enum name="MAV_ENERGY_SYSTEM">
-      <description>Energy system identifier.
-        Batteries and and other fuel systems are grouped by energy systems that support particular functions.
-        Referenced by ENERGY_SYSTEM_INFO, BATTERY_INFO, and FUEL_INFORMATION_V2.
-        BATTERY_STATUS_V2 and FUEL_STATUS_V2 are associated with an energy system via their instance association with the INFO messages.</description>
-      <entry value="0" name="MAV_ENERGY_SYSTEM_UNKNOWN">
-        <description>Energy system is unknown</description>
+    <enum name="MAV_ENERGY_SYSTEM_FLAGS" bitmask="true">
+      <description>Energy system function flags.
+        In an ENERGY_SYSTEM_STATUS it indicates the function domains the energy system supplies.
+        In source messages (BATTERY_INFO.energy_system, FUEL_INFORMATION_V2.energy_system) it indicates the functional domains the source contributes to;
+        if any bits in a source message match corresponding bits in an energy system, the source should appear in a drop down for the energy system.
+
+        ENERGY_SYSTEM_STATUS should never be emitted with a zero value.
+        A source that has zero may be grouped with other sources that set 0, but this is not encouraged.
+      </description>
+      <entry value="1" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION">
+        <description>Propulsion energy system.</description>
       </entry>
-      <entry value="1" name="MAV_ENERGY_SYSTEM_ALL">
-        <description>Energy system supports all flight systems</description>
+      <entry value="2" name="MAV_ENERGY_SYSTEM_FLAGS_AVIONICS">
+        <description>Avionics energy system.</description>
       </entry>
-      <entry value="2" name="MAV_ENERGY_SYSTEM_PROPULSION">
-        <description>Propulsion energy system</description>
+      <entry value="4" name="MAV_ENERGY_SYSTEM_FLAGS_PAYLOAD">
+        <description>Payload energy system.</description>
       </entry>
-      <entry value="3" name="MAV_ENERGY_SYSTEM_AVIONICS">
-        <description>Avionics energy system</description>
+      <entry value="8" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION_VTOL_MC">
+        <description>Propulsion energy system for a VTOL in MC mode.
+          Used when reporting modes usage separately (for either different or the same underlying sources).
+          MAV_ENERGY_SYSTEM_FLAGS_PROPULSION can be used if there is a single physical source and you want to report the consumption in the current mode.</description>
       </entry>
-      <entry value="4" name="MAV_ENERGY_SYSTEM_PAYLOAD">
-        <description>Payload energy system</description>
+      <entry value="16" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION_VTOL_FW">
+        <description>Propulsion energy system for a VTOL in FW mode.
+          Used when reporting modes usage separately (for either different or the same underlying sources).
+          MAV_ENERGY_SYSTEM_FLAGS_PROPULSION can be used if there is a single physical source and you want to report the consumption in the current mode.</description>
       </entry>
-      <entry value="5" name="MAV_ENERGY_SYSTEM_USER_DEFINED1">
-        <description>User-defined energy system (1). Name is provided in ENERGY_SYSTEM_INFO. </description>
+      <entry value="32" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED1">
+        <description>User-defined energy system (1). Name is provided in ENERGY_SYSTEM_INFO.</description>
       </entry>
-      <entry value="6" name="MAV_ENERGY_SYSTEM_USER_DEFINED2">
-        <description></description>
+      <entry value="64" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED2">
+        <description>User-defined energy system (2). Name is provided in ENERGY_SYSTEM_INFO.</description>
       </entry>
-      <entry value="7" name="MAV_ENERGY_SYSTEM_USER_DEFINED3">
-        <description></description>
+      <entry value="128" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED3">
+        <description>User-defined energy system (3). Name is provided in ENERGY_SYSTEM_INFO.</description>
       </entry>
-      <entry value="8" name="MAV_ENERGY_SYSTEM_USER_DEFINED4">
-        <description></description>
+      <entry value="256" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED4">
+        <description>User-defined energy system (4). Name is provided in ENERGY_SYSTEM_INFO.</description>
       </entry>
-      <entry value="9" name="MAV_ENERGY_SYSTEM_USER_DEFINED5">
-        <description></description>
+      <entry value="512" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED5">
+        <description>User-defined energy system (5). Name is provided in ENERGY_SYSTEM_INFO.</description>
       </entry>
     </enum>
-    <enum name="MAV_ENERGY_STATUS">
-      <description>Status of an aggregated energy system, as reported in ENERGY_SYSTEM_STATUS.
-        Applies to the energy system as a whole (not necessarily a specific battery or fuel tank contributing to it).
-        Note that the associated action/reaction of a vehicle depends on the energy system: an emergency status in a propulsion system should trigger an emergency landing, while a similar status in a payload might trigger a return to home.
+    <enum name="MAV_ENERGY_STATUS_FLAGS" bitmask="true">
+      <description>Status and configuration flags for an energy system, as reported in ENERGY_SYSTEM_STATUS.
+        Applies to the energy system as a whole (not a specific battery or fuel tank contributing to it).
+
+        The severity flags (LOW, CRITICAL, EMERGENCY) are not mutually exclusive: an emitter should set only the severity flag that currently applies, and a consumer should act on the most severe flag more than one is set.
+        MAV_ENERGY_STATUS_FLAGS_FLIGHT_CRITICAL is used to indicate that a consumer should treat the energy system as flight-critical
+        (this allows an integrator indicate that a user defined energy system or the payload handle emergency levels in the same way as MAV_ENERGY_SYSTEM_FLAGS_PROPULSION or MAV_ENERGY_SYSTEM_FLAGS_AVIONIC).
       </description>
-      <entry value="0" name="MAV_ENERGY_STATUS_UNDEFINED">
-        <description>Energy system status not provided.</description>
-      </entry>
-      <entry value="1" name="MAV_ENERGY_STATUS_LOW">
+      <entry value="1" name="MAV_ENERGY_STATUS_FLAGS_LOW">
         <description>Energy state is low, warn and monitor close.</description>
       </entry>
-      <entry value="2" name="MAV_ENERGY_STATUS_CRITICAL">
+      <entry value="2" name="MAV_ENERGY_STATUS_FLAGS_CRITICAL">
         <description>Energy state is critical. For flight-critical energy systems (i.e. propulsion), return or abort immediately.</description>
       </entry>
-      <entry value="3" name="MAV_ENERGY_STATUS_EMERGENCY">
+      <entry value="4" name="MAV_ENERGY_STATUS_FLAGS_EMERGENCY">
         <description>Energy state is at emergency/failure level. For flight-critical energy systems (i.e. propulsion) land immediately.</description>
       </entry>
-      <entry value="4" name="MAV_ENERGY_STATUS_UNAVAILABLE">
+      <entry value="8" name="MAV_ENERGY_STATUS_FLAGS_INACTIVE">
+        <description>Energy system inactive. It is not being used/drained.</description>
+      </entry>
+      <entry value="16" name="MAV_ENERGY_STATUS_FLAGS_UNAVAILABLE">
         <description>Energy system unavailable. Arming might be blocked for a propulsion energy system.</description>
+      </entry>
+      <entry value="32" name="MAV_ENERGY_STATUS_FLAGS_FLIGHT_CRITICAL">
+        <description>This energy system should be treated as flight-critical: LOW, CRITICAL or EMERGENCY severity flags should trigger the same kind of reaction as they would on a propulsion system (e.g. immediate return/landing).
+          This allows an emitter to indicate whether a payload or user defined energy system should have the same low/level behaviour as propulsion (or something less serious).
+        </description>
       </entry>
     </enum>
   </enums>
@@ -970,19 +986,20 @@
 
         ENERGY_SYSTEM_STATUS provides corresponding status information.
 
-        An energy system represents the energy supply for a single functional domain (which might be "all" if all functions are supplied by a single system).
-        Each energy system aggregates one or more batteries and/or fuel systems and represents them as a single time or percentage remaining (it is up to the emitting system to determine the aggregation strategy).
+        An energy system represents the energy supply for one or more functional domains (set every applicable domain flag to represent "all").
+        Each energy system aggregates one or more batteries and/or fuel systems and represents them as a single percentage and (optionally) time remaining.
+        It is up to the emitting system to determine how it calculates these values.
         The intent is that a GCS can display a high level energy system as a simple indicator, and users can drill down to see the individual sources that contribute to it.
 
-        The ENERGY_SYSTEM_INFO, ENERGY_SYSTEM_STATUS, FUEL_INFORMATION_V2, are grouped having the same value in energy_system field (BATTERY_INFO.battery_function is used for batteries).
+        A source (BATTERY_INFO.energy_system, FUEL_INFORMATION_V2.energy_system) is associated with an ENERGY_SYSTEM_INFO/ENERGY_SYSTEM_STATUS stream if any bit is set in both energy_system values (bitwise AND is non-zero) - see MAV_ENERGY_SYSTEM_FLAGS. A single source may be associated with more than one energy_system stream this way (for example, a VTOL propulsion battery reported separately for MC and FW regimes).
         The BATTERY_STATUS_V2 and FUEL_STATUS_V2 are mapped via their corresponding INFO messages.
 
         For many cases the default functional domains are sufficient.
-        If more granular functions are needed then user defined energy_systems can be used (such as MAV_ENERGY_SYSTEM_USER_DEFINED1).
+        If more granular functions are needed then user defined energy_systems can be used (such as MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED1).
         These can be given a human-readable name in the energy_system_name field.
         Systems that support component metadata can use this as a key to provide translation information.
       </description>
-      <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system. Vehicle unique.</field>
+      <field type="uint16_t" name="energy_system" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system. Vehicle unique.</field>
       <field type="char[25]" name="energy_system_name">User-defined energy system name (allows a GCS to provide a human readable string for an energy_system such as MAV_ENERGY_SYSTEM_USER_DEFINED1). Empty for predefined energy_system types. This is UTF-8 encoded and without null termination character.</field>
     </message>
     <message id="366" name="ENERGY_SYSTEM_STATUS">
@@ -993,11 +1010,11 @@
         See ENERGY_SYSTEM_INFO for an overview of energy systems.
         This provides corresponding low rate/invariant information, including a human readable name if user-defined energy_system values are used.
       </description>
-      <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system.</field>
+      <field type="uint16_t" name="energy_system" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system.</field>
       <field type="float" name="remaining_capacity" units="%" invalid="NaN">Remaining capacity relative to full capacity as a percentage. Values: [0-100], NaN: field not provided.</field>
       <field type="float" name="remaining_time" units="s">Estimated time remaining at current consumption rate.
         When landed, estimated time at nominal in-use consumption rate (such as during hover/cruise mode for normal propulsion) hover/cruise mode.</field>
-      <field type="uint16_t" name="status_flags" enum="MAV_ENERGY_STATUS">Health and readiness state of overall power system.</field>
+      <field type="uint16_t" name="status_flags" enum="MAV_ENERGY_STATUS_FLAGS">Health and readiness state of overall power system and configuration flags.</field>
     </message>
     <message id="367" name="FUEL_INFORMATION_V2">
       <wip/>
@@ -1007,7 +1024,7 @@
         FUEL_STATUS_V2 is used for higher-rate fuel status information.
       </description>
       <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as FUEL_STATUS_V2.</field>
-      <field type="uint8_t" name="energy_system" enum="MAV_ENERGY_SYSTEM">Energy system.</field>
+      <field type="uint16_t" name="energy_system" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy systems this source contributes to. Will be associated with any ENERGY_SYSTEM_STATUS that sets any matching flags.</field>
       <field type="uint32_t" name="fuel_type" enum="MAV_FUEL_TYPE">Fuel type. Defines units for fuel capacity and consumption fields in FUEL_STATUS_V2.</field>
       <field type="float" name="maximum_fuel">Capacity when full. Must be provided.</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -99,11 +99,10 @@
       <entry value="131072" name="MAV_BATTERY_STATUS_FLAGS_FAULT_INCOMPATIBLE_CELLS_CONFIGURATION">
         <description>Battery is not compatible due to cell configuration (e.g. 5s1p when vehicle requires 6s).</description>
       </entry>
-      <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL">
+      <entry value="262144" name="MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE">
         <description>
-          Battery capacity_consumed and capacity_remaining values are relative to a full battery (they sum to the total capacity of the battery).
-          This flag would be set for a smart battery that can accurately determine its remaining charge across vehicle reboots and discharge/recharge cycles.
-          If unset the capacity_consumed indicates the consumption since vehicle power-on, as measured using a power monitor. The capacity_remaining, if provided, indicates the estimated remaining capacity on the assumption that the battery was full on vehicle boot.
+          Battery system tracks its own charge and accurately reports state of charge through vehicle power cycles.
+          This should be unset for simple current monitors which track consumption, since vehicle power-on and only provide a reliable estimate of state of charge if the battery is full on boot.
           If unset a GCS is recommended to advise that users fully charge the battery on power on.
         </description>
       </entry>
@@ -628,19 +627,18 @@
       <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: No limit applied</field>
     </message>
     <message id="369" name="BATTERY_STATUS_V2">
+      <wip/>
       <description>Battery dynamic information.
         This should be streamed (nominally at 1Hz).
         Static/invariant battery information is sent in BATTERY_INFO.
-        Note that smart batteries should set the MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL bit to indicate that supplied capacity values are relative to a battery that is known to be full.
-        Power monitors would not set this bit, indicating that capacity_consumed is relative to drone power-on, and that other values are estimated based on the assumption that the battery was full on power-on.
+        Batteries that can accurately estimate their own charge level should set the MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE flag (basic current monitors must not set this bit).
+        NOTE: This message should not be used for providing synthesized total system power status.
       </description>
       <field type="uint8_t" name="id" instance="true">Battery ID</field>
       <field type="int16_t" name="temperature" units="cdegC" invalid="INT16_MAX">Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.</field>
       <field type="float" name="voltage" units="V" invalid="NaN">Battery voltage (total). NaN: field not provided.</field>
       <field type="float" name="current" units="A" invalid="NaN">Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.</field>
-      <field type="float" name="capacity_consumed" units="Ah" invalid="NaN">Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.</field>
-      <field type="float" name="capacity_remaining" units="Ah" invalid="NaN">Remaining charge (until empty). NaN: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.</field>
-      <field type="float" name="state_of_charge" units="%" invalid="NaN">State of Charge (SoC). Remaining capacity relative to current fully-charged capacity as a percentage. Values: [0-100], NaN: field not provided. Note that the value may be calculated from design_capacity if current full_charge_capacity is not known (see BATTERY_INFO).</field>
+      <field type="uint16_t" name="state_of_charge" units="%" multiplier="2E-3" minValue="0" maxValue="50000" invalid="UINT16_MAX">State of Charge (SoC). Values: [0-50000], UINT16_MAX: field not provided. Note that SoC is remaining capacity relative to fully-charged capacity as a percentage.</field>      
       <field type="uint32_t" name="status_flags" enum="MAV_BATTERY_STATUS_FLAGS">Fault, health, readiness, and other status indications.</field>
     </message>
     <message id="414" name="GROUP_START">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -621,50 +621,6 @@
         <description>Exhaust-gas-recirculation (EGR) system fault.</description>
       </entry>
     </enum>
-    <enum name="MAV_ENERGY_SYSTEM_FLAGS" bitmask="true">
-      <description>Energy system function flags.
-        In an ENERGY_SYSTEM_STATUS it indicates the function domains the energy system supplies.
-        In source messages (BATTERY_INFO.energy_system, FUEL_INFORMATION_V2.energy_system) it indicates the functional domains the source contributes to;
-        if any bits in a source message match corresponding bits in an energy system, the source should appear in a drop down for the energy system.
-
-        ENERGY_SYSTEM_STATUS should never be emitted with a zero value.
-        A source that has zero may be grouped with other sources that set 0, but this is not encouraged.
-      </description>
-      <entry value="1" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION">
-        <description>Propulsion energy system.</description>
-      </entry>
-      <entry value="2" name="MAV_ENERGY_SYSTEM_FLAGS_AVIONICS">
-        <description>Avionics energy system.</description>
-      </entry>
-      <entry value="4" name="MAV_ENERGY_SYSTEM_FLAGS_PAYLOAD">
-        <description>Payload energy system.</description>
-      </entry>
-      <entry value="8" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION_VTOL_MC">
-        <description>Propulsion energy system for a VTOL in MC mode.
-          Used when reporting modes usage separately (for either different or the same underlying sources).
-          MAV_ENERGY_SYSTEM_FLAGS_PROPULSION can be used if there is a single physical source and you want to report the consumption in the current mode.</description>
-      </entry>
-      <entry value="16" name="MAV_ENERGY_SYSTEM_FLAGS_PROPULSION_VTOL_FW">
-        <description>Propulsion energy system for a VTOL in FW mode.
-          Used when reporting modes usage separately (for either different or the same underlying sources).
-          MAV_ENERGY_SYSTEM_FLAGS_PROPULSION can be used if there is a single physical source and you want to report the consumption in the current mode.</description>
-      </entry>
-      <entry value="32" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED1">
-        <description>User-defined energy system (1). Name is provided in ENERGY_SYSTEM_INFO.</description>
-      </entry>
-      <entry value="64" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED2">
-        <description>User-defined energy system (2). Name is provided in ENERGY_SYSTEM_INFO.</description>
-      </entry>
-      <entry value="128" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED3">
-        <description>User-defined energy system (3). Name is provided in ENERGY_SYSTEM_INFO.</description>
-      </entry>
-      <entry value="256" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED4">
-        <description>User-defined energy system (4). Name is provided in ENERGY_SYSTEM_INFO.</description>
-      </entry>
-      <entry value="512" name="MAV_ENERGY_SYSTEM_FLAGS_USER_DEFINED5">
-        <description>User-defined energy system (5). Name is provided in ENERGY_SYSTEM_INFO.</description>
-      </entry>
-    </enum>
     <enum name="MAV_ENERGY_STATUS_FLAGS" bitmask="true">
       <description>Status and configuration flags for an energy system, as reported in ENERGY_SYSTEM_STATUS.
         Applies to the energy system as a whole (not a specific battery or fuel tank contributing to it).
@@ -991,7 +947,7 @@
         It is up to the emitting system to determine how it calculates these values.
         The intent is that a GCS can display a high level energy system as a simple indicator, and users can drill down to see the individual sources that contribute to it.
 
-        A source (BATTERY_INFO.energy_system, FUEL_INFORMATION_V2.energy_system) is associated with an ENERGY_SYSTEM_INFO/ENERGY_SYSTEM_STATUS stream if any bit is set in both energy_system values (bitwise AND is non-zero) - see MAV_ENERGY_SYSTEM_FLAGS. A single source may be associated with more than one energy_system stream this way (for example, a VTOL propulsion battery reported separately for MC and FW regimes).
+        A source (BATTERY_INFO.energy_systems, FUEL_INFORMATION_V2.energy_systems) is associated with an ENERGY_SYSTEM_INFO/ENERGY_SYSTEM_STATUS stream if any bit is set in both energy_systems values (bitwise AND is non-zero) - see MAV_ENERGY_SYSTEM_FLAGS. A single source may be associated with more than one energy_systems stream this way (for example, a VTOL propulsion battery reported separately for MC and FW regimes).
         The BATTERY_STATUS_V2 and FUEL_STATUS_V2 are mapped via their corresponding INFO messages.
 
         For many cases the default functional domains are sufficient.
@@ -999,7 +955,7 @@
         These can be given a human-readable name in the energy_system_name field.
         Systems that support component metadata can use this as a key to provide translation information.
       </description>
-      <field type="uint16_t" name="energy_system" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system. Vehicle unique.</field>
+      <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system. Vehicle unique.</field>
       <field type="char[25]" name="energy_system_name">User-defined energy system name (allows a GCS to provide a human readable string for an energy_system such as MAV_ENERGY_SYSTEM_USER_DEFINED1). Empty for predefined energy_system types. This is UTF-8 encoded and without null termination character.</field>
     </message>
     <message id="366" name="ENERGY_SYSTEM_STATUS">
@@ -1008,13 +964,13 @@
       <description>Energy system (propulsion, avionics, payload, all, or user-defined) status information.
 
         See ENERGY_SYSTEM_INFO for an overview of energy systems.
-        This provides corresponding low rate/invariant information, including a human readable name if user-defined energy_system values are used.
+        This provides corresponding low rate/invariant information, including a human readable name if user-defined energy_systems values are used.
       </description>
-      <field type="uint16_t" name="energy_system" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system.</field>
+      <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system.</field>
       <field type="float" name="remaining_capacity" units="%" invalid="NaN">Remaining capacity relative to full capacity as a percentage. Values: [0-100], NaN: field not provided.</field>
       <field type="float" name="remaining_time" units="s">Estimated time remaining at current consumption rate.
         When landed, estimated time at nominal in-use consumption rate (such as during hover/cruise mode for normal propulsion) hover/cruise mode.</field>
-      <field type="uint16_t" name="status_flags" enum="MAV_ENERGY_STATUS_FLAGS">Health and readiness state of overall power system and configuration flags.</field>
+      <field type="uint8_t" name="status_flags" enum="MAV_ENERGY_STATUS_FLAGS">Health and readiness state of overall power system and configuration flags.</field>
     </message>
     <message id="367" name="FUEL_INFORMATION_V2">
       <wip/>
@@ -1024,7 +980,7 @@
         FUEL_STATUS_V2 is used for higher-rate fuel status information.
       </description>
       <field type="uint8_t" name="id" instance="true">Fuel ID. Must match ID of other messages for same fuel system, such as FUEL_STATUS_V2.</field>
-      <field type="uint16_t" name="energy_system" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy systems this source contributes to. Will be associated with any ENERGY_SYSTEM_STATUS that sets any matching flags.</field>
+      <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy systems this source contributes to. Will be associated with any ENERGY_SYSTEM_STATUS that sets any matching flags.</field>
       <field type="uint32_t" name="fuel_type" enum="MAV_FUEL_TYPE">Fuel type. Defines units for fuel capacity and consumption fields in FUEL_STATUS_V2.</field>
       <field type="float" name="maximum_fuel">Capacity when full. Must be provided.</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -968,7 +968,7 @@
       </description>
       <field type="uint8_t" name="energy_systems" enum="MAV_ENERGY_SYSTEM_FLAGS">Energy system.</field>
       <field type="float" name="remaining_capacity" units="%" invalid="NaN">Remaining capacity relative to full capacity as a percentage. Values: [0-100], NaN: field not provided.</field>
-      <field type="float" name="remaining_time" units="s">Estimated time remaining at current consumption rate.
+      <field type="float" name="remaining_time" units="s" invalid="NaN">Estimated time remaining at current consumption rate.
         When landed, estimated time at nominal in-use consumption rate (such as during hover/cruise mode for normal propulsion) hover/cruise mode.</field>
       <field type="uint8_t" name="status_flags" enum="MAV_ENERGY_STATUS_FLAGS">Health and readiness state of overall power system and configuration flags.</field>
     </message>


### PR DESCRIPTION
This PR has been updated to reflect the "energy system proposal". The goal of this proposal is to be able to provide a system level view of the vehicle energy system and status (along with warning level notifications at a system level), while still allowing users to find out about the specific batteries and fuel systems that comprise it.

## Overview

An energy system represents the energy supply for one or more functional domains, such as propulsion, avionics, payloads, or user defined domains.
Each energy system aggregates one or more batteries and/or fuel systems and represents them as a single time remaining or percentage remaining value.

The intent is that a GCS can display a high level energy system as a simple indicator, and users can drill down to determine what functions it supports, and the individual sources that contribute to it.

The design of the proposal is such that you can represent the energy system functions either on their own or grouped, and each energy source (such as a battery) can contribute to any source. 
It's up to the integrator to decide if they'd rather just represent all functions in one energy system or split them out.
The flight stack is free to represent the energy systems that it wants, and to use whatever algorithm it likes to indicate the % and time remaining for that system.

In addition, the design adds source for VTOL MC and FW modes. This means that you can represent the energy systems for those modes separately: allowing you to show the time remaining if you were to switch modes.

## Messages

The messages are:
- `ENERGY_SYSTEM_STATUS` - time and percentage remaining plus status of the overall system. This is what emits "critical level" information, while a battery status emits per-battery faults.
  - If you don't want to provide information about specific sources you don't have to - you could just emit this.
- `FUEL_INFORMATION_V2` and `FUEL_STATUS_V2` - fuel tank invariant/variant info. 
- `BATTERY_STATUS_V2`, `BATTERY_CELL_STATUS` and `BATTERY_INFO`  - battery variant, cell status and invariant info.

Optional:
- `ENERGY_SYSTEM_INFO` - invariant battery info. Currently only the name for the user-defined energy systems, if used. Therefore optional.

The  `ENERGY_SYSTEM_` messages `energy_system` field contains a bitmask of the functions supported by the particular system. 
The energy source `_INFO` messages similarly have an `energy_system` bitmask field indicating which functions they contribute to. If a function is part of any energy source, that source will appear in it.

## Streaming

A flight stack that supports this proposal 
- must emit one or more _energy system_ status messages in order to provide system level consumption and status warning messages.
  These should be streamed by default.
- may optionally also support _energy source_ messages for batteries or fuel.
  These should be requested by a GCS at the rate it requires (status messages are often streamed at 1Hz).

## GCS

A GCS that receives ENERGY_SYSTEM_STATUS messages should create ...




## Cases to discuss (TBD)



- Simple systems
- VTOL- separate indicator for power remaining in hover vs FW flight.
- COmplicated energy systems with fuel tanks and batteries.
- What messages should be streamed by default and which should be requested.
- How a GCS should respond if it gets or does not get particular messages.




## Scenarios (TBD)

### Single battery system

### Multiple battery system, energy system `all`

### Multiple source system, multiple energy types

?


<!--
This implements changes as discussed in  #2471 and https://github.com/ArduPilot/ardupilot/issues/33196

1. Removes the capacity fields. With a high-enough resolution SoC these can be calculated from maximum values in BATTERY_INFO
2. Changes `MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL` to `MAV_BATTERY_STATUS_FLAGS_TRACKS_CHARGE` - same behaviour effectively.
3. Keeps SoC as a flat. There was a suggestion to use a scaled unit16 but even that doesn't give the range if we want to be able to calculate capacity with sufficient granularity on available batteries.
4. Makes it clear this is NOT to be used for system power level. That's a different message.
5. Does not scale voltage and current. There exist systems that exceed the max values you can get using uint16 and mV/mA already.

This replaces #2471

@MaEtUgR @LupusTheCanine @dakejahl @peterbarker 

-->
