### PR TITLE
feat: add DISTANCE_SENSOR_INFO and DISTANCE_SENSOR_V2 messages for ra…

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -854,5 +854,31 @@
       <!-- status -->
       <field type="uint64_t" name="status_flags" enum="EFI_PERFORMANCE_STATUS_FLAGS">EFI status flags.</field>
     </message>
+    <message id="516" name="DISTANCE_SENSOR_INFO">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Static characteristics of a distance sensor (onboard rangefinder).
+        This should be streamed (nominally at 1Hz).
+        Measurements are sent in DISTANCE_SENSOR_V2.</description>
+      <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_V2.</field>
+      <field type="uint8_t" name="type" enum="MAV_DISTANCE_SENSOR">Type of distance sensor.</field>
+      <field type="float" name="min_distance" units="m" invalid="NaN">Minimum distance the sensor can measure</field>
+      <field type="float" name="max_distance" units="m" invalid="NaN">Maximum distance the sensor can measure</field>
+      <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces.</field>
+      <field type="float" name="horizontal_fov" units="rad" invalid="NaN">Horizontal Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
+      <field type="float" name="vertical_fov" units="rad" invalid="NaN">Vertical Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
+    </message>
+    <message id="517" name="DISTANCE_SENSOR_V2">
+      <wip/>
+      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+      <description>Distance sensor measurement, for an onboard rangefinder described by DISTANCE_SENSOR_INFO. Streamed at the sensor update rate.</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_INFO.</field>
+      <field type="float" name="current_distance" units="m" invalid="NaN">Current distance reading. NaN if the reading is invalid or no reading is available.</field>
+      <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>
+      <field type="uint8_t" name="signal_quality" units="%" invalid="0">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. 0 = unknown/unset signal quality, 1 = invalid signal, 100 = perfect signal.</field>
+      <extensions/>
+      <field type="float[4]" name="quaternion" invalid="[0]">Quaternion of the sensor orientation in vehicle body frame (w, x, y, z order, zero-rotation is 1, 0, 0, 0). Zero-rotation is along the vehicle body x-axis. This field is required if the orientation is set to MAV_SENSOR_ROTATION_CUSTOM.This field is required if orientation in DISTANCE_SENSOR_INFO is set to MAV_SENSOR_ROTATION_CUSTOM. Set it to 0 if invalid.</field>
+    </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -891,7 +891,7 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Distance sensor measurement, for an onboard rangefinder described by DISTANCE_SENSOR_INFO. Streamed at the sensor update rate.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp of the sample (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint32_t " name="time_boot_ms" units="ms">Timestamp (time since system boot)</field>
       <field type="uint8_t" name="id" instance="true">Sensor ID. Matches the id field of DISTANCE_SENSOR_INFO.</field>
       <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if not provided.</field>
       <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -874,7 +874,7 @@
       <description>Distance sensor measurement, for an onboard rangefinder described by DISTANCE_SENSOR_INFO. Streamed at the sensor update rate.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_INFO.</field>
-      <field type="float" name="current_distance" units="m" invalid="NaN">Current distance reading. NaN if the reading is invalid or no reading is available.</field>
+      <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if the reading is invalid or no reading is available.</field>
       <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>
       <field type="uint8_t" name="signal_quality" units="%" invalid="0">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. 0 = unknown/unset signal quality, 1 = invalid signal, 100 = perfect signal.</field>
       <extensions/>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -872,7 +872,7 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Distance sensor measurement, for an onboard rangefinder described by DISTANCE_SENSOR_INFO. Streamed at the sensor update rate.</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp of the sample (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_INFO.</field>
       <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if the reading is invalid or no reading is available.</field>
       <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -886,7 +886,7 @@
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Distance sensor measurement, for an onboard rangefinder described by DISTANCE_SENSOR_INFO. Streamed at the sensor update rate.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp of the sample (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
-      <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_INFO.</field>
+      <field type="uint8_t" name="id" instance="true">Sensor ID. Matches the id field of DISTANCE_SENSOR_INFO.</field>
       <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if not provided.</field>
       <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>
       <field type="int8_t" name="signal_quality" units="%" invalid="-1">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. Values: [0-100], 0 = invalid signal, 100 = perfect signal. -1 = unknown/not provided.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -870,13 +870,12 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Static characteristics of a distance sensor (onboard rangefinder).
-        This should be streamed (nominally at 1Hz).
         Measurements are sent in DISTANCE_SENSOR_V2.</description>
-      <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_V2.</field>
+      <field type="uint8_t" name="id" instance="true">Sensor ID. Matches the id field of DISTANCE_SENSOR_V2.</field>
       <field type="uint8_t" name="type" enum="MAV_DISTANCE_SENSOR">Type of distance sensor.</field>
       <field type="uint8_t" name="mode" enum="DISTANCE_SENSOR_MODE">Operating mode of the sensor.</field>
-      <field type="float" name="min_distance" units="m" invalid="NaN">Minimum distance the sensor can measure</field>
-      <field type="float" name="max_distance" units="m" invalid="NaN">Maximum distance the sensor can measure</field>
+      <field type="float" name="min_distance" units="m" invalid="NaN">Minimum distance the sensor can measure.</field>
+      <field type="float" name="max_distance" units="m" invalid="NaN">Maximum distance the sensor can measure.</field>
       <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces.</field>
       <field type="float" name="horizontal_fov" units="rad" invalid="NaN">Horizontal Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
       <field type="float" name="vertical_fov" units="rad" invalid="NaN">Vertical Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -883,8 +883,8 @@
       <field type="float" name="min_distance" units="m" invalid="NaN">Minimum distance the sensor can measure.</field>
       <field type="float" name="max_distance" units="m" invalid="NaN">Maximum distance the sensor can measure.</field>
       <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces.</field>
-      <field type="float" name="horizontal_fov" units="rad" invalid="NaN">Horizontal Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
-      <field type="float" name="vertical_fov" units="rad" invalid="NaN">Vertical Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
+      <field type="float" name="horizontal_fov" units="rad" minValue="0" invalid="NaN">Horizontal Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
+      <field type="float" name="vertical_fov" units="rad" minValue="0" invalid="NaN">Vertical Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
       <field type="float[4]" name="quaternion" invalid="[0]">Quaternion of the sensor orientation in vehicle body frame (w, x, y, z order, zero-rotation is 1, 0, 0, 0). Zero-rotation is along the vehicle body x-axis. This field is required if orientation is set to MAV_SENSOR_ROTATION_CUSTOM. Set it to 0 if invalid.</field>
     </message>
     <message id="517" name="DISTANCE_SENSOR_V2">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -888,7 +888,7 @@
       <description>Distance sensor measurement, for an onboard rangefinder described by DISTANCE_SENSOR_INFO. Streamed at the sensor update rate.</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp of the sample (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
       <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_INFO.</field>
-      <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if the reading is invalid or no reading is available.</field>
+      <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if not provided.</field>
       <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>
       <field type="int8_t" name="signal_quality" units="%" invalid="-1">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. Values: [0-100], 0 = invalid signal, 100 = perfect signal. -1 = unknown/not provided.</field>
     </message>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -885,6 +885,7 @@
       <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces.</field>
       <field type="float" name="horizontal_fov" units="rad" minValue="0" invalid="NaN">Horizontal Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
       <field type="float" name="vertical_fov" units="rad" minValue="0" invalid="NaN">Vertical Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
+      <extensions/>
       <field type="float[4]" name="quaternion" invalid="[0]">Quaternion of the sensor orientation in vehicle body frame (w, x, y, z order, zero-rotation is 1, 0, 0, 0). Zero-rotation is along the vehicle body x-axis. This field is required if orientation is set to MAV_SENSOR_ROTATION_CUSTOM. Set it to 0 if invalid.</field>
     </message>
     <message id="517" name="DISTANCE_SENSOR_V2">
@@ -894,7 +895,6 @@
       <field type="uint32_t " name="time_boot_ms" units="ms">Timestamp (time since system boot)</field>
       <field type="uint8_t" name="id" instance="true">Sensor ID. Matches the id field of DISTANCE_SENSOR_INFO.</field>
       <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if not provided.</field>
-      <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>
       <field type="int8_t" name="signal_quality" units="%" invalid="INT8_MAX">Signal quality (sensor-type specific). Represents the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. Values: [0-100], 0 = unusable signal, 100 = perfect signal. INT8_MAX = unknown/not provided.</field>
     </message>
   </messages>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -604,6 +604,18 @@
         <description>Exhaust-gas-recirculation (EGR) system fault.</description>
       </entry>
     </enum>
+    <enum name="DISTANCE_SENSOR_MODE">
+      <description>Operating mode of a distance sensor. Used in DISTANCE_SENSOR_INFO.</description>
+      <entry value="0" name="DISTANCE_SENSOR_MODE_DEFAULT">
+        <description>Default operating mode, or mode unknown.</description>
+      </entry>
+      <entry value="1" name="DISTANCE_SENSOR_MODE_SHORT_RANGE">
+        <description>Sensor is operating in short range mode.</description>
+      </entry>
+      <entry value="2" name="DISTANCE_SENSOR_MODE_LONG_RANGE">
+        <description>Sensor is operating in long range mode.</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="354" name="SET_VELOCITY_LIMITS">
@@ -862,11 +874,13 @@
         Measurements are sent in DISTANCE_SENSOR_V2.</description>
       <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_V2.</field>
       <field type="uint8_t" name="type" enum="MAV_DISTANCE_SENSOR">Type of distance sensor.</field>
+      <field type="uint8_t" name="mode" enum="DISTANCE_SENSOR_MODE">Operating mode of the sensor.</field>
       <field type="float" name="min_distance" units="m" invalid="NaN">Minimum distance the sensor can measure</field>
       <field type="float" name="max_distance" units="m" invalid="NaN">Maximum distance the sensor can measure</field>
       <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces.</field>
       <field type="float" name="horizontal_fov" units="rad" invalid="NaN">Horizontal Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
       <field type="float" name="vertical_fov" units="rad" invalid="NaN">Vertical Field of View (angle) where the distance measurement is valid. NaN if unknown.</field>
+      <field type="float[4]" name="quaternion" invalid="[0]">Quaternion of the sensor orientation in vehicle body frame (w, x, y, z order, zero-rotation is 1, 0, 0, 0). Zero-rotation is along the vehicle body x-axis. This field is required if orientation is set to MAV_SENSOR_ROTATION_CUSTOM. Set it to 0 if invalid.</field>
     </message>
     <message id="517" name="DISTANCE_SENSOR_V2">
       <wip/>
@@ -876,9 +890,7 @@
       <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor. Matches the id field of DISTANCE_SENSOR_INFO.</field>
       <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if the reading is invalid or no reading is available.</field>
       <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>
-      <field type="uint8_t" name="signal_quality" units="%" invalid="0">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. 0 = unknown/unset signal quality, 1 = invalid signal, 100 = perfect signal.</field>
-      <extensions/>
-      <field type="float[4]" name="quaternion" invalid="[0]">Quaternion of the sensor orientation in vehicle body frame (w, x, y, z order, zero-rotation is 1, 0, 0, 0). Zero-rotation is along the vehicle body x-axis. This field is required if the orientation is set to MAV_SENSOR_ROTATION_CUSTOM.This field is required if orientation in DISTANCE_SENSOR_INFO is set to MAV_SENSOR_ROTATION_CUSTOM. Set it to 0 if invalid.</field>
+      <field type="int8_t" name="signal_quality" units="%" invalid="-1">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. Values: [0-100], 0 = invalid signal, 100 = perfect signal. -1 = unknown/not provided.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -892,7 +892,7 @@
       <wip/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Distance sensor measurement, for an onboard rangefinder described by DISTANCE_SENSOR_INFO. Streamed at the sensor update rate.</description>
-      <field type="uint32_t " name="time_boot_ms" units="ms">Timestamp (time since system boot)</field>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot)</field>
       <field type="uint8_t" name="id" instance="true">Sensor ID. Matches the id field of DISTANCE_SENSOR_INFO.</field>
       <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if not provided.</field>
       <field type="int8_t" name="signal_quality" units="%" invalid="INT8_MAX">Signal quality (sensor-type specific). Represents the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. Values: [0-100], 0 = unusable signal, 100 = perfect signal. INT8_MAX = unknown/not provided.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -895,7 +895,7 @@
       <field type="uint8_t" name="id" instance="true">Sensor ID. Matches the id field of DISTANCE_SENSOR_INFO.</field>
       <field type="float" name="distance" units="m" invalid="NaN">Current distance reading. NaN if not provided.</field>
       <field type="float" name="covariance" units="m^2" invalid="NaN">Measurement variance. NaN if unknown.</field>
-      <field type="int8_t" name="signal_quality" units="%" invalid="-1">Signal quality of the sensor. Specific to each sensor type, representing the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. Values: [0-100], 0 = invalid signal, 100 = perfect signal. -1 = unknown/not provided.</field>
+      <field type="int8_t" name="signal_quality" units="%" invalid="INT8_MAX">Signal quality (sensor-type specific). Represents the relation of the signal strength with the target reflectivity, distance, size or aspect, but normalised as a percentage. Values: [0-100], 0 = unusable signal, 100 = perfect signal. INT8_MAX = unknown/not provided.</field>
     </message>
   </messages>
 </mavlink>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -604,24 +604,6 @@
         <description>Exhaust-gas-recirculation (EGR) system fault.</description>
       </entry>
     </enum>
-    <enum name="DISTANCE_SENSOR_MODE">
-      <description>Operating mode of a distance sensor. Used in DISTANCE_SENSOR_INFO.</description>
-      <entry value="0" name="DISTANCE_SENSOR_MODE_DEFAULT">
-        <description>Default operating mode, or mode unknown.</description>
-      </entry>
-      <entry value="1" name="DISTANCE_SENSOR_MODE_SHORT_RANGE">
-        <description>Sensor is operating in short range mode.</description>
-      </entry>
-      <entry value="2" name="DISTANCE_SENSOR_MODE_LONG_RANGE">
-        <description>Sensor is operating in long range mode.</description>
-      </entry>
-      <entry value="3" name="DISTANCE_SENSOR_MODE_BALANCED">
-        <description>Sensor is operating in balanced mode.</description>
-      </entry>
-      <entry value="4" name="DISTANCE_SENSOR_MODE_AUTO">
-        <description>Sensor is operating in auto mode.</description>
-      </entry>
-    </enum>
   </enums>
   <messages>
     <message id="354" name="SET_VELOCITY_LIMITS">
@@ -879,7 +861,6 @@
         Measurements are sent in DISTANCE_SENSOR_V2.</description>
       <field type="uint8_t" name="id" instance="true">Sensor ID. Matches the id field of DISTANCE_SENSOR_V2.</field>
       <field type="uint8_t" name="type" enum="MAV_DISTANCE_SENSOR">Type of distance sensor.</field>
-      <field type="uint8_t" name="mode" enum="DISTANCE_SENSOR_MODE">Operating mode of the sensor.</field>
       <field type="float" name="min_distance" units="m" invalid="NaN">Minimum distance the sensor can measure.</field>
       <field type="float" name="max_distance" units="m" invalid="NaN">Maximum distance the sensor can measure.</field>
       <field type="uint8_t" name="orientation" enum="MAV_SENSOR_ORIENTATION">Direction the sensor faces.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -615,6 +615,12 @@
       <entry value="2" name="DISTANCE_SENSOR_MODE_LONG_RANGE">
         <description>Sensor is operating in long range mode.</description>
       </entry>
+      <entry value="3" name="DISTANCE_SENSOR_MODE_BALANCED">
+        <description>Sensor is operating in balanced mode.</description>
+      </entry>
+      <entry value="4" name="DISTANCE_SENSOR_MODE_AUTO">
+        <description>Sensor is operating in auto mode.</description>
+      </entry>
     </enum>
   </enums>
   <messages>


### PR DESCRIPTION
## Summary
Adds two WIP messages to `development.xml`: `DISTANCE_SENSOR_INFO` (id 515), carrying static sensor characteristics at low rate, and `DISTANCE_SENSOR_V2` (id 516), carrying the measurement stream at the sensor update rate. Together they are intended to supersede `DISTANCE_SENSOR` once proven in a flight stack.

## Problem
`DISTANCE_SENSOR` encodes distances as uint16 centimeters, capping the reportable range at 655.35 m — below what current long-range rangefinders can measure. Its `covariance` field (uint8, cm²) saturates at ~16 cm standard deviation, and static characteristics (min/max range, orientation, FoV) are re-sent with every reading.

## Solution
Split into a static/dynamic message pair, following the `BATTERY_INFO` / `BATTERY_STATUS_V2` pattern: `DISTANCE_SENSOR_INFO` holds id, type, min/max range, orientation, FoV, and an optional quaternion extension for `MAV_SENSOR_ROTATION_CUSTOM`; `DISTANCE_SENSOR_V2` holds a slim 18-byte measurement payload (`time_usec`, id, distance, variance, signal quality). Distances and variance use float SI units with NaN invalid sentinels, removing the range ceiling. The `m^2` unit requires adding it to `mavschema.xsd` (companion [pymavlink PR](https://github.com/ArduPilot/pymavlink/pull/1231/changes)).