### PR TITLE
common(MAV_CMD_CONDITION_GATE): Not a destination

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2470,7 +2470,7 @@
         <param index="5" label="Latitude" units="degE7">Target latitude of center of circle in CIRCLE_MODE</param>
         <param index="6" label="Longitude" units="degE7">Target longitude of center of circle in CIRCLE_MODE</param>
       </entry>
-      <entry value="4501" name="MAV_CMD_CONDITION_GATE" hasLocation="true" isDestination="true">
+      <entry value="4501" name="MAV_CMD_CONDITION_GATE" hasLocation="true">
         <description>Delay mission state machine until gate has been reached.</description>
         <param index="1" label="Geometry" minValue="0" increment="1">Geometry: 0: orthogonal to path between previous and next waypoint.</param>
         <param index="2" label="UseAltitude" enum="MAV_BOOL">Use altitude (MAV_BOOL_TRUE). A value of MAV_BOOL_FALSE ignores altitude. Values not equal to 0 or 1 are invalid.</param>


### PR DESCRIPTION
Removed 'isDestination' attribute from MAV_CMD_CONDITION_GATE entry.

Testing for https://github.com/mavlink/mavlink-devguide/pull/761 shows it is an off path point you use to indicate a point on the path. 