### PR TITLE
common: CAMERA_TRACKING_STATUS_FLAGS_COASTING and MTI not WIP

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4025,11 +4025,9 @@
         <description>Camera tracking in error state</description>
       </entry>
       <entry value="4" name="CAMERA_TRACKING_STATUS_FLAGS_MTI">
-        <wip/>
         <description>Camera Moving Target Indicators (MTI) are active</description>
       </entry>
       <entry value="8" name="CAMERA_TRACKING_STATUS_FLAGS_COASTING">
-        <wip/>
         <description>Camera tracking target is obscured and is being predicted</description>
       </entry>
     </enum>


### PR DESCRIPTION
This removes WIP from - [CAMERA_TRACKING_STATUS_FLAGS_MTI](https://mavlink.io/en/messages/common.html#CAMERA_TRACKING_STATUS_FLAGS_MTI)  and [CAMERA_TRACKING_STATUS_FLAGS_COASTING](https://mavlink.io/en/messages/common.html#CAMERA_TRACKING_STATUS_FLAGS_COASTING).

According to @nexton-winjeel in https://github.com/ArduPilot/mavlink/pull/422#issuecomment-4862452305 :

> We're using those two CAMERA_TRACKING_STATUS_FLAGS in production, but I don't have anything public to demonstrate.

Normally we'd want proofs, testing etc. While that's desirable, I see this as low risk to accept, and trust Nick.