### PR TITLE
fix(examples): correct UDP recvfrom() timeout handling in C/C++ udp_example

### DIFF
--- a/examples/c/udp_example.c
+++ b/examples/c/udp_example.c
@@ -82,10 +82,9 @@ void receive_some(int socket_fd, struct sockaddr_in* src_addr, socklen_t* src_ad
             socket_fd, buffer, sizeof(buffer), 0, (struct sockaddr*)(src_addr), src_addr_len);
 
     if (ret < 0) {
-        printf("recvfrom error: %s\n", strerror(errno));
-        return;
-    } else if (ret == 0) {
-        // timeout, try again later
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            printf("recvfrom error: %s\n", strerror(errno));
+        }
         return;
     }
 

--- a/examples/cpp/udp_example.cpp
+++ b/examples/cpp/udp_example.cpp
@@ -108,10 +108,9 @@ void receive_some(
         &src_addr_len);
 
     if (ret < 0) {
-        printf("recvfrom error: %s\n", strerror(errno));
-        return;
-    } else if (ret == 0) {
-        // timeout, try again later
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            printf("recvfrom error: %s\n", strerror(errno));
+        }
         return;
     }
 


### PR DESCRIPTION
This PR fixes incorrect UDP timeout handling in the C and C++ `udp_example` files, where a real socket timeout and a valid empty datagram were being conflated.

## 1. `recvfrom()` timeout misdetection

Both `udp_example.c` (`receive_some`, L87-L89) and `udp_example.cpp` (`receive_some`, L113-L115) treated `ret == 0` from `recvfrom()` as a timeout:

```c
} else if (ret == 0) {
    // timeout, try again later
    return;
}
```

That's wrong for UDP sockets. Unlike TCP, where a `0` return means the peer closed the connection, UDP preserves message boundaries - `recvfrom()` returning `0` just means a zero-length datagram was received. It's a valid receive event, not an error or a timeout.

- **The actual timeout path was mishandled too:** with `SO_RCVTIMEO` set, a real timeout causes `recvfrom()` to return `-1` with `errno` set to `EAGAIN`/`EWOULDBLOCK`. The old code fell into the generic `ret < 0` branch and logged it via `strerror(errno)`, so every normal 100ms timeout was printed as if it were a socket error.
- **The empty-datagram path was silently dropped:** a genuine zero-byte packet from a peer was discarded and treated as "nothing happened," instead of being passed through to the parse loop like any other receive.

To fix this, I moved the `EAGAIN`/`EWOULDBLOCK` check into the `ret < 0` branch so real timeouts are handled silently, and removed the `ret == 0` branch entirely so an empty datagram just falls through to the normal receive path.

## Testing

- Verified the corrected logic against POSIX semantics for `recvfrom()` on UDP sockets (zero-length datagram vs. `EAGAIN`/`EWOULDBLOCK` on timeout).
- Confirmed the fix is applied identically in both `udp_example.c` and `udp_example.cpp` so the two examples stay in sync.
- No functional change to the send/heartbeat path - this only touches the receive error/timeout branch.