### PR TITLE
Add CleitonQ dialect: relay-transparent post-quantum authentication for MAVLink v2

### DIFF
--- a/message_definitions/v1.0/cleitonq.xml
+++ b/message_definitions/v1.0/cleitonq.xml
@@ -74,7 +74,7 @@
         a MAVLink frame (which any relay silently discards).
 
         Fragmentation parameters:
-          - Each chunk carries up to 245 bytes of payload data (data_len <= 245).
+          - Each chunk carries up to 245 bytes of payload data (data_len &lt;= 245).
           - Chunk ordering is defined by chunk_seq (0-based, contiguous).
           - chunk_count is the total number of chunks for this payload.
           - Reassembly is complete when chunk_count chunks with matching

--- a/message_definitions/v1.0/cleitonq.xml
+++ b/message_definitions/v1.0/cleitonq.xml
@@ -101,7 +101,7 @@
         Receivers discard stale partial assemblies when a new session_token
         with the same frame_type arrives.
       </field>
-      <field type="uint8_t" name="frame_type">
+      <field type="uint8_t" name="frame_type" enum="CLEITONQ_FRAME_TYPE">
         Payload type being carried. See CLEITONQ_FRAME_TYPE enum.
         0 = CLEITONQ_FRAME_SIGNED_CMD
         1 = CLEITONQ_FRAME_SESSION_INIT

--- a/message_definitions/v1.0/cleitonq.xml
+++ b/message_definitions/v1.0/cleitonq.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0"?>
+<!--
+  CleitonQ MAVLink Dialect — RFC Draft
+  Author: Cleiton Augusto Correa Bezerra
+
+  Defines two message types for relay-transparent post-quantum authentication
+  over MAVLink v2. Message IDs are in the vendor extension range (50000+) and
+  are pending assignment by the MAVLink working group.
+
+  Wire format rationale:
+    MAVLink v2 payloads are capped at 255 bytes. CleitonQ authentication
+    material (ML-DSA-87 signature: 4627B; ML-KEM-1024 ciphertext: 1568B)
+    exceeds this limit. CLEITONQ_CHUNK provides a generic fragment carrier:
+    receivers reassemble by (session_token, frame_type, chunk_seq).
+
+    A relay that does not know CLEITONQ_CHUNK forwards it as an opaque but
+    valid MAVLink frame — no auth bytes are silently stripped (unlike the
+    naive append-after-frame approach).
+
+  Message IDs (vendor extension range, pending WG assignment):
+    50000 — CLEITONQ_CHUNK
+-->
+<mavlink>
+  <version>3</version>
+  <dialect>0</dialect>
+
+  <enums>
+    <enum name="CLEITONQ_FRAME_TYPE">
+      <description>
+        Identifies the type of CleitonQ payload being carried in a
+        CLEITONQ_CHUNK message. The receiver uses frame_type together with
+        session_token and chunk_seq to reassemble the complete payload.
+      </description>
+      <entry value="0" name="CLEITONQ_FRAME_SIGNED_CMD">
+        <description>
+          CLEITONQ_SIGNED_CMD payload: authenticated MAVLink command.
+          Wire layout (all little-endian, reassembled):
+            original_msg_id : uint16   (2B) — MAVLink message ID being authenticated
+            target_system   : uint8    (1B)
+            target_component: uint8    (1B)
+            nonce           : uint64   (8B) — monotonically increasing anti-replay counter
+            payload_len     : uint16   (2B) — length of original MAVLink payload
+            payload         : uint8[]       — original MAVLink payload bytes
+            signature       : uint8[4627]   — ML-DSA-87 signature over (payload || nonce)
+          Total: 14 + payload_len + 4627 bytes.
+        </description>
+      </entry>
+      <entry value="1" name="CLEITONQ_FRAME_SESSION_INIT">
+        <description>
+          CLEITONQ_SESSION_INIT payload: ML-KEM-1024 session establishment.
+          Wire layout (all little-endian, reassembled):
+            initiator_system : uint8       (1B)  — system_id of the initiating GCS
+            timestamp        : uint64      (8B)  — microseconds since epoch (handshake anti-replay)
+            kem_ciphertext   : uint8[1568]        — ML-KEM-1024 ciphertext
+          Total: 1577 bytes.
+        </description>
+      </entry>
+    </enum>
+  </enums>
+
+  <messages>
+    <message id="50000" name="CLEITONQ_CHUNK">
+      <description>
+        Fragment carrier for CleitonQ post-quantum authentication material.
+
+        CleitonQ authentication payloads (ML-DSA-87 signatures and ML-KEM-1024
+        ciphertexts) exceed the MAVLink v2 payload limit of 255 bytes. This
+        message carries one fragment; receivers reassemble the complete payload
+        using (session_token, frame_type, chunk_seq).
+
+        A relay unaware of CleitonQ forwards CLEITONQ_CHUNK as a valid but
+        unknown MAVLink message — the authentication material is preserved
+        end-to-end, unlike the naive approach of appending auth bytes after
+        a MAVLink frame (which any relay silently discards).
+
+        Fragmentation parameters:
+          - Each chunk carries up to 245 bytes of payload data (data_len <= 245).
+          - Chunk ordering is defined by chunk_seq (0-based, contiguous).
+          - chunk_count is the total number of chunks for this payload.
+          - Reassembly is complete when chunk_count chunks with matching
+            (session_token, frame_type) and chunk_seq in [0, chunk_count-1]
+            are received.
+
+        SIGNED_CMD example (COMMAND_LONG, 40-byte payload):
+          Total bytes: 14 + 40 + 4627 = 4681
+          Chunks needed: ceil(4681 / 245) = 20
+
+        SESSION_INIT example:
+          Total bytes: 1 + 8 + 1568 = 1577
+          Chunks needed: ceil(1577 / 245) = 7
+      </description>
+      <field type="uint8_t" name="target_system" instance="true">
+        System ID of the intended recipient (0 for broadcast).
+      </field>
+      <field type="uint8_t" name="target_component">
+        Component ID of the intended recipient (0 for broadcast).
+      </field>
+      <field type="uint16_t" name="session_token">
+        Per-payload random token used for reassembly. The sender generates a
+        fresh random uint16 for each new SIGNED_CMD or SESSION_INIT payload.
+        Receivers discard stale partial assemblies when a new session_token
+        with the same frame_type arrives.
+      </field>
+      <field type="uint8_t" name="frame_type">
+        Payload type being carried. See CLEITONQ_FRAME_TYPE enum.
+        0 = CLEITONQ_FRAME_SIGNED_CMD
+        1 = CLEITONQ_FRAME_SESSION_INIT
+      </field>
+      <field type="uint8_t" name="chunk_seq">
+        Zero-based sequence number of this chunk within the payload.
+        Range: [0, chunk_count - 1].
+      </field>
+      <field type="uint8_t" name="chunk_count">
+        Total number of chunks for this payload. Constant across all chunks
+        of the same (session_token, frame_type).
+      </field>
+      <field type="uint8_t" name="data_len">
+        Number of valid bytes in the data field for this chunk.
+        data_len MUST equal 245 for all chunks except the last, which may
+        be less. Receivers MUST ignore bytes beyond data_len.
+      </field>
+      <field type="uint8_t[245]" name="data">
+        Fragment data. Valid bytes: data[0..data_len-1].
+        Unused bytes at the end of the last chunk MUST be zero-padded by
+        the sender and MUST be ignored by the receiver.
+      </field>
+    </message>
+  </messages>
+</mavlink>

