### PR TITLE
 feat(failure injection): add datalink and bus failure units

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4958,13 +4958,19 @@
       <entry value="107" name="FAILURE_UNIT_SYSTEM_TRAFFIC_AVOIDANCE">
         <description>Traffic avoidance system like ADS-B or FLARM.</description>
       </entry>
-      <entry value="108" name="FAILURE_UNIT_SYSTEM_DATALINK">
-        <description>Data link used for remote operations, e.g. the LTE or satellite connection.</description>
+      <entry value="150" name="FAILURE_UNIT_DATALINK_LTE">
+        <description>Data link over a cellular (LTE) connection.</description>
       </entry>
-      <entry value="109" name="FAILURE_UNIT_SYSTEM_BUS_CAN">
+      <entry value="151" name="FAILURE_UNIT_DATALINK_WIFI">
+        <description>Data link over a Wi-Fi connection.</description>
+      </entry>
+      <entry value="152" name="FAILURE_UNIT_DATALINK_TELEM_RADIO">
+        <description>Data link over a telemetry radio, e.g. a SiK radio.</description>
+      </entry>
+      <entry value="200" name="FAILURE_UNIT_BUS_CAN">
         <description>CAN bus. Instance is the bus number, e.g. 1 for CAN1.</description>
       </entry>
-      <entry value="110" name="FAILURE_UNIT_SYSTEM_BUS_I2C">
+      <entry value="201" name="FAILURE_UNIT_BUS_I2C">
         <description>I2C bus. Instance is the bus number, e.g. 1 for I2C1.</description>
       </entry>
     </enum>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4958,6 +4958,12 @@
       <entry value="107" name="FAILURE_UNIT_SYSTEM_TRAFFIC_AVOIDANCE">
         <description>Traffic avoidance system like ADS-B or FLARM.</description>
       </entry>
+      <entry value="108" name="FAILURE_UNIT_SYSTEM_DATALINK">
+        <description>Data link used for remote operations, e.g. the LTE or satellite connection</description>
+      </entry>
+      <entry value="109" name="FAILURE_UNIT_SYSTEM_BUS">
+        <description>Communication bus, e.g. CAN, I2C or SPI.</description>
+      </entry>
     </enum>
     <enum name="FAILURE_TYPE">
       <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -4959,10 +4959,13 @@
         <description>Traffic avoidance system like ADS-B or FLARM.</description>
       </entry>
       <entry value="108" name="FAILURE_UNIT_SYSTEM_DATALINK">
-        <description>Data link used for remote operations, e.g. the LTE or satellite connection</description>
+        <description>Data link used for remote operations, e.g. the LTE or satellite connection.</description>
       </entry>
-      <entry value="109" name="FAILURE_UNIT_SYSTEM_BUS">
-        <description>Communication bus, e.g. CAN, I2C or SPI.</description>
+      <entry value="109" name="FAILURE_UNIT_SYSTEM_BUS_CAN">
+        <description>CAN bus. Instance is the bus number, e.g. 1 for CAN1.</description>
+      </entry>
+      <entry value="110" name="FAILURE_UNIT_SYSTEM_BUS_I2C">
+        <description>I2C bus. Instance is the bus number, e.g. 1 for I2C1.</description>
       </entry>
     </enum>
     <enum name="FAILURE_TYPE">


### PR DESCRIPTION
  ## Summary
  Adds `FAILURE_UNIT_SYSTEM_DATALINK` (108), `FAILURE_UNIT_SYSTEM_BUS_CAN` (109) and `FAILURE_UNIT_SYSTEM_BUS_I2C` (110) to the `FAILURE_UNIT` enum.

  ## Problem
  `FAILURE_UNIT_SYSTEM_MAVLINK_SIGNAL` covers the MAVLink telemetry stream between FMU, GCS and onboard computer, but there is no way to inject a failure of the IP data link an onboard computer uses for remote operations,
  such as its LTE or satellite connection. Likewise there is no way to take down a communication bus, so failures affecting everything attached to a CAN or I2C bus cannot be tested.

  ## Solution
  Three entries appended to the `FAILURE_UNIT_SYSTEM_*` block. Buses get one unit per bus type rather than a single generic bus unit, so the `Instance` / `Instance bitmask` params of `MAV_CMD_INJECT_FAILURE` unambiguously
  address the bus number within that type (instance 1 = CAN1 or I2C1), with no implicit numbering scheme spanning bus types and no vendor-specific parameter needed to disambiguate. SPI is left out: it is board-internal,
  effectively per-device on current FMU hardware, and its observable effect is already reachable through the existing per-sensor units.