### PR TITLE
common.xml: specify character encoding for parameter id fields

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -5620,7 +5620,7 @@
       <description>Request to read the onboard parameter with the param_id string id. Onboard parameters are stored as key[const char*] -&gt; value[float]. This allows to send a parameter to any other component (such as the GCS) without the need of previous knowledge of possible parameter names. Thus the same GCS can store different parameters for different autopilots. See also https://mavlink.io/en/services/parameter.html for a full documentation of QGroundControl and IMU code.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
       <field type="int16_t" name="param_index" invalid="-1">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored)</field>
     </message>
     <message id="21" name="PARAM_REQUEST_LIST">
@@ -5630,7 +5630,7 @@
     </message>
     <message id="22" name="PARAM_VALUE">
       <description>Emit the value of a onboard parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows him to re-request missing parameters after a loss or timeout. The parameter microservice is documented at https://mavlink.io/en/services/parameter.html</description>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
       <field type="float" name="param_value">Onboard parameter value</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type.</field>
       <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
@@ -5642,7 +5642,7 @@
       </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
       <field type="float" name="param_value">Onboard parameter value</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type.</field>
     </message>
@@ -5956,7 +5956,7 @@
       <description>Bind a RC channel to a parameter. The parameter should change according to the RC channel value.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
       <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored), send -2 to disable any existing map for this rc_channel_index.</field>
       <field type="uint8_t" name="parameter_rc_channel_index">Index of parameter RC channel. Not equal to the RC channel id. Typically corresponds to a potentiometer-knob on the RC.</field>
       <field type="float" name="param_value0">Initial parameter value</field>
@@ -7787,7 +7787,7 @@
       <description>Request to read the value of a parameter with either the param_id string id or param_index. PARAM_EXT_VALUE should be emitted in response.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
       <field type="int16_t" name="param_index" invalid="-1">Parameter index. Set to -1 to use the Parameter ID field as identifier (else param_id will be ignored)</field>
     </message>
     <message id="321" name="PARAM_EXT_REQUEST_LIST">
@@ -7797,8 +7797,8 @@
     </message>
     <message id="322" name="PARAM_EXT_VALUE">
       <description>Emit the value of a parameter. The inclusion of param_count and param_index in the message allows the recipient to keep track of received parameters and allows them to re-request missing parameters after a loss or timeout.</description>
-      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="char[128]" name="param_value">Parameter value</field>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
+      <field type="char[128]" name="param_value">Parameter value. Raw bytes, interpreted according to param_type; not a text string.</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
       <field type="uint16_t" name="param_count">Total number of parameters</field>
       <field type="uint16_t" name="param_index">Index of this parameter</field>
@@ -7807,14 +7807,14 @@
       <description>Set a parameter value. In order to deal with message loss (and retransmission of PARAM_EXT_SET), when setting a parameter value and the new value is the same as the current value, you will immediately get a PARAM_ACK_ACCEPTED response. If the current state is PARAM_ACK_IN_PROGRESS, you will accordingly receive a PARAM_ACK_IN_PROGRESS in response.</description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="char[128]" name="param_value">Parameter value</field>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
+      <field type="char[128]" name="param_value">Parameter value. Raw bytes, interpreted according to param_type; not a text string.</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
     </message>
     <message id="324" name="PARAM_EXT_ACK">
       <description>Response from a PARAM_EXT_SET message.</description>
-      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
-      <field type="char[128]" name="param_value">Parameter value (new value if PARAM_ACK_ACCEPTED, current value otherwise)</field>
+      <field type="char[16]" name="param_id">Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
+      <field type="char[128]" name="param_value">Parameter value (new value if PARAM_ACK_ACCEPTED, current value otherwise). Raw bytes, interpreted according to param_type; not a text string.</field>
       <field type="uint8_t" name="param_type" enum="MAV_PARAM_EXT_TYPE">Parameter type.</field>
       <field type="uint8_t" name="param_result" enum="PARAM_ACK">Result code.</field>
     </message>
@@ -7968,7 +7968,7 @@
       </description>
       <field type="uint8_t" name="target_system">System ID</field>
       <field type="uint8_t" name="target_component">Component ID</field>
