### PR TITLE
MAV_CMD_DO_SET_GLOBAL_ORIGIN: clarify frame is int

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -141,7 +141,7 @@
           Vehicle should emit GPS_GLOBAL_ORIGIN irrespective of whether the origin is changed.
           This enables transform between the local coordinate frame and the global (GNSS) coordinate frame, which may be necessary when (for example) indoor and outdoor settings are connected and the MAV should move from in- to outdoor.
           This command supersedes SET_GPS_GLOBAL_ORIGIN.
-          Should be sent in a COMMAND_INT (Expected frame is MAV_FRAME_GLOBAL, and this should be assumed when sent in COMMAND_LONG).
+          Should be sent in a COMMAND_INT (Expected frame is MAV_FRAME_GLOBAL_INT). If sent in COMMAND_LONG assumed frame is MAV_FRAME_GLOBAL.
         </description>
         <param index="5" label="Latitude">Latitude</param>
         <param index="6" label="Longitude">Longitude</param>


### PR DESCRIPTION
Typo indicated invalid frame for int in MAV_CMD_DO_SET_GLOBAL_ORIGIN