--- a/message_definitions/v1.0/cleitonq.xml
+++ b/message_definitions/v1.0/cleitonq.xml
@@ -23,7 +23,6 @@
 <mavlink>
   <version>3</version>
   <dialect>0</dialect>
-
   <enums>
     <enum name="CLEITONQ_FRAME_TYPE">
       <description>
@@ -35,13 +34,13 @@
         <description>
           CLEITONQ_SIGNED_CMD payload: authenticated MAVLink command.
           Wire layout (all little-endian, reassembled):
-            original_msg_id : uint16   (2B) — MAVLink message ID being authenticated
+            original_msg_id : uint16   (2B) &#x2014; MAVLink message ID being authenticated
             target_system   : uint8    (1B)
             target_component: uint8    (1B)
-            nonce           : uint64   (8B) — monotonically increasing anti-replay counter
-            payload_len     : uint16   (2B) — length of original MAVLink payload
-            payload         : uint8[]       — original MAVLink payload bytes
-            signature       : uint8[4627]   — ML-DSA-87 signature over (payload || nonce)
+            nonce           : uint64   (8B) &#x2014; monotonically increasing anti-replay counter
+            payload_len     : uint16   (2B) &#x2014; length of original MAVLink payload
+            payload         : uint8[]       &#x2014; original MAVLink payload bytes
+            signature       : uint8[4627]   &#x2014; ML-DSA-87 signature over (payload || nonce)
           Total: 14 + payload_len + 4627 bytes.
         </description>
       </entry>
