### PR TITLE
common.xml: Remove WIP from PARAM_ERROR

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2909,8 +2909,6 @@
       </entry>
     </enum>
     <enum name="MAV_PARAM_ERROR">
-      <wip/>
-      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Parameter protocol error types (see PARAM_ERROR).</description>
       <entry value="0" name="MAV_PARAM_ERROR_NO_ERROR">
         <description>No error occurred (not expected in PARAM_ERROR but may be used in future implementations.</description>
@@ -7962,8 +7960,6 @@
       <field type="uint8_t" name="flags" enum="UTM_DATA_AVAIL_FLAGS">Bitwise OR combination of the data available flags.</field>
     </message>
     <message id="345" name="PARAM_ERROR">
-      <wip/>
-      <!-- This enum is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
       <description>Parameter set/get error. Returned from a MAVLink node in response to an error in the parameter protocol, for example failing to set a parameter because it does not exist.
       </description>
       <field type="uint8_t" name="target_system">System ID</field>


### PR DESCRIPTION
## Summary

`PARAM_ERROR` (message and its `MAV_PARAM_ERROR` enum) was added as WIP in #2344 (merged 2025-09-25) and now has a real implementation in PX4.

- Original WIP entity added in: mavlink/mavlink#2344
- PX4 implementation: PX4/PX4-Autopilot@f03131cfd (PX4/PX4-Autopilot#25699) — `MavlinkParametersManager::send_error()` in `src/modules/mavlink/mavlink_parameters.cpp`
- Not yet in a tagged PX4 release (it missed the v1.17 branch cut), but the implementation is merged to PX4 main

This removes the `<wip/>` tags and their accompanying "work-in-progress" comments from both the `PARAM_ERROR` message and the `MAV_PARAM_ERROR` enum; no other change.

## Test plan

- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/common.xml` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcmbS5CGZxgNk7XKUXZ2mP