### PR TITLE
Fix: check_api_break.py crashes when origin/master doesn't exist

### DIFF
--- a/scripts/check_api_break.py
+++ b/scripts/check_api_break.py
@@ -15,6 +15,7 @@ This script checks for the following changes:
 -      <field type="uint8_t" name="stream_id">The ID of the requested data stream</field>
 -    </message>
 """
+import argparse
 import json
 import os
 import subprocess
@@ -118,10 +119,60 @@ def collect_names(root: etree._Element) -> Tuple[Dict[NameKey, bool], Dict[NameK
     return names, attrs
 
 
-def get_base_commit() -> str:
-    return subprocess.check_output(
-        ["git", "merge-base", "origin/master", "HEAD"], text=True
-    ).strip()
+def get_base_commit(base_override: Optional[str] = None) -> str:
+    """Determine the base commit to diff against.
+
+    Checks in order:
+    1. Explicit base_override passed via CLI (--base)
+    2. Environment variables MAVLINK_BASE_REF or GITHUB_BASE_REF
+    3. Common upstream tracking branches (upstream/master, origin/master, master, main)
+    4. Fallback to HEAD~1 if in a commit history
+    """
+    candidates: List[str] = []
+    if base_override:
+        candidates.append(base_override)
+
+    env_base = os.getenv("MAVLINK_BASE_REF") or os.getenv("GITHUB_BASE_REF")
+    if env_base:
+        candidates.extend([env_base, f"origin/{env_base}", f"upstream/{env_base}"])
+
+    candidates.extend([
+        "upstream/master",
+        "origin/master",
+        "master",
+        "origin/main",
+        "upstream/main",
+        "main",
+    ])
+
+    for ref in candidates:
+        try:
+            output = subprocess.check_output(
+                ["git", "merge-base", ref, "HEAD"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            if output:
+                return output
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+
+    # Fallback to HEAD~1
+    try:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "HEAD~1"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if output:
+            return output
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    raise RuntimeError(
+        "Could not determine base commit. Please specify a base branch using "
+        "--base <ref> or the MAVLINK_BASE_REF environment variable."
+    )
 
 def get_changed_xml_files(base: str) -> List[str]:
     changed = subprocess.check_output(
@@ -263,7 +314,16 @@ def build_removal_comment(
 
 
 def main() -> None:
-    base = get_base_commit()
+    parser = argparse.ArgumentParser(description="Check for breaking changes in MAVLink XML definitions.")
+    parser.add_argument(
+        "-b",
+        "--base",
+        help="Base commit or branch to diff against (default: auto-detected)",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    base = get_base_commit(args.base)
     xml_files = get_changed_xml_files(base)
     if not xml_files:
         print("No XML files changed.")

--- a/scripts/check_api_break.py
+++ b/scripts/check_api_break.py
@@ -119,55 +119,147 @@ def collect_names(root: etree._Element) -> Tuple[Dict[NameKey, bool], Dict[NameK
     return names, attrs
 
 
+def _merge_base(ref: str) -> Optional[str]:
+    try:
+        output = subprocess.check_output(
+            ["git", "merge-base", ref, "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        return output or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def get_ci_event_base_sha() -> Optional[str]:
+    """Return the base commit SHA GitHub Actions computed for this run, if any.
+
+    For `pull_request`/`push` events this is authoritative: GitHub derives it
+    from the real PR/push relationship on its own servers, not from local
+    remotes, so it's correct even in a fork's CI with no `upstream` remote
+    and no risk of a stale local ref. Because of that, any failure to read it
+    here is a hard error rather than a silent fall-through to guessing -
+    getting the base wrong in CI is exactly what this must avoid.
+
+    Returns None for triggers with no such payload (e.g. workflow_dispatch),
+    or when not running in GitHub Actions at all, so callers fall back to the
+    best-effort local resolution.
+    """
+    event_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+
+    event_name = os.getenv("GITHUB_EVENT_NAME")
+    if event_name not in ("pull_request", "push"):
+        return None
+
+    try:
+        with open(event_path, "r", encoding="utf-8") as event_file:
+            event = json.load(event_file)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"Running in CI for a '{event_name}' event but couldn't read/parse "
+            f"GITHUB_EVENT_PATH ({event_path}): {exc}"
+        )
+
+    if event_name == "pull_request":
+        sha = event.get("pull_request", {}).get("base", {}).get("sha")
+        if not sha:
+            raise RuntimeError(
+                "Running in CI for a pull_request event but 'pull_request.base.sha' "
+                "is missing from the event payload."
+            )
+        return sha
+
+    sha = event.get("before")
+    if not sha:
+        raise RuntimeError(
+            "Running in CI for a push event but 'before' is missing from the event payload."
+        )
+    if set(sha) == {"0"}:
+        raise RuntimeError(
+            "This push has no prior commit on the branch (first push of a new branch), "
+            "so there is no base to diff against. Pass --base explicitly to check it anyway."
+        )
+    return sha
+
+
 def get_base_commit(base_override: Optional[str] = None) -> str:
     """Determine the base commit to diff against.
 
     Checks in order:
