### PR TITLE
common.xml: Remove WIP from MAV_CMD_CONDITION_GATE

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2471,8 +2471,6 @@
         <param index="6" label="Longitude" units="degE7">Target longitude of center of circle in CIRCLE_MODE</param>
       </entry>
       <entry value="4501" name="MAV_CMD_CONDITION_GATE" hasLocation="true" isDestination="true">
-        <wip/>
-        <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Delay mission state machine until gate has been reached.</description>
         <param index="1" label="Geometry" minValue="0" increment="1">Geometry: 0: orthogonal to path between previous and next waypoint.</param>
         <param index="2" label="UseAltitude" enum="MAV_BOOL">Use altitude (MAV_BOOL_FALSE: ignore altitude). Values not equal to 0 or 1 are invalid.</param>


### PR DESCRIPTION
## Summary

`MAV_CMD_CONDITION_GATE` was added as WIP in #767 (merged 2017-08-05) and has had a real implementation in PX4 since v1.11.0.

- Original WIP entity added in: mavlink/mavlink#767
- PX4 implementation: PX4/PX4-Autopilot@ed8cb1c5a (PX4/PX4-Autopilot#11878), first released in PX4 v1.11.0
- PX4 code still uses this today (`NAV_CMD_CONDITION_GATE` handling in `src/modules/navigator/mission_block.cpp` and `MissionFeasibility/FeasibilityChecker.cpp`)

This removes the `<wip/>` tag and its accompanying "work-in-progress" comment; no other change.

## Test plan

- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/common.xml` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcmbS5CGZxgNk7XKUXZ2mP