-      <field type="char[16]" name="param_id">Parameter id. Terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
+      <field type="char[16]" name="param_id">Parameter id. Terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string. Encoded as 7-bit ASCII.</field>
       <field type="int16_t" name="param_index">Parameter index. Will be -1 if the param ID field should be used as an identifier (else the param id will be ignored)</field>
       <field type="uint8_t" name="error" enum="MAV_PARAM_ERROR">Error being returned to client.</field>
     </message>


### PR DESCRIPTION
## Summary

Documentation-only. Adds one sentence to each of 12 `char[]` field descriptions in the parameter protocol messages, stating the encoding. No field types, IDs, or CRC-extras change.

| Field | Messages | Added text |
|---|---|---|
| `param_id` (`char[16]`) | `PARAM_REQUEST_READ`, `PARAM_VALUE`, `PARAM_SET`, `PARAM_MAP_RC`, `PARAM_ERROR`, `PARAM_EXT_REQUEST_READ`, `PARAM_EXT_VALUE`, `PARAM_EXT_SET`, `PARAM_EXT_ACK` | *Encoded as 7-bit ASCII.* |
| `param_value` (`char[128]`) | `PARAM_EXT_VALUE`, `PARAM_EXT_SET`, `PARAM_EXT_ACK` | *Raw bytes, interpreted according to param_type; not a text string.* |

Wording follows #2384 (STATUSTEXT).

Part of #2366 — covers the `PARAM_*.id` and `PARAM_EXT_*` items in [@hamishwillee's checklist](https://github.com/mavlink/mavlink/issues/2366#issuecomment-3555730317) (the checklist says `.id`; the XML field name is `param_id`). Further groups will follow as separate PRs, [as requested](https://github.com/mavlink/mavlink/issues/2366#issuecomment-5500932067).

## Evidence: `param_id` is already ASCII-only in practice

No implementation treats `param_id` as text. Flight stacks copy the 16 bytes and compare them against parameter names compiled into firmware, so a non-ASCII name could never match anything.