-    1. Explicit base_override passed via CLI (--base)
-    2. Environment variables MAVLINK_BASE_REF or GITHUB_BASE_REF
-    3. Common upstream tracking branches (upstream/master, origin/master, master, main)
-    4. Fallback to HEAD~1 if in a commit history
+    1. Explicit --base override - required to resolve; errors if it doesn't.
+    2. The GitHub Actions event payload (pull_request.base.sha / push.before) -
+       authoritative when present; errors rather than falling through, since
+       this is the path that CI correctness depends on.
+    3. Local/manual use only: a best-effort guess across common remote and
+       branch names, fetching each candidate remote first to reduce
+       staleness. Every match here is printed and flagged as unverified,
+       since none of these carry the same guarantee as (1) or (2).
     """
-    candidates: List[str] = []
     if base_override:
-        candidates.append(base_override)
+        resolved = _merge_base(base_override)
+        if resolved is None:
+            raise RuntimeError(
+                f"--base {base_override!r} does not resolve to a commit reachable from HEAD."
+            )
+        print(f"Diffing against explicit --base {base_override!r} ({resolved}).", file=sys.stderr)
+        return resolved
+
+    ci_sha = get_ci_event_base_sha()
+    if ci_sha is not None:
+        resolved = _merge_base(ci_sha)
+        if resolved is None:
+            raise RuntimeError(
+                f"Running in CI but the event's base commit {ci_sha!r} isn't reachable from "
+                "HEAD - checkout history may be too shallow (check fetch-depth)."
+            )
+        print(f"Diffing against CI event base commit {resolved}.", file=sys.stderr)
+        return resolved
 
     env_base = os.getenv("MAVLINK_BASE_REF") or os.getenv("GITHUB_BASE_REF")
+    candidates: List[str] = []
     if env_base:
-        candidates.extend([env_base, f"origin/{env_base}", f"upstream/{env_base}"])
+        candidates.extend([f"origin/{env_base}", f"upstream/{env_base}", env_base])
 
     candidates.extend([
         "upstream/master",
         "origin/master",
         "master",
-        "origin/main",
         "upstream/main",
+        "origin/main",
         "main",
     ])
 
-    for ref in candidates:
+    remotes = {ref.split("/", 1)[0] for ref in candidates if "/" in ref}
+    for remote in remotes:
         try:
-            output = subprocess.check_output(
-                ["git", "merge-base", ref, "HEAD"],
-                text=True,
+            subprocess.run(
+                ["git", "fetch", "--quiet", remote],
+                stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
-            ).strip()
-            if output:
-                return output
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            continue
+            )
+        except (subprocess.SubprocessError, OSError):
+            pass
 
-    # Fallback to HEAD~1
-    try:
-        output = subprocess.check_output(
-            ["git", "rev-parse", "HEAD~1"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-        if output:
-            return output
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
+    for ref in candidates:
+        resolved = _merge_base(ref)
+        if resolved is not None:
+            print(
+                f"Diffing against best-effort base '{ref}' ({resolved}). This was guessed, "
+                "not verified - pass --base explicitly if this looks wrong.",
+                file=sys.stderr,
+            )
+            return resolved
+
+    resolved = _merge_base("HEAD~1")
+    if resolved is not None:
+        print(
+            f"Diffing against HEAD~1 ({resolved}) as a last resort - no other base could be "
+            "determined. This is very likely NOT the right comparison; pass --base explicitly.",
+            file=sys.stderr,
+        )
+        return resolved
 
     raise RuntimeError(
         "Could not determine base commit. Please specify a base branch using "
@@ -341,9 +433,14 @@ def main() -> None:
             old_content = subprocess.check_output(
                 ["git", "show", f"{base}:{xml}"], text=True
             )
-            new_content = open(xml).read()
         except subprocess.CalledProcessError:
-            continue  # new file or removed, ignore
+            continue  # new file, nothing to compare against
+
+        try:
+            new_content = open(xml).read()
+        except FileNotFoundError:
+            print(f"Skipped {xml}: removed since base.")
+            continue
 
         old_root = parse_xml(old_content)
         new_root = parse_xml(new_content)

--- a/scripts/test_check_api_break.py
+++ b/scripts/test_check_api_break.py
@@ -137,6 +137,21 @@ class RemovalDetectionTests(unittest.TestCase):
 
 
 class BaseCommitTests(unittest.TestCase):
+    """Covers get_base_commit()'s three tiers: --base override, the CI event
+    payload (authoritative, must error rather than guess on failure), and the
+    local best-effort ref cascade.
+
+    Every test that can reach the cascade neutralizes GITHUB_EVENT_PATH and
+    mocks subprocess.run, because these tests run inside this repo's own
+    GitHub Actions job: without that, a real GITHUB_EVENT_PATH would make the
+    CI-event tier intercept the call, and a real `git fetch` would hit the
+    network for real remotes (origin/upstream) that exist in this repo.
+    """
+
+    # Neutralizes ambient CI env vars so cascade-focused tests behave the same
+    # locally and when this suite runs inside the project's own CI job.
+    _NO_CI_ENV = {"GITHUB_EVENT_PATH": "", "GITHUB_EVENT_NAME": "", "GITHUB_BASE_REF": ""}
+
     def test_override_is_attempted_first(self):
         from unittest.mock import patch
         import subprocess
@@ -150,6 +165,14 @@ class BaseCommitTests(unittest.TestCase):
             res = check_api_break.get_base_commit("custom-branch")
             self.assertEqual(res, "abc1234")
 
+    def test_override_that_does_not_resolve_raises(self):
+        from unittest.mock import patch
+        import subprocess
+
+        with patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, [])):
+            with self.assertRaises(RuntimeError):
+                check_api_break.get_base_commit("no-such-ref")
+
     def test_upstream_master_fallback_when_origin_master_missing(self):
         from unittest.mock import patch
         import subprocess
@@ -159,7 +182,9 @@ class BaseCommitTests(unittest.TestCase):
                 return "fedcba9\n"
             raise subprocess.CalledProcessError(128, cmd)
 
-        with patch("subprocess.check_output", side_effect=fake_check_output):
+        with patch.dict(os.environ, self._NO_CI_ENV), \
+             patch("subprocess.check_output", side_effect=fake_check_output), \
+             patch("subprocess.run"):
             res = check_api_break.get_base_commit()
             self.assertEqual(res, "fedcba9")
 
@@ -172,11 +197,154 @@ class BaseCommitTests(unittest.TestCase):
                 return "1122334\n"
             raise subprocess.CalledProcessError(1, cmd)
 
-        with patch.dict(os.environ, {"MAVLINK_BASE_REF": "pr-target"}), patch(
-            "subprocess.check_output", side_effect=fake_check_output
-        ):
+        env = dict(self._NO_CI_ENV, MAVLINK_BASE_REF="pr-target")
+        with patch.dict(os.environ, env), \
+             patch("subprocess.check_output", side_effect=fake_check_output), \
+             patch("subprocess.run"):
             res = check_api_break.get_base_commit()
             self.assertEqual(res, "1122334")
+
+    def test_env_var_qualified_forms_preferred_over_bare_name(self):
+        # A locally-checked-out branch of the same name as env_base shouldn't
+        # win over the remote-qualified forms - those are more likely fresh.
+        from unittest.mock import patch
+        import subprocess
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[:3] == ["git", "merge-base", "upstream/pr-target"]:
+                return "9988776\n"
+            if cmd[:3] == ["git", "merge-base", "pr-target"]:
+                return "0000000\n"  # a stale local branch - should lose
+            raise subprocess.CalledProcessError(1, cmd)
+
+        env = dict(self._NO_CI_ENV, MAVLINK_BASE_REF="pr-target")
+        with patch.dict(os.environ, env), \
+             patch("subprocess.check_output", side_effect=fake_check_output), \
+             patch("subprocess.run"):
+            res = check_api_break.get_base_commit()
+            self.assertEqual(res, "9988776")
+
+    def test_ci_pull_request_base_sha_takes_priority(self):
+        from unittest.mock import patch
+        import json
+        import subprocess
+        import tempfile
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[:3] == ["git", "merge-base", "cafebabe"]:
+                return "cafebabe\n"
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = os.path.join(tmp, "event.json")
+            with open(event_path, "w", encoding="utf-8") as f:
+                json.dump({"pull_request": {"base": {"sha": "cafebabe"}}}, f)
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_EVENT_NAME": "pull_request",
+                # Should be ignored: the CI event payload outranks it.
+                "MAVLINK_BASE_REF": "should-be-ignored",
+            }
+            with patch.dict(os.environ, env), \
+                 patch("subprocess.check_output", side_effect=fake_check_output):
+                res = check_api_break.get_base_commit()
+                self.assertEqual(res, "cafebabe")
+
+    def test_ci_push_before_sha_used(self):
+        from unittest.mock import patch
+        import json
+        import subprocess
+        import tempfile
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[:3] == ["git", "merge-base", "1122334455"]:
+                return "1122334455\n"
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = os.path.join(tmp, "event.json")
+            with open(event_path, "w", encoding="utf-8") as f:
+                json.dump({"before": "1122334455"}, f)
+
+            env = {"GITHUB_EVENT_PATH": event_path, "GITHUB_EVENT_NAME": "push"}
+            with patch.dict(os.environ, env), \
+                 patch("subprocess.check_output", side_effect=fake_check_output):
+                res = check_api_break.get_base_commit()
+                self.assertEqual(res, "1122334455")
+
+    def test_ci_pull_request_missing_base_sha_raises(self):
+        from unittest.mock import patch
+        import json
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = os.path.join(tmp, "event.json")
+            with open(event_path, "w", encoding="utf-8") as f:
+                json.dump({"pull_request": {"base": {}}}, f)
+
+            env = {"GITHUB_EVENT_PATH": event_path, "GITHUB_EVENT_NAME": "pull_request"}
+            with patch.dict(os.environ, env):
+                with self.assertRaises(RuntimeError):
+                    check_api_break.get_base_commit()
+
+    def test_ci_push_zero_before_raises(self):
+        from unittest.mock import patch
+        import json
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = os.path.join(tmp, "event.json")
+            with open(event_path, "w", encoding="utf-8") as f:
+                json.dump({"before": "0" * 40}, f)
+
+            env = {"GITHUB_EVENT_PATH": event_path, "GITHUB_EVENT_NAME": "push"}
+            with patch.dict(os.environ, env):
+                with self.assertRaises(RuntimeError):
+                    check_api_break.get_base_commit()
+
+    def test_ci_event_sha_unreachable_raises_instead_of_guessing(self):
+        # Simulates a too-shallow checkout: the event's base sha exists but
+        # isn't in local history. This must error, not silently fall through
+        # to the local cascade - that's the whole point of the CI tier.
+        from unittest.mock import patch
+        import json
+        import subprocess
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = os.path.join(tmp, "event.json")
+            with open(event_path, "w", encoding="utf-8") as f:
+                json.dump({"pull_request": {"base": {"sha": "deadbeef"}}}, f)
+
+            env = {"GITHUB_EVENT_PATH": event_path, "GITHUB_EVENT_NAME": "pull_request"}
+            with patch.dict(os.environ, env), \
+                 patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(128, [])):
+                with self.assertRaises(RuntimeError):
+                    check_api_break.get_base_commit()
+
+    def test_workflow_dispatch_has_no_event_base_falls_through_to_cascade(self):
+        from unittest.mock import patch
+        import json
+        import subprocess
+        import tempfile
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[:3] == ["git", "merge-base", "upstream/master"]:
+                return "abcdef1\n"
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            event_path = os.path.join(tmp, "event.json")
+            with open(event_path, "w", encoding="utf-8") as f:
+                json.dump({"inputs": {}}, f)
+
+            env = {"GITHUB_EVENT_PATH": event_path, "GITHUB_EVENT_NAME": "workflow_dispatch"}
+            with patch.dict(os.environ, env), \
+                 patch("subprocess.check_output", side_effect=fake_check_output), \
+                 patch("subprocess.run"):
+                res = check_api_break.get_base_commit()
+                self.assertEqual(res, "abcdef1")
 
     def test_main_passes_base_arg_to_get_base_commit(self):
         from unittest.mock import patch
@@ -186,6 +354,34 @@ class BaseCommitTests(unittest.TestCase):
              patch.object(check_api_break, "get_changed_xml_files", return_value=[]):
             check_api_break.main()
             mock_get_base.assert_called_once_with("custom-ref")
+
+
+class MainRemovedFileTests(unittest.TestCase):
+    def test_file_removed_since_base_is_reported_not_crashed(self):
+        # A whole XML file present at `base` but deleted by HEAD used to crash
+        # main() with an unhandled FileNotFoundError (open() on the no-longer
+        # -existing path wasn't covered by the CalledProcessError handler
+        # around the `git show base:file` read). It should be skipped and
+        # reported instead, consistent with how a brand-new file is skipped.
+        from unittest.mock import patch
+        import io
+        import contextlib
+        import subprocess
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[:2] == ["git", "show"]:
+                return "<mavlink><enums></enums></mavlink>"
+            raise subprocess.CalledProcessError(1, cmd)
+
+        stdout = io.StringIO()
+        with patch("sys.argv", ["check_api_break.py"]), \
+             patch.object(check_api_break, "get_base_commit", return_value="deadbeef"), \
+             patch.object(check_api_break, "get_changed_xml_files", return_value=["removed_dialect.xml"]), \
+             patch("subprocess.check_output", side_effect=fake_check_output), \
+             contextlib.redirect_stdout(stdout):
+            check_api_break.main()  # must not raise
+
+        self.assertIn("Skipped removed_dialect.xml: removed since base.", stdout.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_api_break.py
+++ b/scripts/test_check_api_break.py
@@ -178,7 +178,17 @@ class BaseCommitTests(unittest.TestCase):
             res = check_api_break.get_base_commit()
             self.assertEqual(res, "1122334")
 
+    def test_main_passes_base_arg_to_get_base_commit(self):
+        from unittest.mock import patch
+
+        with patch("sys.argv", ["check_api_break.py", "--base", "custom-ref"]), \
+             patch.object(check_api_break, "get_base_commit", return_value="deadbeef") as mock_get_base, \
+             patch.object(check_api_break, "get_changed_xml_files", return_value=[]):
+            check_api_break.main()
+            mock_get_base.assert_called_once_with("custom-ref")
+
 
 if __name__ == "__main__":
     unittest.main()
+
 

--- a/scripts/test_check_api_break.py
+++ b/scripts/test_check_api_break.py
@@ -136,5 +136,49 @@ class RemovalDetectionTests(unittest.TestCase):
         self.assertNotIn(FieldKey(message=MessageKey(message_name="MY_MSG"), field_name="foo"), removed)
 
 
+class BaseCommitTests(unittest.TestCase):
+    def test_override_is_attempted_first(self):
+        from unittest.mock import patch
+        import subprocess
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[:3] == ["git", "merge-base", "custom-branch"]:
+                return "abc1234\n"
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with patch("subprocess.check_output", side_effect=fake_check_output):
+            res = check_api_break.get_base_commit("custom-branch")
+            self.assertEqual(res, "abc1234")
+
+    def test_upstream_master_fallback_when_origin_master_missing(self):
+        from unittest.mock import patch
+        import subprocess
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[:3] == ["git", "merge-base", "upstream/master"]:
+                return "fedcba9\n"
+            raise subprocess.CalledProcessError(128, cmd)
+
+        with patch("subprocess.check_output", side_effect=fake_check_output):
+            res = check_api_break.get_base_commit()
+            self.assertEqual(res, "fedcba9")
+
+    def test_env_var_base_ref_respected(self):
+        from unittest.mock import patch
+        import subprocess
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[:3] == ["git", "merge-base", "pr-target"]:
+                return "1122334\n"
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with patch.dict(os.environ, {"MAVLINK_BASE_REF": "pr-target"}), patch(
+            "subprocess.check_output", side_effect=fake_check_output
+        ):
+            res = check_api_break.get_base_commit()
+            self.assertEqual(res, "1122334")
+
+
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
What's broken
`check_api_break.py` hardcodes `git merge-base origin/master HEAD`. Fails with fatal: Not a valid object name origin/master for anyone running it from a fork (real repo is `upstream`, not `origin`), in detached HEAD, or in CI setups without an `origin/master` ref.

Fix
Try a list of candidate refs (`--base` override -> `MAVLINK_BASE_REF`/`GITHUB_BASE_REF` -> common upstream/origin master/main combos) and skip past failures instead of crashing on the first miss. Falls back to `HEAD-1`, then a clear error telling you to pass `--base`