### PR TITLE
ardupilotmega: `COPTER_MODE` remove `COPTER_MODE_RATE_ACRO`

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -1220,9 +1220,6 @@
       <entry value="28" name="COPTER_MODE_TURTLE">
         <description>TURTLE</description>
       </entry>
-      <entry value="29" name="COPTER_MODE_RATE_ACRO">
-        <description>RATE_ACRO</description>
-      </entry>
     </enum>
     <enum name="SUB_MODE">
       <description>A mapping of sub flight modes for custom_mode field of heartbeat.</description>


### PR DESCRIPTION
See: https://github.com/ArduPilot/mavlink/pull/513 we never added the mode in the end.