@@ -49,15 +48,14 @@
         <description>
           CLEITONQ_SESSION_INIT payload: ML-KEM-1024 session establishment.
           Wire layout (all little-endian, reassembled):
-            initiator_system : uint8       (1B)  — system_id of the initiating GCS
-            timestamp        : uint64      (8B)  — microseconds since epoch (handshake anti-replay)
-            kem_ciphertext   : uint8[1568]        — ML-KEM-1024 ciphertext
+            initiator_system : uint8       (1B)  &#x2014; system_id of the initiating GCS
+            timestamp        : uint64      (8B)  &#x2014; microseconds since epoch (handshake anti-replay)
+            kem_ciphertext   : uint8[1568]        &#x2014; ML-KEM-1024 ciphertext
           Total: 1577 bytes.
         </description>
       </entry>
     </enum>
   </enums>
-
   <messages>
     <message id="50000" name="CLEITONQ_CHUNK">
       <description>
@@ -69,7 +67,7 @@
         using (session_token, frame_type, chunk_seq).
 
         A relay unaware of CleitonQ forwards CLEITONQ_CHUNK as a valid but
-        unknown MAVLink message — the authentication material is preserved
+        unknown MAVLink message &#x2014; the authentication material is preserved
         end-to-end, unlike the naive approach of appending auth bytes after
         a MAVLink frame (which any relay silently discards).
 


### PR DESCRIPTION
Closes / related: #2527 #2525

This PR adds `message_definitions/v1.0/cleitonq.xml` — the MAVLink dialect for relay-transparent post-quantum authentication.

## What this adds

A single new message type: **CLEITONQ_CHUNK** (ID 50000).

It is a generic fragment carrier that allows PQC authentication material — ML-DSA-87 signatures (4627 bytes) and ML-KEM-1024 ciphertexts (1568 bytes), both of which exceed MAVLink's 255-byte payload limit — to be transmitted as first-class MAVLink frames.

The key design property: a relay that does not know CleitonQ forwards `CLEITONQ_CHUNK` as an unknown but valid MAVLink v2 frame. The authentication material is **inside** the MAVLink frame boundary, not appended after it. This is what makes it relay-transparent.

## Why a new message type (not appended bytes)

Documented in #2525 and #2527: any bytes appended after a valid MAVLink v2 frame are silently discarded by MAVProxy, mavlink-router, and QGC when acting as relays. They re-serialize the parsed frame from internal state. This makes naive PQC signing schemes undeployable in real infrastructure.

## What CLEITONQ_CHUNK carries

Two reassembled payload types (defined in the dialect XML as `CLEITONQ_FRAME_TYPE` enum):

- **CLEITONQ_FRAME_SIGNED_CMD**: ML-DSA-87 authenticated command (NIST FIPS 204, Level 5)
- **CLEITONQ_FRAME_SESSION_INIT**: ML-KEM-1024 session establishment (NIST FIPS 203, Level 5)

Full wire layout and reassembly protocol: https://github.com/cleitonaugusto/CleitonQ/blob/main/rfc/CLEITONQ_RFC_001.md

## Backward compatibility

- Relays that do not know CleitonQ: forward `CLEITONQ_CHUNK` as unknown but valid MAVLink frames. ✓
- Drones that do not implement CleitonQ: silently discard unknown message IDs. ✓
- No existing MAVLink message or behaviour is modified. ✓

## Reference implementation

https://github.com/cleitonaugusto/CleitonQ (Rust, MIT OR Apache-2.0)

Tested end-to-end: CLEITONQ_CHUNK frames carrying ML-DSA-87 signatures survive MAVProxy relay intact and verify correctly at the receiver.

## Performance (ARM64 Neoverse-N2, CI-verified)

| Operation | Latency |
|---|---|
| ML-KEM-1024 session setup | 241 µs |
| ML-DSA-87 sign (30B payload) | 962 µs |
| HMAC-SHA3-256 per packet | 1.1 µs |

## Open questions

1. Message ID 50000 is in the user-defined dialect range (256–65535) — requesting permanent WG assignment.
2. Dialect placement: standalone `cleitonq.xml` initially, potential merge into `common.xml` if the WG decides to standardize PQC for all MAVLink deployments.
3. Neoverse-N2 benchmarks are now produced by a public GitHub Actions workflow (`.github/workflows/arm-bench.yml` on `ubuntu-24.04-arm`), with the full Criterion artifact attached to each run — reproducible by any reviewer. Cortex-A76 (RPi5) numbers remain pending physical hardware; happy to provide them if the WG requires before RFC advancement.
