### PR TITLE
Fix ESC EEPROM length maxValue (222 ->192)

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -616,7 +616,7 @@
       <field type="uint8_t" name="msg_count">Total number of messages required to transfer the complete EEPROM data. For single-message transfers, set to 1. Receivers should collect all messages from index 0 to msg_count-1 before reconstructing the complete data.</field>
       <field type="uint8_t" name="esc_index" maxValue="254">Index of the ESC (0 = ESC1, 1 = ESC2, etc.).</field>
       <field type="uint32_t[6]" name="write_mask">Bitmask indicating which bytes in the data array should be written. Each bit corresponds to a byte index in the data array (bit 0 of write_mask[0] = data[0], bit 31 of write_mask[0] = data[31], bit 0 of write_mask[1] = data[32], etc.). Set bits indicate bytes to write, cleared bits indicate bytes to skip. This allows precise updates of individual parameters without overwriting the entire EEPROM.</field>
-      <field type="uint8_t" name="length" maxValue="222">Number of valid bytes in data array.</field>
+      <field type="uint8_t" name="length" maxValue="192">Number of valid bytes in data array.</field>
       <field type="uint8_t[192]" name="data">Raw ESC EEPROM data. Unused bytes should be set to zero.</field>
     </message>
     <message id="513" name="RANGING_BEACON">


### PR DESCRIPTION
## Fix ESC EEPROM length maxValue mismatch (222 -> 192)
I was going through `development.xml` while looking into something unrelated in the ESC messages, and noticed a mismatch in the ESC EEPROM message.

The `length` field is documented as "number of valid bytes in data array," with `maxValue="222"`. But the `data` field right next to it is declared as `uint8_t[192]` - only 192 bytes. So the schema currently lets a sender declare up to 222 valid bytes even though the array can only hold 192. A receiver that trusts `maxValue` without independently bounds-checking against the array size could end up reading past the end of `data`.

## What I fixed
One-line change: `maxValue="222"` ->  `maxValue="192"` on the `length` field, so it matches the actual size of `data`.

Metadata-only change - no field type or wire size changes - so no wire compatibility impact.