### PR TITLE
Move SET_VELOCITY_LIMITS and VELOCITY_LIMITS from development.xml to common.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -7980,6 +7980,23 @@
       <extensions/>
       <field type="float[58]" name="data">data</field>
     </message>
+    <message id="354" name="SET_VELOCITY_LIMITS">
+      <description>Set temporary maximum limits for horizontal speed, vertical speed and yaw rate.
+        The consumer must stream the current limits in VELOCITY_LIMITS at 1 Hz or more (when limits are being set).
+        The consumer should latch the limits until a new limit is received or the mode is changed.
+      </description>
+      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
+      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
+      <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
+      <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
+      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Field not used (ignore)</field>
+    </message>
+    <message id="355" name="VELOCITY_LIMITS">
+      <description>Current limits for horizontal speed, vertical speed and yaw rate, as set by SET_VELOCITY_LIMITS.</description>
+      <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
+      <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
+      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: No limit applied</field>
+    </message>
     <message id="360" name="ORBIT_EXECUTION_STATUS">
       <description>Vehicle status report that is sent out while orbit execution is in progress (see MAV_CMD_DO_ORBIT).</description>
       <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -606,27 +606,6 @@
     </enum>
   </enums>
   <messages>
-    <message id="354" name="SET_VELOCITY_LIMITS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Set temporary maximum limits for horizontal speed, vertical speed and yaw rate.
-        The consumer must stream the current limits in VELOCITY_LIMITS at 1 Hz or more (when limits are being set).
-        The consumer should latch the limits until a new limit is received or the mode is changed.
-      </description>
-      <field type="uint8_t" name="target_system">System ID (0 for broadcast).</field>
-      <field type="uint8_t" name="target_component">Component ID (0 for broadcast).</field>
-      <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
-      <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: Field not used (ignore)</field>
-      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: Field not used (ignore)</field>
-    </message>
-    <message id="355" name="VELOCITY_LIMITS">
-      <wip/>
-      <!-- This message is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
-      <description>Current limits for horizontal speed, vertical speed and yaw rate, as set by SET_VELOCITY_LIMITS.</description>
-      <field type="float" name="horizontal_speed_limit" default="NaN" units="m/s">Limit for horizontal movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
-      <field type="float" name="vertical_speed_limit" default="NaN" units="m/s">Limit for vertical movement in MAV_FRAME_LOCAL_NED. NaN: No limit applied</field>
-      <field type="float" name="yaw_rate_limit" default="NaN" units="rad/s">Limit for vehicle turn rate around its yaw axis. NaN: No limit applied</field>
-    </message>
     <message id="369" name="BATTERY_STATUS_V2">
       <description>Battery dynamic information.
         This should be streamed (nominally at 1Hz).


### PR DESCRIPTION
## Summary

`SET_VELOCITY_LIMITS` and `VELOCITY_LIMITS` were added as WIP in development.xml in #2015 (merged 2023-09-20) and have had a real implementation in PX4 since v1.15.0, so this promotes them to common.xml.

- Original WIP entities added in: mavlink/mavlink#2015
- PX4 implementation: PX4/PX4-Autopilot@4cf43a68a (PX4/PX4-Autopilot#22102) — `MavlinkReceiver::handle_message_set_velocity_limits()` publishing `velocity_limits` uORB topic consumed by FlightTasks, first released in PX4 v1.15.0
- Ids 354/355 were unused in common.xml, so both messages keep their existing ids
- The `<wip/>` tags and their "work-in-progress" comments are dropped, as these messages are no longer WIP

Note that PX4's implementation is still gated behind `#if defined(MAVLINK_MSG_ID_SET_VELOCITY_LIMITS) // For now only defined if development.xml is used` — this PR is what allows that guard to be lifted.

## Test plan

- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/common.xml` validates
- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/development.xml` validates
- [x] `pymavlink.tools.mavgen` generates C code from both `common.xml` and `development.xml` with no id collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcmbS5CGZxgNk7XKUXZ2mP