### PR TITLE
common(updae): Remove WIP from Events protocol

### DIFF
--- a/.github/workflows/check_api_break.yml
+++ b/.github/workflows/check_api_break.yml
@@ -3,6 +3,8 @@ name: Check MAVLink API Breaks
 on:
   pull_request:
   push:
+    branches:
+      - master
   workflow_dispatch:
 
 # This job runs against untrusted PR content (it checks out and executes

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8230,8 +8230,6 @@
     </message>
     <!-- Events Protocol -->
     <message id="410" name="EVENT">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Event message. Each new event from a particular component gets a new sequence number. The same message might be sent multiple times if (re-)requested. Most events are broadcast, some can be specific to a target component (as receivers keep track of the sequence for missed events, all events need to be broadcast. Thus we use destination_component instead of target_component).</description>
       <field type="uint8_t" name="destination_component">Component ID</field>
       <field type="uint8_t" name="destination_system">System ID</field>
@@ -8242,15 +8240,11 @@
       <field type="uint8_t[40]" name="arguments">Arguments (depend on event ID).</field>
     </message>
     <message id="411" name="CURRENT_EVENT_SEQUENCE">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Regular broadcast for the current latest event sequence number for a component. This is used to check for dropped events.</description>
       <field type="uint16_t" name="sequence">Sequence number.</field>
       <field type="uint8_t" name="flags" enum="MAV_EVENT_CURRENT_SEQUENCE_FLAGS">Flag bitset.</field>
     </message>
     <message id="412" name="REQUEST_EVENT">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Request one or more events to be (re-)sent. If first_sequence==last_sequence, only a single event is requested. Note that first_sequence can be larger than last_sequence (because the sequence number can wrap). Each sequence will trigger an EVENT or EVENT_ERROR response.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
@@ -8258,8 +8252,6 @@
       <field type="uint16_t" name="last_sequence">Last sequence number of the requested event.</field>
     </message>
     <message id="413" name="RESPONSE_EVENT_ERROR">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Response to a REQUEST_EVENT in case of an error (e.g. the event is not available anymore).</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>


### PR DESCRIPTION
The Events interface has been in PX4 since PX4 v1.13 (2022).

This moves `<wip/>` tag from the four Events Protocol messages (EVENT, CURRENT_EVENT_SEQUENCE, REQUEST_EVENT, RESPONSE_EVENT_ERROR). Related enums (MAV_EVENT_ERROR_REASON, MAV_EVENT_CURRENT_SEQUENCE_FLAGS) had no WIP tags to begin with. 

This is consistent with similar messages that were approved by the MAVLink team. It replaces STATUSTEXT with an objectively better interface. ArduPilot does not support this interface, so it can't go in standard.xml.

@peterbarker @auturgy Any reason not to take this?
     