### PR TITLE
fix(scripts): allow removing deprecated items in api-break check

### DIFF
--- a/scripts/check_api_break.py
+++ b/scripts/check_api_break.py
@@ -84,13 +84,13 @@ def collect_names(root: etree._Element) -> Tuple[Dict[NameKey, bool], Dict[NameK
 
     for enum in root.findall(".//enum"):
         enum_name = enum.get("name")
-        enum_is_wip = enum.find("wip") is not None
+        enum_is_wip = enum.find("wip") is not None or enum.find("deprecated") is not None
         enum_key = EnumKey(enum_name=enum_name)
         names[enum_key] = enum_is_wip
 
         for entry in enum.findall("entry"):
             entry_name = entry.get("name")
-            entry_is_wip = enum_is_wip or entry.find("wip") is not None
+            entry_is_wip = enum_is_wip or entry.find("wip") is not None or entry.find("deprecated") is not None
             entry_key = EnumEntryKey(enum=enum_key, entry_name=entry_name)
             names[entry_key] = entry_is_wip
             entry_value = entry.get("value")
@@ -99,7 +99,7 @@ def collect_names(root: etree._Element) -> Tuple[Dict[NameKey, bool], Dict[NameK
 
     for msg in root.findall(".//message"):
         message_name = msg.get("name")
-        message_is_wip = msg.find("wip") is not None
+        message_is_wip = msg.find("wip") is not None or msg.find("deprecated") is not None
         message_key = MessageKey(message_name=message_name)
         names[message_key] = message_is_wip
         message_id = msg.get("id")
@@ -108,7 +108,7 @@ def collect_names(root: etree._Element) -> Tuple[Dict[NameKey, bool], Dict[NameK
 
         for field in msg.findall("field"):
             field_name = field.get("name")
-            field_is_wip = message_is_wip or field.find("wip") is not None
+            field_is_wip = message_is_wip or field.find("wip") is not None or field.find("deprecated") is not None
             field_key = FieldKey(message=message_key, field_name=field_name)
             names[field_key] = field_is_wip
             field_type = field.get("type")

--- a/scripts/check_api_break.py
+++ b/scripts/check_api_break.py
@@ -28,6 +28,14 @@ from lxml import etree
 
 NameKey = Union['EnumKey', 'EnumEntryKey', 'MessageKey', 'FieldKey']
 
+# Lifecycle statuses returned by collect_names().
+WIP = "wip"
+DEPRECATED = "deprecated"
+STABLE = "stable"
+_WIP = WIP
+_DEPRECATED = DEPRECATED
+_STABLE = STABLE
+
 
 class IsRelativeOfBase(ABC):
     @abstractmethod
@@ -77,40 +85,62 @@ def describe_key(name: NameKey) -> str:
     return str(name)
 
 
-def collect_names(root: etree._Element) -> Tuple[Dict[NameKey, bool], Dict[NameKey, Dict[str, Any]]]:
-    """Collect names and wire-critical attributes (id, type, value) from a MAVLink XML root."""
-    names = {}
-    attrs = {}
+def _lifecycle_status(element: etree._Element, parent_status: str = _STABLE) -> str:
+    """Determine lifecycle status of a MAVLink XML element.
+
+    WIP is inherited from parent (an entire message/enum being WIP means all
+    its children are WIP).
+
+    DEPRECATED is NOT inherited: a deprecated message still has a fixed, released
+    wire format while it survives. Surviving fields of a deprecated message must
+    not be mutated or removed. Only elements explicitly marked with <deprecated>
+    (or an entire deprecated message/enum deleted as a whole) qualify.
+    """
+    if element.find("wip") is not None or parent_status == _WIP:
+        return _WIP
+    if element.find("deprecated") is not None:
+        return _DEPRECATED
+    return _STABLE
+
+
+def collect_names(root: etree._Element) -> Tuple[Dict[NameKey, str], Dict[NameKey, Dict[str, Any]]]:
+    """Collect names and wire-critical attributes (id, type, value) from a MAVLink XML root.
+
+    The first dict maps each NameKey to its lifecycle status ('wip', 'deprecated',
+    or 'stable').
+    """
+    names: Dict[NameKey, str] = {}
+    attrs: Dict[NameKey, Dict[str, Any]] = {}
 
     for enum in root.findall(".//enum"):
         enum_name = enum.get("name")
-        enum_is_wip = enum.find("wip") is not None or enum.find("deprecated") is not None
+        enum_status = _lifecycle_status(enum)
         enum_key = EnumKey(enum_name=enum_name)
-        names[enum_key] = enum_is_wip
+        names[enum_key] = enum_status
 
         for entry in enum.findall("entry"):
             entry_name = entry.get("name")
-            entry_is_wip = enum_is_wip or entry.find("wip") is not None or entry.find("deprecated") is not None
+            entry_status = _lifecycle_status(entry, enum_status)
             entry_key = EnumEntryKey(enum=enum_key, entry_name=entry_name)
-            names[entry_key] = entry_is_wip
+            names[entry_key] = entry_status
             entry_value = entry.get("value")
             if entry_value is not None:
                 attrs[entry_key] = {"value": entry_value}
 
     for msg in root.findall(".//message"):
         message_name = msg.get("name")
-        message_is_wip = msg.find("wip") is not None or msg.find("deprecated") is not None
+        message_status = _lifecycle_status(msg)
         message_key = MessageKey(message_name=message_name)
-        names[message_key] = message_is_wip
+        names[message_key] = message_status
         message_id = msg.get("id")
         if message_id is not None:
             attrs[message_key] = {"id": message_id}
 
         for field in msg.findall("field"):
             field_name = field.get("name")
-            field_is_wip = message_is_wip or field.find("wip") is not None or field.find("deprecated") is not None
+            field_status = _lifecycle_status(field, message_status)
             field_key = FieldKey(message=message_key, field_name=field_name)
-            names[field_key] = field_is_wip
+            names[field_key] = field_status
             field_type = field.get("type")
             if field_type is not None:
                 attrs[field_key] = {"type": field_type}
@@ -208,18 +238,22 @@ def describe_mutation(key: NameKey, old_a: Dict[str, Any], new_a: Dict[str, Any]
 
 
 def find_mutations(
-    old_names: Dict[NameKey, bool],
-    new_names: Dict[NameKey, bool],
+    old_names: Dict[NameKey, str],
+    new_names: Dict[NameKey, str],
     old_attrs: Dict[NameKey, Dict[str, Any]],
     new_attrs: Dict[NameKey, Dict[str, Any]],
 ) -> List[str]:
-    """Return description strings for wire-breaking attribute mutations (type, id, value)."""
+    """Return description strings for wire-breaking attribute mutations (type, id, value).
+
+    Only WIP items are exempt — deprecated items are still wire-released and
+    changing their id/type/value is a genuine wire break.
+    """
     mutation_descs: List[str] = []
     for key in old_names:
         if key not in new_names:
             continue
-        if old_names.get(key) or new_names.get(key):
-            continue  # skip WIP items
+        if _WIP in (old_names.get(key), new_names.get(key)):
+            continue  # skip WIP items; deprecated items are still wire-breaking
         old_a = old_attrs.get(key)
         new_a = new_attrs.get(key)
         if old_a is None or new_a is None:
@@ -238,6 +272,7 @@ COMMENT_MARKER = "<!-- mavlink-api-break-check -->"
 def build_removal_comment(
     removed_by_file: Dict[str, List[NameKey]],
     mutations_by_file: Optional[Dict[str, List[str]]] = None,
+    deprecated_by_file: Optional[Dict[str, List[NameKey]]] = None,
 ) -> str:
     """Format a PR comment listing removed messages/enums and attribute mutations."""
     lines: List[str] = [COMMENT_MARKER, ""]
@@ -248,6 +283,14 @@ def build_removal_comment(
             lines.append(f"- `{xml}`")
             for name in sorted(removed_by_file[xml], key=describe_key):
                 lines.append(f"  - Removed {describe_key(name)}")
+        lines.append("")
+
+    if deprecated_by_file:
+        lines.extend(["Detected removal of deprecated items (expected lifecycle cleanup):", ""])
+        for xml in sorted(deprecated_by_file):
+            lines.append(f"- `{xml}`")
+            for name in sorted(deprecated_by_file[xml], key=describe_key):
+                lines.append(f"  - Removed deprecated {describe_key(name)}")
         lines.append("")
 
     if mutations_by_file:
@@ -270,6 +313,7 @@ def main() -> None:
         return
 
     removals_for_comment: Dict[str, List[NameKey]] = {}
+    deprecated_for_comment: Dict[str, List[NameKey]] = {}
     mutations_for_comment: Dict[str, List[str]] = {}
     breaking_by_file: Dict[str, List[str]] = {}
 
@@ -293,16 +337,30 @@ def main() -> None:
 
         # If field is not in new names, it was removed
         removed = [n for n in old_names if n not in new_names]
-        # If removed field is not wip, it is a breaking change
-        breaking_candidates = [r for r in removed if not old_names.get(r)]
 
-        # Moving an entire message/enum (e.g. from a dialect to common) can be ok, so separate those cases
-        removed_enum_or_message = [item for item in breaking_candidates if isinstance(item, (MessageKey, EnumKey))]
+        # All messages and enums removed in this diff (stable or deprecated)
+        removed_enum_or_message = [item for item in removed if isinstance(item, (MessageKey, EnumKey))]
 
-        if removed_enum_or_message:
-            removals_for_comment[xml] = removed_enum_or_message
+        # Stable whole messages/enums removed go to comment for confirmation
+        stable_removed_enum_or_message = [item for item in removed_enum_or_message if old_names.get(item) == _STABLE]
+        if stable_removed_enum_or_message:
+            removals_for_comment[xml] = stable_removed_enum_or_message
 
-        confirmed_breaking = [b for b in breaking_candidates if not any(b.is_relative_of(item) for item in removed_enum_or_message)]
+        # Deprecated whole messages/enums, or deprecated standalone fields/entries in surviving parents
+        deprecated_for_comment_items = [
+            item for item in removed
+            if old_names.get(item) == _DEPRECATED
+            and (isinstance(item, (MessageKey, EnumKey)) or not any(item.is_relative_of(parent) for parent in removed_enum_or_message))
+        ]
+        if deprecated_for_comment_items:
+            deprecated_for_comment[xml] = deprecated_for_comment_items
+
+        # Confirmed breaking: stable items whose parent message/enum was NOT removed
+        confirmed_breaking = [
+            b for b in removed
+            if old_names.get(b) == _STABLE
+            and not any(b.is_relative_of(parent) for parent in removed_enum_or_message)
+        ]
 
         breaking_descs: List[str] = []
         for name in confirmed_breaking:
@@ -319,10 +377,16 @@ def main() -> None:
         if breaking_descs:
             breaking_by_file[xml] = breaking_descs
 
-    if removals_for_comment or mutations_for_comment:
+    if removals_for_comment or deprecated_for_comment or mutations_for_comment:
         if removals_for_comment:
             print("Message or enum removals detected.")
             for xml, removals in removals_for_comment.items():
+                print(f" - {xml}:")
+                for removal in removals:
+                    print(f"   - {describe_key(removal)}")
+        if deprecated_for_comment:
+            print("Deprecated item removals detected (expected lifecycle cleanup).")
+            for xml, removals in deprecated_for_comment.items():
                 print(f" - {xml}:")
                 for removal in removals:
                     print(f"   - {describe_key(removal)}")
@@ -333,7 +397,7 @@ def main() -> None:
                 for desc in descs:
                     print(f"   - {desc}")
 
-        write_pr_comment_artifact(build_removal_comment(removals_for_comment, mutations_for_comment))
+        write_pr_comment_artifact(build_removal_comment(removals_for_comment, mutations_for_comment, deprecated_for_comment))
 
     if breaking_by_file:
         for xml, descs in breaking_by_file.items():

--- a/scripts/test_check_api_break.py
+++ b/scripts/test_check_api_break.py
@@ -136,5 +136,98 @@ class RemovalDetectionTests(unittest.TestCase):
         self.assertNotIn(FieldKey(message=MessageKey(message_name="MY_MSG"), field_name="foo"), removed)
 
 
+class DeprecatedExemptionTests(unittest.TestCase):
+    """Removing or mutating deprecated items should not be flagged as breaking."""
+
+    DEPRECATED_ENTRY_XML = """<mavlink>
+<enums>
+<enum name="MAV_CMD">
+  <entry name="MAV_CMD_DO_MOUNT_CONFIGURE" value="204">
+    <deprecated since="2024-06" replaced_by="GIMBAL_MANAGER_CONFIGURE"/>
+    <description>deprecated</description>
+  </entry>
+  <entry name="MAV_CMD_DO_SET_MODE" value="176">
+    <description>Set system mode.</description>
+  </entry>
+</enum>
+</enums>
+<messages/>
+</mavlink>"""
+
+    def test_deprecated_entry_removal_is_not_breaking(self):
+        new_xml = self.DEPRECATED_ENTRY_XML.replace(
+            '  <entry name="MAV_CMD_DO_MOUNT_CONFIGURE" value="204">\n'
+            '    <deprecated since="2024-06" replaced_by="GIMBAL_MANAGER_CONFIGURE"/>\n'
+            '    <description>deprecated</description>\n'
+            '  </entry>\n', ''
+        )
+        removed = removed_between(self.DEPRECATED_ENTRY_XML, new_xml)
+        self.assertNotIn(
+            EnumEntryKey(enum=EnumKey(enum_name="MAV_CMD"), entry_name="MAV_CMD_DO_MOUNT_CONFIGURE"),
+            removed,
+        )
+
+    def test_deprecated_message_removal_is_not_breaking(self):
+        old_xml = """<mavlink>
+<enums/>
+<messages>
+<message id="10" name="OLD_MSG">
+  <deprecated since="2020-01" replaced_by="NEW_MSG"/>
+  <field type="uint8_t" name="foo">desc</field>
+</message>
+</messages>
+</mavlink>"""
+        new_xml = "<mavlink><enums/><messages/></mavlink>"
+        removed = removed_between(old_xml, new_xml)
+        self.assertNotIn(MessageKey(message_name="OLD_MSG"), removed)
+        self.assertNotIn(
+            FieldKey(message=MessageKey(message_name="OLD_MSG"), field_name="foo"),
+            removed,
+        )
+
+    def test_deprecated_entry_value_mutation_is_not_breaking(self):
+        new_xml = self.DEPRECATED_ENTRY_XML.replace('value="204"', 'value="999"')
+        mutations = mutations_between(self.DEPRECATED_ENTRY_XML, new_xml)
+        self.assertEqual(mutations, [])
+
+    def test_non_deprecated_removal_still_breaks(self):
+        """Regression guard: normal (non-deprecated, non-wip) removals must still be caught."""
+        new_xml = self.DEPRECATED_ENTRY_XML.replace(
+            '<entry name="MAV_CMD_DO_SET_MODE" value="176">\n'
+            '    <description>Set system mode.</description>\n'
+            '  </entry>\n', ''
+        )
+        removed = removed_between(self.DEPRECATED_ENTRY_XML, new_xml)
+        self.assertIn(
+            EnumEntryKey(enum=EnumKey(enum_name="MAV_CMD"), entry_name="MAV_CMD_DO_SET_MODE"),
+            removed,
+        )
+
+    def test_deprecated_field_in_surviving_message_is_not_breaking(self):
+        old_xml = """<mavlink>
+<enums/>
+<messages>
+<message id="10" name="MY_MSG">
+  <field type="uint8_t" name="keep">desc</field>
+  <field type="uint8_t" name="drop">
+    <deprecated since="2023-01" replaced_by="keep"/>
+    desc
+  </field>
+</message>
+</messages>
+</mavlink>"""
+        new_xml = old_xml.replace(
+            '  <field type="uint8_t" name="drop">\n'
+            '    <deprecated since="2023-01" replaced_by="keep"/>\n'
+            '    desc\n'
+            '  </field>\n', ''
+        )
+        removed = removed_between(old_xml, new_xml)
+        self.assertNotIn(
+            FieldKey(message=MessageKey(message_name="MY_MSG"), field_name="drop"),
+            removed,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check_api_break.py
+++ b/scripts/test_check_api_break.py
@@ -19,10 +19,14 @@ _spec.loader.exec_module(check_api_break)
 parse_xml = check_api_break.parse_xml
 collect_names = check_api_break.collect_names
 find_mutations = check_api_break.find_mutations
+build_removal_comment = check_api_break.build_removal_comment
 MessageKey = check_api_break.MessageKey
 EnumKey = check_api_break.EnumKey
 FieldKey = check_api_break.FieldKey
 EnumEntryKey = check_api_break.EnumEntryKey
+STABLE = check_api_break.STABLE
+DEPRECATED = check_api_break.DEPRECATED
+WIP = check_api_break.WIP
 
 
 BASE_XML = """<mavlink>
@@ -47,11 +51,32 @@ def mutations_between(old_xml: str, new_xml: str):
 
 
 def removed_between(old_xml: str, new_xml: str):
-    """Replicate main()'s removal-candidate logic (non-WIP names missing in new)."""
+    """Replicate main()'s breaking removal-candidate logic (stable names missing in new)."""
     old_names, _ = collect_names(parse_xml(old_xml))
     new_names, _ = collect_names(parse_xml(new_xml))
     removed = [n for n in old_names if n not in new_names]
-    return [r for r in removed if not old_names.get(r)]
+    return [r for r in removed if old_names.get(r) == STABLE]
+
+
+def confirmed_breaking_between(old_xml: str, new_xml: str):
+    """Replicate main()'s confirmed breaking removals (stable items in surviving parents)."""
+    old_names, _ = collect_names(parse_xml(old_xml))
+    new_names, _ = collect_names(parse_xml(new_xml))
+    removed = [n for n in old_names if n not in new_names]
+    all_removed_parents = [item for item in removed if isinstance(item, (MessageKey, EnumKey))]
+    return [
+        b for b in removed
+        if old_names.get(b) == STABLE
+        and not any(b.is_relative_of(parent) for parent in all_removed_parents)
+    ]
+
+
+def deprecated_removed_between(old_xml: str, new_xml: str):
+    """Replicate main()'s deprecated removal candidates (deprecated names missing in new)."""
+    old_names, _ = collect_names(parse_xml(old_xml))
+    new_names, _ = collect_names(parse_xml(new_xml))
+    removed = [n for n in old_names if n not in new_names]
+    return [r for r in removed if old_names.get(r) == DEPRECATED]
 
 
 class FindMutationsTests(unittest.TestCase):
@@ -137,7 +162,7 @@ class RemovalDetectionTests(unittest.TestCase):
 
 
 class DeprecatedExemptionTests(unittest.TestCase):
-    """Removing or mutating deprecated items should not be flagged as breaking."""
+    """Deprecated items: removals are non-breaking (routed to PR comment), but mutations still break."""
 
     DEPRECATED_ENTRY_XML = """<mavlink>
 <enums>
@@ -166,6 +191,11 @@ class DeprecatedExemptionTests(unittest.TestCase):
             EnumEntryKey(enum=EnumKey(enum_name="MAV_CMD"), entry_name="MAV_CMD_DO_MOUNT_CONFIGURE"),
             removed,
         )
+        deprecated = deprecated_removed_between(self.DEPRECATED_ENTRY_XML, new_xml)
+        self.assertIn(
+            EnumEntryKey(enum=EnumKey(enum_name="MAV_CMD"), entry_name="MAV_CMD_DO_MOUNT_CONFIGURE"),
+            deprecated,
+        )
 
     def test_deprecated_message_removal_is_not_breaking(self):
         old_xml = """<mavlink>
@@ -178,17 +208,26 @@ class DeprecatedExemptionTests(unittest.TestCase):
 </messages>
 </mavlink>"""
         new_xml = "<mavlink><enums/><messages/></mavlink>"
-        removed = removed_between(old_xml, new_xml)
-        self.assertNotIn(MessageKey(message_name="OLD_MSG"), removed)
+        # MessageKey is deprecated, so it is not a breaking removal candidate
+        candidates = removed_between(old_xml, new_xml)
+        self.assertNotIn(MessageKey(message_name="OLD_MSG"), candidates)
+        # And its fields do not trigger breaking errors because the parent message was removed
+        breaking = confirmed_breaking_between(old_xml, new_xml)
         self.assertNotIn(
             FieldKey(message=MessageKey(message_name="OLD_MSG"), field_name="foo"),
-            removed,
+            breaking,
         )
+        deprecated = deprecated_removed_between(old_xml, new_xml)
+        self.assertIn(MessageKey(message_name="OLD_MSG"), deprecated)
 
-    def test_deprecated_entry_value_mutation_is_not_breaking(self):
+    def test_deprecated_entry_value_mutation_is_still_breaking(self):
+        """Deprecated items are wire-released; mutating wire attributes (value/id/type) still breaks."""
         new_xml = self.DEPRECATED_ENTRY_XML.replace('value="204"', 'value="999"')
         mutations = mutations_between(self.DEPRECATED_ENTRY_XML, new_xml)
-        self.assertEqual(mutations, [])
+        self.assertEqual(
+            mutations,
+            ["enum entry MAV_CMD.MAV_CMD_DO_MOUNT_CONFIGURE (value: 204 -> 999)"],
+        )
 
     def test_non_deprecated_removal_still_breaks(self):
         """Regression guard: normal (non-deprecated, non-wip) removals must still be caught."""
@@ -226,6 +265,86 @@ class DeprecatedExemptionTests(unittest.TestCase):
         self.assertNotIn(
             FieldKey(message=MessageKey(message_name="MY_MSG"), field_name="drop"),
             removed,
+        )
+        deprecated = deprecated_removed_between(old_xml, new_xml)
+        self.assertIn(
+            FieldKey(message=MessageKey(message_name="MY_MSG"), field_name="drop"),
+            deprecated,
+        )
+
+    def test_deprecated_removal_comment_formatting(self):
+        """Deprecated removals are formatted in the PR comment for maintainer confirmation."""
+        entry = EnumEntryKey(enum=EnumKey(enum_name="MAV_CMD"), entry_name="MAV_CMD_DO_MOUNT_CONFIGURE")
+        comment = build_removal_comment(
+            removed_by_file={},
+            mutations_by_file=None,
+            deprecated_by_file={"common.xml": [entry]},
+        )
+        self.assertIn("Detected removal of deprecated items (expected lifecycle cleanup):", comment)
+        self.assertIn("- `common.xml`", comment)
+        self.assertIn("Removed deprecated enum entry MAV_CMD.MAV_CMD_DO_MOUNT_CONFIGURE", comment)
+
+    def test_surviving_deprecated_message_field_removal_is_breaking(self):
+        """Deprecated status is NOT inherited: removing a field from a surviving deprecated message still breaks."""
+        old_xml = """<mavlink>
+<enums/>
+<messages>
+<message id="300" name="PROTOCOL_VERSION">
+  <deprecated since="2025-11" replaced_by="Nothing"/>
+  <field type="uint16_t" name="version">desc</field>
+  <field type="uint16_t" name="min_version">desc</field>
+</message>
+</messages>
+</mavlink>"""
+        new_xml = old_xml.replace('  <field type="uint16_t" name="version">desc</field>\n', '')
+        removed = removed_between(old_xml, new_xml)
+        self.assertIn(
+            FieldKey(message=MessageKey(message_name="PROTOCOL_VERSION"), field_name="version"),
+            removed,
+        )
+
+    def test_surviving_deprecated_message_field_mutation_is_breaking(self):
+        """Mutating a field type in a surviving deprecated message still breaks."""
+        old_xml = """<mavlink>
+<enums/>
+<messages>
+<message id="300" name="PROTOCOL_VERSION">
+  <deprecated since="2025-11" replaced_by="Nothing"/>
+  <field type="uint16_t" name="version">desc</field>
+</message>
+</messages>
+</mavlink>"""
+        new_xml = old_xml.replace('type="uint16_t" name="version"', 'type="uint32_t" name="version"')
+        mutations = mutations_between(old_xml, new_xml)
+        self.assertEqual(
+            mutations,
+            ["field PROTOCOL_VERSION.version (type: uint16_t -> uint32_t)"],
+        )
+
+    def test_newly_added_deprecated_does_not_self_exempt_wire_mutation(self):
+        """Adding <deprecated> in the same diff as an enum value mutation does NOT exempt it."""
+        old_xml = """<mavlink>
+<enums>
+<enum name="MY_ENUM">
+  <entry name="ENTRY_A" value="1"/>
+</enum>
+</enums>
+<messages/>
+</mavlink>"""
+        new_xml = """<mavlink>
+<enums>
+<enum name="MY_ENUM">
+  <entry name="ENTRY_A" value="999">
+    <deprecated since="2026-09"/>
+  </entry>
+</enum>
+</enums>
+<messages/>
+</mavlink>"""
+        mutations = mutations_between(old_xml, new_xml)
+        self.assertEqual(
+            mutations,
+            ["enum entry MY_ENUM.ENTRY_A (value: 1 -> 999)"],
         )
 
 


### PR DESCRIPTION
## Problem
`check_api_break.py` only skipped `<wip>` items when checking for breaking changes. That meant removing any `<deprecated>` item even ones years past their sunset date  hard-failed CI. There are 20 deprecated items sitting in common/minimal/standard.xml (some deprecated since 2018) that nobody can clean up without bypassing CI.

## Fix
Split the binary wip/not-wip check into three lifecycle states:

- **WIP** - unreleased, no one depends on it. Removals/mutations silently ignored.
- **DEPRECATED** - released but sunset. Removals are expected cleanup, so they just get flagged in the PR comment for maintainer confirmation instead of blocking. Wire mutations (value/type/id) still hard-fail - legacy nodes might still be talking on these. Deprecation is NOT inherited by child elements, so surviving deprecated messages still enforce strict wire stability.
- **STABLE** - unchanged, still hard-fails on removal.

`collect_names()` now returns a status per name instead of a bool, and `main()` buckets removals accordingly.

## Tests
Added `DeprecatedExemptionTests` (9 cases): deprecated entry/message removal isn't breaking, mutations on deprecated items still are, field cleanup in a surviving message works, surviving deprecated message child mutations/removals still break, self-exemption prevention, comment formatting, plus a regression guard for stable removals. All 21 tests pass.
