### PR TITLE
check_api_break: compare numeric attributes by value, not spelling

### DIFF
--- a/scripts/check_api_break.py
+++ b/scripts/check_api_break.py
@@ -339,13 +339,47 @@ def write_pr_comment_artifact(body: str) -> bool:
     return True
 
 
+# Attributes written as a number rather than a name. Two spellings of the same
+# number describe the same bytes on the wire, so comparing them as raw strings
+# reports a break that is not one. Both notations are already in the tree:
+# storm32.xml and marsh.xml write enum values in hex, everything else decimal.
+NUMERIC_ATTRS = frozenset({"value", "id"})
+
+
+def as_number(text: Any) -> Optional[int]:
+    """Return the integer an attribute denotes, or None if it does not denote one."""
+    if text is None:
+        return None
+    literal = str(text).strip()
+    # Base 0 honours the 0x/0o/0b prefixes; base 10 then covers zero-padded
+    # decimals like "007", which base 0 rejects.
+    for base in (0, 10):
+        try:
+            return int(literal, base)
+        except ValueError:
+            continue
+    return None
+
+
+def attr_changed(attr: str, old_val: Any, new_val: Any) -> bool:
+    """Whether a wire-critical attribute really changed, not just its spelling."""
+    if old_val == new_val:
+        return False
+    if attr in NUMERIC_ATTRS:
+        old_num = as_number(old_val)
+        new_num = as_number(new_val)
+        if old_num is not None and new_num is not None:
+            return old_num != new_num
+    return True
+
+
 def describe_mutation(key: NameKey, old_a: Dict[str, Any], new_a: Dict[str, Any]) -> str:
     """Describe a wire-breaking attribute mutation for a given key."""
     changes = []
     for attr in sorted(set(old_a) | set(new_a)):
         old_val = old_a.get(attr)
         new_val = new_a.get(attr)
-        if old_val != new_val:
+        if attr_changed(attr, old_val, new_val):
             changes.append(f"{attr}: {old_val} -> {new_val}")
     return f"{describe_key(key)} ({', '.join(changes)})"
 
