### PR TITLE
feat(failure injection): add  traffic avoidance systems to failure_unit

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4960,6 +4960,9 @@
       <entry value="106" name="FAILURE_UNIT_SYSTEM_ESC">
         <description>Interrupts the telemetry reported by the ESC.</description>
       </entry>
+      <entry value="107" name="FAILURE_UNIT_SYSTEM_TRAFFIC_AVOIDANCE">
+        <description>Traffic avoidance system like ADS-B or FLARM.</description>
+      </entry>
     </enum>
     <enum name="FAILURE_TYPE">
       <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4992,7 +4992,7 @@
         <description>Unit is sometimes working, sometimes not.</description>
       </entry>
       <entry value="8" name="FAILURE_TYPE_DRIFT">
-        <description>Unit is drifting.</description>
+        <description>Unit is publishing plausible values but drifting away from true values.</description>
       </entry>
     </enum>
     <enum name="NAV_VTOL_LAND_OPTIONS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4991,6 +4991,9 @@
       <entry value="7" name="FAILURE_TYPE_INTERMITTENT">
         <description>Unit is sometimes working, sometimes not.</description>
       </entry>
+      <entry value="8" name="FAILURE_TYPE_DRIFT">
+        <description>Unit is drifting.</description>
+      </entry>
     </enum>
     <enum name="NAV_VTOL_LAND_OPTIONS">
       <entry value="0" name="NAV_VTOL_LAND_OPTIONS_DEFAULT">


### PR DESCRIPTION
Follow up PR to https://github.com/mavlink/mavlink/pull/2524

Extend the failure injection enums with a traffic avoidance failure unit and a drift failure type.

## Problem

Currently there is no way to inject failures for traffic avoidance systems (ADS-B / FLARM), and no failure type to model a value that slowly deviates from truth over time.

## Solution

Add `FAILURE_UNIT_SYSTEM_TRAFFIC_AVOIDANCE` (107) to `FAILURE_UNIT` and `FAILURE_TYPE_DRIFT` (8) to `FAILURE_TYPE`.