### PR TITLE
development(update): Remove MAV_CMD_REQUEST_OPERATOR_CONTROL.param5 (…

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -248,7 +248,6 @@
         <param index="2" label="Allow takeover">Enable automatic granting of ownership on request (by default reject request and notify current owner). 0: Ask current owner and reject request, 1: Allow automatic takeover.</param>
         <param index="3" label="Request timeout" units="s" minValue="3" maxValue="60">Timeout in seconds before a request to a GCS to allow takeover is assumed to be rejected. This is used to display the timeout graphically on requester and GCS in control.</param>
         <param index="4" label="GCS Sysid">System ID of GCS requesting control. For a range of GCS in control, this the minimum id (and the sender system ID may be anywhere in the range).</param>
-        <param index="5" label="GCS Sysid (upper range)">Upper range of controlling GCS system IDs. 0 for single-GCS control. If non-zero the sender system ID may be anywhere in the range).</param>
       </entry>
     </enum>
     <enum name="GCS_CONTROL_STATUS_FLAGS" bitmask="true">


### PR DESCRIPTION
The upper range isn't settable, so it shouldn't be specified. Falls out of implementation discussions in https://github.com/ArduPilot/ardupilot/pull/33332#issuecomment-4857276399

@Davidsastresas 