### PR TITLE
update(pymavlink): Update to latest - to get XSD changes and other fixes

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14', '15', '16',' 17', '18', 'lts/*']
+        node-version: ['14', '16', '17', '18', 'lts/*']
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Updates pymavlink to latest. 

Also in dropped node 15 from test matrix in https://github.com/mavlink/mavlink/pull/2563/changes/f469a48771ec173a89b325e923f3bef070da3ba1 - there was a fail on a test because pymavlink was updated. Claude details:
<details>
  Only one job fails: "Node 15 test" (Node 14, 16, 17, 18, and lts/* all pass). The error you highlighted, Cannot find module 'node:os', is the real failure. The FileNotFoundError: ...
  testmav1.0_ardupilotmega line is a red herring — it appears in every Node job (I checked the passing Node 18 job too), because scripts/test.sh node runs python3 make_tests.py > made_tests.js ; mocha
  test with a ; not &&, so that pre-existing, unrelated Python crash never stops the script. It's not new and not your bug to fix here.

  Root cause of the real failure: this PR bumped pymavlink's bundled JS test runner to mocha@^11.7.5 (part of b94a0236/83c4cc40 upstream — "bump mocha to v11 and drop Node 12 from CI"). Mocha 11's
  engines field requires ^18.18.0 || ^20.9.0 || >=21.1.0. Its dependency chain does require('node:os'), which needs Node's node:-prefixed core-module require support — added in Node 14.18.0 and 16.0.0.
  Node 15 was EOL before that backport shipped and never got a patch for it (its final release, 15.14.0, predates the fix), so it's structurally incapable of running mocha 11, even though the
  newer-looking Node 14 and older-looking Node 16/17 both happen to work fine.

  Fix: this isn't a pymavlink or generator bug — it's that mavlink/mavlink's own workflow still tests an EOL, non-LTS Node version.
</details>

Claude generated list of changes:

64 commits went into pymavlink between the previous submodule pointer (5977f445) and the new one (9e9a9917) in commit 1dc654b7. Highlights:

  - XSD/generator changes: b5676e40 add scaling value 2E-3, 81c82290 add remove_on_date to deprecated tag, b4c7ca29 MAV_CMD missionOnly default fix, generator UTF-8 encoding fixes, sha256 optimizations
  in the C generator
  - mavutil fixes: context manager support (aab0b9d7, d11dc48a), macOS serial port auto-detect (8cbc05bf), Windows UDP bind fix (3cedcf10), PX4 OFFBOARD mode fix (a2b74990), several unused-parameter
  cleanups
  - Compatibility: dropped Python 3.8 support (37fcb539), added Python 3.14 wheel builds (c82c63f6), RISC-V wheels (fd622382)
  - CI/tooling: mocha v11 bump, dropped Node 12/end-of-life Node testing, dependabot bumps, deterministic MAVLINK_*_XML_HASH (b4eab0b2)
  - Misc: Ada version 2 protocol support (a5812a89), mavloss per-(sysid,compid) breakdown (875b9ab1), payload zero-fill clamp fix (9e9a9917, the tip commit itself)

  Full list (oldest last, newest first — 64 total):
```
  9e9a9917 mavlink_helpers: clamp payload zero-fill to MAVLINK_MAX_PAYLOAD_LEN
  b4eab0b2 mavgen_c.py: make MAVLINK_*_XML_HASH deterministic
  4a3a48d4 mavutil: remove unused n parameter from mavfile.close()
  9ca447d7 README: document running the tests locally
  f802aab8 Ignore test output artifacts and local mavlink dependency clone
  92465b73 mavutil: remove unused custom_mode/custom_sub_mode from set_mode_apm
  84bd11d9 mavutil: remove unused broadcast parameter from mavmcast
  54eef85d mavutil: remove unused retries parameter from mavwebsocket_client
  839c3817 mavutil: add type annotations to mavfile_state and param_state
  c35e868e tests: add context manager tests
  aab0b9d7 mavutil: support use as a context manager
  d11dc48a DFReader: support use as a context manager
  56e088bc mavutil: add type annotations to module-level globals and helpers
  b5676e40 XSD: add scaling value 2E-3
  def8bff9 .github: Bump pypa/cibuildwheel
  428a16bf generator/javascript*: refresh lockfiles onto patched mocha transitives
  95b08ae1 generator/javascript*: bump underscore to 1.13.8
  d5e02eba generator/javascript*: remove unused eslint, glob and winston deps
  aa9da36f generator/javascript: drop devDependencies from vendored local_modules
  d3fa1e4f generator/javascript: resync package-lock with mocha v11
  b4c7ca29 MAV_CMD missionOnly attribute - should default to false
  22b3891b tests: release UDP port between MAVFTP tests
  f1760df1 README: document macOS dependencies
  8cbc05bf mavutil: auto-detect serial ports on macOS
  56a3bb0c mavutil: fix type error in cache
  a2b74990 mavutil: fix interpret_px4_mode for OFFBOARD on PX4 v1.12+ (#793)
  875b9ab1 mavloss: per-(sysid,compid) loss breakdown with optional message-type stats
  b94a0236 generator/javascript, ci: bump mocha to v11 and drop Node 12 from CI
  60a8fdaf mavgen_python: widen byte-buffer annotations to accept bytearray
  3cedcf10 mavutil: fix missing socket.bind under Windows in udpout connections
  0e091e95 mavgen_python: emit per-param label attribute on EnumEntry
  d9b1a788 fix: recv method from mavtcp always return bytes
  99a60b69 Update an argument to git-clone away from its deprecated name
  83c4cc40 Stop testing on end-of-life versions of Node.js
  12fad6b8 generator: explicitly use utf-8 encoding when writing generated source files
  faffdabb specify UTF-8 encoding when opening files for reading
  37fcb539 Drop support for Python 3.8
  d32ec978 Expand_typescript_generator_import_regression
  241e4fb3 Fix_typescript_generator_imports
  e5709544 Move mavbitmask_change.py in from ArduPilot repository
  c82c63f6 CI: add python 3.14 wheels to build
  1b5c7ee5 .github: Bump the github-actions group across 1 directory with 4 updates
  93489bcf Use break instead of continue on corruption in scan_offsets
  20774b31 Improve error handling in scan_offsets function by replacing panic calls with error messages.
  ec06837a generator/C: shrink sha256 counter for very minor optimization
  376c9551 generator/C: optimize sha256 state struct organization
  f92f7bf6 generator/C: optimize sha256 result calculation
  15bfb6e8 generator/C: optimize sha256 finalization
  5385355a generator/C: improve sha256 word preparation
  273a42a5 generator/C: compute sha256 message schedule alongside compression func
  6e301bbc generator/C: test differently sized inputs with mavlink sha256
  cc43bdab generator/C: test strings and binary blobs with mavlink sha256
  604428f7 generator/C: convert sha256 tabs to 8 spaces
  2aadcafc mavgen_python: Check reset buffer logic even if a message is generated
  87745be0 tests: use importlib in place of pkg_resources
  a7283917 generator: fix inconsistent tabs and spaces in Python outputs
  2e01c343 mavutil.py: default to using 'all' dialect in place of ardupilotmega
  a5812a89 Added support for version 2 protocol generation for Ada.
  b684ea52 .github: Bump the github-actions group across 1 directory with 4 updates
  fd622382 Build RISC-V Wheels
  13f4daa4 recv_match condition adapted to multi vehicle
  81c82290 XSD: Add remove_on_date option to deprecated tag
  7ec04b5a Add missing include
  75dfe5fc README.md: stop using suto and setup.py
```