### PR TITLE
common: add SYS_STATUS extended bits for 3rd and 4th magnetometers

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -220,6 +220,12 @@
       <entry value="32" name="MAV_SYS_STATUS_SENSOR_3D_ACCEL4">
         <description>0x20 4th 3D accelerometer</description>
       </entry>
+      <entry value="64" name="MAV_SYS_STATUS_SENSOR_3D_MAG3">
+        <description>0x40 3rd 3D magnetometer</description>
+      </entry>
+      <entry value="128" name="MAV_SYS_STATUS_SENSOR_3D_MAG4">
+        <description>0x80 4th 3D magnetometer</description>
+      </entry>
     </enum>
     <enum name="MAV_FRAME">
       <description>Coordinate frames used by MAVLink. Not all frames are supported by all commands, messages, or vehicles.


### PR DESCRIPTION
### Summary

Add `MAV_SYS_STATUS_SENSOR_3D_MAG3` and `MAV_SYS_STATUS_SENSOR_3D_MAG4` to `MAV_SYS_STATUS_SENSOR_EXTENDED`.

This allows autopilots to report the presence, enabled state, and health of third and fourth magnetometers individually through the extended fields of `SYS_STATUS`.

### Motivation

`SYS_STATUS` currently provides individual status bits for only the first and second magnetometers, while extended status bits are already available for third and fourth gyroscopes and accelerometers.

Flight controllers may use more than two magnetometers. For example, a system using one internal compass and two external GNSS compasses has three magnetometers in total. In this configuration, the status of the third magnetometer cannot currently be represented individually.

Adding MAG3 and MAG4 provides consistent support for systems with up to four gyroscopes, accelerometers, and magnetometers.

### Changes

Add the following entries to `MAV_SYS_STATUS_SENSOR_EXTENDED`:

- `MAV_SYS_STATUS_SENSOR_3D_MAG3` (`0x40`)
- `MAV_SYS_STATUS_SENSOR_3D_MAG4` (`0x80`)

These bits can be used in:

- `onboard_control_sensors_present_extended`
- `onboard_control_sensors_enabled_extended`
- `onboard_control_sensors_health_extended`

### Compatibility

This is an additive MAVLink 2 extension and does not change any existing field definitions or bit values.

### Testing

- Verified that `common.xml` parses successfully.
- Verified that `git diff --check` reports no formatting errors.
