### PR TITLE
development: `MAV_CMD_ESTIMATOR_SENSOR_ENABLE` param 1 "Source" should not have min and increment as there is a enum

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -188,7 +188,7 @@
         <description>Enable or disable a specific estimator sensor fusion source at runtime.
           This allows a GCS or companion computer to dynamically control which sensors the estimator fuses without changing parameters.
         </description>
-        <param index="1" label="Source" enum="ESTIMATOR_SENSOR_FUSION_SOURCE" minValue="0" increment="1">Sensor fusion source type.</param>
+        <param index="1" label="Source" enum="ESTIMATOR_SENSOR_FUSION_SOURCE">Sensor fusion source type.</param>
         <param index="2" label="Instance" minValue="0" increment="1">Sensor instance (0-based, for multi-instance).</param>
         <param index="3" label="Enable" enum="MAV_BOOL">Enable (1) or Disable (0) the source.</param>
         <param index="4" label="Estimator Instance" default="NaN" minValue="0" increment="1">Estimator instance (0-based, for systems with multiple estimators).</param>


### PR DESCRIPTION
Added in https://github.com/mavlink/mavlink/pull/2439