### PR TITLE
common.xml: Remove WIP from ESC_INFO and ESC_STATUS

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7671,8 +7671,6 @@
       <field type="float" name="yaw_rate" invalid="NaN">Yaw angular rate unitless (-1..1, positive: to the right, negative: to the left, NaN to be ignored).</field>
     </message>
     <message id="290" name="ESC_INFO">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>ESC information for lower rate streaming. Recommended streaming rate 1Hz. See ESC_STATUS for higher-rate ESC data.</description>
       <field type="uint8_t" name="index" instance="true">Index of the first ESC in this message (ESC are indexed in motor order). minValue = 0, maxValue = 60, increment = 4.</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>
@@ -7685,8 +7683,6 @@
       <field type="int16_t[4]" name="temperature" units="cdegC" invalid="[INT16_MAX]">Temperature of each ESC. INT16_MAX: if data not supplied by ESC.</field>
     </message>
     <message id="291" name="ESC_STATUS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>ESC information for higher rate streaming. Recommended streaming rate is ~10 Hz. Information that changes more slowly is sent in ESC_INFO. It should typically only be streamed on high-bandwidth links (i.e. to a companion computer).</description>
       <field type="uint8_t" name="index" instance="true">Index of the first ESC in this message (ESC are indexed in motor order). minValue = 0, maxValue = 60, increment = 4.</field>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude the number.</field>


### PR DESCRIPTION
## Summary

`ESC_INFO` and `ESC_STATUS` were added as WIP together in #1322 (merged 2020-07-09) and have had real implementations in PX4 since v1.12.0.

- Original WIP entities added in: mavlink/mavlink#1322
- PX4 implementation: PX4/PX4-Autopilot@c15efea42 (PX4/PX4-Autopilot#14408), first released in PX4 v1.12.0
- PX4 still streams both messages today (`src/modules/mavlink/streams/ESC_INFO.hpp`, `src/modules/mavlink/streams/ESC_STATUS.hpp`)

This removes the `<wip/>` tags and their accompanying "work-in-progress" comments from both messages; no other change.

## Test plan

- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/common.xml` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcmbS5CGZxgNk7XKUXZ2mP