### PR TITLE
Fix typo in MAV_MODE_FLAG_SAFETY_ARMED description

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -225,7 +225,7 @@
     <enum name="MAV_MODE_FLAG" bitmask="true">
       <description>These flags encode the MAV mode, see MAV_MODE enum for useful combinations.</description>
       <entry value="128" name="MAV_MODE_FLAG_SAFETY_ARMED">
-        <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignore when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
+        <description>0b10000000 MAV safety set to armed. Motors are enabled / running / can start. Ready to fly. Additional note: this flag is to be ignored when sent in the command MAV_CMD_DO_SET_MODE and MAV_CMD_COMPONENT_ARM_DISARM shall be used instead. The flag can still be used to report the armed state.</description>
       </entry>
       <entry value="64" name="MAV_MODE_FLAG_MANUAL_INPUT_ENABLED">
         <description>0b01000000 remote control input is enabled.</description>


### PR DESCRIPTION
Corrected a typo in the description of MAV_MODE_FLAG_SAFETY_ARMED.

I noticed it when reading on the website, so thought I would fix it