### PR TITLE
check_api_break: detect reordered extension fields

### DIFF
--- a/scripts/check_api_break.py
+++ b/scripts/check_api_break.py
@@ -107,14 +107,34 @@ def collect_names(root: etree._Element) -> Tuple[Dict[NameKey, bool], Dict[NameK
         if message_id is not None:
             attrs[message_key] = {"id": message_id}
 
-        for field in msg.findall("field"):
+        # Fields before <extensions/> are re-sorted by size when a message is
+        # serialized, so their order in the XML is not wire-visible and must not
+        # be compared. Extension fields are the opposite: they are never
+        # reordered, and their serialization order is defined by the XML
+        # definition order, so position is part of the wire format for them.
+        # Record it for those fields only.
+        extension_index = None
+        for child in msg:
+            if child.tag == "extensions":
+                extension_index = 0
+                continue
+            if child.tag != "field":
+                continue
+
+            field = child
             field_name = field.get("name")
             field_is_wip = message_is_wip or field.find("wip") is not None
             field_key = FieldKey(message=message_key, field_name=field_name)
             names[field_key] = field_is_wip
+            field_attrs: Dict[str, Any] = {}
             field_type = field.get("type")
             if field_type is not None:
-                attrs[field_key] = {"type": field_type}
+                field_attrs["type"] = field_type
+            if extension_index is not None:
+                field_attrs["extension_index"] = extension_index
+                extension_index += 1
+            if field_attrs:
+                attrs[field_key] = field_attrs
 
     return names, attrs
 

--- a/scripts/test_check_api_break.py
+++ b/scripts/test_check_api_break.py
@@ -40,6 +40,24 @@ BASE_XML = """<mavlink>
 </mavlink>"""
 
 
+# A message shaped like the real ones that carry extensions (e.g. RAW_IMU in
+# common.xml): two ordinary fields, then <extensions/>, then two extension
+# fields of different types, so their order is visible in the payload layout.
+EXT_XML = """<mavlink>
+<enums>
+</enums>
+<messages>
+<message id="27" name="EXT_MSG">
+  <field type="uint64_t" name="time_usec">Timestamp.</field>
+  <field type="int16_t" name="xacc">X acceleration.</field>
+  <extensions/>
+  <field type="uint8_t" name="id">Id.</field>
+  <field type="int16_t" name="temperature">Temperature.</field>
+</message>
+</messages>
+</mavlink>"""
+
+
 def mutations_between(old_xml: str, new_xml: str):
     old_names, old_attrs = collect_names(parse_xml(old_xml))
     new_names, new_attrs = collect_names(parse_xml(new_xml))
@@ -101,6 +119,67 @@ class FindMutationsTests(unittest.TestCase):
         # silently changing behavior.
         new_xml = BASE_XML.replace(' value="2"', '')
         self.assertEqual(mutations_between(BASE_XML, new_xml), [])
+
+
+class ExtensionFieldOrderTests(unittest.TestCase):
+    """Extension fields are not reordered when a message is serialized, so their
+    XML order is part of the wire format. Fields before <extensions/> are sorted
+    by size by the generator, so their XML order is not."""
+
+    def test_extension_field_reorder_detected(self):
+        new_xml = EXT_XML.replace(
+            '  <field type="uint8_t" name="id">Id.</field>\n'
+            '  <field type="int16_t" name="temperature">Temperature.</field>',
+            '  <field type="int16_t" name="temperature">Temperature.</field>\n'
+            '  <field type="uint8_t" name="id">Id.</field>',
+        )
+        self.assertEqual(
+            sorted(mutations_between(EXT_XML, new_xml)),
+            [
+                "field EXT_MSG.id (extension_index: 0 -> 1)",
+                "field EXT_MSG.temperature (extension_index: 1 -> 0)",
+            ],
+        )
+
+    def test_appending_an_extension_field_is_not_a_mutation(self):
+        # Appending to the end is the supported way to extend a message and
+        # must stay silent, otherwise the check blocks the one change it is
+        # meant to allow.
+        new_xml = EXT_XML.replace(
+            '  <field type="int16_t" name="temperature">Temperature.</field>',
+            '  <field type="int16_t" name="temperature">Temperature.</field>\n'
+            '  <field type="uint32_t" name="added_later">Added later.</field>',
+        )
+        self.assertEqual(mutations_between(EXT_XML, new_xml), [])
+
+    def test_non_extension_field_reorder_is_not_a_mutation(self):
+        new_xml = EXT_XML.replace(
+            '  <field type="uint64_t" name="time_usec">Timestamp.</field>\n'
+            '  <field type="int16_t" name="xacc">X acceleration.</field>',
+            '  <field type="int16_t" name="xacc">X acceleration.</field>\n'
+            '  <field type="uint64_t" name="time_usec">Timestamp.</field>',
+        )
+        self.assertEqual(mutations_between(EXT_XML, new_xml), [])
+
+    def test_extension_index_recorded_only_after_the_marker(self):
+        _names, attrs = collect_names(parse_xml(EXT_XML))
+        msg = MessageKey(message_name="EXT_MSG")
+        before = attrs[FieldKey(message=msg, field_name="time_usec")]
+        after = attrs[FieldKey(message=msg, field_name="id")]
+        self.assertNotIn("extension_index", before)
+        self.assertEqual(after["extension_index"], 0)
+
+    def test_message_without_extensions_is_unaffected(self):
+        _names, attrs = collect_names(parse_xml(BASE_XML))
+        field = attrs[FieldKey(message=MessageKey(message_name="MY_MSG"), field_name="foo")]
+        self.assertEqual(field, {"type": "uint8_t"})
+
+    def test_extension_field_type_change_still_detected(self):
+        new_xml = EXT_XML.replace('type="uint8_t" name="id"', 'type="uint16_t" name="id"')
+        self.assertEqual(
+            mutations_between(EXT_XML, new_xml),
+            ["field EXT_MSG.id (type: uint8_t -> uint16_t)"],
+        )
 
 
 class RemovalDetectionTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

`check_api_break.py` cannot see a reordering of extension fields, which is a wire break.

Fields before `<extensions/>` are re-sorted by size when a message is serialized, so their order in
the XML does not reach the wire. Extension fields are the opposite. Per the
[XML definition guide](https://mavlink.io/en/guide/define_xml_element.html), they are
"[not reordered](https://mavlink.io/en/guide/serialization.html#field_reordering)" and
"for extension fields the serialization order is defined by XML definition order".

So swapping two extension fields of different types changes the payload layout, and a peer built
from the older definition decodes every byte after the swap point incorrectly.

`collect_names` recorded only a field's `type`, so a swap produced an identical set of names and
attributes on both sides. The check passed silently. Of the things this script can get wrong, a
missed break is worse than a noisy one, since the noisy case is visible in CI and this one is not.

## Reproduction on a real dialect

Swapping the two extension fields of `RAW_IMU` in `common.xml`, which are `uint8_t id` and
`int16_t temperature`:

```
$ python scripts/check_api_break.py --base HEAD~1     # before this PR
exit code: 0                                           # nothing reported

$ python scripts/check_api_break.py --base HEAD~1     # after this PR
Wire-breaking attribute mutations detected.
 - message_definitions/v1.0/common.xml:
   - field RAW_IMU.id (extension_index: 0 -> 1)
   - field RAW_IMU.temperature (extension_index: 1 -> 0)
exit code: 1
```

## Fix

Record the position of each field that follows `<extensions/>` as `extension_index`, and let the
existing `find_mutations` comparison handle it like `type`, `id` and `value`.

Fields before the marker deliberately get no index. Recording one for them would flag reordering that
the generator undoes anyway.

Appending a new extension field, which is the supported way to extend a message, leaves every
existing position unchanged and stays silent. That case has its own test, since a fix that blocked it
would be worse than the bug.

## Verification

`python -m unittest scripts/test_check_api_break.py` gives 31 tests, up from 25. `ruff check` is
clean on both files.

Six new tests, each checked against something that breaks it rather than assumed to be meaningful:

| Test | Fails against |
|---|---|
| extension field reorder detected | the current script |
| extension index recorded only after the marker | the current script |
| appending an extension field is not a mutation | a variant that indexes every field |
| non-extension field reorder is not a mutation | a variant that indexes every field |
| message without extensions is unaffected | a variant that indexes every field |
| extension field type change still detected | a variant that never increments the index |

A variant that never starts counting at the marker is also caught.

**No false positives on real history.** I replayed the last 150 commits touching
`message_definitions` through both the old and new logic, 173 file-revisions in total, and compared
what each reported. The patched version reports nothing the old one did not.

Parsing all 19 dialects gives 191 extension fields across the messages that have them, and every
message's indices form a contiguous run from 0, so nothing in the tree is mis-parsed.

## Note

This does not attempt to detect an extension field inserted in the middle rather than appended. That
shifts the indices of everything after it, so it does surface here, but it also shows up as several
mutations rather than one clear message. Happy to special-case it if you would rather it read
differently.