@@ -367,7 +401,10 @@ def find_mutations(
         new_a = new_attrs.get(key)
         if old_a is None or new_a is None:
             continue
-        if old_a != new_a:
+        if any(
+            attr_changed(attr, old_a.get(attr), new_a.get(attr))
+            for attr in set(old_a) | set(new_a)
+        ):
             mutation_descs.append(describe_mutation(key, old_a, new_a))
     return mutation_descs
 

--- a/scripts/test_check_api_break.py
+++ b/scripts/test_check_api_break.py
@@ -384,6 +384,87 @@ class MainRemovedFileTests(unittest.TestCase):
         self.assertIn("Skipped removed_dialect.xml: removed since base.", stdout.getvalue())
 
 
+class NumericAttributeTests(unittest.TestCase):
+    """value= and id= are numbers. Rewriting one in a different notation leaves
+    the wire format identical, so it must not be reported as a break, while a
+    genuine change to the number still must be."""
+
+    # Shaped after MLRS_RADIO_LINK_STATS_FLAGS in storm32.xml, which is one of
+    # the enums that already writes its values in hex.
+    HEX_XML = """<mavlink>
+<enums>
+<enum name="HEX_ENUM">
+  <entry name="HEX_ENUM_A" value="0x0001"/>
+  <entry name="HEX_ENUM_B" value="0x0040"/>
+</enum>
+</enums>
+<messages>
+<message id="27" name="HEX_MSG">
+  <field type="uint8_t" name="foo">desc</field>
+</message>
+</messages>
+</mavlink>"""
+
+    def test_hex_rewritten_as_decimal_is_not_a_mutation(self):
+        new_xml = self.HEX_XML.replace('value="0x0040"', 'value="64"')
+        self.assertEqual(mutations_between(self.HEX_XML, new_xml), [])
+
+    def test_hex_zero_padding_change_is_not_a_mutation(self):
+        new_xml = self.HEX_XML.replace('value="0x0001"', 'value="0x1"')
+        self.assertEqual(mutations_between(self.HEX_XML, new_xml), [])
+
+    def test_message_id_notation_change_is_not_a_mutation(self):
+        new_xml = self.HEX_XML.replace('id="27"', 'id="0x1B"')
+        self.assertEqual(mutations_between(self.HEX_XML, new_xml), [])
+
+    def test_real_value_change_still_detected_across_notations(self):
+        # The report keeps the spellings as written, which is what a reviewer
+        # needs to see, rather than the normalized integers.
+        new_xml = self.HEX_XML.replace('value="0x0040"', 'value="65"')
+        self.assertEqual(
+            mutations_between(self.HEX_XML, new_xml),
+            ["enum entry HEX_ENUM.HEX_ENUM_B (value: 0x0040 -> 65)"],
+        )
+
+    def test_real_value_change_within_hex_still_detected(self):
+        new_xml = self.HEX_XML.replace('value="0x0040"', 'value="0x0080"')
+        self.assertEqual(
+            mutations_between(self.HEX_XML, new_xml),
+            ["enum entry HEX_ENUM.HEX_ENUM_B (value: 0x0040 -> 0x0080)"],
+        )
+
+    def test_field_type_is_compared_as_text_not_as_a_number(self):
+        # type= is a name, so it must never go through numeric normalization.
+        new_xml = self.HEX_XML.replace('type="uint8_t"', 'type="uint16_t"')
+        self.assertEqual(
+            mutations_between(self.HEX_XML, new_xml),
+            ["field HEX_MSG.foo (type: uint8_t -> uint16_t)"],
+        )
+
+    def test_as_number_parses_the_notations_that_appear_in_definitions(self):
+        as_number = check_api_break.as_number
+        self.assertEqual(as_number("0x0040"), 64)
+        self.assertEqual(as_number("0X40"), 64)
+        self.assertEqual(as_number("64"), 64)
+        self.assertEqual(as_number("007"), 7)   # base 0 rejects this, base 10 does not
+        self.assertEqual(as_number(" 64 "), 64)
+        self.assertEqual(as_number("-1"), -1)
+
+    def test_as_number_returns_none_for_things_that_are_not_numbers(self):
+        as_number = check_api_break.as_number
+        self.assertIsNone(as_number(None))
+        self.assertIsNone(as_number(""))
+        self.assertIsNone(as_number("uint8_t"))
+        self.assertIsNone(as_number("1e3"))
+
+    def test_non_numeric_attribute_values_fall_back_to_text_comparison(self):
+        # If a value= is ever written as something unparseable, the check must
+        # keep its old string behavior rather than silently treating the pair
+        # as equal.
+        self.assertTrue(check_api_break.attr_changed("value", "TBD", "TBD_LATER"))
+        self.assertFalse(check_api_break.attr_changed("value", "TBD", "TBD"))
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/scripts/test_check_api_break.py
+++ b/scripts/test_check_api_break.py
@@ -458,7 +458,7 @@ class NumericAttributeTests(unittest.TestCase):
         self.assertIsNone(as_number("1e3"))
 
     def test_non_numeric_attribute_values_fall_back_to_text_comparison(self):
-        # If a value= is ever written as something unparseable, the check must
+        # If a value= is ever written as something unparsable, the check must
         # keep its old string behavior rather than silently treating the pair
         # as equal.
         self.assertTrue(check_api_break.attr_changed("value", "TBD", "TBD_LATER"))


### PR DESCRIPTION
## Problem

`value=` and `id=` hold numbers, but `find_mutations` compares them as raw strings. Two spellings of
the same number are identical on the wire, so rewriting one is reported as a wire-breaking mutation
and fails the check.

Both notations are already in the tree. `storm32.xml` and `marsh.xml` write nine enum values in hex,
everything else is decimal:

```
storm32.xml  MLRS_RADIO_LINK_STATS_FLAGS_RSSI_DBM   value="0x0001"
storm32.xml  MLRS_RADIO_LINK_STATS_FLAGS_TX_TRANSMIT_ANTENNA2  value="0x0040"
marsh.xml    MARSH_MODE_SINGLE_MESSAGE              value="0x1000000"
```

So normalising one of those enums to match the rest of the tree, or just dropping the zero padding,
is a cosmetic edit that the check rejects:

```
0x0040 -> 64      enum entry ... (value: 0x0040 -> 64)      exit 1
0x0001 -> 0x1     enum entry ... (value: 0x0001 -> 0x1)     exit 1
```

Neither changes a byte.

## Fix

Compare these attributes as integers, and fall back to the existing string comparison when either
side does not parse as one. A `value=` written as something unexpected therefore keeps today's
behaviour rather than being silently treated as unchanged.

`type=` is a name, not a number, so it stays a string comparison.

Parsing accepts what the definitions actually contain: base 0 for the `0x`/`0o`/`0b` prefixes, then
base 10, which covers zero-padded decimals like `007` that base 0 rejects.

Reports still print the spellings as written rather than the normalised integers, since that is what
a reviewer needs to see:

```
enum entry HEX_ENUM.HEX_ENUM_B (value: 0x0040 -> 65)
```

## Verification

`python -m unittest scripts/test_check_api_break.py` gives 34 tests, up from 25. `ruff check` clean.

Six of the nine new tests fail against the current script. The others are checked against variants of
the fix rather than assumed meaningful: one that lets an unparseable pair fall through as equal
(catches 2), and one that drops the base-10 fallback so `007` stops parsing (catches 1).

For honesty about what the tests do not pin down: adding `type` to the numeric attribute set is not
caught, because a type name never parses as a number and so takes the string path anyway. That
mutant is equivalent rather than a real defect.

**No detection is lost.** I replayed the last 150 commits touching `message_definitions`, 173
file-revisions, through both the old and the new comparison. Nothing the old logic flagged goes
unflagged by the new one.

## Note

This is independent of #2597 and branches from the same commit, so they can go in either order.
#2597 touches `collect_names`; this touches the comparison. If both are wanted I am happy to rebase
whichever lands second.
