### PR TITLE
fix(xml): remove trailing whitespace in development, minimal, and stemstudios XML files

### DIFF
--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -199,7 +199,7 @@
           - In single-owner mode there is a single GCS "owner" that can send state changing operations to the whole system, and this command can be used to request takeover of that ownership role.
           - In multi-owner mode the flight stack allows multiple GCS to be "owners" and send (most) state changing operations (which GCS those are is implementation-dependent, and not controlled by this protocol).
             However only one GCS owner can control manual input of the vehicle: this command can be used to request takeover of that ownership role.
-        
+
           A controlled system should only accept MAVLink operations that change the state of the vehicle, such as commands and command-like messages, which are sent by its controlling GCS(s) (or from other components in its own system/with the same system id, such as a companion computer).
           Commands to control the vehicle from other systems should be rejected with MAV_RESULT_NOT_IN_CONTROL (except for this command, which may be acknowledged with MAV_RESULT_ACCEPTED if control is granted).
           Messages and commands that don't control or change vehicle movement or functionality, such as telemetry requests, may still be send from (and to) a controlled system.
@@ -225,7 +225,7 @@
           While any owning GCS are connected the system should consider itself connected to a GCS, and still owned by all GCS (even those that are not connected).
           If all owning GCS are disconnected the vehicle should GCS loss failsafe, and broadcast a CONTROL_STATUS indicating that it has no owner(s).
           In simultaneous-owner scenarios this allows an owner to disconnect and reconnect without the vehicle failsafing, provided at least one owner is connected.
-               
+
           Note that in most systems the only controlled component will be the "system manager component", and that will be the autopilot (although it could be a companion computer).
           However separate GCS control of a particular component is also permitted, if supported by the component.
           In this case the GCS will address MAV_CMD_REQUEST_OPERATOR_CONTROL to the specific component it wants to control.
@@ -242,7 +242,7 @@
     <enum name="GCS_CONTROL_STATUS_FLAGS" bitmask="true">
       <description>CONTROL_STATUS flags.</description>
       <entry value="1" name="GCS_CONTROL_STATUS_FLAGS_SYSTEM_MANAGER">
-        <description>If set, this CONTROL_STATUS publishes the controlling GCS(s) of the whole system. 
+        <description>If set, this CONTROL_STATUS publishes the controlling GCS(s) of the whole system.
           If unset, the CONTROL_STATUS indicates the controlling GCS(s) for just the component emitting the message.
           Note that to request control of the system a GCS should send MAV_CMD_REQUEST_OPERATOR_CONTROL to the component emitting CONTROL_STATUS with this flag set.
         </description>
@@ -685,8 +685,8 @@
       <wip since="2026-03"/>
       <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>
-        Highly bandwidth-efficient RC override message for professional networked operations (LTE, Zigbee, GCP). 
-        Supersedes RC_CHANNELS_OVERRIDE by adding 32-channel support and a bitmask for multi-master conflict avoidance. 
+        Highly bandwidth-efficient RC override message for professional networked operations (LTE, Zigbee, GCP).
+        Supersedes RC_CHANNELS_OVERRIDE by adding 32-channel support and a bitmask for multi-master conflict avoidance.
         Uses centered-at-zero values and extension-field placement to maximize MAVLink 2 trailing-zero truncation.
       </description>
       <field type="uint8_t" name="target_system">System ID.</field>
@@ -694,8 +694,8 @@
       <field type="uint32_t" name="active_mask">Bitmap of included channels (bit 0 = CH1). 1: Valid/Override, 0: Ignore.</field>
       <extensions/>
       <field type="int16_t[32]" name="channels" minValue="-4096" maxValue="4096">
-        RC channels in centered 13-bit format. Range: -4096 to 4096, Center: 0. 
-        Conversion to PWM: (x * 5/32) + 1500. 
+        RC channels in centered 13-bit format. Range: -4096 to 4096, Center: 0.
+        Conversion to PWM: (x * 5/32) + 1500.
         Unused channels must be set to 0 to enable MAVLink 2 trailing-zero trimming.
       </field>
     </message>
@@ -750,7 +750,7 @@
       <description>Information about GCS(s) in control of this MAV.
         This should be broadcast at low rate (nominally 1 Hz) and emitted when ownership or takeover status change.
         Components in the system should only accept "state changing commands/messages" from any system id in `gcs_main` or  `gcs_secondary`.
-        
+
         - In single-owner mode there is a single GCS that can send "state changing commands/messages" listed in `gcs_main` (`gcs_secondary` must be set to all-zero).
         - In multi-owner mode, all GCS with ids in `gcs_main` and `gcs_secondary` can send "state changing commands/messages".
           However `gcs_main` is the only GCS that can perform "special controlled operations" such as manual control.

--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -307,14 +307,14 @@
     </enum>
     <enum name="MAV_COMPONENT">
       <description>Legacy component ID values for particular types of hardware/software that might make up a MAVLink system (autopilot, cameras, servos, avoidance systems etc.).
-      
+
         Components are not required or expected to use IDs with names that correspond to their type or function, but may choose to do so.
         Using an ID that matches the type may slightly reduce the chances of component id clashes, as, for historical reasons, it is less likely to be used by some other type of component.
         System integration will still need to ensure that all components have unique IDs.
 
         Component IDs are used for addressing messages to a particular component within a system.
         A component can use any unique ID between 1 and 255 (MAV_COMP_ID_ALL value is the broadcast address, used to send to all components).
-        
+
         Historically component ID were also used for identifying the type of component.
         New code must not use component IDs to infer the component type, but instead check the MAV_TYPE in the HEARTBEAT message!
       </description>

--- a/message_definitions/v1.0/stemstudios.xml
+++ b/message_definitions/v1.0/stemstudios.xml
@@ -43,7 +43,7 @@ Documentation:
         - Set the LED colors to change according to the flight mode.
         - Turn all LEDs off (clear).
         Which LED strip to configure is specified by the id field.
-        The colors field is an array of up to 8 colors, each represented as a 32-bit integer in the format 0xWWRRGGBB 
+        The colors field is an array of up to 8 colors, each represented as a 32-bit integer in the format 0xWWRRGGBB
         where WW is white, RR is the intensity of the red color channel, GG is green, and BB is blue.
       </description>
       <field type="uint8_t" name="target_system">System ID.</field>

--- a/scripts/format_xml.sh
+++ b/scripts/format_xml.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -o pipefail
 
 # A POSIX variable
 OPTIND=1         # Reset in case getopts has been used previously in the shell.
@@ -40,7 +41,7 @@ echo "$xml_files"
 ret=0
 for f in $xml_files
 do
-    xmllint -format "${f}" > "${f}".new
+    xmllint -format "${f}" | sed 's/[[:blank:]]*$//' > "${f}".new
     case "$mode" in
     format)
         if ! cmp "${f}" "${f}".new >/dev/null 2>&1


### PR DESCRIPTION
 ## Summary
  Remove trailing whitespace from multiple message definition xml's

  ## Problem
  Several lines carry trailing whitespace. Editors with trim-on-save enabled (e.g. VS Code `files.trimTrailingWhitespace`) rewrite those lines automatically, so unrelated whitespace hunks leak into every functional PR that touches these file, polluting review diffs and blame.

  ## Solution
  Strip trailing whitespace in one dedicated commit. No change to any message, enum, field, or description content.