### PR TITLE
common.xml: Remove WIP from LINK_NODE_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5593,8 +5593,6 @@
       <field type="char[32]" name="key">key</field>
     </message>
     <message id="8" name="LINK_NODE_STATUS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Status generated in each node in the communication chain and injected into MAVLink stream.</description>
       <field type="uint64_t" name="timestamp" units="ms">Timestamp (time since system boot).</field>
       <field type="uint8_t" name="tx_buf" units="%">Remaining free transmit buffer space</field>


### PR DESCRIPTION
## Summary

`LINK_NODE_STATUS` was added as WIP in #1101 (merged 2019-05-29) and has had a real implementation in PX4 since v1.12.0.

- Original WIP entity added in: mavlink/mavlink#1101
- PX4 implementation: https://github.com/PX4/PX4-Autopilot/pull/15928 (PX4/PX4-Autopilot@5097d531b ), first released in PX4 v1.12.0
- PX4 still streams this message today (`src/modules/mavlink/streams/LINK_NODE_STATUS.hpp`)

This removes the `<wip/>` tag and its accompanying "work-in-progress" comment; no other change.

## Test plan

- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/common.xml` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcmbS5CGZxgNk7XKUXZ2mP