### PR TITLE
common: add SYS_STATUS extended bits for 3rd and 4th IMUs

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -208,6 +208,18 @@
       <entry value="2" name="MAV_SYS_STATUS_SENSOR_LEAK">
         <description>0x02 Leak detection</description>
       </entry>
+      <entry value="4" name="MAV_SYS_STATUS_SENSOR_3D_GYRO3">
+        <description>0x04 3D 3rd gyro</description>
+      </entry>
+      <entry value="8" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL3">
+        <description>0x08 3D 3rd accelerometer</description>
+      </entry>
+      <entry value="16" name="MAV_SYS_STATUS_SENSOR_3D_GYRO4">
+        <description>0x10 3D 4th gyro</description>
+      </entry>
+      <entry value="32" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL4">
+        <description>0x20 3D 4th accelerometer</description>
+      </entry>
     </enum>
     <enum name="MAV_FRAME">
       <description>Coordinate frames used by MAVLink. Not all frames are supported by all commands, messages, or vehicles.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -209,16 +209,16 @@
         <description>0x02 Leak detection</description>
       </entry>
       <entry value="4" name="MAV_SYS_STATUS_SENSOR_3D_GYRO3">
-        <description>0x04 3D 3rd gyro</description>
+        <description>0x04 3rd 3D gyro</description>
       </entry>
       <entry value="8" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL3">
-        <description>0x08 3D 3rd accelerometer</description>
+        <description>0x08 3rd 3D accelerometer</description>
       </entry>
       <entry value="16" name="MAV_SYS_STATUS_SENSOR_3D_GYRO4">
-        <description>0x10 3D 4th gyro</description>
+        <description>0x10 4th 3D gyro</description>
       </entry>
       <entry value="32" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL4">
-        <description>0x20 3D 4th accelerometer</description>
+        <description>0x20 4th 3D accelerometer</description>
       </entry>
     </enum>
     <enum name="MAV_FRAME">


### PR DESCRIPTION
## Summary

This PR adds new `MAV_SYS_STATUS_SENSOR_EXTENDED` bits for reporting the 3rd and 4th gyros and accelerometers in `SYS_STATUS`.

Added entries:

- `MAV_SYS_STATUS_SENSOR_3D_GYRO3`
- `MAV_SYS_STATUS_SENSOR_3D_ACCEL3`
- `MAV_SYS_STATUS_SENSOR_3D_GYRO4`
- `MAV_SYS_STATUS_SENSOR_3D_ACCEL4`

## Motivation

`SYS_STATUS` currently provides sensor status bits for the first and second gyros, accelerometers, and magnetometers.

Modern autopilot hardware commonly has three onboard IMUs. In addition, some systems may expose a fourth gyro/accelerometer when an external device is connected.

Without these extended bits, `SYS_STATUS` cannot represent the presence, enabled state, or health of the 3rd and 4th gyros/accelerometers.

## Details

This PR uses the existing `MAV_SYS_STATUS_SENSOR_EXTENDED` bitmask, which is already carried by the MAVLink 2 extension fields in `SYS_STATUS`:

- `onboard_control_sensors_present_extended`
- `onboard_control_sensors_enabled_extended`
- `onboard_control_sensors_health_extended`

No `SYS_STATUS` wire format change is introduced.

The existing `MAV_SYS_STATUS_SENSOR` bits are left unchanged.

## Scope

This PR intentionally adds only gyro and accelerometer bits, because the purpose is to represent additional IMUs.

Magnetometer reporting is left unchanged.

## Compatibility

This is a non-breaking enum extension.

Existing implementations that do not use these new bits are unaffected.
Implementations that support additional IMUs can set these bits in the existing `SYS_STATUS` extended sensor fields.