| Where the bytes cross the wire | PX4 `5a0034b7` | ArduPilot `7cf7aa9d` |
|---|---|---|
| `PARAM_SET` received | [`strncpy` → `param_find_no_notification()`](https://github.com/PX4/PX4-Autopilot/blob/5a0034b732bd00d2d8da26fb7d8e86c47e47c5b2/src/modules/mavlink/mavlink_parameters.cpp#L195-L214) | [`strncpy` → `AP_Param::find()`](https://github.com/ArduPilot/ardupilot/blob/7cf7aa9d48decfc3e6e87fe58a67766ec7a1e781/libraries/GCS_MAVLink/GCS_Param.cpp#L265-L276) |
| `PARAM_REQUEST_READ` received | [`strncpy` → `param_find_no_notification()`](https://github.com/PX4/PX4-Autopilot/blob/5a0034b732bd00d2d8da26fb7d8e86c47e47c5b2/src/modules/mavlink/mavlink_parameters.cpp#L301-L306) | [`memcpy` → `AP_Param::find()`](https://github.com/ArduPilot/ardupilot/blob/7cf7aa9d48decfc3e6e87fe58a67766ec7a1e781/libraries/GCS_MAVLink/GCS_Param.cpp#L225-L253) |
| `PARAM_MAP_RC` received | [`strncpy` into uORB `char[]`](https://github.com/PX4/PX4-Autopilot/blob/5a0034b732bd00d2d8da26fb7d8e86c47e47c5b2/src/modules/mavlink/mavlink_parameters.cpp#L378-L381) | not implemented |
| `PARAM_VALUE` sent | [`strncpy` from `param_name()` (compiled C literal)](https://github.com/PX4/PX4-Autopilot/blob/5a0034b732bd00d2d8da26fb7d8e86c47e47c5b2/src/modules/mavlink/mavlink_parameters.cpp#L642) | [`AP_Param::copy_name_token()`](https://github.com/ArduPilot/ardupilot/blob/7cf7aa9d48decfc3e6e87fe58a67766ec7a1e781/libraries/GCS_MAVLink/GCS_Param.cpp#L79-L84) |
| `PARAM_ERROR` sent | [`strncpy` from the received name](https://github.com/PX4/PX4-Autopilot/blob/5a0034b732bd00d2d8da26fb7d8e86c47e47c5b2/src/modules/mavlink/mavlink_parameters.cpp#L719) | [`strncpy_noterm` echo of received name](https://github.com/ArduPilot/ardupilot/blob/7cf7aa9d48decfc3e6e87fe58a67766ec7a1e781/libraries/GCS_MAVLink/GCS_Param.cpp#L430-L446) |
| `PARAM_EXT_*` | not implemented | not implemented |

**What those lookups compare against is ASCII by construction:**

- PX4: [`param_find_internal()` does a `strcmp` binary search](https://github.com/PX4/PX4-Autopilot/blob/5a0034b732bd00d2d8da26fb7d8e86c47e47c5b2/src/lib/parameters/parameters.cpp#L204) over a table [generated as C string literals](https://github.com/PX4/PX4-Autopilot/blob/5a0034b732bd00d2d8da26fb7d8e86c47e47c5b2/src/lib/parameters/templates/px4_parameters.hpp.jinja#L26) from names that must match [`[A-Z_][A-Z0-9_]*`](https://github.com/PX4/PX4-Autopilot/blob/5a0034b732bd00d2d8da26fb7d8e86c47e47c5b2/src/lib/parameters/px4params/srcparser.py#L191-L193) at build time. A name outside that set never enters the table.
- ArduPilot: [`AP_Param::find()` does `strcasecmp`](https://github.com/ArduPilot/ardupilot/blob/7cf7aa9d48decfc3e6e87fe58a67766ec7a1e781/libraries/AP_Param/AP_Param.cpp#L970) against `var_info` entries that are [string literals in source](https://github.com/ArduPilot/ardupilot/blob/7cf7aa9d48decfc3e6e87fe58a67766ec7a1e781/ArduCopter/Parameters.cpp#L608) (`AP_GROUPINFO("WP_NAVALT_MIN", …)`). There is no build-time regex; names are ASCII by convention in source (every entry is uppercase letters, digits, and underscores), and `AP_MAX_NAME_SIZE` is 16 bytes.

QGroundControl (`b2254ebf`), the main sender, [decodes as UTF-8](https://github.com/mavlink/qgroundcontrol/blob/b2254ebfa831eb1805a6966d754cd1033fc9f810/src/FactSystem/ParameterManager.cc#L107-L108) and encodes via [`toLocal8Bit()`](https://github.com/mavlink/qgroundcontrol/blob/b2254ebfa831eb1805a6966d754cd1033fc9f810/src/FactSystem/ParameterManager.cc#L306), [`toLatin1()`](https://github.com/mavlink/qgroundcontrol/blob/b2254ebfa831eb1805a6966d754cd1033fc9f810/src/Vehicle/Vehicle.cc#L2918-L2924), or [`toStdString()`](https://github.com/mavlink/qgroundcontrol/blob/b2254ebfa831eb1805a6966d754cd1033fc9f810/src/Camera/QGCCameraIO.cc#L199) depending on the path. All three produce identical bytes for 7-bit ASCII, which is the case this PR documents; it constrains nothing that works today.

## Evidence: `PARAM_EXT_*.param_value` is not a string

The field is declared `char[128]` but holds the raw encoding of whatever `param_type` says (int, float, or custom bytes). @julianoes [in the issue](https://github.com/mavlink/mavlink/issues/2366#issuecomment-3565188580): *"it's just supposed to be 128 bytes that you can fill with stuff. It should really be `uint8_t`."*

QGC, the only implementer among the three, treats it exactly that way: [pack copies a `QByteArray`](https://github.com/mavlink/qgroundcontrol/blob/b2254ebfa831eb1805a6966d754cd1033fc9f810/src/Camera/QGCCameraIO.cc#L179-L181); [decode `memcpy`s 128 bytes into a typed union](https://github.com/mavlink/qgroundcontrol/blob/b2254ebfa831eb1805a6966d754cd1033fc9f810/src/Camera/QGCCameraIO.cc#L259-L263).

Changing the type to `uint8_t[128]` would break generated APIs, so this PR documents intent only.

## Checks

- [x] `./scripts/format_xml.sh -c`
- [x] `python3 scripts/xml_consistency_check.py --exception` — 0 new warnings
- [x] `codespell --ignore-words-list=ned message_definitions/v1.0/common.xml`
- [x] `python3 scripts/check_api_break.py` — no API break
- [x] mavgen C and Python regenerate; new text present in `mavlink_msg_param_value.h`
