### PR TITLE
common: added reboot to mass storage option

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1081,7 +1081,7 @@
         <description>Power on component. Do nothing if component is already powered (ACK command with MAV_RESULT_ACCEPTED).</description>
       </entry>
       <entry value="5" name="REBOOT_SHUTDOWN_ACTION_REBOOT_TO_MASS_STORAGE">
-        <description>Reboot component into a mass storage mode if supported.</description>
+        <description>Reboot component into a mass storage mode.</description>
       </entry>
     </enum>
     <enum name="REBOOT_SHUTDOWN_CONDITIONS">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1080,6 +1080,9 @@
       <entry value="4" name="REBOOT_SHUTDOWN_ACTION_POWER_ON">
         <description>Power on component. Do nothing if component is already powered (ACK command with MAV_RESULT_ACCEPTED).</description>
       </entry>
+      <entry value="5" name="REBOOT_SHUTDOWN_ACTION_REBOOT_TO_MASS_STORAGE">
+        <description>Reboot component into a mass storage mode if supported.</description>
+      </entry>
     </enum>
     <enum name="REBOOT_SHUTDOWN_CONDITIONS">
       <description>Specifies the conditions under which the MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command should be accepted.</description>


### PR DESCRIPTION
this will be used to trigger a flight controller to reboot into a mass-storage over USB mode, allowing easier access to the microSD without removing it from the flight controller