### PR TITLE
common.xml: Remove WIP from TIME_ESTIMATE_TO_TARGET

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -8107,8 +8107,6 @@
       <field type="uint16_t" name="present" display="bitmask">Relay present. Relay instance numbers are represented as individual bits in this mask by offset.  Bits will be true if a relay instance is configured.</field>
     </message>
     <message id="380" name="TIME_ESTIMATE_TO_TARGET">
-      <wip/>
-      <!-- This message is work-in-progress it can therefore change, and should NOT be used in stable production environments -->
       <description>Time/duration estimates for various events and actions given the current vehicle state and position.</description>
       <field type="int32_t" name="safe_return" units="s">Estimated time to complete the vehicle's configured "safe return" action from its current position (e.g. RTL, Smart RTL, etc.). -1 indicates that the vehicle is landed, or that no time estimate available.</field>
       <field type="int32_t" name="land" units="s">Estimated time for vehicle to complete the LAND action from its current position. -1 indicates that the vehicle is landed, or that no time estimate available.</field>


### PR DESCRIPTION
## Summary

`TIME_ESTIMATE_TO_TARGET` was added as WIP in #995 (merged 2019-04-04) and has had a real implementation in PX4 since v1.14.0.

- Original WIP entity added in: mavlink/mavlink#995
- PX4 implementation: PX4/PX4-Autopilot@4bf6ebf4c (PX4/PX4-Autopilot#20029), first released in PX4 v1.14.0
- PX4 still streams this message today (`src/modules/mavlink/streams/TIME_ESTIMATE_TO_TARGET.hpp`)

This removes the `<wip/>` tag and its accompanying "work-in-progress" comment; no other change.

## Test plan

- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/common.xml` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcmbS5CGZxgNk7XKUXZ2mP