### PR TITLE
Fix: GITHUB_TOKEN not passed to check_api_break.py

### DIFF
--- a/.github/workflows/check_api_break.yml
+++ b/.github/workflows/check_api_break.yml
@@ -5,9 +5,13 @@ on:
   push:
   workflow_dispatch:
 
+# This job runs against untrusted PR content (it checks out and executes
+# the PR branch's own script/tests), so it must not hold any token beyond
+# the default read-only access - not even for same-repo PRs. It writes any
+# PR comment it wants posted to an artifact instead of calling the GitHub
+# API itself; see post_api_break_comment.yml for why and how that's posted.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   check-api-break:
@@ -30,5 +34,12 @@ jobs:
 
       - name: Run API break check
         run: python scripts/check_api_break.py
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload PR comment artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-break-comment
+          path: api-break-comment/
+          retention-days: 1
+          if-no-files-found: ignore

--- a/.github/workflows/check_api_break.yml
+++ b/.github/workflows/check_api_break.yml
@@ -30,3 +30,5 @@ jobs:
 
       - name: Run API break check
         run: python scripts/check_api_break.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post_api_break_comment.yml
+++ b/.github/workflows/post_api_break_comment.yml
@@ -12,9 +12,17 @@ name: Post API Break Comment
 # triggering run came from - which is what lets it post the comment.
 #
 # To keep that token safe, this job never checks out or runs any code from
-# the pull request: it only downloads the plain-text artifact (PR number +
-# comment body) that the trusted script already rendered, and posts it
-# as-is via the GitHub CLI.
+# the pull request: it only downloads the plain-text comment body that the
+# trusted script already rendered, and posts it as-is via the GitHub CLI.
+#
+# It does NOT trust a PR number from the artifact: check_api_break.yml runs
+# the PR branch's own workflow file and script, so a malicious PR could
+# make that job write an arbitrary PR number to the artifact and get this
+# privileged job to post to any PR/issue in the repo (a known "artifact
+# poisoning" pattern - see GitHub Security Lab's "Keeping your GitHub
+# Actions and workflows secure" series). Instead, the PR number is looked
+# up from github.event.workflow_run.head_sha, which is set by GitHub from
+# the run being reported on and can't be forged by PR content.
 #
 # The comment body is stamped with a hidden COMMENT_MARKER (see
 # check_api_break.py) so re-runs on the same PR update that one comment
@@ -48,16 +56,28 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post comment
-        if: steps.download.outcome == 'success' && hashFiles('pr_number.txt', 'comment.md') != ''
+        if: steps.download.outcome == 'success' && hashFiles('comment.md') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
-          pr_number="$(cat pr_number.txt)"
+          # Look up the real PR for this run's commit via the API rather than
+          # trusting any PR number the artifact might contain - see the header
+          # comment above for why the artifact can't be trusted for this.
+          pr_number="$(
+            gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+              --jq '.[0].number // empty'
+          )"
+
+          if [[ -z "$pr_number" ]]; then
+            echo "::error::No open pull request found for commit $HEAD_SHA."
+            exit 1
+          fi
           if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
-            echo "::error::pr_number.txt did not contain a plain integer: $pr_number"
+            echo "::error::Unexpected PR number lookup result: $pr_number"
             exit 1
           fi
 

