### PR TITLE
Add MAV_AUTOPILOT_FLIX

### DIFF
--- a/message_definitions/v1.0/minimal.xml
+++ b/message_definitions/v1.0/minimal.xml
@@ -67,6 +67,9 @@
       <entry value="20" name="MAV_AUTOPILOT_REFLEX">
         <description>Fusion Reflex - https://fusion.engineering</description>
       </entry>
+      <entry value="21" name="MAV_AUTOPILOT_FLIX">
+        <description>Flix quadcopter - https://quadcopter.dev</description>
+      </entry>
     </enum>
     <enum name="MAV_TYPE">
       <description>MAVLINK component type reported in HEARTBEAT message. Flight controllers must report the type of the vehicle on which they are mounted (e.g. MAV_TYPE_OCTOROTOR). All other components must report a value appropriate for their type (e.g. a camera must use MAV_TYPE_CAMERA).</description>


### PR DESCRIPTION
Hi!

This PR adds a new `MAV_AUTOPILOT` enum entry: `MAV_AUTOPILOT_FLIX`.

Flix is an extremely compact (~ 2000 SLOC) yet functional autopilot software and a DIY quadcopter. It's intended for educational and research use.

The project repo: https://github.com/okalachev/flix.

Flix has about 100 user builds around the world, and there have also been three educational events. See the documented usage gallery here: https://github.com/okalachev/flix/blob/master/docs/user.md.

The new `MAV_AUTOPILOT_FLIX` entry will allow ground control software such as [mavlink-joystick](https://github.com/goldarte/mavlink-joystick) to reliably distinguish Flix from other autopilots.