### PR TITLE
Report a reference to a deprecated enum as deprecated, not as missing

### DIFF
--- a/scripts/test_xml_consistency_check.py
+++ b/scripts/test_xml_consistency_check.py
@@ -182,5 +182,51 @@ class CmdParamRangeTests(ConsistencyCheckTestCase):
         self.assertEqual(messages, [])
 
 
+class DeprecatedEnumReferenceTestCase(ConsistencyCheckTestCase):
+    """A deprecated enum is skipped when the checker collects enums, so a
+    reference to one is not found in `enums`. It still exists in the XML
+    though, so it must be reported as deprecated rather than as missing."""
+
+    def test_field_referencing_deprecated_enum_says_deprecated(self):
+        field = parse_field('<field type="uint8_t" name="mode" enum="OLD_ENUM">desc</field>')
+        messages = self.warnings(
+            check_field, "test.xml", "MY_MSG", field, {}, {"OLD_ENUM"}
+        )
+        self.assertEqual(
+            messages,
+            ["test.xml: Message MY_MSG field mode enum OLD_ENUM is deprecated"],
+        )
+
+    def test_field_referencing_unknown_enum_still_says_does_not_exist(self):
+        field = parse_field('<field type="uint8_t" name="mode" enum="GONE_ENUM">desc</field>')
+        messages = self.warnings(
+            check_field, "test.xml", "MY_MSG", field, {}, {"OLD_ENUM"}
+        )
+        self.assertEqual(
+            messages,
+            ["test.xml: Message MY_MSG field mode enum GONE_ENUM does not exist"],
+        )
+
+    def test_cmd_param_referencing_deprecated_enum_says_deprecated(self):
+        param = parse_param('<param index="1" enum="OLD_ENUM">desc</param>')
+        messages = self.warnings(
+            check_cmd_param, "test.xml", "MY_CMD", param, {}, {"OLD_ENUM"}
+        )
+        self.assertEqual(
+            messages,
+            ["test.xml: Command MY_CMD param 1 enum OLD_ENUM is deprecated"],
+        )
+
+    def test_cmd_param_referencing_unknown_enum_still_says_does_not_exist(self):
+        param = parse_param('<param index="1" enum="GONE_ENUM">desc</param>')
+        messages = self.warnings(
+            check_cmd_param, "test.xml", "MY_CMD", param, {}, {"OLD_ENUM"}
+        )
+        self.assertEqual(
+            messages,
+            ["test.xml: Command MY_CMD param 1 enum GONE_ENUM does not exist"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/xml_consistency_allowlist.txt
+++ b/scripts/xml_consistency_allowlist.txt
@@ -11,12 +11,14 @@
 common.xml: Enum: CAMERA_TRACKING_STATUS_FLAGS bitmask should not contain 0
 common.xml: Message GIMBAL_DEVICE_INFORMATION field cap_flags enum GIMBAL_DEVICE_CAP_FLAGS does not fit in type: uint16_t
 
-# --- Messages referencing removed/missing enums ---
-common.xml: Message HIL_CONTROLS field mode enum MAV_MODE does not exist
+# --- Live messages referencing deprecated enums ---
+common.xml: Message HIL_CONTROLS field mode enum MAV_MODE is deprecated
 
-# --- Commands referencing removed/missing enums ---
-common.xml: Command MAV_CMD_DO_MOUNT_CONFIGURE param 1 enum MAV_MOUNT_MODE does not exist
-common.xml: Command MAV_CMD_DO_MOUNT_CONTROL param 7 enum MAV_MOUNT_MODE does not exist
+# --- Superseded commands referencing deprecated enums ---
+# Both are <superseded/> rather than <deprecated/> and say they are still usable
+# with legacy gimbals, so the reference to MAV_MOUNT_MODE is intentional.
+common.xml: Command MAV_CMD_DO_MOUNT_CONFIGURE param 1 enum MAV_MOUNT_MODE is deprecated
+common.xml: Command MAV_CMD_DO_MOUNT_CONTROL param 7 enum MAV_MOUNT_MODE is deprecated
 
 # --- Command params with small integer ranges (no enum defined yet) ---
 common.xml: Command MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT param 1 min, max close and increment of 1, should there be a enum?

--- a/scripts/xml_consistency_check.py
+++ b/scripts/xml_consistency_check.py
@@ -98,7 +98,7 @@ def check_enum(enum, file_name):
     return {"name": name, "bitmask": bitmask, "values": values}
 
 
-def check_field(file_name, msg_name, field, enums):
+def check_field(file_name, msg_name, field, enums, deprecated_enums=frozenset()):
     name = field.get('name')
     enum = field.get('enum')
     units = field.get('units')
@@ -111,7 +111,10 @@ def check_field(file_name, msg_name, field, enums):
     if enum is not None:
         # Enum should exist
         if enum not in enums:
-            warn(f"{file_name}: Message {msg_name} field {name} enum {enum} does not exist")
+            if enum in deprecated_enums:
+                warn(f"{file_name}: Message {msg_name} field {name} enum {enum} is deprecated")
+            else:
+                warn(f"{file_name}: Message {msg_name} field {name} enum {enum} does not exist")
             return
 
         enums[enum]["used"] = True
@@ -137,7 +140,7 @@ def check_field(file_name, msg_name, field, enums):
             warn(f"{file_name}: Message {msg_name} field {name} enum {enum} does not fit in type: {type}")
 
 
-def check_cmd_param(file_name, cmd_name, entry, enums):
+def check_cmd_param(file_name, cmd_name, entry, enums, deprecated_enums=frozenset()):
     index = entry.get('index')
     enum = entry.get('enum')
     units = entry.get('units')
@@ -152,7 +155,10 @@ def check_cmd_param(file_name, cmd_name, entry, enums):
     if enum is not None:
         # Enum should exist
         if enum not in enums:
-            warn(f"{file_name}: Command {cmd_name} param {index} enum {enum} does not exist")
+            if enum in deprecated_enums:
+                warn(f"{file_name}: Command {cmd_name} param {index} enum {enum} is deprecated")
+            else:
+                warn(f"{file_name}: Command {cmd_name} param {index} enum {enum} does not exist")
             return
 
         enums[enum]["used"] = True
@@ -255,10 +261,15 @@ so that CI can gate on new warnings while tolerating ones we can't fix yet.
 
     # Get all enums
     all_enums = {}
+    # Deprecated enums are not checked and are not counted as "used", but they do
+    # still exist. Remember their names so that a reference to one is reported as
+    # deprecated rather than as missing.
+    deprecated_enums = set()
     for key in xml:
         for enum in xml[key].find_all('enum'):
             if enum.find('deprecated', recursive=False) is not None:
                 # Skip and deprecated items
+                deprecated_enums.add(enum.get('name'))
                 continue
             decoded = check_enum(enum, key)
             name = decoded["name"]
@@ -316,7 +327,7 @@ so that CI can gate on new warnings while tolerating ones we can't fix yet.
             name = message.get('name')
             fields = message.find_all('field')
             for field in fields:
-                check_field(key, name, field, all_enums)
+                check_field(key, name, field, all_enums, deprecated_enums)
 
     # Check params in MAV_CMD
     for key in xml:
@@ -328,7 +339,7 @@ so that CI can gate on new warnings while tolerating ones we can't fix yet.
                 name = entry.get('name')
                 seen_indices = set()   # Indices seen so far, to check for duplicates
                 for param in entry.find_all('param'):
-                    check_cmd_param(key, name, param, all_enums)
+                    check_cmd_param(key, name, param, all_enums, deprecated_enums)
                     idx = param.get('index')
 
                     # Flag duplicate indices regardless of whether they're in the


### PR DESCRIPTION
## What this does

Makes the consistency checker say "is deprecated" when something references a deprecated enum, instead of claiming the enum does not exist.

## The problem

When collecting enums, the checker skips anything carrying a `<deprecated/>` marker:

```python
for enum in xml[key].find_all('enum'):
    if enum.find('deprecated', recursive=False) is not None:
        # Skip and deprecated items
        continue
```

Those names never enter `all_enums`, so a field or command param that points at one falls into the `enum not in enums` branch and gets reported as `does not exist`. That is not true. The enum is in the file, it is just deprecated.

Three allowlist entries are this false report, and the section headings had taken the message at face value:

```
# --- Messages referencing removed/missing enums ---
common.xml: Message HIL_CONTROLS field mode enum MAV_MODE does not exist

# --- Commands referencing removed/missing enums ---
common.xml: Command MAV_CMD_DO_MOUNT_CONFIGURE param 1 enum MAV_MOUNT_MODE does not exist
common.xml: Command MAV_CMD_DO_MOUNT_CONTROL param 7 enum MAV_MOUNT_MODE does not exist
```

Neither enum is removed or missing. `MAV_MODE` is at `common.xml:67` and `MAV_MOUNT_MODE` at `common.xml:395`, both with a `<deprecated/>` marker.

## The change

Remember the names of the enums that were skipped, and use that to choose the message. A genuinely missing enum still reports `does not exist`.

They are held in a separate set rather than added to `all_enums`, so deprecated enums stay out of the enum checks and out of the unused scan. No new warnings appear as a result of this change.

## Why the distinction is worth having

Once the message is accurate, the three entries say different things:

- `HIL_CONTROLS` is **not** deprecated. A live message pointing at a deprecated enum is a real thing to revisit one day.
- `MAV_CMD_DO_MOUNT_CONFIGURE` and `MAV_CMD_DO_MOUNT_CONTROL` are `<superseded/>` and say they are still usable with legacy gimbals, so their reference to `MAV_MOUNT_MODE` is deliberate and can stay.

Both readings were hidden while the warning claimed the enum did not exist.

## Tests

Four cases added to `test_xml_consistency_check.py`, covering a deprecated enum and a genuinely missing one, for both fields and command params. They fail against the unpatched checker.

## Verification

Run locally on Windows, Python 3.11:

- `python scripts/xml_consistency_check.py --exception`: 0 new consistency warnings and 0 stale allowlist entries across `common.xml`, `minimal.xml`, `standard.xml`, `development.xml`.
- `python -m unittest scripts/test_xml_consistency_check.py`: 14 tests, OK.
- `ruff check scripts/`: all checks passed.

No message definitions are touched, so nothing about the wire format changes.