--- a/.github/workflows/post_api_break_comment.yml
+++ b/.github/workflows/post_api_break_comment.yml
@@ -1,0 +1,81 @@
+name: Post API Break Comment
+
+# Posts the PR comment prepared by check_api_break.yml.
+#
+# It's split into its own workflow, triggered by workflow_run rather than
+# posting directly from check_api_break.yml, because that job checks out
+# and executes untrusted PR content: for `pull_request` runs triggered from
+# a fork, GITHUB_TOKEN is always read-only there no matter what permissions
+# are requested, and it must stay that way. A workflow_run job, by
+# contrast, always runs the workflow file and permissions from the base
+# repo's default branch, with a normal token - regardless of where the
+# triggering run came from - which is what lets it post the comment.
+#
+# To keep that token safe, this job never checks out or runs any code from
+# the pull request: it only downloads the plain-text artifact (PR number +
+# comment body) that the trusted script already rendered, and posts it
+# as-is via the GitHub CLI.
+#
+# The comment body is stamped with a hidden COMMENT_MARKER (see
+# check_api_break.py) so re-runs on the same PR update that one comment
+# instead of piling up a new one on every push. The lookup for the comment
+# to update is scoped to comments whose *author* is this workflow's own
+# github-actions[bot] identity, not just ones containing the marker text -
+# `user.login` is set by GitHub from the authenticated actor and can't be
+# forged by a PR comment, whereas the marker text alone could be copied
+# into an unrelated comment to trick this job into editing someone else's.
+on:
+  workflow_run:
+    workflows: ["Check MAVLink API Breaks"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR comment artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: api-break-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post comment
+        if: steps.download.outcome == 'success' && hashFiles('pr_number.txt', 'comment.md') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          pr_number="$(cat pr_number.txt)"
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number.txt did not contain a plain integer: $pr_number"
+            exit 1
+          fi
+
+          # Must be our own bot's comment, not merely one containing the marker text -
+          # anyone can post a comment with that text, but user.login is set by GitHub
+          # from the authenticated actor and can't be spoofed by a PR commenter. The
+          # marker is a fixed literal (kept in sync with COMMENT_MARKER in
+          # check_api_break.py), so it's safe to inline into the jq filter as-is.
+          existing_id="$(
+            gh api "repos/${REPO}/issues/${pr_number}/comments" --paginate \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- mavlink-api-break-check -->"))) | .id' \
+              | tail -n1
+          )"
+
+          if [[ -n "$existing_id" ]]; then
+            echo "Updating existing comment $existing_id on #$pr_number."
+            gh api --method PATCH "repos/${REPO}/issues/comments/${existing_id}" -F body=@comment.md
+          else
+            echo "No existing comment found, creating a new one on #$pr_number."
+            gh pr comment "$pr_number" --repo "$REPO" --body-file comment.md
+          fi

--- a/scripts/check_api_break.py
+++ b/scripts/check_api_break.py
@@ -22,7 +22,6 @@ import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
-from urllib import error, request
 
 from lxml import etree
 
@@ -160,38 +159,38 @@ def get_pull_request_info() -> Optional[Tuple[str, int]]:
     return None
 
 
-def post_pr_comment(body: str) -> bool:
-    """Post a comment to the pull request."""
+PR_COMMENT_ARTIFACT_DIR = "api-break-comment"
+
+
+def write_pr_comment_artifact(body: str) -> bool:
+    """Write the PR number and comment body to disk as a build artifact.
+
+    This job runs against untrusted PR content (it checks out and executes
+    the PR branch's own script/tests), and for `pull_request` runs triggered
+    from a fork, GITHUB_TOKEN is always read-only regardless of the
+    permissions granted to this workflow. So this job must never hold a
+    token, and must never try to call the GitHub API directly.
+
+    Instead it writes the comment to disk; a separate, trusted workflow
+    (triggered by `workflow_run`, which does not check out or execute any
+    PR content) picks up this artifact and posts the actual comment with a
+    token that does have write access.
+    """
     pr_info = get_pull_request_info()
     if not pr_info:
-        print("No pull request context found, skipping PR comment.")
+        print("No pull request context found, skipping PR comment artifact.")
         return False
 
-    repo, pr_number = pr_info
-    token = os.getenv("GITHUB_TOKEN")
-    if not token:
-        print("GITHUB_TOKEN not set, skipping PR comment.")
-        return False
+    _repo, pr_number = pr_info
 
-    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
-    data = json.dumps({"body": body}).encode()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "User-Agent": "mavlink-check-api-break",
-        "Content-Type": "application/json",
-    }
+    os.makedirs(PR_COMMENT_ARTIFACT_DIR, exist_ok=True)
+    with open(os.path.join(PR_COMMENT_ARTIFACT_DIR, "pr_number.txt"), "w", encoding="utf-8") as pr_file:
+        pr_file.write(str(pr_number))
+    with open(os.path.join(PR_COMMENT_ARTIFACT_DIR, "comment.md"), "w", encoding="utf-8") as comment_file:
+        comment_file.write(body)
 
