### PR TITLE
Move MAV_CMD_EXTERNAL_WIND_ESTIMATE from development.xml to common.xml

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2657,6 +2657,15 @@
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude" units="m">Altitude, not used. Should be sent as NaN. May be supported in a future version of this message.</param>
       </entry>
+      <entry value="43004" name="MAV_CMD_EXTERNAL_WIND_ESTIMATE" hasLocation="false" isDestination="false">
+        <description>Set an external estimate of wind direction and speed.
+          This might be used to provide an initial wind estimate to the estimator (EKF) in the case where the vehicle is wind dead-reckoning, extending the time when operating without GPS before before position drift builds to an unsafe level. For this use case the command might reasonably be sent every few minutes when operating at altitude, and the value is cleared if the estimator resets itself.
+        </description>
+        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
+        <param index="2" label="Wind speed accuracy" units="m/s">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
+        <param index="3" label="Direction" units="deg" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
+        <param index="4" label="Direction accuracy" units="deg">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
+      </entry>
       <!-- END of payload range (30000 to 30999) -->
       <!-- BEGIN user defined range (31000 to 31999) -->
       <entry value="31000" name="MAV_CMD_WAYPOINT_USER_1" hasLocation="true" isDestination="true">

--- a/message_definitions/v1.0/development.xml
+++ b/message_definitions/v1.0/development.xml
@@ -164,15 +164,6 @@
         </description>
         <param index="1" label="Number" minValue="0" increment="1">Set/unset emergency 0: unset, 1: set</param>
       </entry>
-      <entry value="43004" name="MAV_CMD_EXTERNAL_WIND_ESTIMATE" hasLocation="false" isDestination="false">
-        <description>Set an external estimate of wind direction and speed.
-          This might be used to provide an initial wind estimate to the estimator (EKF) in the case where the vehicle is wind dead-reckoning, extending the time when operating without GPS before before position drift builds to an unsafe level. For this use case the command might reasonably be sent every few minutes when operating at altitude, and the value is cleared if the estimator resets itself.
-        </description>
-        <param index="1" label="Wind speed" units="m/s" minValue="0">Horizontal wind speed.</param>
-        <param index="2" label="Wind speed accuracy" units="m/s">Estimated 1 sigma accuracy of wind speed. Set to NaN if unknown.</param>
-        <param index="3" label="Direction" units="deg" minValue="0" maxValue="360">Azimuth (relative to true north) from where the wind is blowing.</param>
-        <param index="4" label="Direction accuracy" units="deg">Estimated 1 sigma accuracy of wind direction. Set to NaN if unknown.</param>
-      </entry>
       <entry value="43006" name="MAV_CMD_ESTIMATOR_SENSOR_ENABLE" hasLocation="false" isDestination="false">
         <description>Enable or disable a specific estimator sensor fusion source at runtime.
           This allows a GCS or companion computer to dynamically control which sensors the estimator fuses without changing parameters.


### PR DESCRIPTION
## Summary

`MAV_CMD_EXTERNAL_WIND_ESTIMATE` was added to development.xml in #2122 (merged 2024-06-25) and has had a real implementation in ArduPilot since ArduPilot/ardupilot#27847 (merged 2024-09-04).

- Original entity added in: mavlink/mavlink#2122
- ArduPilot implementation: ArduPilot/ardupilot#27847 ("Support MAV_CMD_EXTERNAL_WIND_ESTIMATE", merge commit `d802b0e`) — `GCS_MAVLINK::handle_command_int_external_wind_estimate()` in `libraries/GCS_MAVLink/GCS_Common.cpp`, forwarding to `AP_AHRS::set_external_wind_estimate()`, first released in ArduPilot Copter/Plane 4.6.0 (2025-05-22)
- Value 43004 was unused in common.xml, so the command keeps its existing value

## Test plan

- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/common.xml` validates
- [x] `xmllint --noout --schema pymavlink/generator/mavschema.xsd message_definitions/v1.0/development.xml` validates
- [x] `pymavlink.tools.mavgen` generates C code from both `common.xml` and `development.xml` with no id collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcmbS5CGZxgNk7XKUXZ2mP