### PR TITLE
update(common): AVAILABLE_MODES.seq

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8245,7 +8245,7 @@
       <field type="uint32_t" name="properties" enum="MAV_MODE_PROPERTY">Mode properties.</field>
       <field type="char[35]" name="mode_name">Name of custom mode, with null termination character. Should be omitted for standard modes.</field>
       <extensions/>
-      <field type="uint8_t" name="seq">Sequence number. The value iterates sequentially whenever the set of AVAILABLE_MODES changes and should match value of AVAILABLE_MODES_MONITOR. Note, a GCS must ignore 0 values.</field>
+      <field type="uint8_t" name="seq">Sequence number. The value iterates sequentially whenever the set of AVAILABLE_MODES changes and should match value of AVAILABLE_MODES_MONITOR. Note, a GCS must ignore 0 values, and should re-start the download if the value changes part-way through fetching modes.</field>
     </message>
     <message id="436" name="CURRENT_MODE">
       <description>Get the current mode.

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8244,6 +8244,8 @@
       <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags</field>
       <field type="uint32_t" name="properties" enum="MAV_MODE_PROPERTY">Mode properties.</field>
       <field type="char[35]" name="mode_name">Name of custom mode, with null termination character. Should be omitted for standard modes.</field>
+      <extensions/>
+      <field type="uint8_t" name="seq">Sequence number. The value iterates sequentially whenever the set of AVAILABLE_MODES changes and should match value of AVAILABLE_MODES_MONITOR.</field>
     </message>
     <message id="436" name="CURRENT_MODE">
       <description>Get the current mode.
@@ -8263,7 +8265,7 @@
         It should be streamed at low rate (nominally 0.3 Hz).
         See https://mavlink.io/en/services/standard_modes.html
       </description>
-      <field type="uint8_t" name="seq">Sequence number. The value iterates sequentially whenever AVAILABLE_MODES changes (e.g. support for a new mode is added/removed dynamically).</field>
+      <field type="uint8_t" name="seq">Sequence number. The iterates sequentially whenever AVAILABLE_MODES changes (e.g. support for a new mode is added/removed dynamically). 0 initially. 1 on first change of mode set.</field>
     </message>
     <message id="440" name="ILLUMINATOR_STATUS">
       <description>Illuminator status</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8265,7 +8265,7 @@
         It should be streamed at low rate (nominally 0.3 Hz).
         See https://mavlink.io/en/services/standard_modes.html
       </description>
-      <field type="uint8_t" name="seq">Sequence number. The iterates sequentially whenever AVAILABLE_MODES changes (e.g. support for a new mode is added/removed dynamically). 0 initially. 1 on first change of mode set.</field>
+      <field type="uint8_t" name="seq">Sequence number. Iterates sequentially whenever AVAILABLE_MODES changes (e.g. support for a new mode is added/removed dynamically). 0 initially. 1 on first change of mode set.</field>
     </message>
     <message id="440" name="ILLUMINATOR_STATUS">
       <description>Illuminator status</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8245,7 +8245,7 @@
       <field type="uint32_t" name="properties" enum="MAV_MODE_PROPERTY">Mode properties.</field>
       <field type="char[35]" name="mode_name">Name of custom mode, with null termination character. Should be omitted for standard modes.</field>
       <extensions/>
-      <field type="uint8_t" name="seq">Sequence number. The value iterates sequentially whenever the set of AVAILABLE_MODES changes and should match value of AVAILABLE_MODES_MONITOR.</field>
+      <field type="uint8_t" name="seq">Sequence number. The value iterates sequentially whenever the set of AVAILABLE_MODES changes and should match value of AVAILABLE_MODES_MONITOR. Note, a GCS must ignore 0 values.</field>
     </message>
     <message id="436" name="CURRENT_MODE">
       <description>Get the current mode.


### PR DESCRIPTION
This fixes case where a GCS connects to a flight stack, downloads the AVAILABLE_MODES, then immediately gets `AVAILABLE_MODES_MONITOR`.
Because the GCS doesn't know the sequence number when it first downloaded AVAILABLE_MODES it can't assume that it has the current modes and has to download them again. 

This proposes 
1. `AVAILABLE_MODES_MONITOR.seq`: clarify is 0 initially, updates to 1 on first mode change (matches PX4, ArduPilot). This ensures on first connection a GCS can know that modes have not updated.
2. `AVAILABLE_MODES.seq` - add as extension. The GCS always knows the current sequence.

Possible option coming out of https://github.com/ArduPilot/ardupilot/issues/33811