-    try:
-        with request.urlopen(request.Request(url, data=data, headers=headers, method="POST")):
-            print(f"Posted PR comment about message/enum removals to #{pr_number}.")
-        return True
-    except error.HTTPError as exception:
-        print(f"Failed to post PR comment (HTTP {exception.code}): {exception.reason}")
-    except error.URLError as exception:
-        print(f"Failed to post PR comment (network): {exception.reason}")
-
-    return False
+    print(f"Wrote PR comment artifact for #{pr_number}.")
+    return True
 
 
 def describe_mutation(key: NameKey, old_a: Dict[str, Any], new_a: Dict[str, Any]) -> str:
@@ -227,12 +226,18 @@ def find_mutations(
     return mutation_descs
 
 
+# Identifies the bot's own comment across runs so it can be updated in place
+# instead of accumulating a new comment on every push. Must stay in sync with
+# the marker check in post_api_break_comment.yml.
+COMMENT_MARKER = "<!-- mavlink-api-break-check -->"
+
+
 def build_removal_comment(
     removed_by_file: Dict[str, List[NameKey]],
     mutations_by_file: Optional[Dict[str, List[str]]] = None,
 ) -> str:
     """Format a PR comment listing removed messages/enums and attribute mutations."""
-    lines: List[str] = []
+    lines: List[str] = [COMMENT_MARKER, ""]
 
     if removed_by_file:
         lines.extend(["Detected removed MAVLink messages or enums:", ""])
@@ -325,7 +330,7 @@ def main() -> None:
                 for desc in descs:
                     print(f"   - {desc}")
 
-        post_pr_comment(build_removal_comment(removals_for_comment, mutations_for_comment))
+        write_pr_comment_artifact(build_removal_comment(removals_for_comment, mutations_for_comment))
 
     if breaking_by_file:
         for xml, descs in breaking_by_file.items():

--- a/scripts/check_api_break.py
+++ b/scripts/check_api_break.py
@@ -163,7 +163,7 @@ PR_COMMENT_ARTIFACT_DIR = "api-break-comment"
 
 
 def write_pr_comment_artifact(body: str) -> bool:
-    """Write the PR number and comment body to disk as a build artifact.
+    """Write the comment body to disk as a build artifact.
 
     This job runs against untrusted PR content (it checks out and executes
     the PR branch's own script/tests), and for `pull_request` runs triggered
@@ -174,7 +174,12 @@ def write_pr_comment_artifact(body: str) -> bool:
     Instead it writes the comment to disk; a separate, trusted workflow
     (triggered by `workflow_run`, which does not check out or execute any
     PR content) picks up this artifact and posts the actual comment with a
-    token that does have write access.
+    token that does have write access. That workflow looks up the target
+    PR number itself from trustworthy `workflow_run` event data rather than
+    from anything written here, since this job's own code (this script and
+    its workflow file) is exactly the untrusted PR content it can't hold a
+    token against - a PR number written here could just as easily be
+    forged.
     """
     pr_info = get_pull_request_info()
     if not pr_info:
@@ -184,8 +189,6 @@ def write_pr_comment_artifact(body: str) -> bool:
     _repo, pr_number = pr_info
 
     os.makedirs(PR_COMMENT_ARTIFACT_DIR, exist_ok=True)
-    with open(os.path.join(PR_COMMENT_ARTIFACT_DIR, "pr_number.txt"), "w", encoding="utf-8") as pr_file:
-        pr_file.write(str(pr_number))
     with open(os.path.join(PR_COMMENT_ARTIFACT_DIR, "comment.md"), "w", encoding="utf-8") as comment_file:
         comment_file.write(body)
 


### PR DESCRIPTION
 ## What's broken
check_api_break.yml grants `pull-requests: write` permission, but the step running `check_api_break.py` never passes `GITHUB_TOKEN` to its environment. The script checks `os.getenv('GITHUB_TOKEN')`, finds nothing, and silently skips posting the PR comment.
## Fix
Added an `env` block to the step so `secrets.GITHUB_TOKEN` is actually available to the script.
## Changes
 `.github/workflows/check_api_break.yml`: Added `env: GITHUB_TOKEN` to the 'Run API break check' step