### PR TITLE
fix/mavlink-xml-markdown-command-count

### DIFF
--- a/doc/mavlink_xml_to_markdown.py
+++ b/doc/mavlink_xml_to_markdown.py
@@ -220,7 +220,7 @@ class MAVXML:
                 matching_count += 1
             else:
                 non_matching_count += 1
-        result_string = result_string = (
+        result_string = (
             f"{'[Messages](#messages)' if matching_count + non_matching_count > 0 else 'Messages'} | {matching_count} | {non_matching_count}\n"
         )
         entity_summary += result_string
@@ -232,19 +232,19 @@ class MAVXML:
                 matching_count += 1
             else:
                 non_matching_count += 1
-        result_string = result_string = (
+        result_string = (
             f"{'[Enums](#enumerated-types)' if matching_count + non_matching_count > 0 else 'Enums'} | {matching_count} | {non_matching_count}\n"
         )
         entity_summary += result_string
 
         matching_count = 0
         non_matching_count = 0
-        for commands in self.commands.values():
-            if commands.basename == commands.basename:
+        for command in self.commands.values():
+            if command.basename == self.basename:
                 matching_count += 1
             else:
                 non_matching_count += 1
-        result_string = result_string = (
+        result_string = (
             f"{'[Commands](#mav_commands)' if matching_count + non_matching_count > 0 else 'Commands'} | {matching_count} | {non_matching_count}\n\n"
         )
         entity_summary += result_string


### PR DESCRIPTION
### Summary
Fixes a copy-paste logic bug in `doc/mavlink_xml_to_markdown.py` where included MAVLink commands (`MAV_CMD`) were incorrectly counted as "Defined" rather than "Included" in the dialect summary markdown tables. Also cleans up redundant double assignments.

### Root Cause
When calculating the summary table counts for a dialect:
- Messages use `if message.basename == self.basename:`
- Enums use `if enum.basename == self.basename:`
- Commands used `if commands.basename == commands.basename:`

Because comparing `commands.basename` to itself is always `True`, any commands imported from included XML files (such as `common.xml`) were always counted as defined in the current file (`matching_count`) rather than included (`non_matching_count`).

### Changes
- Changed `if commands.basename == commands.basename:` to `if command.basename == self.basename:`.
- Renamed loop variable from `commands` (plural) to `command` (singular) for clarity.
- Removed accidental double assignments (`result_string = result_string = ...`) on lines 223, 235, and 247.
