### PR TITLE
standard(MAV_BOOL): Enum is  not bitmask

### DIFF
--- a/message_definitions/v1.0/standard.xml
+++ b/message_definitions/v1.0/standard.xml
@@ -4,7 +4,7 @@
   <include>minimal.xml</include>
   <dialect>0</dialect>
   <enums>
-    <enum name="MAV_BOOL" bitmask="true">
+    <enum name="MAV_BOOL">
       <description>Enum used to indicate true or false (also: success or failure, enabled or disabled, active or inactive).</description>
       <entry value="0" name="MAV_BOOL_FALSE">
         <description>False.</description>

--- a/scripts/xml_consistency_allowlist.txt
+++ b/scripts/xml_consistency_allowlist.txt
@@ -9,7 +9,6 @@
 
 # --- Pre-existing warnings (not fixable in the short term) ---
 common.xml: Enum: CAMERA_TRACKING_STATUS_FLAGS bitmask should not contain 0
-standard.xml: Enum: MAV_BOOL bitmask should not contain 0
 common.xml: Message GIMBAL_DEVICE_INFORMATION field cap_flags enum GIMBAL_DEVICE_CAP_FLAGS does not fit in type: uint16_t
 
 # --- Messages referencing removed/missing enums ---


### PR DESCRIPTION
Makes MAV_BOOL into an ordinary enum (not bitmask) as discussed in https://github.com/mavlink/mavlink/pull/2220#issuecomment-5260906383 and [20260812-Dev-Meeting](https://github.com/mavlink/mavlink/wiki/20260812-Dev-Meeting).

Also removed the now redundant fail case from the XML checker allow list.