### PR TITLE
fix(scripts): define missing show_help function in format_xml.sh

### DIFF
--- a/scripts/format_xml.sh
+++ b/scripts/format_xml.sh
@@ -10,11 +10,39 @@ mode="format"
 xml_dir="message_definitions"
 keep_old=0
 
-while getopts "h?cd:o" opt; do
+show_help() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [xml_file]
+
+Format or check formatting of MAVLink XML definition files using xmllint.
+
+Options:
+  -h        Show this help message and exit.
+  -c        Check mode: report files that need formatting instead of
+            formatting them in place.
+  -d DIR    XML directory to process (default: message_definitions).
+  -o        Keep a .old backup of each file that is reformatted.
+
+If xml_file is given, only that file (relative to DIR) is processed;
+otherwise all *.xml files under DIR are processed.
+EOF
+}
+
+while getopts ":hcd:o" opt; do
     case "$opt" in
-    h|\?)
+    h)
         show_help
         exit 0
+        ;;
+    \?)
+        echo "Error: Invalid option -$OPTARG" >&2
+        show_help
+        exit 1
+        ;;
+    :)
+        echo "Error: Option -$OPTARG requires an argument." >&2
+        show_help
+        exit 1
         ;;
     c)  mode="check"
         ;;


### PR DESCRIPTION
### Summary
`format_xml.sh -h` was broken - it called `show_help` but that function never existed, so it errored out instead of printing usage 
### Changes
- Added the missing `show_help()` function.
- Removed `?` from the getopts string (it's not a real flag, getopts uses
  it internally for unknown options - having it there was a no-op bug).
- Invalid flags now exit 1 instead of 0.

### Testing
```
./scripts/format_xml.sh -h   # prints help, exit 0
./scripts/format_xml.sh -z   # prints help, exit 1
```