### PR TITLE
Spell-check development.xml, and fix the two typos it was hiding

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -52,12 +52,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: pipx install codespell
-      # Discover typos in all non-XML files and the four XML files that this repo controls
+      # Discover typos in all non-XML files and the XML files that this repo controls
       - run: codespell --skip="*.xml"
       - run: codespell --ignore-words-list=ned message_definitions/v1.0/all.xml
                                                message_definitions/v1.0/common.xml
                                                message_definitions/v1.0/minimal.xml
                                                message_definitions/v1.0/standard.xml
+                                               message_definitions/v1.0/development.xml
 
   python-lint:
     name: Lint Python code with ruff

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -761,7 +761,7 @@
       </description>
       <field type="uint8_t" name="flags" enum="GCS_CONTROL_STATUS_FLAGS">Control status. For example, whether takeover of the `gcs_main` role is allowed, and whether this CONTROL_STATUS instance defines the default controlling GCS for the whole system.</field>
       <field type="uint8_t" name="gcs_main" invalid="0">System ID of GCS in control. 0: no GCS in control.</field>
-      <field type="uint8_t[10]" name="gcs_secondary" invalid="[0,]">System IDs from which the system can recieve state-changing commands/messages in multi-control mode. All values should be zero for single-ower mode.</field>
+      <field type="uint8_t[10]" name="gcs_secondary" invalid="[0,]">System IDs from which the system can receive state-changing commands/messages in multi-control mode. All values should be zero for single-owner mode.</field>
     </message>
     <message id="292" name="ESC_EEPROM">
       <description>ESC EEPROM data message for reading and writing ESC configuration.


### PR DESCRIPTION
## What this does

Adds `development.xml` to the codespell CI step, and fixes the two typos that were sitting in it because nothing checked.

## Why

The spell-check step covers four files, with the comment "the four XML files that this repo controls":

```yaml
- run: codespell --ignore-words-list=ned message_definitions/v1.0/all.xml
                                         message_definitions/v1.0/common.xml
                                         message_definitions/v1.0/minimal.xml
                                         message_definitions/v1.0/standard.xml
```

`development.xml` is controlled by this repo too. It is the staging file for definitions on their way into `common.xml`, and `scripts/xml_consistency_check.py` already treats it as managed:

```python
managed_dialects = ["common.xml", "minimal.xml", "standard.xml", "development.xml"]
```

So the two lists disagree, and `development.xml` is the one managed dialect that has never been spell-checked.

## The typos

Both are in the `gcs_secondary` field description of `GCS_CONTROL_STATUS`:

> System IDs from which the system can **recieve** state-changing commands/messages in multi-control mode. All values should be zero for **single-ower** mode.

codespell finds `recieve`. It does not flag `single-ower`, which I noticed reading the line.

These are not internal comments. Field descriptions render into the mavlink.io documentation and into the generated code comments for every language binding, so a reader hits them in C, Python, C#, Java and the rest.

## Verification

Run locally on Windows, Python 3.11:

- `codespell --ignore-words-list=ned` over all five files now passes, where it failed on `development.xml` before the fix.
- `python scripts/xml_consistency_check.py --exception` reports 0 new consistency warnings and 0 stale allowlist entries across `common.xml`, `minimal.xml`, `standard.xml`, `development.xml`.
- `python -m unittest scripts/test_xml_consistency_check.py` passes.

Only the one description line changes, so nothing about message IDs, field types or wire format is touched.
